### PR TITLE
things - fixes and features 

### DIFF
--- a/src/filetransferinstance.cpp
+++ b/src/filetransferinstance.cpp
@@ -209,7 +209,10 @@ bool isFileWritable(QString& path)
 void FileTransferInstance::acceptRecvRequest()
 {
     QString path = Settings::getInstance().getAutoAcceptDir(Core::getInstance()->getFriendAddress(friendId));
-    if (path.isEmpty()) path = Settings::getInstance().getGlobalAutoAcceptDir();
+    
+    if (path.isEmpty())
+        path = Settings::getInstance().getGlobalAutoAcceptDir();
+    
     if (!path.isEmpty())
     {
         QDir dir(path);

--- a/src/misc/settings.cpp
+++ b/src/misc/settings.cpp
@@ -104,7 +104,7 @@ void Settings::load()
 
     s.beginGroup("General");
         enableIPv6 = s.value("enableIPv6", true).toBool();
-        translation = s.value("translation", "").toString();
+        translation = s.value("translation", "en").toString();
         makeToxPortable = s.value("makeToxPortable", false).toBool();
         autostartInTray = s.value("autostartInTray", false).toBool();
         closeToTray = s.value("closeToTray", false).toBool();        
@@ -167,10 +167,6 @@ void Settings::load()
         inDev = s.value("inDev", "").toString();
         outDev = s.value("outDev", "").toString();
     s.endGroup();
-
-    // try to set a smiley pack if none is selected
-    if (!SmileyPack::isValid(smileyPack) && !SmileyPack::listSmileyPacks().isEmpty())
-        smileyPack = SmileyPack::listSmileyPacks()[0].second;
 
     // Read the embedded DHT bootsrap nodes list if needed
     if (dhtServerList.isEmpty())
@@ -283,7 +279,7 @@ void Settings::save(QString path)
     s.endGroup();
 
     s.beginGroup("AutoAccept");
-        s.setValue("autoSaveEnabled", autoSaveEnabled);    
+        s.setValue("autoSaveEnabled", autoSaveEnabled);  
         s.setValue("globalAutoAcceptDir", globalAutoAcceptDir);
         for (auto& id : autoAccept.keys())
             s.setValue(id, autoAccept.value(id));

--- a/src/misc/settings.cpp
+++ b/src/misc/settings.cpp
@@ -114,8 +114,6 @@ void Settings::load()
         proxyPort = s.value("proxyPort", 0).toInt();
         currentProfile = s.value("currentProfile", "").toString();
     	autoAwayTime = s.value("autoAwayTime", 10).toInt();
-        autoSaveEnabled = s.value("autoSaveEnabled", false).toBool();
-        autoSaveDir = s.value("autoSaveDir", QStandardPaths::locate(QStandardPaths::HomeLocation, QString(), QStandardPaths::LocateDirectory)).toString();
     s.endGroup();
 
     s.beginGroup("Widgets");
@@ -156,7 +154,11 @@ void Settings::load()
     s.endGroup();
 
     s.beginGroup("AutoAccept");
-        globalAutoAcceptDir = s.value("globalAutoAcceptDir", "").toString();
+        autoSaveEnabled = s.value("autoSaveEnabled", false).toBool();
+        globalAutoAcceptDir = s.value("globalAutoAcceptDir",
+                                      QStandardPaths::locate(QStandardPaths::HomeLocation, QString(), QStandardPaths::LocateDirectory)
+                                      ).toString();
+        
         for (auto& key : s.childKeys())
             autoAccept[key] = s.value(key).toString();
     s.endGroup();
@@ -241,8 +243,6 @@ void Settings::save(QString path)
         s.setValue("proxyPort", proxyPort);
         s.setValue("currentProfile", currentProfile);
         s.setValue("autoAwayTime", autoAwayTime);
-        s.setValue("autoSaveEnabled", autoSaveEnabled);
-        s.setValue("autoSaveDir", autoSaveDir);
     s.endGroup();
 
     s.beginGroup("Widgets");
@@ -283,6 +283,7 @@ void Settings::save(QString path)
     s.endGroup();
 
     s.beginGroup("AutoAccept");
+        s.setValue("autoSaveEnabled", autoSaveEnabled);    
         s.setValue("globalAutoAcceptDir", globalAutoAcceptDir);
         for (auto& id : autoAccept.keys())
             s.setValue(id, autoAccept.value(id));
@@ -473,17 +474,6 @@ QString Settings::getTranslation() const
 void Settings::setTranslation(QString newValue)
 {
     translation = newValue;
-}
-
-
-QString Settings::getAutoSaveFilesDir() const
-{
-    return autoSaveDir;
-}
-
-void Settings::setAutoSaveFilesDir(QString newValue)
-{
-    autoSaveDir = newValue;
 }
 
 bool Settings::getForceTCP() const

--- a/src/misc/settings.h
+++ b/src/misc/settings.h
@@ -70,9 +70,6 @@ public:
     QString getTranslation() const;
     void setTranslation(QString newValue);
     
-    QString getAutoSaveFilesDir() const;
-    void setAutoSaveFilesDir(QString newValue);
-    
     void setAutoSaveEnabled(bool newValue);
     bool getAutoSaveEnabled() const;
 
@@ -210,13 +207,11 @@ private:
 
     bool enableIPv6;
     QString translation;
-    QString autoSaveDir;
     static bool makeToxPortable;
     bool autostartInTray;
     bool closeToTray;
     bool minimizeToTray;
     bool useEmoticons;
-    bool autoSaveEnabled;
 
     bool forceTCP;
 
@@ -234,6 +229,7 @@ private:
 
     QHash<QString, QByteArray> widgetSettings;
     QHash<QString, QString> autoAccept;
+    bool autoSaveEnabled;    
     QString globalAutoAcceptDir;
 
     // GUI

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -202,7 +202,7 @@ void ChatForm::onFileRecvRequest(ToxFile file)
                                                                    QTime::currentTime().toString("hh:mm"), false)));
 
     if (!Settings::getInstance().getAutoAcceptDir(Core::getInstance()->getFriendAddress(f->friendId)).isEmpty()
-     || !Settings::getInstance().getGlobalAutoAcceptDir().isEmpty())
+     || Settings::getInstance().getAutoSaveEnabled())
         fileTrans->pressFromHtml("btnB");
 }
 

