### PR TITLE
Improved bootstrap script for Linux

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,29 +1,99 @@
 #!/bin/bash
 
+################ parameters ################
 # directory where the script is located
 SCRIPT_NAME=$(readlink -f $0)
 SCRIPT_DIR=`dirname $SCRIPT_NAME`
 
-# create libs dir if necessary
-mkdir -p ${SCRIPT_DIR}/libs
+# directory where dependencies will be installed
+INSTALL_DIR=libs
+
+# just for convenience
+BASE_DIR=${SCRIPT_DIR}/${INSTALL_DIR}
+
+# directory names of cloned repositories
+SODIUM_DIR=libsodium-0.5.0
+TOX_CORE_DIR=libtoxcore-latest
+
+# this boolean describes whether the installation of
+# libsodium should be skipped or not
+# the default value is 'false' and will be set to 'true'
+# if this script gets the parameter -t or --tox
+TOX_ONLY=false
+
+
+
+########## check input parameters ##########
+if [ $# -ge 1 ] ; then
+    if [ ${1} = "-t" -o ${1} = "--tox" ] ; then
+        TOX_ONLY=true
+    else
+        if [ ${1} != "-h" -a ${1} != "--help" ] ; then
+            echo "[ERROR] Unknown parameter \"${1}\""
+            echo ""
+        fi
+    
+		# print help
+		echo "Use this script to install/update libsodium and libtoxcore in ${INSTALL_DIR}"
+		echo ""
+		echo "usage:"
+		echo "    ${0} [-t|--tox|-h|--help]"
+		echo ""
+		echo "parameters:"
+		echo "    -h|--help: displays this help"
+		echo "    -t|--tox : only install/update libtoxcore"
+		echo "               requires an already installed libsodium"
+		echo ""
+		echo "example usages:"
+		echo "    ${0}    -- to install libsodium and libtoxcore"
+		echo "    ${0} -t -- to update already installed libtoxcore"
+		exit 1
+	fi
+fi
+
+
+
+############### prepare step ###############
+# create INSTALL_DIR directory if necessary
+mkdir -p ${BASE_DIR}
 
 # maybe an earlier run of this script failed
-# thus we should remove the libtoxcore-latest dir
-# if exists, otherwise cloning the git repo may fail
-rm -rf ${SCRIPT_DIR}/libs/libtoxcore-latest 
+# thus we should remove the cloned repositories
+# if exists, otherwise cloning them may fail
+rm -rf ${BASE_DIR}/${SODIUM_DIR}
+rm -rf ${SBASE_DIR}/${TOX_CORE}
+
+
+
+############### install step ###############
+# clone current master of libsodium and switch to version 0.5.0
+# afterwards install libsodium to INSTALL_DIR
+# skip the installation if TOX_ONLY is true
+if [[ $TOX_ONLY = "false" ]]; then
+    git clone git://github.com/jedisct1/libsodium.git ${BASE_DIR}/${SODIUM_DIR}
+    pushd ${BASE_DIR}/${SODIUM_DIR}
+    git checkout tags/0.5.0
+    ./autogen.sh
+    ./configure --prefix=${BASE_DIR}/
+    make -j2 check
+    make install
+    popd
+fi
 
 # clone current master of libtoxcore
-git clone https://github.com/irungentoo/toxcore.git ${SCRIPT_DIR}/libs/libtoxcore-latest
-
-# compile and install libtoxcore
-pushd ${SCRIPT_DIR}/libs/libtoxcore-latest
+# make sure to compile with libsodium we just installed to INSTALL_DIR
+# afterwards install libtoxcore to INSTALL_DIR
+git clone https://github.com/irungentoo/toxcore.git ${BASE_DIR}/${TOX_CORE_DIR}
+pushd ${BASE_DIR}/${TOX_CORE_DIR}
 ./autogen.sh
-./configure --prefix=${SCRIPT_DIR}/libs/
+./configure --prefix=${BASE_DIR}/ --with-libsodium-headers=${BASE_DIR}/include --with-libsodium-libs=${BASE_DIR}/lib
 make -j2
 make install
 popd
 
-# remove clone dir
-rm -rf ${SCRIPT_DIR}/libs/libtoxcore-latest
 
 
+############### cleanup step ###############
+# remove cloned repositories
+rm -rf ${BASE_DIR}/${SODIUM_DIR}
+rm -rf ${BASE_DIR}/${TOX_CORE_DIR}


### PR DESCRIPTION
I added libsodium to bootstrap script for Linux because:
1. The install guide of toxcore uses a specific version of libsodium
2. Some distributions may not provide a prepacked libsodium or it might be the wrong version

Furthermore I added the option (-t or --tox) to only install libtoxcore. This can be used to simply update libtoxcore to the current head. Since the Windows prepacked zip archive already includes all dependencies I had to only modify the Linux version.
