### PR TITLE
Context menu style fix for chat title

### DIFF
--- a/ui/settings/mainHead.css
+++ b/ui/settings/mainHead.css
@@ -1,4 +1,4 @@
-QWidget
+QWidget .QLabel, QWidget .QLineEdit
 {
     color: black;
     background: white;


### PR DESCRIPTION
This doesn't make the context menu "useful" (due to CroppingLabel hiding the QLineEdit when focus is lost), but makes it look better and consistent with the other context menus.
