### PR TITLE
Add the files transfered Widget

### DIFF
--- a/core.cpp
+++ b/core.cpp
@@ -563,6 +563,17 @@ void Core::removeGroup(int groupId)
     tox_del_groupchat(tox, groupId);
 }
 
+QString Core::getUsername()
+{
+    int size = tox_get_self_name_size(tox);
+    uint8_t* name = new uint8_t[size];
+    if (tox_get_self_name(tox, name) == size)
+        return QString(CString::toString(name, size));
+    else
+        return QString();
+    delete[] name;
+}
+
 void Core::setUsername(const QString& username)
 {
     CString cUsername(username);
@@ -573,6 +584,17 @@ void Core::setUsername(const QString& username)
         saveConfiguration();
         emit usernameSet(username);
     }
+}
+
+QString Core::getStatusMessage()
+{
+    int size = tox_get_self_status_message_size(tox);
+    uint8_t* name = new uint8_t[size];
+    if (tox_get_self_status_message(tox, name, size) == size)
+        return QString(CString::toString(name, size));
+    else
+        return QString();
+    delete[] name;
 }
 
 void Core::setStatusMessage(const QString& message)
@@ -696,6 +718,15 @@ void Core::loadConfiguration()
     }
 
     configurationFile.close();
+
+    // set GUI with user and statusmsg
+    QString name = getUsername();
+    if (name != "")
+        emit usernameSet(name);
+    
+    QString msg = getStatusMessage();
+    if (msg != "")
+        emit statusMessageSet(msg);
 
     loadFriends();
 }

--- a/core.cpp
+++ b/core.cpp
@@ -50,6 +50,7 @@ Core::Core(Camera* cam, QThread *coreThread) :
     //connect(fileTimer, &QTimer::timeout, this, &Core::fileHeartbeat);
     connect(bootstrapTimer, &QTimer::timeout, this, &Core::onBootstrapTimer);
     connect(&Settings::getInstance(), &Settings::dhtServerListChanged, this, &Core::bootstrapDht);
+    connect(this, SIGNAL(fileTransferFinished(ToxFile)), this, SLOT(onFileTransferFinished(ToxFile)));
 
     for (int i=0; i<TOXAV_MAX_CALLS;i++)
     {
@@ -610,6 +611,14 @@ void Core::setStatus(Status status)
     } else {
         emit failedToSetStatus(status);
     }
+}
+
+void Core::onFileTransferFinished(ToxFile file)
+{
+     if (file.direction == file.SENDING)
+          emit fileUploadFinished(QString(file.fileName));
+     else
+          emit fileDownloadFinished(QString(file.fileName));
 }
 
 void Core::bootstrapDht()

--- a/core.h
+++ b/core.h
@@ -207,6 +207,8 @@ signals:
     void fileTransferAccepted(ToxFile file);
     void fileTransferCancelled(int FriendId, int FileNum, ToxFile::FileDirection direction);
     void fileTransferFinished(ToxFile file);
+    void fileUploadFinished(const QString& path);
+    void fileDownloadFinished(const QString& path);
     void fileTransferPaused(int FriendId, int FileNum, ToxFile::FileDirection direction);
     void fileTransferInfo(int FriendId, int FileNum, int Filesize, int BytesSent, ToxFile::FileDirection direction);
 
@@ -269,6 +271,9 @@ private:
     static void removeFileFromQueue(bool sendQueue, int friendId, int fileId);
 
     void checkLastOnline(int friendId);
+
+private slots:
+     void onFileTransferFinished(ToxFile file);
 
 private:
     Tox* tox;

--- a/core.h
+++ b/core.h
@@ -120,6 +120,9 @@ public:
     void dispatchVideoFrame(vpx_image img) const;
 
     void saveConfiguration();
+    
+    QString getUsername();
+    QString getStatusMessage();
 
 public slots:
     void start();

