### PR TITLE
Re-word 'Compact layout' → 'Compact contact list'

### DIFF
--- a/src/widget/form/settings/generalsettings.ui
+++ b/src/widget/form/settings/generalsettings.ui
@@ -193,7 +193,7 @@
           <item>
            <widget class="QCheckBox" name="cbCompactLayout">
             <property name="text">
-             <string>Compact layout</string>
+             <string>Compact contact list (required restart)</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
Apparently it can be worded better, to be more self-explanatory for users
