### PR TITLE
Fix 436, and also fix a threading issue WRT profiles

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -1184,7 +1184,7 @@ void Core::saveConfiguration(const QString& path)
     }
 }
 
-void Core::switchConfiguration(QString profile)
+void Core::switchConfiguration(const QString& profile)
 {
     if (profile.isEmpty())
     {
@@ -1204,7 +1204,7 @@ void Core::switchConfiguration(QString profile)
         tox = nullptr;
     }
     emit selfAvatarChanged(QPixmap(":/img/contact_dark.png"));
-    Widget::getInstance()->clearContactsList(); // we need this to block, so no signals for us
+    emit blockingClearContacts(); // we need this to block, but signals are required for thread safety
     
     loadPath = QDir(Settings::getSettingsDirPath()).filePath(profile + TOX_EXT);
     Settings::getInstance().setCurrentProfile(profile); 

--- a/src/core.h
+++ b/src/core.h
@@ -53,7 +53,6 @@ public:
 
     void saveConfiguration();
     void saveConfiguration(const QString& path);
-    void switchConfiguration(QString profile);
     
     QString getIDString();
     
@@ -70,6 +69,7 @@ public slots:
     void start();
     void process();
     void bootstrapDht();
+    void switchConfiguration(const QString& profile);
 
     void acceptFriendRequest(const QString& userId);
     void requestFriendship(const QString& friendAddress, const QString& message);
@@ -107,6 +107,7 @@ public slots:
 signals:
     void connected();
     void disconnected();
+    void blockingClearContacts();
 
     void friendRequestReceived(const QString& userId, const QString& message);
     void friendMessageReceived(int friendId, const QString& message, bool isAction);

--- a/src/core.h
+++ b/src/core.h
@@ -64,6 +64,8 @@ public:
     void increaseVideoBusyness();
     void decreaseVideoBusyness();
 
+    bool anyActiveCalls();
+
 public slots:
     void start();
     void process();

--- a/src/coreav.cpp
+++ b/src/coreav.cpp
@@ -28,6 +28,14 @@ ALCdevice* Core::alOutDev, *Core::alInDev;
 ALCcontext* Core::alContext;
 ALuint Core::alMainSource;
 
+bool Core::anyActiveCalls()
+{
+    for (auto& call : calls)
+        if (call.active)
+            return true;
+    return false;
+}
+
 void Core::prepareCall(int friendId, int callId, ToxAv* toxav, bool videoEnabled)
 {
     qDebug() << QString("Core: preparing call %1").arg(callId);

--- a/src/widget/form/settings/identityform.cpp
+++ b/src/widget/form/settings/identityform.cpp
@@ -114,7 +114,8 @@ void IdentityForm::onLoadClicked()
             QMessageBox::warning(this, tr("Call active", "popup title"),
                 tr("You can't switch profiles while a call is active!", "popup text"));
         else
-            Core::getInstance()->switchConfiguration(bodyUI->profiles->currentText());
+            emit Widget::getInstance()->changeProfile(bodyUI->profiles->currentText());
+            // I think by directly calling the function, I may have been causing thread issues
     }
 }
 

--- a/src/widget/form/settings/identityform.cpp
+++ b/src/widget/form/settings/identityform.cpp
@@ -108,7 +108,14 @@ void IdentityForm::setStatusMessage(const QString &msg)
 
 void IdentityForm::onLoadClicked()
 {
-    Core::getInstance()->switchConfiguration(bodyUI->profiles->currentText());
+    if (bodyUI->profiles->currentText() != Settings::getInstance().getCurrentProfile())
+    {
+        if (Core::getInstance()->anyActiveCalls())
+            QMessageBox::warning(this, tr("Call active", "popup title"),
+                tr("You can't switch profiles while a call is active!", "popup text"));
+        else
+            Core::getInstance()->switchConfiguration(bodyUI->profiles->currentText());
+    }
 }
 
 void IdentityForm::onRenameClicked()

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -146,6 +146,7 @@ Widget::Widget(QWidget *parent)
     connect(core, &Core::groupNamelistChanged, this, &Widget::onGroupNamelistChanged);
     connect(core, &Core::emptyGroupCreated, this, &Widget::onEmptyGroupCreated);
     connect(core, &Core::avInvite, this, &Widget::playRingtone);
+    connect(core, &Core::blockingClearContacts, this, &Widget::clearContactsList, Qt::BlockingQueuedConnection);
 
     connect(core, SIGNAL(messageSentResult(int,QString,int)), this, SLOT(onMessageSendResult(int,QString,int)));
     connect(core, SIGNAL(groupSentResult(int,QString,int)), this, SLOT(onGroupSendResult(int,QString,int)));
@@ -153,6 +154,7 @@ Widget::Widget(QWidget *parent)
     connect(this, &Widget::statusSet, core, &Core::setStatus);
     connect(this, &Widget::friendRequested, core, &Core::requestFriendship);
     connect(this, &Widget::friendRequestAccepted, core, &Core::acceptFriendRequest);
+    connect(this, &Widget::changeProfile, core, &Core::switchConfiguration);
 
     connect(ui->addButton, SIGNAL(clicked()), this, SLOT(onAddClicked()));
     connect(ui->groupButton, SIGNAL(clicked()), this, SLOT(onGroupClicked()));

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -69,6 +69,7 @@ signals:
     void statusSelected(Status status);
     void usernameChanged(const QString& username);
     void statusMessageChanged(const QString& statusMessage);
+    void changeProfile(const QString& profile);
 
 private slots:
     void onConnected();


### PR DESCRIPTION
Turns out that directly calling functions on objects owned by a different thread is A Bad Idea™. It's a minor miracle qTox didn't crash whenever any profile switch occurred.
