### PR TITLE
Widget code cleanup

### DIFF
--- a/widget/widget.h
+++ b/widget/widget.h
@@ -145,7 +145,6 @@ private:
     FriendWidget* activeFriendWidget;
     GroupWidget* activeGroupWidget;
     FriendListWidget* contactListWidget;
-    int isFriendWidgetActive, isGroupWidgetActive;
     SelfCamView* camview;
     Camera* camera;
     bool notify(QObject *receiver, QEvent *event);


### PR DESCRIPTION
Usage of nullptr for activeFriendWidget and activeGroupWidget is more simple.
