### PR TITLE
Defining link color in chat area css

### DIFF
--- a/ui/chatArea/innerStyle.css
+++ b/ui/chatArea/innerStyle.css
@@ -88,6 +88,6 @@ div.button {
   color: @white;
 }
 
-*:link {
+a {
     color: blue;
 }

--- a/ui/chatArea/innerStyle.css
+++ b/ui/chatArea/innerStyle.css
@@ -87,3 +87,7 @@ div.button {
   margin-left: 0px;
   color: @white;
 }
+
+*:link {
+    color: blue;
+}


### PR DESCRIPTION
Fixes #852. Links now visible with white on black system theme.
