### PR TITLE
Fixes issue #740, now contacts with new events are not moved to the bottom when going offline

### DIFF
--- a/src/widget/friendlistwidget.cpp
+++ b/src/widget/friendlistwidget.cpp
@@ -32,7 +32,7 @@ FriendListWidget::FriendListWidget(QWidget *parent) :
 
     for (Status s : {Status::Online, Status::Away, Status::Busy, Status::Offline})
     {
-        QLayout *l = new QVBoxLayout();
+        QVBoxLayout *l = new QVBoxLayout();
         l->setSpacing(0);
         l->setMargin(0);
 
@@ -46,12 +46,12 @@ FriendListWidget::FriendListWidget(QWidget *parent) :
     mainLayout->addLayout(layouts[static_cast<int>(Status::Offline)], 4, 0);
 }
 
-QLayout* FriendListWidget::getGroupLayout()
+QVBoxLayout* FriendListWidget::getGroupLayout()
 {
     return groupLayout;
 }
 
-QLayout* FriendListWidget::getFriendLayout(Status s)
+QVBoxLayout* FriendListWidget::getFriendLayout(Status s)
 {
     auto res = layouts.find(static_cast<int>(s));
     if (res != layouts.end())
@@ -61,8 +61,11 @@ QLayout* FriendListWidget::getFriendLayout(Status s)
     return layouts[static_cast<int>(Status::Online)];
 }
 
-void FriendListWidget::moveWidget(QWidget *w, Status s)
+void FriendListWidget::moveWidget(QWidget *w, Status s, int hasNewEvents)
 {
     mainLayout->removeWidget(w);
-    getFriendLayout(s)->addWidget(w);
+    if (hasNewEvents == 0)
+        getFriendLayout(s)->addWidget(w);
+    else
+        getFriendLayout(s)->insertWidget(0, w);
 }

--- a/src/widget/friendlistwidget.h
+++ b/src/widget/friendlistwidget.h
@@ -21,7 +21,7 @@
 #include <QHash>
 #include "src/corestructs.h"
 
-class QLayout;
+class QVBoxLayout;
 class QGridLayout;
 class QPixmap;
 
@@ -31,17 +31,17 @@ class FriendListWidget : public QWidget
 public:
     explicit FriendListWidget(QWidget *parent = 0);
 
-    QLayout* getGroupLayout();
-    QLayout* getFriendLayout(Status s);
-    void moveWidget(QWidget *w, Status s);
+    QVBoxLayout* getGroupLayout();
+    QVBoxLayout* getFriendLayout(Status s);
+    void moveWidget(QWidget *w, Status s, int hasNewEvents);
 
 signals:
 
 public slots:
 
 private:
-    QHash<int, QLayout*> layouts;
-    QLayout *groupLayout;
+    QHash<int, QVBoxLayout*> layouts;
+    QVBoxLayout *groupLayout;
     QGridLayout *mainLayout;
 };
 

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -725,7 +725,7 @@ void Widget::onFriendStatusChanged(int friendId, Status status)
     if (!f)
         return;
 
-    contactListWidget->moveWidget(f->getFriendWidget(), status);
+    contactListWidget->moveWidget(f->getFriendWidget(), status, f->getEventFlag());
 
     bool isActualChange = f->getStatus() != status;
 


### PR DESCRIPTION
It works, but perhaps that's not the best way to do it. May be it's better to create two layouts for status==offline: one for contacts having new events and the other - for contacts without new events?
And why layouts was of type QLayout, not QVBoxLayout?
