### PR TITLE
Placeholder text for chat input and friend invite

### DIFF
--- a/widget/form/addfriendform.cpp
+++ b/widget/form/addfriendform.cpp
@@ -35,6 +35,7 @@ AddFriendForm::AddFriendForm() : dns(this)
     toxIdLabel.setText(tr("Tox ID","Tox ID of the person you're sending a friend request to"));
     messageLabel.setText(tr("Message","The message you send in friend requests"));
     sendButton.setText(tr("Send friend request"));
+    message.setPlaceholderText(tr("Tox me maybe?","Default message in friend requests if the field is left blank. Write something appropriate!"));
 
     main->setLayout(&layout);
     layout.addWidget(&toxIdLabel);
@@ -81,7 +82,7 @@ void AddFriendForm::showWarning(const QString &message) const
 QString AddFriendForm::getMessage() const
 {
     const QString msg = message.toPlainText();
-    return !msg.isEmpty() ? msg : tr("Tox me maybe?","Default message in friend requests if the field is left blank. Write something appropriate!");
+    return !msg.isEmpty() ? msg : message.placeholderText();
 }
 
 void AddFriendForm::onSendTriggered()

--- a/widget/tool/chattextedit.cpp
+++ b/widget/tool/chattextedit.cpp
@@ -20,6 +20,7 @@
 ChatTextEdit::ChatTextEdit(QWidget *parent) :
     QTextEdit(parent)
 {
+    setPlaceholderText("Type your message here...");
 }
 
 void ChatTextEdit::keyPressEvent(QKeyEvent * event)


### PR DESCRIPTION
I added a placeholder text for the chat input widget. Furthermore the default invite message is a placeholder text and will be used if no message was entered. This makes things more transparent.
