### PR TITLE
fix #775

### DIFF
--- a/src/filetransferinstance.cpp
+++ b/src/filetransferinstance.cpp
@@ -18,6 +18,8 @@
 #include "core.h"
 #include "misc/settings.h"
 #include "misc/style.h"
+#include "src/friendlist.h"
+#include "src/friend.h"
 #include <math.h>
 #include <QFileDialog>
 #include <QMessageBox>
@@ -208,7 +210,7 @@ bool isFileWritable(QString& path)
 
 void FileTransferInstance::acceptRecvRequest()
 {
-    QString path = Settings::getInstance().getAutoAcceptDir(Core::getInstance()->getFriendAddress(friendId));
+    QString path = Settings::getInstance().getAutoAcceptDir(FriendList::findFriend(friendId)->getToxID());
     
     if (path.isEmpty())
         path = Settings::getInstance().getGlobalAutoAcceptDir();

--- a/src/misc/settings.h
+++ b/src/misc/settings.h
@@ -164,8 +164,8 @@ public:
     int getEmojiFontPointSize() const;
     void setEmojiFontPointSize(int value);
 
-    QString getAutoAcceptDir(const QString& id) const;
-    void setAutoAcceptDir(const QString&id, const QString& dir);
+    QString getAutoAcceptDir(const ToxID& id) const;
+    void setAutoAcceptDir(const ToxID&id, const QString& dir);
 
     QString getGlobalAutoAcceptDir() const;
     void setGlobalAutoAcceptDir(const QString& dir);
@@ -295,6 +295,7 @@ private:
     {
         QString alias;
         QString addr;
+        QString autoAcceptDir;
     };
 
     QHash<QString, friendProp> friendLst;

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -217,7 +217,7 @@ void ChatForm::onFileRecvRequest(ToxFile file)
     chatWidget->insertMessage(ChatActionPtr(new FileTransferAction(fileTrans, getElidedName(name),
                                                                    QTime::currentTime().toString("hh:mm"), false)));
 
-    if (!Settings::getInstance().getAutoAcceptDir(Core::getInstance()->getFriendAddress(f->getFriendID())).isEmpty()
+    if (!Settings::getInstance().getAutoAcceptDir(f->getToxID()).isEmpty()
      || Settings::getInstance().getAutoSaveEnabled())
         fileTrans->pressFromHtml("btnB");
 }

--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -49,7 +49,7 @@ FriendWidget::FriendWidget(int FriendId, QString id)
 void FriendWidget::contextMenuEvent(QContextMenuEvent * event)
 {
     QPoint pos = event->globalPos();
-    QString id = Core::getInstance()->getFriendAddress(friendId);
+    ToxID id = FriendList::findFriend(friendId)->getToxID();
     QString dir = Settings::getInstance().getAutoAcceptDir(id);
     QMenu menu;
     QMenu* inviteMenu = menu.addMenu(tr("Invite to group","Menu to invite a friend to a groupchat"));


### PR DESCRIPTION
Auto-accept and corresponding folder not being remembered fix.

Per friend auto-accept settings moved to `Friend` group, also `fullAddresses` renamed to `Friend`.
