### PR TITLE
Alphabetize groupchat user list

### DIFF
--- a/src/group.cpp
+++ b/src/group.cpp
@@ -145,7 +145,9 @@ GroupWidget *Group::getGroupWidget()
 
 QStringList Group::getPeerList() const
 {
-    return peers.values();
+    QStringList peerNames(peers.values());
+    peerNames.sort(Qt::CaseInsensitive);
+    return peerNames;
 }
 
 void Group::setEventFlag(int f)


### PR DESCRIPTION
fixes #701 , and cleans up the tab-completion code a little. Because I sort the peer-list beforehand, there's no more need to store the completion-list as a map, since we iterate over the sorted peer-list from beginning to end. This, in turn, obviates the need for "SortableString".

@dubslow are you still wondering why QObject is necessary here? :stuck_out_tongue_winking_eye: 
