### PR TITLE
File transfer improvements

### DIFF
--- a/core.cpp
+++ b/core.cpp
@@ -442,6 +442,11 @@ void Core::onFileControlCallback(Tox* tox, int32_t friendnumber, uint8_t receive
     }
     else if (receive_send == 0 && control_type == TOX_FILECONTROL_ACCEPT)
     {
+        if (file->status == ToxFile::BROKEN)
+        {
+            emit static_cast<Core*>(core)->fileTransferBrokenUnbroken(*file, false);
+            file->status = ToxFile::TRANSMITTING;
+        }
         emit static_cast<Core*>(core)->fileTransferRemotePausedUnpaused(*file, false);
     }
     else if ((receive_send == 0 || receive_send == 1) && control_type == TOX_FILECONTROL_PAUSE)
@@ -463,6 +468,9 @@ void Core::onFileControlCallback(Tox* tox, int32_t friendnumber, uint8_t receive
             tox_file_send_control(tox, file->friendId, 0, file->fileNum, TOX_FILECONTROL_KILL, nullptr, 0); // don't sure about it
             return;
         }
+
+        file->status = ToxFile::TRANSMITTING;
+        emit static_cast<Core*>(core)->fileTransferBrokenUnbroken(*file, false);
 
         file->bytesSent = resumePos;
         tox_file_send_control(tox, file->friendId, 0, file->fileNum, TOX_FILECONTROL_ACCEPT, nullptr, 0);

--- a/core.h
+++ b/core.h
@@ -150,6 +150,7 @@ signals:
     void fileTransferPaused(int FriendId, int FileNum, ToxFile::FileDirection direction);
     void fileTransferInfo(int FriendId, int FileNum, int64_t Filesize, int64_t BytesSent, ToxFile::FileDirection direction);
     void fileTransferRemotePausedUnpaused(ToxFile file, bool paused);
+    void fileTransferBrokenUnbroken(ToxFile file, bool broken);
 
     void fileSendFailed(int FriendId, const QString& fname);
 

--- a/corestructs.h
+++ b/corestructs.h
@@ -50,7 +50,8 @@ struct ToxFile
     {
         STOPPED,
         PAUSED,
-        TRANSMITTING
+        TRANSMITTING,
+        BROKEN
     };
 
     enum FileDirection : bool

--- a/filetransferinstance.cpp
+++ b/filetransferinstance.cpp
@@ -24,6 +24,7 @@
 #include <QPainter>
 
 #define CONTENT_WIDTH 250
+#define MAX_PREVIEW_SIZE 25*1024*1024
 
 uint FileTransferInstance::Idconter = 0;
 
@@ -44,13 +45,17 @@ FileTransferInstance::FileTransferInstance(ToxFile File)
     size = getHumanReadableSize(File.filesize);
     speed = "0B/s";
     eta = "00:00";
+
     if (File.direction == ToxFile::SENDING)
     {
-        QImage preview;
-        File.file->seek(0);
-        if (preview.loadFromData(File.file->readAll()))
+        if (File.file->size() <= MAX_PREVIEW_SIZE)
         {
-            pic = preview.scaledToHeight(50);
+            QImage preview;
+            File.file->seek(0);
+            if (preview.loadFromData(File.file->readAll()))
+            {
+                pic = preview.scaledToHeight(50);
+            }
         }
         File.file->seek(0);
     }