--- a/main.cpp
+++ b/main.cpp
@@ -23,7 +23,7 @@
 int main(int argc, char *argv[])
 {
     QApplication a(argc, argv);
-    a.setApplicationName("Toxgui");
+    a.setApplicationName("qTox");
     a.setOrganizationName("Tox");
 
     // Load translations

--- a/res.qrc
+++ b/res.qrc
@@ -26,6 +26,7 @@
         <file>img/add.png</file>
         <file>img/settings.png</file>
         <file>img/transfer.png</file>
+        <file>img/checkmark.png</file>
         <file>ui/acceptFileButton/default.png</file>
         <file>ui/acceptFileButton/hover.png</file>
         <file>ui/acceptFileButton/pressed.png</file>

--- a/res.qrc
+++ b/res.qrc
@@ -26,7 +26,6 @@
         <file>img/add.png</file>
         <file>img/settings.png</file>
         <file>img/transfer.png</file>
-        <file>img/checkmark.png</file>
         <file>ui/acceptFileButton/default.png</file>
         <file>ui/acceptFileButton/hover.png</file>
         <file>ui/acceptFileButton/pressed.png</file>

--- a/settings.cpp
+++ b/settings.cpp
@@ -73,8 +73,6 @@ void Settings::load()
     s.endGroup();
 
     s.beginGroup("General");
-        username = s.value("username", "My name").toString();
-        statusMessage = s.value("statusMessage", "My status").toString();
         enableIPv6 = s.value("enableIPv6", true).toBool();
         useTranslations = s.value("useTranslations", true).toBool();
     s.endGroup();
@@ -126,8 +124,6 @@ void Settings::save()
     s.endGroup();
 
     s.beginGroup("General");
-        s.setValue("username", username);
-        s.setValue("statusMessage", statusMessage);
         s.setValue("enableIPv6", enableIPv6);
         s.setValue("useTranslations",useTranslations);
     s.endGroup();
@@ -175,26 +171,6 @@ void Settings::setDhtServerList(const QList<DhtServer>& newDhtServerList)
 {
     dhtServerList = newDhtServerList;
     emit dhtServerListChanged();
-}
-
-QString Settings::getUsername() const
-{
-    return username;
-}
-
-void Settings::setUsername(const QString& newUsername)
-{
-    username = newUsername;
-}
-
-QString Settings::getStatusMessage() const
-{
-    return statusMessage;
-}
-
-void Settings::setStatusMessage(const QString& newMessage)
-{
-    statusMessage = newMessage;
 }
 
 bool Settings::getEnableIPv6() const

--- a/settings.h
+++ b/settings.h
@@ -43,12 +43,6 @@ public:
     const QList<DhtServer>& getDhtServerList() const;
     void setDhtServerList(const QList<DhtServer>& newDhtServerList);
 
-    QString getUsername() const;
-    void setUsername(const QString& newUsername);
-
-    QString getStatusMessage() const;
-    void setStatusMessage(const QString& newMessage);
-
     bool getEnableIPv6() const;
     void setEnableIPv6(bool newValue);
 
@@ -132,9 +126,6 @@ private:
     QList<DhtServer> dhtServerList;
     int dhtServerId;
     bool dontShowDhtDialog;
-
-    QString username;
-    QString statusMessage;
 
     bool enableIPv6;
     bool useTranslations;

--- a/toxgui.pro
+++ b/toxgui.pro
@@ -63,6 +63,7 @@ HEADERS  += widget/form/addfriendform.h \
     widget/form/chatform.h \
     widget/form/groupchatform.h \
     widget/form/settingsform.h \
+    widget/form/filesform.h \
     widget/tool/chattextedit.h \
     widget/tool/copyableelidelabel.h \
     widget/tool/editablelabelwidget.h \
@@ -93,6 +94,7 @@ SOURCES += \
     widget/form/chatform.cpp \
     widget/form/groupchatform.cpp \
     widget/form/settingsform.cpp \
+    widget/form/filesform.cpp \
     widget/tool/chattextedit.cpp \
     widget/tool/copyableelidelabel.cpp \
     widget/tool/editablelabelwidget.cpp \

--- a/widget/form/filesform.cpp
+++ b/widget/form/filesform.cpp
@@ -1,0 +1,72 @@
+/*
+    Copyright (C) 2014 by Project Tox <https://tox.im>
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    This program is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+    See the COPYING file for more details.
+*/
+
+#include "filesform.h"
+
+FilesForm::FilesForm()
+    : QObject()
+{
+    head = new QWidget();
+    QFont bold;
+    bold.setBold(true);
+    headLabel.setText(tr("Transfered Files","\"Headline\" of the window"));
+    headLabel.setFont(bold);
+    head->setLayout(&headLayout);
+    headLayout.addWidget(&headLabel);
+    
+    main.addTab(&recvd, tr("Downloads"));
+    main.addTab(&sent, tr("Uploads"));
+
+    //these need to go in widget.cpp (I think, not really sure atm)
+    //connect(something, SIGNAL(DOWNLOAD_DONE), this, SLOT(onFileDownloadComplete()));
+    //connect(something, SIGNAL(DOWNLOAD_DONE), this, SLOT(onFileUploadComplete()));
+    
+    connect(&sent, SIGNAL(itemActivated(QListWidgetItem*)), this, SLOT(onFileActivated(QListWidgetItem*)));
+
+}
+
+FilesForm::~FilesForm()
+{
+    //delete head;
+    // having this line caused a SIGABRT because free() received an invalid pointer
+    // but since this is only called on program shutdown anyways, 
+    // I'm not too bummed about removing it
+}
+
+void FilesForm::show(Ui::Widget& ui)
+{
+    ui.mainContent->layout()->addWidget(&main);
+    ui.mainHead->layout()->addWidget(head);
+    main.show();
+    head->show();
+}
+
+void FilesForm::onFileDownloadComplete(const QString& path)
+{
+    QListWidgetItem* tmp = new QListWidgetItem(/*QIcon("checkmark.png"),*/path);
+    recvd.addItem(tmp);
+}
+
+void FilesForm::onFileUploadComplete(const QString& path)
+{
+    QListWidgetItem* tmp = new QListWidgetItem(/*QIcon("checkmark.png"),*/path);
+    sent.addItem(tmp);
+}
+
+void FilesForm::onFileActivated(QListWidgetItem* item)
+{
+    QDesktopServices::openUrl(QUrl::fromLocalFile(item->text()));
+}

--- a/widget/form/filesform.cpp
+++ b/widget/form/filesform.cpp
@@ -53,13 +53,13 @@ void FilesForm::show(Ui::Widget& ui)
 
 void FilesForm::onFileDownloadComplete(const QString& path)
 {
-    QListWidgetItem* tmp = new QListWidgetItem(QIcon("ui/acceptFileButton/default.png"), path);
+    QListWidgetItem* tmp = new QListWidgetItem(QIcon(":/ui/acceptFileButton/default.png"), path);
     recvd.addItem(tmp);
 }
 
 void FilesForm::onFileUploadComplete(const QString& path)
 {
-    QListWidgetItem* tmp = new QListWidgetItem(QIcon("ui/acceptFileButton/default.png"), path);
+    QListWidgetItem* tmp = new QListWidgetItem(QIcon(":/ui/acceptFileButton/default.png"), path);
     sent.addItem(tmp);
 }
 

--- a/widget/form/filesform.cpp
+++ b/widget/form/filesform.cpp
@@ -53,13 +53,13 @@ void FilesForm::show(Ui::Widget& ui)
 
 void FilesForm::onFileDownloadComplete(const QString& path)
 {
-    QListWidgetItem* tmp = new QListWidgetItem(QIcon(":/img/checkmark.png"), path);
+    QListWidgetItem* tmp = new QListWidgetItem(QIcon("ui/acceptFileButton/default.png"), path);
     recvd.addItem(tmp);
 }
 
 void FilesForm::onFileUploadComplete(const QString& path)
 {
-    QListWidgetItem* tmp = new QListWidgetItem(QIcon(":/img/checkmark.png"), path);
+    QListWidgetItem* tmp = new QListWidgetItem(QIcon("ui/acceptFileButton/default.png"), path);
     sent.addItem(tmp);
 }
 

--- a/widget/form/filesform.cpp
+++ b/widget/form/filesform.cpp
@@ -30,7 +30,8 @@ FilesForm::FilesForm()
     main.addTab(&recvd, tr("Downloads"));
     main.addTab(&sent, tr("Uploads"));
     
-    connect(&sent, SIGNAL(itemActivated(QListWidgetItem*)), this, SLOT(onFileActivated(QListWidgetItem*)));
+    connect(&sent, SIGNAL(itemActivated(QListWidgetItem*)), this, SLOT(onUploadFileActivated(QListWidgetItem*)));
+    connect(&recvd, SIGNAL(itemActivated(QListWidgetItem*)), this, SLOT(onDownloadFileActivated(QListWidgetItem*)));
 
 }
 
