### PR TITLE
Try fix jenkins windows builds

### DIFF
--- a/qtox.pro
+++ b/qtox.pro
@@ -46,7 +46,7 @@ contains(JENKINS,YES) {
 
 # Rules for Windows, Mac OSX, and Linux
 win32 {
-    LIBS += -L$$PWD/libs/lib -llibopencv_core249 -llibopencv_highgui249 -llibopencv_imgproc249 -lOpenAL32
+    LIBS += -L$$PWD/libs/lib -lopencv_core249 -lopencv_highgui249 -lopencv_imgproc249 -lOpenAL32
     LIBS += $$PWD/libs/lib/libtoxav.a $$PWD/libs/lib/libopus.a $$PWD/libs/lib/libvpx.a $$PWD/libs/lib/libtoxcore.a -lws2_32 $$PWD/libs/lib/libsodium.a -lpthread -liphlpapi
 } else {
     macx {


### PR DESCRIPTION
I have no idea whether that would help, but considering that jenkins has problem with:

```
/usr/lib64/gcc/i686-w64-mingw32/4.8.2/../../../../i686-w64-mingw32/bin/ld: cannot find -llibopencv_core249
/usr/lib64/gcc/i686-w64-mingw32/4.8.2/../../../../i686-w64-mingw32/bin/ld: cannot find -llibopencv_highgui249
/usr/lib64/gcc/i686-w64-mingw32/4.8.2/../../../../i686-w64-mingw32/bin/ld: cannot find -llibopencv_imgproc249
```

and there's: https://stackoverflow.com/questions/14914830/linking-opencv-a-libraries-with-mingw-and-qt-5-0/14927151#14927151

I guess it's worth a try.
