### PR TITLE
Focus the text input area when clicking on the text area

### DIFF
--- a/src/widget/chatareawidget.cpp
+++ b/src/widget/chatareawidget.cpp
@@ -87,6 +87,7 @@ void ChatAreaWidget::mouseReleaseEvent(QMouseEvent * event)
             }
         }
     }
+    emit onClick();
 }
 
 void ChatAreaWidget::onAnchorClicked(const QUrl &url)

--- a/src/widget/chatareawidget.h
+++ b/src/widget/chatareawidget.h
@@ -41,6 +41,7 @@ public slots:
 
 signals:
     void onFileTranfertInterract(QString widgetName, QString buttonName);
+    void onClick();
 
 protected:
     void mouseReleaseEvent(QMouseEvent * event);

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -152,6 +152,7 @@ GenericChatForm::GenericChatForm(QWidget *parent) :
 
     connect(emoteButton,  SIGNAL(clicked()), this, SLOT(onEmoteButtonClicked()));
     connect(chatWidget, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(onChatContextMenuRequested(QPoint)));
+    connect(chatWidget, SIGNAL(onClick()), this, SLOT(onChatWidgetClicked()));
 
     chatWidget->document()->setDefaultStyleSheet(Style::getStylesheet(":ui/chatArea/innerStyle.css"));
     chatWidget->setStyleSheet(Style::getStylesheet(":/ui/chatArea/chatArea.css"));
@@ -250,6 +251,11 @@ void GenericChatForm::onEmoteButtonClicked()
         QPoint pos = -QPoint(widget.sizeHint().width() / 2, widget.sizeHint().height()) - QPoint(0, 10);
         widget.exec(sender->mapToGlobal(pos));
     }
+}
+
+void GenericChatForm::onChatWidgetClicked()
+{
+    msgEdit->setFocus();
 }
 
 void GenericChatForm::onEmoteInsertRequested(QString str)

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -69,6 +69,7 @@ protected slots:
     void onEmoteButtonClicked();
     void onEmoteInsertRequested(QString str);
     void clearChatArea(bool);
+    void onChatWidgetClicked();
 
 protected:
     QString getElidedName(const QString& name);


### PR DESCRIPTION
This pulls request focuses the text input area whenever the user clicks on the chat area. 
This is useful when you have selected text, copy-pasted it, and then easily want to get back to the chat: you get a huge area to click on now where you can start typing right away instead of having to click on the much smaller input box.
