### PR TITLE
HTML table chat representation replacement

### DIFF
--- a/widget/chatareawidget.cpp
+++ b/widget/chatareawidget.cpp
@@ -33,6 +33,22 @@ ChatAreaWidget::ChatAreaWidget(QWidget *parent) :
     setOpenLinks(false);
     setAcceptRichText(false);
 
+    chatTextTable = textCursor().insertTable(1,3);
+
+    QTextTableFormat tableFormat;
+    tableFormat.setColumnWidthConstraints({QTextLength(QTextLength::VariableLength,0),
+                                           QTextLength(QTextLength::PercentageLength,100),
+                                           QTextLength(QTextLength::VariableLength,0)});
+    tableFormat.setBorderStyle(QTextFrameFormat::BorderStyle_None);
+    chatTextTable->setFormat(tableFormat);
+    chatTextTable->format().setCellSpacing(2);
+    chatTextTable->format().setWidth(QTextLength(QTextLength::PercentageLength,100));
+
+    nameFormat.setAlignment(Qt::AlignRight);
+    nameFormat.setNonBreakableLines(true);
+    dateFormat.setAlignment(Qt::AlignLeft);
+    dateFormat.setNonBreakableLines(true);
+
     connect(this, &ChatAreaWidget::anchorClicked, this, &ChatAreaWidget::onAnchorClicked);
     connect(verticalScrollBar(), SIGNAL(rangeChanged(int,int)), this, SLOT(onSliderRangeChanged()));
 }
@@ -87,12 +103,17 @@ void ChatAreaWidget::insertMessage(ChatAction *msgAction)
 
     checkSlider();
 
-    moveCursor(QTextCursor::End);
-    moveCursor(QTextCursor::PreviousCell);
-    QTextCursor cur = textCursor();
+    int row = chatTextTable->rows() - 1;
+    chatTextTable->cellAt(row,0).firstCursorPosition().setBlockFormat(nameFormat);
+    chatTextTable->cellAt(row,2).firstCursorPosition().setBlockFormat(dateFormat);
+    QTextCursor cur = chatTextTable->cellAt(row,1).firstCursorPosition();
     cur.clearSelection();
     cur.setKeepPositionOnInsert(true);
-    insertHtml(msgAction->getHtml());
+    chatTextTable->cellAt(row,0).firstCursorPosition().insertHtml(msgAction->getName());
+    chatTextTable->cellAt(row,1).firstCursorPosition().insertHtml(msgAction->getMessage());
+    chatTextTable->cellAt(row,2).firstCursorPosition().insertHtml(msgAction->getDate());
+    chatTextTable->appendRows(1);
+
     msgAction->setTextCursor(cur);
 
     messages.append(msgAction);

--- a/widget/chatareawidget.h
+++ b/widget/chatareawidget.h
@@ -19,6 +19,7 @@
 
 #include <QTextBrowser>
 #include <QList>
+#include <QTextTable>
 
 class ChatAction;
 
@@ -46,6 +47,8 @@ private:
     QList<ChatAction*> messages;
     bool lockSliderToBottom;
     int sliderPosition;
+    QTextTable *chatTextTable;
+    QTextBlockFormat nameFormat, dateFormat;
 };
 
 #endif // CHATAREAWIDGET_H

--- a/widget/tool/chataction.cpp
+++ b/widget/tool/chataction.cpp
@@ -43,9 +43,9 @@ QString ChatAction::QImage2base64(const QImage &img)
 QString ChatAction::getName()
 {
     if (isMe)
-        return QString("<div class=name_me>" + name + "</div>");
+        return QString("<div class=name_me>" + toHtmlChars(name) + "</div>");
     else
-        return QString("<div class=name>" + name + "</div>");
+        return QString("<div class=name>" + toHtmlChars(name) + "</div>");
 }
 
 QString ChatAction::getDate()

--- a/widget/tool/chataction.cpp
+++ b/widget/tool/chataction.cpp
@@ -40,34 +40,42 @@ QString ChatAction::QImage2base64(const QImage &img)
     return ba.toBase64();
 }
 
-QString ChatAction::wrapName(const QString &name)
+QString ChatAction::getName()
 {
     if (isMe)
-        return QString("<td><div class=name_me>" + name + "</div></td>\n");
+        return QString("<div class=name_me>" + name + "</div>");
     else
-        return QString("<td><div class=name>" + name + "</div></td>\n");
+        return QString("<div class=name>" + name + "</div>");
 }
 
-QString ChatAction::wrapDate(const QString &date)
+QString ChatAction::getDate()
 {
-    QString res = "<td align=right><div class=date>" + date + "</div></td>\n";
-    return res;
-}
-
-QString ChatAction::wrapMessage(const QString &message)
-{
-    QString res = "<td width=100%><div class=message>" + message + "</div></td>\n";
-    return res;
-}
-
-QString ChatAction::wrapWholeLine(const QString &line)
-{
-    QString res = "<tr>\n" + line + "</tr>\n";
+    QString res = "<div class=date>" + date + "</div>";
     return res;
 }
 
 MessageAction::MessageAction(const QString &author, const QString &message, const QString &date, const bool &me) :
