### PR TITLE
Make quote colour more readable

### DIFF
--- a/ui/chatArea/innerStyle.css
+++ b/ui/chatArea/innerStyle.css
@@ -34,7 +34,7 @@ div.date_me {
 }
 
 span.quote {
-  color: #6bc260;
+  color: #279419;
 }
 
 div.green {


### PR DESCRIPTION
![screenshot3](https://cloud.githubusercontent.com/assets/3148759/5473605/a6321cb0-8602-11e4-839a-59be09884609.png) `new | old`

It's not according to mock-up colour scheme, but it looks much better and, what is more important, text is more readable.