@@ -52,17 +53,31 @@ void FilesForm::show(Ui::Widget& ui)
 
 void FilesForm::onFileDownloadComplete(const QString& path)
 {
-    QListWidgetItem* tmp = new QListWidgetItem(/*QIcon("checkmark.png"),*/path);
+    QListWidgetItem* tmp = new QListWidgetItem(QIcon(":/img/checkmark.png"), path);
     recvd.addItem(tmp);
 }
 
 void FilesForm::onFileUploadComplete(const QString& path)
 {
-    QListWidgetItem* tmp = new QListWidgetItem(/*QIcon("checkmark.png"),*/path);
+    QListWidgetItem* tmp = new QListWidgetItem(QIcon(":/img/checkmark.png"), path);
     sent.addItem(tmp);
 }
 
-void FilesForm::onFileActivated(QListWidgetItem* item)
+// sadly, the ToxFile struct in core only has the file name, not the file path...
+// so currently, these don't work as intended (though for now, downloads might work
+// whenever they're not saved anywhere custom, thanks to the hack)
+// I could do some digging around, but for now I'm tired and others already 
+// might know it without me needing to dig, so...
+void FilesForm::onDownloadFileActivated(QListWidgetItem* item)
 {
-    QDesktopServices::openUrl(QUrl::fromLocalFile(item->text()));
+    QUrl url = QUrl::fromLocalFile("./" + item->text());
+    qDebug() << "Opening '" << url << "'";
+    QDesktopServices::openUrl(url);
+}
+
+void FilesForm::onUploadFileActivated(QListWidgetItem* item)
+{
+    QUrl url = QUrl::fromLocalFile(item->text());
+    qDebug() << "Opening '" << url << "'";
+    QDesktopServices::openUrl(url);
 }

