### PR TITLE
Update settings.cpp

### DIFF
--- a/src/misc/settings.cpp
+++ b/src/misc/settings.cpp
@@ -28,7 +28,7 @@
 #include <QList>
 
 const QString Settings::FILENAME = "settings.ini";
-bool Settings::makeToxPortable{false};
+bool Settings::makeToxPortable{true};
 
 Settings::Settings() :
     loaded(false), useCustomDhtList{false}


### PR DESCRIPTION
Make portable the default, so information is saved to the excutable directory. This allows for better usability for people operating qTox out of a removable device.
