### PR TITLE
New OS X updater

### DIFF
--- a/osx/postinstall
+++ b/osx/postinstall
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-rm -rf ~/Library/Preferences/tox/update

--- a/osx/preinstall
+++ b/osx/preinstall
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-killall qtox

--- a/osx/updater.go
+++ b/osx/updater.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"os/user"
+)
+
+func fs_type(path string) int {
+	//name := "FileOrDir"
+	f, err := os.Open(path)
+	if err != nil {
+		fmt.Println(err)
+		return -1
+	}
+	defer f.Close()
+	fi, err := f.Stat()
+	if err != nil {
+		fmt.Println(err)
+		return -1
+	}
+	switch mode := fi.Mode(); {
+	case mode.IsDir():
+		return 0
+	case mode.IsRegular():
+		return 1
+	}
+
+	return -1
+}
+
+func main() {
+	usr, e := user.Current()
+	if e != nil {
+		log.Fatal(e)
+	}
+
+	update_dir := usr.HomeDir + "/Library/Preferences/tox/update/"
+	if _, err := os.Stat(update_dir); os.IsNotExist(err) {
+		fmt.Println("Error: No update folder, is check for updates enabled?")
+		return
+	}
+	fmt.Println("qTox Updater")
+
+	files, _ := ioutil.ReadDir(update_dir)
+	killqtox := exec.Command("/usr/bin/killall", "qtox")
+	_ = killqtox.Run()
+
+	for _, file := range files {
+		if fs_type(update_dir+file.Name()) == 1 {
+			fmt.Print("Installing: ")
+			fmt.Println("/Applications/qtox.app/Contents/" + file.Name())
+			if _, err := os.Stat("/Applications/qtox.app/Contents/" + file.Name()); os.IsNotExist(err) {
+				newfile := exec.Command("/usr/libexec/authopen", "-c", "-x", "-m", "drwxrwxr-x+", "/Applications/qtox.app/Contents/"+file.Name())
+				newfile.Run()
+			}
+
+			cat := exec.Command("/bin/cat", update_dir+file.Name())
+			auth := exec.Command("/usr/libexec/authopen", "-w", "/Applications/qtox.app/Contents/"+file.Name())
+			auth.Stdin, _ = cat.StdoutPipe()
+			auth.Stdout = os.Stdout
+			auth.Stderr = os.Stderr
+			_ = auth.Start()
+			_ = cat.Run()
+			_ = auth.Wait()
+
+		} else {
+			files, _ := ioutil.ReadDir(update_dir + file.Name())
+			for _, file2 := range files {
+				fmt.Print("Installing: ")
+				fmt.Println("/Applications/qtox.app/Contents/" + file.Name() + "/" + file2.Name())
+
+				if _, err := os.Stat("/Applications/qtox.app/Contents/" + file.Name() + "/" + file2.Name()); os.IsNotExist(err) {
+					newfile := exec.Command("/usr/libexec/authopen", "-c", "-x", "-m", "drwxrwxr-x+", "/Applications/qtox.app/Contents/"+file.Name()+"/"+file2.Name())
+					newfile.Run()
+				}
+
+				cat := exec.Command("/bin/cat", update_dir+file.Name()+"/"+file2.Name())
+				auth := exec.Command("/usr/libexec/authopen", "-w", "/Applications/qtox.app/Contents/"+file.Name()+"/"+file2.Name())
+				auth.Stdin, _ = cat.StdoutPipe()
+				auth.Stdout = os.Stdout
+				auth.Stderr = os.Stderr
+				_ = auth.Start()
+				_ = cat.Run()
+				_ = auth.Wait()
+			}
+		}
+
+	}
+	os.RemoveAll(update_dir)
+	fmt.Println("Update metadata wiped, launching qTox")
+	launchqtox := exec.Command("/usr/bin/open", "-b", "im.tox.qtox")
+}

--- a/osx/updater.go
+++ b/osx/updater.go
@@ -93,4 +93,5 @@ func main() {
 	os.RemoveAll(update_dir)
 	fmt.Println("Update metadata wiped, launching qTox")
 	launchqtox := exec.Command("/usr/bin/open", "-b", "im.tox.qtox")
+	launchqtox.Run()
 }

--- a/src/autoupdate.cpp
+++ b/src/autoupdate.cpp
@@ -46,8 +46,7 @@ unsigned char AutoUpdater::key[crypto_sign_PUBLICKEYBYTES] =
 
 #elif defined(Q_OS_OSX)
 const QString AutoUpdater::platform = "osx";
-const QString AutoUpdater::updaterBin = "installer -pkg "+Settings::getInstance().getSettingsDirPath()
-                                                    +"/update/qtox.pkg -target CurrentUserHomeDirectory";
+const QString AutoUpdater::updaterBin = "/Applications/qtox.app/Contents/MacOS/updater";
 const QString AutoUpdater::updateServer = "https://dist-build.tox.im";
 
 unsigned char AutoUpdater::key[crypto_sign_PUBLICKEYBYTES] =


### PR DESCRIPTION
The new updater is super nice, it closes a currently running qTox, updates the files from the update folder with a proper admin permissions prompt, wipes the folder, and relaunches qTox magically.

Keep in mind that I did write it in Go so binaries we'd deploy of it in the app would be fully statically linked and work ootb everywhere, but take up 2 mb.