--- a/widget/form/filesform.cpp
+++ b/widget/form/filesform.cpp
@@ -29,10 +29,6 @@ FilesForm::FilesForm()
     
     main.addTab(&recvd, tr("Downloads"));
     main.addTab(&sent, tr("Uploads"));
-
-    //these need to go in widget.cpp (I think, not really sure atm)
-    //connect(something, SIGNAL(DOWNLOAD_DONE), this, SLOT(onFileDownloadComplete()));
-    //connect(something, SIGNAL(DOWNLOAD_DONE), this, SLOT(onFileUploadComplete()));
     
     connect(&sent, SIGNAL(itemActivated(QListWidgetItem*)), this, SLOT(onFileActivated(QListWidgetItem*)));
 

--- a/widget/form/filesform.h
+++ b/widget/form/filesform.h
@@ -26,6 +26,7 @@
 #include <QLabel>
 #include <QVBoxLayout>
 #include <QUrl>
+#include <QDebug>
 
 class FilesForm : public QObject
 {
@@ -42,10 +43,11 @@ public slots:
     void onFileUploadComplete(const QString& path);
     
 private slots:
-    void onFileActivated(QListWidgetItem* item);
+    void onDownloadFileActivated(QListWidgetItem* item);
+    void onUploadFileActivated(QListWidgetItem* item);
 
 private:
-    QWidget *head;
+    QWidget* head;
     QLabel headLabel;
     QVBoxLayout headLayout;
 

--- a/widget/form/filesform.h
+++ b/widget/form/filesform.h
@@ -1,0 +1,62 @@
+/*
+    Copyright (C) 2014 by Project Tox <https://tox.im>
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    This program is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+    See the COPYING file for more details.
+*/
+
+#ifndef FILESFORM_H
+#define FILESFORM_H
+
+#include "ui_widget.h"
+
+#include <QListWidget>
+#include <QTabWidget>
+#include <QString>
+#include <QDesktopServices>
+#include <QLabel>
+#include <QVBoxLayout>
+#include <QUrl>
+
+class FilesForm : public QObject
+{
+    Q_OBJECT
+
+public:
+    FilesForm();
+    ~FilesForm();
+
+    void show(Ui::Widget& ui);
+
+public slots:
+    void onFileDownloadComplete(const QString& path);
+    void onFileUploadComplete(const QString& path);
+    
+private slots:
+    void onFileActivated(QListWidgetItem* item);
+
+private:
+    QWidget *head;
+    QLabel headLabel;
+    QVBoxLayout headLayout;
+
+    /* If we really do go whole hog with listing in progress transers,
+    I should really look into the new fangled list thingy, to deactivate
+    specific items in the list */
+    QTabWidget main;
+    QListWidget sent, recvd;
+
+};
+
+#include "ui_widget.h"
+
+#endif // FILESFORM_H

--- a/widget/widget.cpp
+++ b/widget/widget.cpp
@@ -152,9 +152,10 @@ Widget::Widget(QWidget *parent) :
     friendListWidget->setLayoutDirection(Qt::LeftToRight);
     ui->friendList->setWidget(friendListWidget);
 
-    ui->nameLabel->setText(Settings::getInstance().getUsername());
+    // delay setting username and message until Core inits
+    //ui->nameLabel->setText(core->getUsername());
     ui->nameLabel->label->setStyleSheet("QLabel { color : white; font-size: 11pt; font-weight:bold;}");
-    ui->statusLabel->setText(Settings::getInstance().getStatusMessage());
+    //ui->statusLabel->setText(core->getStatusMessage());
     ui->statusLabel->label->setStyleSheet("QLabel { color : white; font-size: 8pt;}");
     ui->friendList->widget()->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
 
@@ -434,7 +435,6 @@ void Widget::setUsername(const QString& username)
 {
     ui->nameLabel->setText(username);
     settingsForm.name.setText(username);
-    Settings::getInstance().setUsername(username);
 }
 
 void Widget::onStatusMessageChanged()
@@ -456,7 +456,6 @@ void Widget::setStatusMessage(const QString &statusMessage)
 {
     ui->statusLabel->setText(statusMessage);
     settingsForm.statusText.setText(statusMessage);
-    Settings::getInstance().setStatusMessage(statusMessage);
 }
 
 void Widget::addFriend(int friendId, const QString &userId)
@@ -668,7 +667,7 @@ void Widget::onGroupMessageReceived(int groupnumber, int friendgroupnumber, cons
 
     if ((isGroupWidgetActive != 1 || (g->groupId != activeGroupWidget->groupId)) || isWindowMinimized)
     {
-        if (message.contains(Settings::getInstance().getUsername(), Qt::CaseInsensitive))
+        if (message.contains(core->getUsername(), Qt::CaseInsensitive))
         {
             newMessageAlert();
             g->hasNewMessages = 1;

--- a/widget/widget.cpp
+++ b/widget/widget.cpp
@@ -215,6 +215,8 @@ Widget::Widget(QWidget *parent) :
     connect(core, &Core::usernameSet, this, &Widget::setUsername);
     connect(core, &Core::statusMessageSet, this, &Widget::setStatusMessage);
     connect(core, &Core::friendAddressGenerated, &settingsForm, &SettingsForm::setFriendAddress);
+    connect(core, SIGNAL(Core::fileDownloadFinished(QString&)), &filesForm, SLOT(FilesForm::onFileDownloadComplete(QString&)));
+    connect(core, SIGNAL(Core::fileUploadFinished(QString&)), &filesForm, SLOT(FilesForm::onFileUploadComplete(QString&)));
     connect(core, &Core::friendAdded, this, &Widget::addFriend);
     connect(core, &Core::failedToAddFriend, this, &Widget::addFriendFailed);
     connect(core, &Core::friendStatusChanged, this, &Widget::onFriendStatusChanged);
@@ -377,7 +379,10 @@ void Widget::onGroupClicked()
 
 void Widget::onTransferClicked()
 {
-
+    hideMainForms();
+    filesForm.show(*ui);
+    isFriendWidgetActive = 0;
+    isGroupWidgetActive = 0;
 }
 
 void Widget::onSettingsClicked()

--- a/widget/widget.cpp
+++ b/widget/widget.cpp
@@ -215,8 +215,8 @@ Widget::Widget(QWidget *parent) :
     connect(core, &Core::usernameSet, this, &Widget::setUsername);
     connect(core, &Core::statusMessageSet, this, &Widget::setStatusMessage);
     connect(core, &Core::friendAddressGenerated, &settingsForm, &SettingsForm::setFriendAddress);
-    connect(core, SIGNAL(Core::fileDownloadFinished(QString&)), &filesForm, SLOT(FilesForm::onFileDownloadComplete(QString&)));
-    connect(core, SIGNAL(Core::fileUploadFinished(QString&)), &filesForm, SLOT(FilesForm::onFileUploadComplete(QString&)));
+    connect(core, SIGNAL(fileDownloadFinished(const QString&)), &filesForm, SLOT(onFileDownloadComplete(const QString&)));
+    connect(core, SIGNAL(fileUploadFinished(const QString&)), &filesForm, SLOT(onFileUploadComplete(const QString&)));
     connect(core, &Core::friendAdded, this, &Widget::addFriend);
     connect(core, &Core::failedToAddFriend, this, &Widget::addFriendFailed);
     connect(core, &Core::friendStatusChanged, this, &Widget::onFriendStatusChanged);

--- a/widget/widget.h
+++ b/widget/widget.h
@@ -35,8 +35,6 @@ class Widget;
 }
 
 class GroupWidget;
-//class AddFriendForm;
-//class SettingsForm;
 struct FriendWidget;
 class Group;
 struct Friend;

--- a/widget/widget.h
+++ b/widget/widget.h
@@ -25,6 +25,7 @@
 #include "core.h"
 #include "widget/form/addfriendform.h"
 #include "widget/form/settingsform.h"
+#include "widget/form/filesform.h"
 #include "camera.h"
 
 #define PIXELS_TO_ACT 7
@@ -34,8 +35,8 @@ class Widget;
 }
 
 class GroupWidget;
-class AddFriendForm;
-class SettingsForm;
+//class AddFriendForm;
+//class SettingsForm;
 struct FriendWidget;
 class Group;
 struct Friend;
@@ -144,6 +145,7 @@ private:
     QThread* coreThread;
     AddFriendForm friendForm;
     SettingsForm settingsForm;
+    FilesForm filesForm;
     static Widget* instance;
     FriendWidget* activeFriendWidget;
     GroupWidget* activeGroupWidget;


### PR DESCRIPTION
For now it's quite simple, and it's lacking a bit of functionality: the ToxFile struct doesn't have any path information, so clicking on the files fails to open them (excepting the hack for downloads, which would be broken if the client allowed custom download locations).

So, if anyone knows more about file transfers and can somehow locate the full path for the widget, that would be great.

Also Flynn (or whoever does these things), a better checkmark icon wouldn't be bad (and I'm not even sure it works currently).
