### PR TITLE
check if call is active before mute

### DIFF
--- a/coreav.cpp
+++ b/coreav.cpp
@@ -273,7 +273,9 @@ void Core::decreaseVideoBusyness()
 
 void Core::micMuteToggle(int callId)
 {
-    calls[callId].muteMic = !calls[callId].muteMic;
+    if (calls[callId].active) {
+        calls[callId].muteMic = !calls[callId].muteMic;
+    }
 }
 
 void Core::onAvCancel(void* _toxav, int32_t callId, void* core)


### PR DESCRIPTION
Check if call is active before apply mute. Prevents segfault which happends if user tries to press mic mute button for call which is not active.
