### PR TITLE
Fixed language error and added translation string.

### DIFF
--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -673,7 +673,7 @@ void ChatForm::onFileSendFailed(int FriendId, const QString &fname)
     if (FriendId != f->getFriendID())
         return;
 
-    addSystemInfoMessage(tr("Failed to send file") + ": \"" + fname + "\"", "red", QDateTime::currentDateTime());
+    addSystemInfoMessage(tr("Failed to send file \"%1\"").arg(fname), "red", QDateTime::currentDateTime());
 }
 
 void ChatForm::onAvatarChange(int FriendId, const QPixmap &pic)

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -673,7 +673,7 @@ void ChatForm::onFileSendFailed(int FriendId, const QString &fname)
     if (FriendId != f->getFriendID())
         return;
 
-    addSystemInfoMessage("File: \"" + fname + "\" failed to send.", "red", QDateTime::currentDateTime());
+    addSystemInfoMessage(tr("Failed to send file") + ": \"" + fname + "\"", "red", QDateTime::currentDateTime());
 }
 
 void ChatForm::onAvatarChange(int FriendId, const QPixmap &pic)

--- a/translations/de.ts
+++ b/translations/de.ts
@@ -594,22 +594,27 @@ Wollen Sie ein anderes probieren?</translation>
         <translation>Mache Tox portabel</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="101"/>
-        <source>Show system tray</source>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="99"/>
+        <source>System tray integration</source>
+        <translation>Systemtray Integration</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="108"/>
+        <source>Show system tray icon</source>
         <translation>Im Systemtray zeigen</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="114"/>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="123"/>
         <source>Start in tray</source>
         <translation>Ins Tray starten</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="127"/>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="136"/>
         <source>Close to tray</source>
         <translation>Ins Tray schließen</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="140"/>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="149"/>
         <source>Minimize to tray</source>
         <translation>Ins Tray minimieren</translation>
     </message>

--- a/translations/de.ts
+++ b/translations/de.ts
@@ -37,6 +37,11 @@
         <translation>Aufnahmegerät</translation>
     </message>
     <message>
+        <location filename="../src/widget/form/settings/avsettings.ui" line="95"/>
+        <source>Rescan audio devices</source>
+        <translation>Erneut nach Audiogeräten suchen</translation>
+    </message>
+    <message>
         <location filename="../src/widget/form/settings/avsettings.ui" line="98"/>
         <source>Video Settings</source>
         <translation>Video Einstellungen</translation>

--- a/translations/de.ts
+++ b/translations/de.ts
@@ -258,6 +258,11 @@ Soll der Proxy ignoriert und eine direkte Internetverbindung genutzt werden?</tr
         <translation>Anruf abgewiesen</translation>
     </message>
     <message>
+        <location filename="../src/widget/form/chatform.cpp" line="676"/>
+        <source>Failed to send file</source>
+        <translation>Fehler beim Senden der Datei</translation>
+    </message>
+    <message>
         <location filename="../src/widget/form/chatform.cpp" line="804"/>
         <source>Call with %1 ended. %2</source>
         <translation>Anruf zu %1 beendet. %2 </translation>


### PR DESCRIPTION
There was a translation error in the German version that is fixed now.

There where still the English strings:
![language-error](https://cloud.githubusercontent.com/assets/2056876/5340065/72687a08-7ee8-11e4-9e93-cc6d3d646bd8.png)
