### PR TITLE
Destroy AL context before closing old device

### DIFF
--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -87,8 +87,6 @@ void Audio::openOutput(const QString& outDevDescr)
 {
     auto* tmp = alOutDev;
     alOutDev = nullptr;
-    if (tmp)
-        alcCloseDevice(tmp);
     if (outDevDescr.isEmpty())
         alOutDev = alcOpenDevice(nullptr);
     else
@@ -104,6 +102,8 @@ void Audio::openOutput(const QString& outDevDescr)
             alcMakeContextCurrent(nullptr);
             alcDestroyContext(alContext);
         }
+        if (tmp)
+            alcCloseDevice(tmp);
         alContext=alcCreateContext(alOutDev,nullptr);
         if (!alcMakeContextCurrent(alContext))
         {


### PR DESCRIPTION
I refuse to compile this code, so it's not tested.  
This should fix the segfault in alcDestroyContext.
