### PR TITLE
messages splitting fix

### DIFF
--- a/src/core.cpp
+++ b/src/core.cpp
@@ -49,6 +49,8 @@ QList<ToxFile> Core::fileRecvQueue;
 QHash<int, ToxGroupCall> Core::groupCalls;
 QThread* Core::coreThread{nullptr};
 
+#define MAX_GROUP_MESSAGE_LEN 1024
+
 Core::Core(Camera* cam, QThread *CoreThread, QString loadPath) :
     tox(nullptr), camera(cam), loadPath(loadPath), ready{false}
 {
@@ -779,7 +781,7 @@ void Core::sendTyping(int friendId, bool typing)
 
 void Core::sendGroupMessage(int groupId, const QString& message)
 {
-    QList<CString> cMessages = splitMessage(message);
+    QList<CString> cMessages = splitMessage(message, MAX_GROUP_MESSAGE_LEN);
 
     for (auto &cMsg :cMessages)
     {
@@ -792,7 +794,7 @@ void Core::sendGroupMessage(int groupId, const QString& message)
 
 void Core::sendGroupAction(int groupId, const QString& message)
 {
-    QList<CString> cMessages = splitMessage(message);
+    QList<CString> cMessages = splitMessage(message, MAX_GROUP_MESSAGE_LEN);
 
     for (auto &cMsg :cMessages)
     {
@@ -1741,17 +1743,17 @@ QString Core::getFriendUsername(int friendnumber) const
     return CString::toString(name, tox_get_name_size(tox, friendnumber));
 }
 
-QList<CString> Core::splitMessage(const QString &message)
+QList<CString> Core::splitMessage(const QString &message, int maxLen)
 {
     QList<CString> splittedMsgs;
     QByteArray ba_message(message.toUtf8());
 
-    while (ba_message.size() > TOX_MAX_MESSAGE_LENGTH)
+    while (ba_message.size() > maxLen)
     {
-        int splitPos = ba_message.lastIndexOf(' ', TOX_MAX_MESSAGE_LENGTH - 1);
+        int splitPos = ba_message.lastIndexOf(' ', maxLen - 1);
         if (splitPos <= 0)
         {
-            splitPos = TOX_MAX_MESSAGE_LENGTH;
+            splitPos = maxLen;
             if (ba_message[splitPos] & 0x80)
             {
                 do {

--- a/src/core.h
+++ b/src/core.h
@@ -50,7 +50,7 @@ public:
     static const QString TOX_EXT;
     static const QString CONFIG_FILE_NAME;
     static QString sanitize(QString name);
-    static QList<CString> splitMessage(const QString &message);
+    static QList<CString> splitMessage(const QString &message, int maxLen);
 
     QString getPeerName(const ToxID& id) const;
 

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -103,7 +103,7 @@ void ChatForm::onSendTriggered()
     if (isAction)
         msg = msg = msg.right(msg.length() - 4);
 
-    QList<CString> splittedMsg = Core::splitMessage(msg);
+    QList<CString> splittedMsg = Core::splitMessage(msg, TOX_MAX_MESSAGE_LENGTH);
     QDateTime timestamp = QDateTime::currentDateTime();
 
     for (CString& c_msg : splittedMsg)


### PR DESCRIPTION
As was mentioned in #940 messages in group chats should be split by `MAX_GROUP_MESSAGE_DATA_LEN` and `MAX_GROUP_MESSAGE_DATA_LEN` < `TOX_MAX_MESSAGE_LENGTH`.
Too hard to calculate exact length, so I just hardcoded 1024.