--- a/src/widget/form/settings/generalform.cpp
+++ b/src/widget/form/settings/generalform.cpp
@@ -184,16 +184,12 @@ void GeneralForm::onAutoAwayChanged()
 
 void GeneralForm::onAutoAcceptFileChange()
 {
+    Settings::getInstance().setAutoSaveEnabled(bodyUI->autoacceptFiles->isChecked());
+    
     if(bodyUI->autoacceptFiles->isChecked() == true)
-    {
-        Settings::getInstance().setAutoSaveEnabled(true);
         connect(bodyUI->autoSaveFilesDir, SIGNAL(clicked()), this, SLOT(onAutoSaveDirChange()));
-    }
     else
-    {
-        Settings::getInstance().setAutoSaveEnabled(false);
         disconnect(bodyUI->autoSaveFilesDir, SIGNAL(clicked()),this, SLOT(onAutoSaveDirChange()));
-    }
 }
 
 void GeneralForm::onAutoSaveDirChange()

--- a/src/widget/form/settings/generalform.cpp
+++ b/src/widget/form/settings/generalform.cpp
@@ -51,7 +51,7 @@ GeneralForm::GeneralForm(SettingsWidget *myParent) :
     bodyUI->statusChanges->setChecked(Settings::getInstance().getStatusChangeNotificationEnabled());
     bodyUI->useEmoticons->setChecked(Settings::getInstance().getUseEmoticons());
     bodyUI->autoacceptFiles->setChecked(Settings::getInstance().getAutoSaveEnabled());
