### PR TITLE
Correct qTox.desktop

### DIFF
--- a/qTox.desktop
+++ b/qTox.desktop
@@ -7,6 +7,6 @@ Comment=qTox is a powerful Tox client that follows the Tox design guidelines.
 TryExec=qtox
 Exec=qtox %u
 Icon=qtox
-Categories=InstantMessaging;;AudioVideo;Network;
+Categories=InstantMessaging;AudioVideo;Network;
 Terminal=false
 MimeType=x-scheme-handler/tox;application/x-tox;


### PR DESCRIPTION
With an additional ';' installing qTox desktop file resulted in warning:

/usr/share/applications/qTox.desktop: error: value "InstantMessaging;;AudioVideo;Network;" for key "Categories" in group "Desktop Entry" contains an unregistered value ""; values extending the format should start with "X-"