-    ChatAction(me)
+    ChatAction(me, author, date),
+    message(message)
+{
+}
+
+void MessageAction::setTextCursor(QTextCursor cursor)
+{
+    // When this function is called, we're supposed to only update ourselve when needed
+    // Nobody should ask us to do anything with our content, we're on our own
+    // Except we never udpate on our own, so we can safely free our resources
+
+    (void) cursor;
+    message.clear();
+    message.squeeze();
+    name.clear();
+    name.squeeze();
+    date.clear();
+    date.squeeze();
+}
+
+QString MessageAction::getMessage()
 {
     QString message_ = SmileyPack::getInstance().smileyfied(toHtmlChars(message));
 
@@ -100,29 +108,11 @@ MessageAction::MessageAction(const QString &author, const QString &message, cons
     }
     message_ = message_.left(message_.length()-4);
 
-    content = wrapWholeLine(wrapName(author) + wrapMessage(message_) + wrapDate(date));
-}
-
-void MessageAction::setTextCursor(QTextCursor cursor)
-{
-    // When this function is called, we're supposed to only update ourselve when needed
-    // Nobody should ask us to do anything with our content, we're on our own
-    // Except we never udpate on our own, so we can safely free our resources
-
-    (void) cursor;
-    content.clear();
-    content.squeeze();
-}
-
-QString MessageAction::getHtml()
-{
-    return content;
+    return QString("<div class=message>" + message_ + "</div>");
 }
 
 FileTransferAction::FileTransferAction(FileTransferInstance *widget, const QString &author, const QString &date, const bool &me) :
-    ChatAction(me),
-    sender(author),
-    timestamp(date)
+    ChatAction(me, author, date)
 {
     w = widget;
 
@@ -133,22 +123,16 @@ FileTransferAction::~FileTransferAction()
 {
 }
 
-QString FileTransferAction::getHtml()
+QString FileTransferAction::getMessage()
 {
     QString widgetHtml;
     if (w != nullptr)
         widgetHtml = w->getHtmlImage();
     else
         widgetHtml = "<div class=quote>EMPTY CONTENT</div>";
-    QString res = wrapWholeLine(wrapName(sender) + wrapMessage(widgetHtml) + wrapDate(timestamp));
-    return res;
+    return widgetHtml;
 }
 
-QString FileTransferAction::wrapMessage(const QString &message)
-{
-    QString res = "<td width=100%>" + message + "</td>\n";
-    return res;
-}
 void FileTransferAction::setTextCursor(QTextCursor cursor)
 {
     cur = cursor;
@@ -166,7 +150,7 @@ void FileTransferAction::updateHtml()
     int pos = cur.selectionStart();
     cur.removeSelectedText();
     cur.setKeepPositionOnInsert(false);
-    cur.insertHtml(getHtml());
+    cur.insertHtml(getMessage());
     cur.setKeepPositionOnInsert(true);
     int end = cur.position();
     cur.setPosition(pos);
@@ -176,10 +160,10 @@ void FileTransferAction::updateHtml()
     if (w->getState() == FileTransferInstance::TransfState::tsCanceled
             || w->getState() == FileTransferInstance::TransfState::tsFinished)
     {
-        sender.clear();
-        sender.squeeze();
-        timestamp.clear();
-        timestamp.squeeze();
+        name.clear();
+        name.squeeze();
+        date.clear();
+        date.squeeze();
         cur = QTextCursor();
     }
 }

--- a/widget/tool/chataction.h
+++ b/widget/tool/chataction.h
@@ -25,22 +25,21 @@ class FileTransferInstance;
 class ChatAction : public QObject
 {
 public:
-    ChatAction(const bool &me) : isMe(me) {;}
+    ChatAction(const bool &me, const QString &author, const QString &date) : isMe(me), name(author), date(date) {;}
     virtual ~ChatAction(){;}
-    virtual QString getHtml() = 0;
     virtual void setTextCursor(QTextCursor cursor){(void)cursor;} ///< Call once, and then you MUST let the object update itself
+
+    virtual QString getName();
+    virtual QString getMessage() = 0;
+    virtual QString getDate();
 
 protected:
     QString toHtmlChars(const QString &str);
     QString QImage2base64(const QImage &img);
 
-    virtual QString wrapName(const QString &name);
-    virtual QString wrapDate(const QString &date);
-    virtual QString wrapMessage(const QString &message);
-    virtual QString wrapWholeLine(const QString &line);
-
-private:
+protected:
     bool isMe;
+    QString name, date;
 };
 
 class MessageAction : public ChatAction
@@ -48,11 +47,11 @@ class MessageAction : public ChatAction
 public:
     MessageAction(const QString &author, const QString &message, const QString &date, const bool &me);
     virtual ~MessageAction(){;}
-    virtual QString getHtml();
+    virtual QString getMessage();
     virtual void setTextCursor(QTextCursor cursor) final;
 
 private:
-    QString content;
+    QString message;
 };
 
 class FileTransferAction : public ChatAction
@@ -61,8 +60,7 @@ class FileTransferAction : public ChatAction
 public:
     FileTransferAction(FileTransferInstance *widget, const QString &author, const QString &date, const bool &me);
     virtual ~FileTransferAction();
-    virtual QString getHtml();
-    virtual QString wrapMessage(const QString &message);
+    virtual QString getMessage();
     virtual void setTextCursor(QTextCursor cursor) final;
 
 private slots:
@@ -70,7 +68,6 @@ private slots:
 
 private:
     FileTransferInstance *w;
-    QString sender, timestamp;
     QTextCursor cur;
 };
 


### PR DESCRIPTION
Implemented in previous commits message inserting by QTextCursor placed a new message as separate table, not as line in the existing table.
This patch replaces pure HTML table by QTextTable (similar with newChatForm branch).
Also this fix name and date wrapping in the case of long message problem (except groupchats (names there should be shortened manually).