-    bodyUI->autoSaveFilesDir->setText(Settings::getInstance().getAutoSaveFilesDir());
+    bodyUI->autoSaveFilesDir->setText(Settings::getInstance().getGlobalAutoAcceptDir());
     
     for (auto entry : SmileyPack::listSmileyPacks())
     {
@@ -172,8 +172,7 @@ void GeneralForm::onEmoticonSizeChanged()
 
 void GeneralForm::onTimestampSelected(int index)
 {
-    Settings::getInstance().setTimestampFormat(
-                bodyUI->timestamp->currentText().split(" ").at(0));
+    Settings::getInstance().setTimestampFormat(timeFormats[index]);
 }
 
 void GeneralForm::onAutoAwayChanged()
@@ -199,12 +198,12 @@ void GeneralForm::onAutoAcceptFileChange()
 
 void GeneralForm::onAutoSaveDirChange()
 {
-    QString previousDir = Settings::getInstance().getAutoSaveFilesDir();
+    QString previousDir = Settings::getInstance().getGlobalAutoAcceptDir();
     QString directory = QFileDialog::getExistingDirectory(0, tr("Choose an auto accept directory","popup title"));
     if(directory.isEmpty())
         directory = previousDir;
     
-    Settings::getInstance().setAutoSaveFilesDir(directory);
+    Settings::getInstance().setGlobalAutoAcceptDir(directory);
     bodyUI->autoSaveFilesDir->setText(directory);
 }
 

--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -49,28 +49,28 @@ void FriendWidget::contextMenuEvent(QContextMenuEvent * event)
     QPoint pos = event->globalPos();
     QString id = Core::getInstance()->getFriendAddress(friendId);
     QString dir = Settings::getInstance().getAutoAcceptDir(id);
-    QString globalDir = Settings::getInstance().getGlobalAutoAcceptDir();
     QMenu menu;
     QMenu* inviteMenu = menu.addMenu(tr("Invite to group","Menu to invite a friend to a groupchat"));
     QAction* copyId = menu.addAction(tr("Copy friend ID","Menu to copy the Tox ID of that friend"));
     QMap<QAction*, Group*> groupActions;
+    
     for (Group* group : GroupList::groupList)
     {
         QAction* groupAction = inviteMenu->addAction(group->widget->getName());
         groupActions[groupAction] =  group;
     }
+    
     if (groupActions.isEmpty())
         inviteMenu->setEnabled(false);
+    
     menu.addSeparator();
     QAction* autoAccept = menu.addAction(tr("Auto accept files from this friend", "context menu entry"));
     QAction* disableAutoAccept = menu.addAction(tr("Manually accept files from this friend", "context menu entry"));
-    QAction* globalAA = menu.addAction(tr("Auto accept files from all friends", "context menu entry"));
-    QAction* disableGlobalAA = menu.addAction(tr("Disable global auto accept", "context menu entry"));
+    
     if (dir.isEmpty())
         disableAutoAccept->setEnabled(false);
-    if (globalDir.isEmpty())
-        disableGlobalAA->setEnabled(false);
     menu.addSeparator();
+    
     QAction* removeFriendAction = menu.addAction(tr("Remove friend", "Menu to remove the friend from our friendlist"));
 
     QAction* selectedItem = menu.exec(pos);
@@ -99,25 +99,6 @@ void FriendWidget::contextMenuEvent(QContextMenuEvent * event)
                 qDebug() << "FriendWidget: setting auto accept dir for" << friendId << "to" << dir;
                 Settings::getInstance().setAutoAcceptDir(id, dir);
             }
