### PR TITLE
Add tooltips to user-provided text (helps to accommodate too-long names)

### DIFF
--- a/core.cpp
+++ b/core.cpp
@@ -664,9 +664,9 @@ void Core::setStatus(Status status)
 void Core::onFileTransferFinished(ToxFile file)
 {
      if (file.direction == file.SENDING)
-          emit fileUploadFinished(QString(file.fileName));
+          emit fileUploadFinished(file.filePath);
      else
-          emit fileDownloadFinished(QString(file.fileName));
+          emit fileDownloadFinished(file.filePath);
 }
 
 void Core::bootstrapDht()
@@ -952,6 +952,7 @@ void Core::sendAllFileData(Core *core, ToxFile* file)
             removeFileFromQueue(true, file->friendId, file->fileNum);
             return;
         }
+        qDebug() << "chunkSize: " << chunkSize;
         chunkSize = std::min(chunkSize, file->filesize);
         uint8_t* data = new uint8_t[chunkSize];
         file->file->seek(file->bytesSent);

--- a/friend.cpp
+++ b/friend.cpp
@@ -36,12 +36,14 @@ Friend::~Friend()
 void Friend::setName(QString name)
 {
     widget->name.setText(name);
+    widget->name.setToolTip(name); // for overlength names
     chatForm->setName(name);
 }
 
 void Friend::setStatusMessage(QString message)
 {
     widget->statusMessage.setText(message);
+    widget->statusMessage.setToolTip(message); // for overlength messsages
     chatForm->setStatusMessage(message);
 }
 

--- a/qtox.pro
+++ b/qtox.pro
@@ -23,7 +23,7 @@
 QT       += core gui network multimedia multimediawidgets
 greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 
-TARGET    = toxgui
+TARGET    = qtox
 TEMPLATE  = app
 FORMS    += widget.ui
 CONFIG   += c++11

--- a/widget.ui
+++ b/widget.ui
@@ -2697,7 +2697,7 @@ QSplitter:handle{
              <enum>Qt::NoFocus</enum>
             </property>
             <property name="toolTip">
-             <string>(button inactive currently)</string>
+             <string>View completed file transfers</string>
             </property>
             <property name="text">
              <string/>

--- a/widget/form/chatform.cpp
+++ b/widget/form/chatform.cpp
@@ -207,11 +207,13 @@ void ChatForm::show(Ui::Widget &ui)
 void ChatForm::setName(QString newName)
 {
     name->setText(newName);
+    name->setToolTip(newName); // for overlength names
 }
 
 void ChatForm::setStatusMessage(QString newMessage)
 {
     statusMessage->setText(newMessage);
+    statusMessage->setToolTip(newMessage); // for overlength messsages
 }
 
 void ChatForm::onSendTriggered()

--- a/widget/form/filesform.h
+++ b/widget/form/filesform.h
@@ -27,6 +27,7 @@
 #include <QVBoxLayout>
 #include <QUrl>
 #include <QDebug>
+#include <QFileInfo>
 
 class FilesForm : public QObject
 {
@@ -43,8 +44,7 @@ public slots:
     void onFileUploadComplete(const QString& path);
     
 private slots:
-    void onDownloadFileActivated(QListWidgetItem* item);
-    void onUploadFileActivated(QListWidgetItem* item);
+    void onFileActivated(QListWidgetItem* item);
 
 private:
     QWidget* head;
@@ -55,10 +55,15 @@ private:
     I should really look into the new fangled list thingy, to deactivate
     specific items in the list */
     QTabWidget main;
-    QListWidget sent, recvd;
+    QListWidget* sent, * recvd;
 
 };
 
-#include "ui_widget.h"
+class ListWidgetItem : public QListWidgetItem
+{
+    using QListWidgetItem::QListWidgetItem;
+  public:
+    QString path;
+};
 
 #endif // FILESFORM_H

--- a/widget/widget.cpp
+++ b/widget/widget.cpp
@@ -422,6 +422,7 @@ void Widget::onUsernameChanged()
 {
     const QString newUsername = settingsForm.name.text();
     ui->nameLabel->setText(newUsername);
+    ui->nameLabel->setToolTip(newUsername); // for overlength names
     settingsForm.name.setText(newUsername);
     core->setUsername(newUsername);
 }
@@ -429,6 +430,7 @@ void Widget::onUsernameChanged()
 void Widget::onUsernameChanged(const QString& newUsername, const QString& oldUsername)
 {
     ui->nameLabel->setText(oldUsername); // restore old username until Core tells us to set it
+    ui->nameLabel->setToolTip(oldUsername); // for overlength names
     settingsForm.name.setText(oldUsername);
     core->setUsername(newUsername);
 }
@@ -436,6 +438,7 @@ void Widget::onUsernameChanged(const QString& newUsername, const QString& oldUse
 void Widget::setUsername(const QString& username)
 {
     ui->nameLabel->setText(username);
+    ui->nameLabel->setToolTip(username); // for overlength names
     settingsForm.name.setText(username);
 }
 
@@ -443,6 +446,7 @@ void Widget::onStatusMessageChanged()
 {
     const QString newStatusMessage = settingsForm.statusText.text();
     ui->statusLabel->setText(newStatusMessage);
+    ui->statusLabel->setToolTip(newStatusMessage); // for overlength messsages
     settingsForm.statusText.setText(newStatusMessage);
     core->setStatusMessage(newStatusMessage);
 }
@@ -450,6 +454,7 @@ void Widget::onStatusMessageChanged()
 void Widget::onStatusMessageChanged(const QString& newStatusMessage, const QString& oldStatusMessage)
 {
     ui->statusLabel->setText(oldStatusMessage); // restore old status message until Core tells us to set it
+    ui->statusLabel->setToolTip(oldStatusMessage); // for overlength messsages
     settingsForm.statusText.setText(oldStatusMessage);
     core->setStatusMessage(newStatusMessage);
 }
@@ -457,6 +462,7 @@ void Widget::onStatusMessageChanged(const QString& newStatusMessage, const QStri
 void Widget::setStatusMessage(const QString &statusMessage)
 {
     ui->statusLabel->setText(statusMessage);
+    ui->statusLabel->setToolTip(statusMessage); // for overlength messsages
     settingsForm.statusText.setText(statusMessage);
 }
 


### PR DESCRIPTION
Ideally this would be done only if the widget is too small for the message, but
that can be quite difficult

Additionally, it doesn't cover the case of having a Tox ID for the name... eh
