### PR TITLE
fix videosurface (missing buffer flip) and some glitches in av settings

### DIFF
--- a/src/video/cameraworker.cpp
+++ b/src/video/cameraworker.cpp
@@ -112,7 +112,7 @@ void CameraWorker::_probeResolutions()
 
             //qDebug() << "PROBING:" << res << " got " << w << h;
 
-            if (!resolutions.contains(QSize(w,h)))
+            if (w>0 && h>0 && !resolutions.contains(QSize(w,h)))
                 resolutions.append(QSize(w,h));
         }
 

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -125,7 +125,9 @@ void AVForm::onResProbingFinished(QList<QSize> res)
 	bodyUI->videoModescomboBox->blockSignals(true);
     for (QSize r : res)
         bodyUI->videoModescomboBox->addItem(QString("%1x%2").arg(QString::number(r.width()),QString::number(r.height())), r);
-	bodyUI->videoModescomboBox->blockSignals(false);
+	//reset index, otherwise cameras with only one resolution won't get initialized
+    bodyUI->videoModescomboBox->setCurrentIndex(-1);
+    bodyUI->videoModescomboBox->blockSignals(false);
 
     bodyUI->videoModescomboBox->setCurrentIndex(bodyUI->videoModescomboBox->count()-1);
 }

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -140,7 +140,11 @@ void AVForm::getAudioInDevices()
         while (*pDeviceList)
         {
             int len = strlen(pDeviceList);
-            QString inDev = QString::fromLocal8Bit(pDeviceList,len);
+#ifdef Q_OS_WIN32			
+            QString inDev = QString::fromUtf8(pDeviceList,len);
+#else
+			QString inDev = QString::fromLocal8Bit(pDeviceList,len);
+#endif
             bodyUI->inDevCombobox->addItem(inDev);
             if (settingsInDev == inDev)
             {
@@ -170,7 +174,11 @@ void AVForm::getAudioOutDevices()
         while (*pDeviceList)
         {
             int len = strlen(pDeviceList);
-            QString outDev = QString::fromLocal8Bit(pDeviceList,len);
+#ifdef Q_OS_WIN32			
+            QString outDev = QString::fromUtf8(pDeviceList,len);
+#else
+			QString outDev = QString::fromLocal8Bit(pDeviceList,len);
+#endif
             bodyUI->outDevCombobox->addItem(outDev);
             if (settingsOutDev == outDev)
             {

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -67,6 +67,10 @@ void AVForm::present()
     Camera::getInstance()->probeProp(Camera::HUE);
 
     Camera::getInstance()->probeResolutions();
+	
+	bodyUI->videoModescomboBox->blockSignals(true);
+	bodyUI->videoModescomboBox->addItem(tr("Initializing Camera..."));
+	bodyUI->videoModescomboBox->blockSignals(false);
 }
 
 void AVForm::on_ContrastSlider_sliderMoved(int position)
@@ -89,7 +93,7 @@ void AVForm::on_HueSlider_sliderMoved(int position)
     Camera::getInstance()->setProp(Camera::HUE, position / 100.0);
 }
 
-void AVForm::on_videoModescomboBox_activated(int index)
+void AVForm::on_videoModescomboBox_currentIndexChanged(int index)
 {
     Camera::getInstance()->setResolution(bodyUI->videoModescomboBox->itemData(index).toSize());
 }
@@ -118,8 +122,10 @@ void AVForm::onPropProbingFinished(Camera::Prop prop, double val)
 void AVForm::onResProbingFinished(QList<QSize> res)
 {
     bodyUI->videoModescomboBox->clear();
+	bodyUI->videoModescomboBox->blockSignals(true);
     for (QSize r : res)
         bodyUI->videoModescomboBox->addItem(QString("%1x%2").arg(QString::number(r.width()),QString::number(r.height())), r);
+	bodyUI->videoModescomboBox->blockSignals(false);
 
     bodyUI->videoModescomboBox->setCurrentIndex(bodyUI->videoModescomboBox->count()-1);
 }

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -138,11 +138,13 @@ void AVForm::hideEvent(QHideEvent *)
 void AVForm::getAudioInDevices()
 {
     QString settingsInDev = Settings::getInstance().getInDev();
-    bool inDevFound = false;
+	int inDevIndex = 0;
     bodyUI->inDevCombobox->clear();
     const ALchar *pDeviceList = alcGetString(NULL, ALC_CAPTURE_DEVICE_SPECIFIER);
     if (pDeviceList)
     {
+		//prevent currentIndexChanged to be fired while adding items
+		bodyUI->inDevCombobox->blockSignals(true);
         while (*pDeviceList)
         {
             int len = strlen(pDeviceList);
@@ -154,21 +156,21 @@ void AVForm::getAudioInDevices()
             bodyUI->inDevCombobox->addItem(inDev);
             if (settingsInDev == inDev)
             {
-                bodyUI->inDevCombobox->setCurrentIndex(bodyUI->inDevCombobox->count()-1);
-                inDevFound = true;
+				inDevIndex = bodyUI->inDevCombobox->count()-1;
             }
             pDeviceList += len+1;
         }
+		//addItem changes currentIndex -> reset
+		bodyUI->inDevCombobox->setCurrentIndex(-1);
+		bodyUI->inDevCombobox->blockSignals(false);
     }
-
-    if (!inDevFound)
-        Settings::getInstance().setInDev(bodyUI->inDevCombobox->itemText(0));
+	bodyUI->inDevCombobox->setCurrentIndex(inDevIndex);
 }
 
 void AVForm::getAudioOutDevices()
 {
     QString settingsOutDev = Settings::getInstance().getOutDev();
-    bool outDevFound = false;
+	int outDevIndex = 0;
     bodyUI->outDevCombobox->clear();
     const ALchar *pDeviceList;
     if (alcIsExtensionPresent(NULL, "ALC_ENUMERATE_ALL_EXT") != AL_FALSE)
@@ -177,6 +179,8 @@ void AVForm::getAudioOutDevices()
         pDeviceList = alcGetString(NULL, ALC_DEVICE_SPECIFIER);
     if (pDeviceList)
     {
+		//prevent currentIndexChanged to be fired while adding items
+		bodyUI->outDevCombobox->blockSignals(true);
         while (*pDeviceList)
         {
             int len = strlen(pDeviceList);
@@ -188,15 +192,15 @@ void AVForm::getAudioOutDevices()
             bodyUI->outDevCombobox->addItem(outDev);
             if (settingsOutDev == outDev)
             {
-                bodyUI->outDevCombobox->setCurrentIndex(bodyUI->outDevCombobox->count()-1);
-                outDevFound = true;
+                outDevIndex = bodyUI->outDevCombobox->count()-1;
             }
             pDeviceList += len+1;
         }
+		//addItem changes currentIndex -> reset
+		bodyUI->outDevCombobox->setCurrentIndex(-1);
+		bodyUI->outDevCombobox->blockSignals(false);
     }
-
-    if (!outDevFound)
-        Settings::getInstance().setOutDev(bodyUI->outDevCombobox->itemText(0));
+	bodyUI->outDevCombobox->setCurrentIndex(outDevIndex);
 }
 
 void AVForm::onInDevChanged(const QString &deviceDescriptor)

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -135,6 +135,11 @@ void AVForm::hideEvent(QHideEvent *)
     bodyUI->CamVideoSurface->setSource(nullptr);
 }
 
+void AVForm::showEvent(QShowEvent *)
+{
+    bodyUI->CamVideoSurface->setSource(Camera::getInstance());
+}
+
 void AVForm::getAudioInDevices()
 {
     QString settingsInDev = Settings::getInstance().getInDev();

--- a/src/widget/form/settings/avform.h
+++ b/src/widget/form/settings/avform.h
@@ -59,6 +59,7 @@ private slots:
     void onResProbingFinished(QList<QSize> res);
 
     virtual void hideEvent(QHideEvent*);
+    virtual void showEvent(QShowEvent*);
 
 private:
     Ui::AVSettings *bodyUI;

--- a/src/widget/form/settings/avform.h
+++ b/src/widget/form/settings/avform.h
@@ -47,7 +47,7 @@ private slots:
     void on_SaturationSlider_sliderMoved(int position);
     void on_BrightnessSlider_sliderMoved(int position);
     void on_HueSlider_sliderMoved(int position);
-    void on_videoModescomboBox_activated(int index);
+    void on_videoModescomboBox_currentIndexChanged(int index);
 
     // audio
     void onInDevChanged(const QString& deviceDescriptor);

--- a/src/widget/videosurface.cpp
+++ b/src/widget/videosurface.cpp
@@ -30,7 +30,7 @@ VideoSurface::VideoSurface(QWidget* parent)
     , hasSubscribed(false)
     , pboIndex(0)
 {
-    setAutoBufferSwap(false);
+    setAutoBufferSwap(true);
 }
 
 VideoSurface::VideoSurface(VideoSource *source, QWidget* parent)

--- a/src/widget/videosurface.cpp
+++ b/src/widget/videosurface.cpp
@@ -22,7 +22,7 @@
 #include <QDebug>
 
 VideoSurface::VideoSurface(QWidget* parent)
-    : QGLWidget(QGLFormat(QGL::SampleBuffers | QGL::SingleBuffer), parent)
+    : QGLWidget(QGLFormat(QGL::SingleBuffer), parent)
     , source(nullptr)
     , pbo{nullptr, nullptr}
     , textureId(0)
@@ -30,7 +30,7 @@ VideoSurface::VideoSurface(QWidget* parent)
     , hasSubscribed(false)
     , pboIndex(0)
 {
-    setAutoBufferSwap(true);
+    
 }
 
 VideoSurface::VideoSurface(VideoSource *source, QWidget* parent)
@@ -65,8 +65,8 @@ void VideoSurface::setSource(VideoSource *src)
 
 void VideoSurface::initializeGL()
 {
+    QGLWidget::initializeGL();
     qDebug() << "VideoSurface: Init";
-
     // pbo
     pbo[0] = new QOpenGLBuffer(QOpenGLBuffer::PixelUnpackBuffer);
     pbo[0]->setUsagePattern(QOpenGLBuffer::StreamDraw);


### PR DESCRIPTION
Hello,

this PR addresses three issues:
1. Opengl buffers are not flipped during paintGL. At least on Windows this prevents video from working. Enabling setAutoBufferSwap solves the problem.
2. Audio devices using special characters are not displayed correctly and cannot be opened.
According: http://openal.org/pipermail/openal/2014-August/000202.html at least on Windows the strings are UTF8 rather than any local encoding. I'm not sure about other platforms, so I just applied the change on windows.
3. Video is not correctly initialized in the av settings form (resolution not set). Furthermore the 0x0 resolution is removed and audio initialization code tries to avoid opening audio devices twice.

cheers
Martin