-        }
-        else if (selectedItem == disableAutoAccept)
-        {
-            Settings::getInstance().setAutoAcceptDir(id, "");
-        }
-        else if (selectedItem == globalAA)
-        {
-            if (globalDir.isEmpty())
-                globalDir = QDir::homePath();
-            globalDir = QFileDialog::getExistingDirectory(0, tr("Choose an auto accept directory","popup title"), dir);
-            if (!globalDir.isEmpty())
-            {
-                qDebug() << "FriendWidget: setting global auto accept dir to" << globalDir;
-                Settings::getInstance().setGlobalAutoAcceptDir(globalDir);
-            }
-        }
-        else if (selectedItem == disableGlobalAA)
-        {
-            Settings::getInstance().setGlobalAutoAcceptDir("");
         }
         else if (groupActions.contains(selectedItem))
         {

--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -65,10 +65,8 @@ void FriendWidget::contextMenuEvent(QContextMenuEvent * event)
     
     menu.addSeparator();
     QAction* autoAccept = menu.addAction(tr("Auto accept files from this friend", "context menu entry"));
-    QAction* disableAutoAccept = menu.addAction(tr("Manually accept files from this friend", "context menu entry"));
-    
-    if (dir.isEmpty())
-        disableAutoAccept->setEnabled(false);
+    autoAccept->setCheckable(true);
+    autoAccept->setChecked(!dir.isEmpty());
     menu.addSeparator();
     
     QAction* removeFriendAction = menu.addAction(tr("Remove friend", "Menu to remove the friend from our friendlist"));
@@ -91,11 +89,18 @@ void FriendWidget::contextMenuEvent(QContextMenuEvent * event)
         }
         else if (selectedItem == autoAccept)
         {
-            if (dir.isEmpty())
-                dir = QDir::homePath();
-            dir = QFileDialog::getExistingDirectory(0, tr("Choose an auto accept directory","popup title"), dir);
-            if (!dir.isEmpty())
+            if (!autoAccept->isChecked())
             {
+                qDebug() << "not checked";
+                dir = QDir::homePath();
+                autoAccept->setChecked(false);
+                Settings::getInstance().setAutoAcceptDir(id, "");
+            }
+            
+            if (autoAccept->isChecked())
+            {
+                dir = QFileDialog::getExistingDirectory(0, tr("Choose an auto accept directory","popup title"), dir);
+                autoAccept->setChecked(true);
                 qDebug() << "FriendWidget: setting auto accept dir for" << friendId << "to" << dir;
                 Settings::getInstance().setAutoAcceptDir(id, dir);
             }

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -518,6 +518,7 @@ void Widget::onAddClicked()
 {
     hideMainForms();
     addFriendForm->show(*ui);
+    setWindowTitle(tr("Add friend") + " - qTox");
 }
 
 void Widget::onGroupClicked()
@@ -529,6 +530,7 @@ void Widget::onTransferClicked()
 {
     hideMainForms();
     filesForm->show(*ui);
+    setWindowTitle(tr("File transfers") + " - qTox");
     activeChatroomWidget = nullptr;
 }
 
@@ -553,6 +555,7 @@ void Widget::onSettingsClicked()
 {
     hideMainForms();
     settingsWidget->show(*ui);
+    setWindowTitle(tr("Settings") + " - qTox");
     activeChatroomWidget = nullptr;
 }
 
@@ -712,6 +715,7 @@ void Widget::onChatroomWidgetClicked(GenericChatroomWidget *widget)
     }
     activeChatroomWidget = widget;
     widget->setAsActiveChatroom();
+    setWindowTitle(widget->getName() + " - qTox");
     widget->resetEventFlags();
     widget->updateStatusLight();
 }
@@ -959,10 +963,7 @@ bool Widget::isFriendWidgetCurActiveWidget(Friend* f)
     if (!f)
         return false;
 
-    if (activeChatroomWidget == static_cast<GenericChatroomWidget*>(f->widget))
-        return true;
-    else
-        return false;
+    return (activeChatroomWidget == static_cast<GenericChatroomWidget*>(f->widget));
 }
 
 bool Widget::event(QEvent * e)


### PR DESCRIPTION
Global autoaccept is supported now, per friend and global.
several lines and method became unused after some changes in settings.cpp filetransferinstance.cpp and friendwidget.cpp

autoaccept from friend has checkbox now instead two actions in menu 
![menu6](https://cloud.githubusercontent.com/assets/2544251/4927749/4ff6e658-653e-11e4-9d5e-b96bd3068be0.png)

Window has dynamic title now describing current action
![menu7](https://cloud.githubusercontent.com/assets/2544251/4927766/6c62318a-653e-11e4-97ca-75b19867ccff.png)

one more thing which I forgot?
