### PR TITLE
Add a compact friends list layout

### DIFF
--- a/src/misc/settings.cpp
+++ b/src/misc/settings.cpp
@@ -960,11 +960,13 @@ void Settings::setFauxOfflineMessaging(bool value)
     fauxOfflineMessaging = value;
 }
 
-bool Settings::getCompactLayout() const {
+bool Settings::getCompactLayout() const
+{
     return compactLayout;
 }
 
-void Settings::setCompactLayout(bool value) {
+void Settings::setCompactLayout(bool value)
+{
     compactLayout = value;
     emit compactLayoutChanged();
 }

--- a/src/misc/settings.cpp
+++ b/src/misc/settings.cpp
@@ -142,6 +142,7 @@ void Settings::load()
         globalAutoAcceptDir = s.value("globalAutoAcceptDir",
                                       QStandardPaths::locate(QStandardPaths::HomeLocation, QString(), QStandardPaths::LocateDirectory)
                                       ).toString();
+        compactLayout = s.value("compactLayout", false).toBool();
     s.endGroup();
 
     s.beginGroup("Advanced");
@@ -289,6 +290,7 @@ void Settings::save(QString path, bool writeFriends)
         s.setValue("checkUpdates", checkUpdates);
         s.setValue("showInFront", showInFront);
         s.setValue("fauxOfflineMessaging", fauxOfflineMessaging);
+        s.setValue("compactLayout", compactLayout);
         s.setValue("autoSaveEnabled", autoSaveEnabled);
         s.setValue("globalAutoAcceptDir", globalAutoAcceptDir);
     s.endGroup();
@@ -956,6 +958,15 @@ bool Settings::getFauxOfflineMessaging() const
 void Settings::setFauxOfflineMessaging(bool value)
 {
     fauxOfflineMessaging = value;
+}
+
+bool Settings::getCompactLayout() const {
+    return compactLayout;
+}
+
+void Settings::setCompactLayout(bool value) {
+    compactLayout = value;
+    emit compactLayoutChanged();
 }
 
 int Settings::getThemeColor() const

--- a/src/misc/settings.h
+++ b/src/misc/settings.h
@@ -215,6 +215,9 @@ public:
     bool getFauxOfflineMessaging() const;
     void setFauxOfflineMessaging(bool value);
 
+    bool getCompactLayout() const;
+    void setCompactLayout(bool compact);
+
 public:
     void save(bool writeFriends = true);
     void save(QString path, bool writeFriends = true);
@@ -238,6 +241,7 @@ private:
     bool dontShowDhtDialog;
 
     bool fauxOfflineMessaging;
+    bool compactLayout;
     bool enableIPv6;
     QString translation;
     static bool makeToxPortable;
@@ -313,6 +317,7 @@ signals:
     void smileyPackChanged();
     void emojiFontChanged();
     void timestampFormatChanged();
+    void compactLayoutChanged();
 };
 
 #endif // SETTINGS_HPP

--- a/src/widget/form/settings/generalform.cpp
+++ b/src/widget/form/settings/generalform.cpp
@@ -68,6 +68,7 @@ GeneralForm::GeneralForm(SettingsWidget *myParent) :
     bodyUI->autoSaveFilesDir->setText(Settings::getInstance().getGlobalAutoAcceptDir());
     bodyUI->showInFront->setChecked(Settings::getInstance().getShowInFront());
     bodyUI->cbFauxOfflineMessaging->setChecked(Settings::getInstance().getFauxOfflineMessaging());
+    bodyUI->cbCompactLayout->setChecked(Settings::getInstance().getCompactLayout());
 
     for (auto entry : SmileyPack::listSmileyPacks())
     {
@@ -141,6 +142,7 @@ GeneralForm::GeneralForm(SettingsWidget *myParent) :
     connect(bodyUI->proxyPort, SIGNAL(valueChanged(int)), this, SLOT(onProxyPortEdited(int)));
     connect(bodyUI->reconnectButton, &QPushButton::clicked, this, &GeneralForm::onReconnectClicked);
     connect(bodyUI->cbFauxOfflineMessaging, &QCheckBox::stateChanged, this, &GeneralForm::onFauxOfflineMessaging);
+    connect(bodyUI->cbCompactLayout, &QCheckBox::stateChanged, this, &GeneralForm::onCompactLayout);
 
 #ifndef QTOX_PLATFORM_EXT
     bodyUI->autoAwayLabel->setEnabled(false);   // these don't seem to change the appearance of the widgets,
@@ -329,6 +331,11 @@ void GeneralForm::onSetShowInFront()
 void GeneralForm::onFauxOfflineMessaging()
 {
     Settings::getInstance().setFauxOfflineMessaging(bodyUI->cbFauxOfflineMessaging->isChecked());
+}
+
+void GeneralForm::onCompactLayout()
+{
+    Settings::getInstance().setCompactLayout(bodyUI->cbCompactLayout->isChecked());
 }
 
 void GeneralForm::onThemeColorChanged(int)

--- a/src/widget/form/settings/generalform.h
+++ b/src/widget/form/settings/generalform.h
@@ -55,6 +55,7 @@ private slots:
     void onCheckUpdateChanged();
     void onSetShowInFront();
     void onFauxOfflineMessaging();
+    void onCompactLayout();
     void onThemeColorChanged(int);
 
 private:

--- a/src/widget/form/settings/generalsettings.ui
+++ b/src/widget/form/settings/generalsettings.ui
@@ -184,6 +184,13 @@
            </widget>
           </item>
           <item>
+           <widget class="QCheckBox" name="cbCompactLayout">
+            <property name="text">
+             <string>Compact layout</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <layout class="QHBoxLayout" name="horizontalLayout_2">
             <item alignment="Qt::AlignLeft">
              <widget class="QLabel" name="autoAwayLabel">

--- a/src/widget/genericchatroomwidget.cpp
+++ b/src/widget/genericchatroomwidget.cpp
@@ -140,7 +140,8 @@ bool GenericChatroomWidget::isCompact() const
     return compact;
 }
 
-void GenericChatroomWidget::setCompact(bool compact) {
+void GenericChatroomWidget::setCompact(bool compact)
+{
     this->compact = compact;
     Style::repolish(this);
 }

--- a/src/widget/genericchatroomwidget.cpp
+++ b/src/widget/genericchatroomwidget.cpp
@@ -16,6 +16,7 @@
 
 #include "genericchatroomwidget.h"
 #include "src/misc/style.h"
+#include "src/misc/settings.h"
 #include "maskablepixmapwidget.h"
 #include "croppinglabel.h"
 #include <QMouseEvent>
@@ -24,7 +25,16 @@
 GenericChatroomWidget::GenericChatroomWidget(QWidget *parent)
     : QFrame(parent)
 {
-    setFixedHeight(55);
+    setProperty("compact", Settings::getInstance().getCompactLayout());
+
+    if(property("compact").toBool())
+    {
+        setFixedHeight(25);
+    }
+    else
+    {
+        setFixedHeight(55);
+    }
 
     setLayout(&layout);
     layout.setSpacing(0);
@@ -34,7 +44,14 @@ GenericChatroomWidget::GenericChatroomWidget(QWidget *parent)
     setLayoutDirection(Qt::LeftToRight); // parent might have set Qt::RightToLeft
 
     // avatar
-    avatar = new MaskablePixmapWidget(this, QSize(40,40), ":/img/avatar_mask.png");
+    if(property("compact").toBool())
+    {
+        avatar = new MaskablePixmapWidget(this, QSize(20,20), ":/img/avatar_mask.png");
+    }
+    else
+    {
+        avatar = new MaskablePixmapWidget(this, QSize(40,40), ":/img/avatar_mask.png");
+    }
 
     // status text
     statusMessageLabel = new CroppingLabel(this);
@@ -43,20 +60,35 @@ GenericChatroomWidget::GenericChatroomWidget(QWidget *parent)
     // name text
     nameLabel = new CroppingLabel(this);
     nameLabel->setObjectName("name");
+    
+    if(property("compact").toBool())
+    {
+        layout.addSpacing(18);
+        layout.addWidget(avatar);
+        layout.addSpacing(5);
+        layout.addWidget(nameLabel);
+        layout.addWidget(statusMessageLabel);
+        layout.addSpacing(5);
+        layout.addWidget(&statusPic);
+        layout.addSpacing(5);
+        layout.activate();
+    }
+    else
+    {
+        textLayout.addStretch();
+        textLayout.addWidget(nameLabel);
+        textLayout.addWidget(statusMessageLabel);
+        textLayout.addStretch();
 
-    textLayout.addStretch();
-    textLayout.addWidget(nameLabel);
-    textLayout.addWidget(statusMessageLabel);
-    textLayout.addStretch();
-
-    layout.addSpacing(20);
-    layout.addWidget(avatar);
-    layout.addSpacing(10);
-    layout.addLayout(&textLayout);
-    layout.addSpacing(10);
-    layout.addWidget(&statusPic);
-    layout.addSpacing(10);
-    layout.activate();
+        layout.addSpacing(20);
+        layout.addWidget(avatar);
+        layout.addSpacing(10);
+        layout.addLayout(&textLayout);
+        layout.addSpacing(10);
+        layout.addWidget(&statusPic);
+        layout.addSpacing(10);
+        layout.activate();
+    }
 
     setProperty("active", false);
     setStyleSheet(Style::getStylesheet(":/ui/chatroomWidgets/genericChatroomWidget.css"));
@@ -101,4 +133,14 @@ void GenericChatroomWidget::mouseReleaseEvent(QMouseEvent*)
 void GenericChatroomWidget::reloadTheme()
 {
     setStyleSheet(Style::getStylesheet(":/ui/chatroomWidgets/genericChatroomWidget.css"));
+}
+
+bool GenericChatroomWidget::isCompact() const
+{
+    return compact;
+}
+
+void GenericChatroomWidget::setCompact(bool compact) {
+    this->compact = compact;
+    Style::repolish(this);
 }

--- a/src/widget/genericchatroomwidget.cpp
+++ b/src/widget/genericchatroomwidget.cpp
@@ -27,7 +27,7 @@ GenericChatroomWidget::GenericChatroomWidget(QWidget *parent)
 {
     setProperty("compact", Settings::getInstance().getCompactLayout());
 
-    if(property("compact").toBool())
+    if (property("compact").toBool())
     {
         setFixedHeight(25);
     }
@@ -44,7 +44,7 @@ GenericChatroomWidget::GenericChatroomWidget(QWidget *parent)
     setLayoutDirection(Qt::LeftToRight); // parent might have set Qt::RightToLeft
 
     // avatar
-    if(property("compact").toBool())
+    if (property("compact").toBool())
     {
         avatar = new MaskablePixmapWidget(this, QSize(20,20), ":/img/avatar_mask.png");
     }
@@ -61,7 +61,7 @@ GenericChatroomWidget::GenericChatroomWidget(QWidget *parent)
     nameLabel = new CroppingLabel(this);
     nameLabel->setObjectName("name");
     
-    if(property("compact").toBool())
+    if (property("compact").toBool())
     {
         layout.addSpacing(18);
         layout.addWidget(avatar);

--- a/src/widget/genericchatroomwidget.h
+++ b/src/widget/genericchatroomwidget.h
@@ -53,6 +53,11 @@ public:
 
     void reloadTheme();
 
+    bool isCompact() const;
+    void setCompact(bool compact);
+
+    Q_PROPERTY(bool compact READ isCompact WRITE setCompact)
+
 signals:
     void chatroomWidgetClicked(GenericChatroomWidget* widget);
 
@@ -65,6 +70,7 @@ protected:
     MaskablePixmapWidget* avatar;
     QLabel statusPic;
     CroppingLabel *nameLabel, *statusMessageLabel;
+    bool compact;
 
     friend class Style; ///< To update our stylesheets
 };

--- a/ui/chatroomWidgets/genericChatroomWidget.css
+++ b/ui/chatroomWidgets/genericChatroomWidget.css
@@ -1,5 +1,5 @@
-GenericChatroomWidget 
-{ 
+GenericChatroomWidget
+{
   background-color: @themeMedium;
 }
 
@@ -8,30 +8,54 @@ GenericChatroomWidget[active="true"]
   background-color: @white;
 }
 
-GenericChatroomWidget[active="false"]:hover 
-{ 
-  background-color: @themeLight; 
-} 
+GenericChatroomWidget[active="false"]:hover
+{
+  background-color: @themeLight;
+}
 
-GenericChatroomWidget[active="true"] > QLabel#status 
+GenericChatroomWidget[active="true"][compact="true"] > QLabel#status
+{
+  font: @small;
+  color: @mediumGrey;
+}
+
+GenericChatroomWidget[active="false"][compact="true"] > QLabel#status
+{
+  font: @small;
+  color: @lightGrey;
+}
+
+GenericChatroomWidget[active="true"][compact="true"] > QLabel#name
+{
+  font: @medium;
+  color: @darkGrey;
+}
+
+GenericChatroomWidget[active="false"][compact="true"] > QLabel#name
+{
+  font: @medium;
+  color: @white;
+}
+
+GenericChatroomWidget[active="true"][compact="false"] > QLabel#status
 {
   font: @medium;
   color: @mediumGrey;
 }
 
-GenericChatroomWidget[active="false"] > QLabel#status 
+GenericChatroomWidget[active="false"][compact="false"] > QLabel#status
 {
   font: @medium;
   color: @lightGrey;
 }
 
-GenericChatroomWidget[active="true"] > QLabel#name
+GenericChatroomWidget[active="true"][compact="false"] > QLabel#name
 {
   font: @big;
   color: @darkGrey;
 }
 
-GenericChatroomWidget[active="false"] > QLabel#name
+GenericChatroomWidget[active="false"][compact="false"] > QLabel#name
 {
   font: @big;
   color: @white;


### PR DESCRIPTION
When the friends list gets large, you can't fit all your online friends on it anymore, which gets annoying, so I've written a compact layout mode for the friends list.

Here's what it looks like:
![scrot-757](https://cloud.githubusercontent.com/assets/290001/5395391/c8444f62-8148-11e4-919a-9a7a8afa8d5a.png)

The only problem there is, I think, is that when you check/uncheck the compact layout checkbox in general settings, the friends list layout won't reload and you need to restart qTox for the changes to have any effect. I'm not sure how to fix this. If anyone can point me in the right direction, I don't mind fixing this.
