### PR TITLE
css styles for mainHead and mainContent in widget.cpp

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -18,7 +18,9 @@
 #include "misc/settings.h"
 #include <QApplication>
 #include <QFontDatabase>
+#include <QMessageBox>
 #include <QTranslator>
+#include <QSystemTrayIcon>
 #include <QDebug>
 
 int main(int argc, char *argv[])
@@ -46,8 +48,23 @@ int main(int argc, char *argv[])
     // Install Unicode 6.1 supporting font
     QFontDatabase::addApplicationFont("://DejaVuSans.ttf");
 
+    if (!QSystemTrayIcon::isSystemTrayAvailable()) {
+        QMessageBox::critical(0, QObject::tr("Systray"),
+                              QObject::tr("No system tray detected"));
+        return 1;
+    }
+
     Widget* w = Widget::getInstance();
-    w->show();
+    //w->show();
+
+    QSystemTrayIcon *icon = new QSystemTrayIcon(w);
+
+    QObject::connect(icon,
+                     SIGNAL(activated(QSystemTrayIcon::ActivationReason)),
+                     w,
+                     SLOT(onIconClick()));
+    icon->setIcon(w->windowIcon());
+    icon->show();
 
     int errorcode = a.exec();
 

--- a/main.cpp
+++ b/main.cpp
@@ -55,7 +55,6 @@ int main(int argc, char *argv[])
     }
 
     Widget* w = Widget::getInstance();
-    //w->show();
 
     QSystemTrayIcon *icon = new QSystemTrayIcon(w);
 

--- a/res.qrc
+++ b/res.qrc
@@ -136,5 +136,7 @@
         <file>ui/chatroomWidgets/genericChatroomWidget.css</file>
         <file>ui/fileTransferInstance/sliverRTEdge.png</file>
         <file>ui/window/statusPanel.css</file>
+        <file>ui/settings/mainContent.css</file>
+        <file>ui/settings/mainHead.css</file>
     </qresource>
 </RCC>

--- a/ui/settings/mainContent.css
+++ b/ui/settings/mainContent.css
@@ -1,0 +1,36 @@
+QCheckBox
+{
+    color: black;
+}
+
+QLabel
+{
+    color: black;
+}
+
+QGroupBox::title
+{
+    color: black;
+    background-color: white;
+}
+
+QWidget
+{
+    color: black;
+    background-color: white;
+}
+
+QComboBox
+{
+    background-color: white;
+}
+
+QComboBox:on QComboBox:off QComboBox:drop-down
+{
+    background: rgba(18, 18, 18, 204);
+}
+
+QComboBox:active
+{
+    background: white;
+}

--- a/ui/settings/mainHead.css
+++ b/ui/settings/mainHead.css
@@ -1,0 +1,5 @@
+QWidget
+{
+    color: black;
+    background: white;
+}

--- a/widget/form/settings/generalform.cpp
+++ b/widget/form/settings/generalform.cpp
@@ -37,13 +37,14 @@ GeneralForm::GeneralForm() :
         bodyUI->smileyPackBrowser->addItem(entry.first, entry.second);
     }
     bodyUI->smileyPackBrowser->setCurrentIndex(bodyUI->smileyPackBrowser->findData(Settings::getInstance().getSmileyPack()));
-    
+    reloadSmiles();
+
     bodyUI->cbUDPDisabled->setChecked(Settings::getInstance().getForceTCP());
     bodyUI->proxyAddr->setText(Settings::getInstance().getProxyAddr());
     int port = Settings::getInstance().getProxyPort();
     if (port != -1)
         bodyUI->proxyPort->setText(QString::number(port));
-    
+
     connect(bodyUI->cbEnableIPv6, &QCheckBox::stateChanged, this, &GeneralForm::onEnableIPv6Updated);
     connect(bodyUI->cbUseTranslations, &QCheckBox::stateChanged, this, &GeneralForm::onUseTranslationUpdated);
     connect(bodyUI->cbMakeToxPortable, &QCheckBox::stateChanged, this, &GeneralForm::onMakeToxPortableUpdated);
@@ -78,6 +79,7 @@ void GeneralForm::onSmileyBrowserIndexChanged(int index)
 {
     QString filename = bodyUI->smileyPackBrowser->itemData(index).toString();
     Settings::getInstance().setSmileyPack(filename);
+    reloadSmiles();
 }
 
 void GeneralForm::onUDPUpdated()
@@ -103,4 +105,15 @@ void GeneralForm::onProxyPortEdited()
     }
     else
         Settings::getInstance().setProxyPort(-1);
