### PR TITLE
relative to system wide default font sizes in css

### DIFF
--- a/misc/style.cpp
+++ b/misc/style.cpp
@@ -23,6 +23,7 @@
 #include <QRegularExpression>
 #include <QWidget>
 #include <QStyle>
+#include <QFontInfo>
 
 // helper functions
 QFont appFont(int pixelSize, int weight)
@@ -78,14 +79,17 @@ QFont Style::getFont(Style::Font font)
 {
     // fonts as defined in
     // https://github.com/ItsDuke/Tox-UI/blob/master/UI%20GUIDELINES.md
+
+    static int defSize = QFontInfo(QFont()).pixelSize();
+
     static QFont fonts[] = {
-        appFont(16, QFont::Bold),
-        appFont(14, QFont::Normal),
-        appFont(14, QFont::Bold),
-        appFont(13, QFont::Normal),
-        appFont(13, QFont::Bold),
-        appFont(12, QFont::Normal),
-        appFont(12, QFont::Light),
+        appFont(defSize + 2, QFont::Bold),
+        appFont(defSize    , QFont::Normal),
+        appFont(defSize    , QFont::Bold),
+        appFont(defSize - 1, QFont::Normal),
+        appFont(defSize - 1, QFont::Bold),
+        appFont(defSize - 2, QFont::Normal),
+        appFont(defSize - 2, QFont::Light),
     };
 
     return fonts[font];

--- a/misc/style.h
+++ b/misc/style.h
@@ -41,13 +41,13 @@ public:
 
     enum Font
     {
-        ExtraBig,   // 14px, bold
-        Big,        // 12px
-        BigBold,    // 12px, bold
-        Medium,     // 11px
-        MediumBold, // 11px, bold
-        Small,      // 10px
-        SmallLight  // 10px, light
+        ExtraBig,   // [SystemDefault + 2]px, bold
+        Big,        // [SystemDefault    ]px
+        BigBold,    // [SystemDefault    ]px, bold
+        Medium,     // [SystemDefault - 1]px
+        MediumBold, // [SystemDefault - 1]px, bold
+        Small,      // [SystemDefault - 2]px
+        SmallLight  // [SystemDefault - 2]px, light
     };
 
     static QString getStylesheet(const QString& filename);

--- a/ui/window/statusPanel.css
+++ b/ui/window/statusPanel.css
@@ -9,7 +9,7 @@
 }
 
 #statusPanel > #statusHead > #statusLabel {
-  font: @smallLight;
+  font: @medium;
   color: @lightGrey;
 }
 


### PR DESCRIPTION
Font sizes should be relative to the sizes in the system environment, as @krepa098 said.
Also changed own status font size.

PS: this PR in conflict with PR #385 (commit: 200c6d3).