@@ -116,7 +121,7 @@ void FileTransferInstance::onFileTransferFinished(ToxFile File)
     {
         QImage preview;
         QFile previewFile(File.filePath);
-        if (previewFile.open(QIODevice::ReadOnly) && previewFile.size() <= 1024*1024*25) // Don't preview big (>25MiB) images
+        if (previewFile.open(QIODevice::ReadOnly) && previewFile.size() <= MAX_PREVIEW_SIZE) // Don't preview big (>25MiB) images
         {
             if (preview.loadFromData(previewFile.readAll()))
             {

--- a/filetransferinstance.cpp
+++ b/filetransferinstance.cpp
@@ -291,6 +291,12 @@ QString FileTransferInstance::getHtmlImage()
             rightBtnImg = QImage(":/ui/fileTransferInstance/pauseGreyFileButton.png");
 
         res = draw2ButtonsForm("silver", leftBtnImg, rightBtnImg);
+    } else if (state == tsBroken)
+    {
+        QImage leftBtnImg(":/ui/fileTransferInstance/stopFileButton.png");
+        QImage rightBtnImg(":/ui/fileTransferInstance/pauseGreyFileButton.png");
+
+        res = draw2ButtonsForm("red", leftBtnImg, rightBtnImg);
     } else if (state == tsCanceled)
     {
         res = drawButtonlessForm("red");
@@ -415,4 +421,17 @@ QImage FileTransferInstance::drawProgressBarImg(const double &part, int w, int h
     qPainter.drawRect(1, 0, (w - 2) * (part), h - 1);
 
     return progressBar;
+}
+
+void FileTransferInstance::onFileTransferBrokenUnbroken(ToxFile File, bool broken)
+{
+    if (File.fileNum != fileNum || File.friendId != friendId || File.direction != direction)
+        return;
+
+    if (broken)
+        state = tsBroken;
+    else
+        state = tsProcessing;
+
+    emit stateUpdated();
 }

--- a/filetransferinstance.h
+++ b/filetransferinstance.h
@@ -43,6 +43,7 @@ public slots:
     void onFileTransferAccepted(ToxFile File);
     void onFileTransferPaused(int FriendId, int FileNum, ToxFile::FileDirection Direction);
     void onFileTransferRemotePausedUnpaused(ToxFile File, bool paused);
+    void onFileTransferBrokenUnbroken(ToxFile File, bool broken);
     void pressFromHtml(QString);
 
 signals:

--- a/filetransferinstance.h
+++ b/filetransferinstance.h
@@ -28,7 +28,7 @@ class FileTransferInstance : public QObject
 {
     Q_OBJECT
 public:
-    enum TransfState {tsPending, tsProcessing, tsPaused, tsFinished, tsCanceled};
+    enum TransfState {tsPending, tsProcessing, tsPaused, tsFinished, tsCanceled, tsBroken};
 
 public:
     explicit FileTransferInstance(ToxFile File);

--- a/widget/form/chatform.cpp
+++ b/widget/form/chatform.cpp
@@ -119,6 +119,7 @@ void ChatForm::startFileSend(ToxFile file)
     connect(Core::getInstance(), SIGNAL(fileTransferAccepted(ToxFile)), fileTrans, SLOT(onFileTransferAccepted(ToxFile)));
     connect(Core::getInstance(), SIGNAL(fileTransferPaused(int,int,ToxFile::FileDirection)), fileTrans, SLOT(onFileTransferPaused(int,int,ToxFile::FileDirection)));
     connect(Core::getInstance(), SIGNAL(fileTransferRemotePausedUnpaused(ToxFile,bool)), fileTrans, SLOT(onFileTransferRemotePausedUnpaused(ToxFile,bool)));
+    connect(Core::getInstance(), SIGNAL(fileTransferBrokenUnbroken(ToxFile, bool)), fileTrans, SLOT(onFileTransferBrokenUnbroken(ToxFile, bool)));
 
     QString name = Widget::getInstance()->getUsername();
     if (name == previousName)
@@ -142,6 +143,7 @@ void ChatForm::onFileRecvRequest(ToxFile file)
     connect(Core::getInstance(), SIGNAL(fileTransferAccepted(ToxFile)), fileTrans, SLOT(onFileTransferAccepted(ToxFile)));
     connect(Core::getInstance(), SIGNAL(fileTransferPaused(int,int,ToxFile::FileDirection)), fileTrans, SLOT(onFileTransferPaused(int,int,ToxFile::FileDirection)));
     connect(Core::getInstance(), SIGNAL(fileTransferRemotePausedUnpaused(ToxFile,bool)), fileTrans, SLOT(onFileTransferRemotePausedUnpaused(ToxFile,bool)));
+    connect(Core::getInstance(), SIGNAL(fileTransferBrokenUnbroken(ToxFile, bool)), fileTrans, SLOT(onFileTransferBrokenUnbroken(ToxFile, bool)));
 
     Widget* w = Widget::getInstance();
     if (!w->isFriendWidgetCurActiveWidget(f)|| w->getIsWindowMinimized() || !w->isActiveWindow())


### PR DESCRIPTION
Auto resume file transfers after peer goes back online #210 (resume broken transfers)
Preview only for small images for all destinations (less than 25M).