+}
+
+void GeneralForm::reloadSmiles()
+{
+    QString smiles[] = {":)", ";)", ":p", ":O", ":'("};
+    int pixSize = 30;
+    bodyUI->smile1->setPixmap(SmileyPack::getInstance().getAsIcon(smiles[0]).pixmap(pixSize, pixSize));
+    bodyUI->smile2->setPixmap(SmileyPack::getInstance().getAsIcon(smiles[1]).pixmap(pixSize, pixSize));
+    bodyUI->smile3->setPixmap(SmileyPack::getInstance().getAsIcon(smiles[2]).pixmap(pixSize, pixSize));
+    bodyUI->smile4->setPixmap(SmileyPack::getInstance().getAsIcon(smiles[3]).pixmap(pixSize, pixSize));
+    bodyUI->smile5->setPixmap(SmileyPack::getInstance().getAsIcon(smiles[4]).pixmap(pixSize, pixSize));
 }

--- a/widget/form/settings/generalform.h
+++ b/widget/form/settings/generalform.h
@@ -43,6 +43,7 @@ private slots:
 
 private:
     Ui::GeneralSettings *bodyUI;
+    void reloadSmiles();
 };
 
 #endif

--- a/widget/form/settings/generalsettings.ui
+++ b/widget/form/settings/generalsettings.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>527</width>
-    <height>367</height>
+    <height>373</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -72,6 +72,45 @@
       <item>
        <widget class="QComboBox" name="smileyPackBrowser"/>
       </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item alignment="Qt::AlignLeft">
+         <widget class="QLabel" name="smile1">
+          <property name="text">
+           <string>:)</string>
+          </property>
+         </widget>
+        </item>
+        <item alignment="Qt::AlignLeft">
+         <widget class="QLabel" name="smile2">
+          <property name="text">
+           <string>;)</string>
+          </property>
+         </widget>
+        </item>
+        <item alignment="Qt::AlignLeft">
+         <widget class="QLabel" name="smile3">
+          <property name="text">
+           <string>:p</string>
+          </property>
+         </widget>
+        </item>
+        <item alignment="Qt::AlignLeft">
+         <widget class="QLabel" name="smile4">
+          <property name="text">
+           <string>:O</string>
+          </property>
+         </widget>
+        </item>
+        <item alignment="Qt::AlignLeft">
+         <widget class="QLabel" name="smile5">
+          <property name="text">
+           <string>:'(</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
      </layout>
     </widget>
    </item>
@@ -83,11 +122,11 @@
      <layout class="QVBoxLayout" name="verticalLayoutProxy">
       <item>
        <widget class="QCheckBox" name="cbUDPDisabled">
-        <property name="text">
-         <string extracomment="Text on checkbox to disable UDP">Disable UDP (not recommended)</string>
-        </property>
         <property name="toolTip">
          <string extracomment="force tcp checkbox tooltip">This allows, e.g., toxing over Tor. It adds load to the Tox network however, so use only when necessary.</string>
+        </property>
+        <property name="text">
+         <string extracomment="Text on checkbox to disable UDP">Disable UDP (not recommended)</string>
         </property>
        </widget>
       </item>
@@ -112,12 +151,10 @@
       <item>
        <layout class="QHBoxLayout" name="horizontalLayoutProxyBoxes">
         <item>
-         <widget class="QLineEdit" name="proxyAddr">
-         </widget>
+         <widget class="QLineEdit" name="proxyAddr"/>
         </item>
         <item>
-         <widget class="QLineEdit" name="proxyPort">
-         </widget>
+         <widget class="QLineEdit" name="proxyPort"/>
         </item>
        </layout>
       </item>

--- a/widget/widget.cpp
+++ b/widget/widget.cpp
@@ -74,6 +74,8 @@ Widget::Widget(QWidget *parent)
     ui->mainHead->setLayout(new QVBoxLayout());
     ui->mainHead->layout()->setMargin(0);
     ui->mainHead->layout()->setSpacing(0);
+    ui->mainHead->setStyleSheet(Style::getStylesheet(":ui/settings/mainHead.css"));
+    ui->mainContent->setStyleSheet(Style::getStylesheet(":ui/settings/mainContent.css"));
 
     contactListWidget = new FriendListWidget();
     ui->friendList->setWidget(contactListWidget);

--- a/widget/widget.cpp
+++ b/widget/widget.cpp
@@ -283,6 +283,14 @@ void Widget::onDisconnected()
     emit statusSet(Status::Offline);
 }
 
+void Widget::onIconClick()
+{
+    if(this->isHidden() == true)
+        this->show();
+    else
+        this->hide();
+}
+
 void Widget::onFailedToStartCore()
 {
     QMessageBox critical(this);

--- a/widget/widget.h
+++ b/widget/widget.h
@@ -104,6 +104,8 @@ private slots:
     void setStatusBusy();
     void onMessageSendResult(int friendId, const QString& message, int messageId);
     void onGroupSendResult(int groupId, const QString& message, int result);
+    void onIconClick();
+
 
 private:
     void hideMainForms();


### PR DESCRIPTION
fixes problems with ugly UI on non-standard system theme (KDE example)
before: https://i.imgur.com/XJ0mbpi.png
after: https://imgur.com/a/UbgNz
