### PR TITLE
fix #624

### DIFF
--- a/src/widget/tool/chatactions/messageaction.cpp
+++ b/src/widget/tool/chatactions/messageaction.cpp
@@ -28,7 +28,7 @@ QString MessageAction::getMessage(QString div)
     QString message_ = SmileyPack::getInstance().smileyfied(toHtmlChars(message));
 
     // detect urls
-    QRegExp exp("(www\\.|http[s]?:\\/\\/|ftp:\\/\\/)\\S+");
+    QRegExp exp("(?:\\b)(www\\.|http[s]?:\\/\\/|ftp:\\/\\/)\\S+");
     int offset = 0;
     while ((offset = exp.indexIn(message_, offset)) != -1)
     {


### PR DESCRIPTION
`\b` matches punctuation still, but since `\s` isn't an anchor (i.e. it would be part of the match), we can't use it without lookbehind assertions (which Qt doesn't support).

So `a-www.` will match, but `awww.` won't at least...
