### PR TITLE
URLs and emoticons in nicknames/status mesages in chat/friend list

### DIFF
--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -858,6 +858,9 @@ QSplitter:handle{
                  <property name="text">
                   <string>Your name</string>
                  </property>
+                 <property name="openExternalLinks">
+                  <bool>false</bool>
+                 </property>
                 </widget>
                </item>
                <item>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -940,6 +940,9 @@ QSplitter:handle{
                  <property name="text">
                   <string>Your status</string>
                  </property>
+                 <property name="highlightURLs">
+                  <bool>true</bool>
+                 </property>
                 </widget>
                </item>
               </layout>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -858,9 +858,6 @@ QSplitter:handle{
                  <property name="text">
                   <string>Your name</string>
                  </property>
-                 <property name="openExternalLinks">
-                  <bool>false</bool>
-                 </property>
                 </widget>
                </item>
                <item>
@@ -942,9 +939,6 @@ QSplitter:handle{
                  </property>
                  <property name="text">
                   <string>Your status</string>
-                 </property>
-                 <property name="openExternalLinks">
-                  <bool>false</bool>
                  </property>
                 </widget>
                </item>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -940,6 +940,9 @@ QSplitter:handle{
                  <property name="text">
                   <string>Your status</string>
                  </property>
+                 <property name="openExternalLinks">
+                  <bool>false</bool>
+                 </property>
                 </widget>
                </item>
               </layout>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -940,9 +940,6 @@ QSplitter:handle{
                  <property name="text">
                   <string>Your status</string>
                  </property>
-                 <property name="highlightURLs">
-                  <bool>true</bool>
-                 </property>
                 </widget>
                </item>
               </layout>

--- a/src/widget/croppinglabel.cpp
+++ b/src/widget/croppinglabel.cpp
@@ -45,7 +45,12 @@ void CroppingLabel::setEditable(bool editable)
         unsetCursor();
 }
 
-void CroppingLabel::setEdlideMode(Qt::TextElideMode elide)
+void CroppingLabel::setOpenExternalLinks(bool openExternalLinks)
+{
+    setOpenExternalLinks(openExternalLinks);
+}
+
+void CroppingLabel::setElideMode(Qt::TextElideMode elide)
 {
     elideMode = elide;
 }
@@ -118,14 +123,16 @@ bool CroppingLabel::eventFilter(QObject *obj, QEvent *e)
 
 void CroppingLabel::setElidedText()
 {
-    QString elidedText = fontMetrics().elidedText(origText, elideMode, width());
+    QString parsedText = Widget::parseURLs(origText, width());
+
+    QString elidedText = fontMetrics().elidedText(parsedText, elideMode, width());
  
     if (elidedText != origText)
         setToolTip(origText);
     else
         setToolTip(QString());
 
-    QLabel::setText(Widget::parseURLs(elidedText));
+    QLabel::setText(elidedText);
 }
 
 void CroppingLabel::hideTextEdit(bool acceptText)

--- a/src/widget/croppinglabel.cpp
+++ b/src/widget/croppinglabel.cpp
@@ -45,11 +45,6 @@ void CroppingLabel::setEditable(bool editable)
         unsetCursor();
 }
 
-void CroppingLabel::setOpenExternalLinks(bool openExternalLinks)
-{
-    setOpenExternalLinks(openExternalLinks);
-}
-
 void CroppingLabel::setElideMode(Qt::TextElideMode elide)
 {
     elideMode = elide;
@@ -123,16 +118,20 @@ bool CroppingLabel::eventFilter(QObject *obj, QEvent *e)
 
 void CroppingLabel::setElidedText()
 {
-    QString parsedText = Widget::parseURLs(origText, width());
+    QString elidedText = fontMetrics().elidedText(origText, elideMode, width());
 
-    QString elidedText = fontMetrics().elidedText(parsedText, elideMode, width());
- 
     if (elidedText != origText)
-        setToolTip(origText);
-    else
-        setToolTip(QString());
+    {
+        QString parsedText = Widget::parseURLs(origText, elidedText.length()-1);
+        QLabel::setTextFormat(Qt::RichText);
+        QLabel::setText(parsedText + "&hellip;");
+    } else {
+        QString parsedText = Widget::parseURLs(origText);
+        QLabel::setText(parsedText);
+    }
 
-    QLabel::setText(elidedText);
+    // Don't underline links in tooltips because they are unclickable
+    setToolTip(origText);
 }
 
 void CroppingLabel::hideTextEdit(bool acceptText)

--- a/src/widget/croppinglabel.cpp
+++ b/src/widget/croppinglabel.cpp
@@ -51,9 +51,14 @@ void CroppingLabel::setElideMode(Qt::TextElideMode elide)
     elideMode = elide;
 }
 
+void CroppingLabel::setHighlightURLs(bool highlightURLs)
+{
+    this->highlightURLs = highlightURLs;
+}
+
 void CroppingLabel::setClickableURLs(bool clickableURLs)
 {
-    this->highlightURLs = clickableURLs;
+    setHighlightURLs(clickableURLs);
     setOpenExternalLinks(clickableURLs);
 }
 

--- a/src/widget/croppinglabel.cpp
+++ b/src/widget/croppinglabel.cpp
@@ -122,10 +122,10 @@ void CroppingLabel::setElidedText()
 
     if (elidedText != origText)
     {
-        QString parsedText = Widget::parseURLs(origText, elidedText.length() - 1);
+        QString parsedText = Widget::parseMessage(origText, elidedText.length() - 1);
         QLabel::setText("<div>" + parsedText.trimmed() + "&hellip;</div>");
     } else {
-        QString parsedText = Widget::parseURLs(origText);
+        QString parsedText = Widget::parseMessage(origText);
         QLabel::setText(parsedText);
     }
 

--- a/src/widget/croppinglabel.cpp
+++ b/src/widget/croppinglabel.cpp
@@ -15,6 +15,7 @@
 */
 
 #include "croppinglabel.h"
+#include "src/widget/widget.h"
 #include <QResizeEvent>
 #include <QLineEdit>
 
@@ -25,6 +26,7 @@ CroppingLabel::CroppingLabel(QWidget* parent)
     , elideMode(Qt::ElideRight)
 {
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+    setOpenExternalLinks(true);
 
     textEdit = new QLineEdit(this);
     textEdit->hide();
@@ -117,12 +119,13 @@ bool CroppingLabel::eventFilter(QObject *obj, QEvent *e)
 void CroppingLabel::setElidedText()
 {
     QString elidedText = fontMetrics().elidedText(origText, elideMode, width());
+ 
     if (elidedText != origText)
         setToolTip(origText);
     else
         setToolTip(QString());
 
-    QLabel::setText(elidedText);
+    QLabel::setText(Widget::parseURLs(elidedText));
 }
 
 void CroppingLabel::hideTextEdit(bool acceptText)

--- a/src/widget/croppinglabel.cpp
+++ b/src/widget/croppinglabel.cpp
@@ -122,9 +122,8 @@ void CroppingLabel::setElidedText()
 
     if (elidedText != origText)
     {
-        QString parsedText = Widget::parseURLs(origText, elidedText.length()-1);
-        QLabel::setTextFormat(Qt::RichText);
-        QLabel::setText(parsedText + "&hellip;");
+        QString parsedText = Widget::parseURLs(origText, elidedText.length() - 1);
+        QLabel::setText("<div>" + parsedText.trimmed() + "&hellip;</div>");
     } else {
         QString parsedText = Widget::parseURLs(origText);
         QLabel::setText(parsedText);

--- a/src/widget/croppinglabel.cpp
+++ b/src/widget/croppinglabel.cpp
@@ -24,9 +24,10 @@ CroppingLabel::CroppingLabel(QWidget* parent)
     , blockPaintEvents(false)
     , editable(false)
     , elideMode(Qt::ElideRight)
+    , highlightURLs(false)
 {
     setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
-    setOpenExternalLinks(true);
+    setOpenExternalLinks(false);
 
     textEdit = new QLineEdit(this);
     textEdit->hide();
@@ -48,6 +49,12 @@ void CroppingLabel::setEditable(bool editable)
 void CroppingLabel::setElideMode(Qt::TextElideMode elide)
 {
     elideMode = elide;
+}
+
+void CroppingLabel::setClickableURLs(bool clickableURLs)
+{
+    this->highlightURLs = clickableURLs;
+    setOpenExternalLinks(clickableURLs);
 }
 
 void CroppingLabel::setText(const QString& text)
@@ -122,10 +129,10 @@ void CroppingLabel::setElidedText()
 
     if (elidedText != origText)
     {
-        QString parsedText = Widget::parseMessage(origText, elidedText.length() - 1);
+        QString parsedText = Widget::parseMessage(origText, highlightURLs, elidedText.length() - 1);
         QLabel::setText("<div>" + parsedText.trimmed() + "&hellip;</div>");
     } else {
-        QString parsedText = Widget::parseMessage(origText);
+        QString parsedText = Widget::parseMessage(origText, highlightURLs);
         QLabel::setText(parsedText);
     }
 

--- a/src/widget/croppinglabel.h
+++ b/src/widget/croppinglabel.h
@@ -29,6 +29,7 @@ public:
 
     void setEditable(bool editable);
     void setElideMode(Qt::TextElideMode elide);
+    void setClickableURLs(bool clickableURLs);
 
     virtual void setText(const QString& text);
     virtual void resizeEvent(QResizeEvent *ev);
@@ -54,6 +55,7 @@ private:
     bool blockPaintEvents;
     bool editable;
     Qt::TextElideMode elideMode;
+    bool highlightURLs;
 };
 
 #endif // CROPPINGLABEL_H

--- a/src/widget/croppinglabel.h
+++ b/src/widget/croppinglabel.h
@@ -29,6 +29,7 @@ public:
 
     void setEditable(bool editable);
     void setElideMode(Qt::TextElideMode elide);
+    void setHighlightURLs(bool highlightURLs);
     void setClickableURLs(bool clickableURLs);
 
     virtual void setText(const QString& text);

--- a/src/widget/croppinglabel.h
+++ b/src/widget/croppinglabel.h
@@ -28,7 +28,6 @@ public:
     explicit CroppingLabel(QWidget *parent = 0);
 
     void setEditable(bool editable);
-    void setOpenExternalLinks(bool openExternalLinks);
     void setElideMode(Qt::TextElideMode elide);
 
     virtual void setText(const QString& text);

--- a/src/widget/croppinglabel.h
+++ b/src/widget/croppinglabel.h
@@ -28,7 +28,8 @@ public:
     explicit CroppingLabel(QWidget *parent = 0);
 
     void setEditable(bool editable);
-    void setEdlideMode(Qt::TextElideMode elide);
+    void setOpenExternalLinks(bool openExternalLinks);
+    void setElideMode(Qt::TextElideMode elide);
 
     virtual void setText(const QString& text);
     virtual void resizeEvent(QResizeEvent *ev);

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -53,6 +53,7 @@ ChatForm::ChatForm(Friend* chatFriend)
     statusMessageLabel->setObjectName("statusLabel");
     statusMessageLabel->setFont(Style::getFont(Style::Medium));
     statusMessageLabel->setMinimumHeight(Style::getFont(Style::Medium).pixelSize());
+    statusMessageLabel->setClickableURLs(true);
 
     isTypingLabel = new QLabel();
     QFont font = isTypingLabel->font();

--- a/src/widget/form/groupchatform.cpp
+++ b/src/widget/form/groupchatform.cpp
@@ -23,6 +23,8 @@
 #include "src/widget/maskablepixmapwidget.h"
 #include "src/core.h"
 #include "src/misc/style.h"
+#include <QApplication>
+#include <QDesktopServices>
 #include <QPushButton>
 #include <QMimeData>
 #include <QDragEnterEvent>
@@ -52,6 +54,7 @@ GroupChatForm::GroupChatForm(Group* chatGroup)
     }
 
     nameLabel->setText(group->getGroupWidget()->getName());
+    nameLabel->setHighlightURLs(true);
 
     nusersLabel->setFont(Style::getFont(Style::Medium));
     nusersLabel->setText(GroupChatForm::tr("%1 users in chat","Number of users in chat").arg(group->getPeersCount()));
@@ -82,6 +85,7 @@ GroupChatForm::GroupChatForm(Group* chatGroup)
     connect(volButton, SIGNAL(clicked()), this, SLOT(onVolMuteToggle()));
     connect(nameLabel, &CroppingLabel::textChanged, this, [=](QString text, QString orig)
         {if (text != orig) emit groupTitleChanged(group->getGroupId(), text.left(128));} );
+    connect(nameLabel, &QLabel::linkActivated, this, &GroupChatForm::onLinkActivated);
 
     setAcceptDrops(true);
 }
@@ -126,6 +130,14 @@ void GroupChatForm::onUserListChanged()
         nameLabel->setObjectName("peersLabel");
         namesListLayout->addWidget(nameLabel);
     }
+}
+
+void GroupChatForm::onLinkActivated(const QString &link)
+{
+    // Only open links in group chat titles when Ctrl is held, to not block 
+    // normal editing
+    if (QApplication::queryKeyboardModifiers() & Qt::ControlModifier)
+        QDesktopServices::openUrl(link);
 }
 
 void GroupChatForm::dragEnterEvent(QDragEnterEvent *ev)

--- a/src/widget/form/groupchatform.h
+++ b/src/widget/form/groupchatform.h
@@ -43,6 +43,7 @@ private slots:
     void onMicMuteToggle();
     void onVolMuteToggle();
     void onCallClicked();
+    void onLinkActivated(const QString& link);
 
 protected:
     // drag & drop

--- a/src/widget/genericchatroomwidget.cpp
+++ b/src/widget/genericchatroomwidget.cpp
@@ -92,6 +92,8 @@ GenericChatroomWidget::GenericChatroomWidget(QWidget *parent)
 
     setProperty("active", false);
     setStyleSheet(Style::getStylesheet(":/ui/chatroomWidgets/genericChatroomWidget.css"));
+
+    connect(statusMessageLabel, &CroppingLabel::clicked, [&](){emit chatroomWidgetClicked(this);});
 }
 
 bool GenericChatroomWidget::isActive()

--- a/src/widget/genericchatroomwidget.cpp
+++ b/src/widget/genericchatroomwidget.cpp
@@ -56,7 +56,6 @@ GenericChatroomWidget::GenericChatroomWidget(QWidget *parent)
     // status text
     statusMessageLabel = new CroppingLabel(this);
     statusMessageLabel->setObjectName("status");
-    statusMessageLabel->setClickableURLs(true);
 
     // name text
     nameLabel = new CroppingLabel(this);

--- a/src/widget/genericchatroomwidget.cpp
+++ b/src/widget/genericchatroomwidget.cpp
@@ -56,6 +56,7 @@ GenericChatroomWidget::GenericChatroomWidget(QWidget *parent)
     // status text
     statusMessageLabel = new CroppingLabel(this);
     statusMessageLabel->setObjectName("status");
+    statusMessageLabel->setClickableURLs(true);
 
     // name text
     nameLabel = new CroppingLabel(this);

--- a/src/widget/tool/chatactions/chataction.cpp
+++ b/src/widget/tool/chatactions/chataction.cpp
@@ -15,6 +15,7 @@
 */
 
 #include "chataction.h"
+#include "src/widget/widget.h"
 #include <QStringList>
 #include <QBuffer>
 #include <QTextTable>
@@ -22,17 +23,6 @@
 #include <QTextEdit>
 
 QTextBlockFormat ChatAction::nameFormat, ChatAction::dateFormat;
-
-QString ChatAction::toHtmlChars(const QString &str)
-{
-    static QList<QPair<QString, QString>> replaceList = {{"&","&amp;"}, {">","&gt;"}, {"<","&lt;"}};
-    QString res = str;
-
-    for (auto &it : replaceList)
-        res = res.replace(it.first,it.second);
-
-    return res;
-}
 
 QString ChatAction::QImage2base64(const QImage &img)
 {
@@ -46,17 +36,17 @@ QString ChatAction::QImage2base64(const QImage &img)
 QString ChatAction::getName()
 {
     if (isMe)
-        return QString("<div class=%1>%2</div>").arg("name_me").arg(toHtmlChars(name));
+        return QString("<div class=%1>%2</div>").arg("name_me").arg(Widget::toHtmlChars(name));
     else
-        return QString("<div class=%1>%2</div>").arg("name").arg(toHtmlChars(name));
+        return QString("<div class=%1>%2</div>").arg("name").arg(Widget::toHtmlChars(name));
 }
 
 QString ChatAction::getDate()
 {
     if (isMe)
-        return QString("<div class=date_me>" + toHtmlChars(date) + "</div>");
+        return QString("<div class=date_me>" + Widget::toHtmlChars(date) + "</div>");
     else
-        return QString("<div class=date>" + toHtmlChars(date) + "</div>");
+        return QString("<div class=date>" + Widget::toHtmlChars(date) + "</div>");
 }
 
 void ChatAction::assignPlace(QTextTable *position, QTextEdit *te)

--- a/src/widget/tool/chatactions/chataction.h
+++ b/src/widget/tool/chatactions/chataction.h
@@ -47,7 +47,6 @@ protected:
     virtual QString getMessage() = 0;
     virtual QString getDate();
 
-    QString toHtmlChars(const QString &str);
     QString QImage2base64(const QImage &img);
 
 protected:

--- a/src/widget/tool/chatactions/messageaction.cpp
+++ b/src/widget/tool/chatactions/messageaction.cpp
@@ -15,8 +15,6 @@
 */
 
 #include "messageaction.h"
-#include "src/misc/smileypack.h"
-#include "src/misc/settings.h"
 #include "src/widget/widget.h"
 #include <QTextTable>
 
@@ -30,13 +28,9 @@ MessageAction::MessageAction(const QString &author, const QString &message, cons
 QString MessageAction::getMessage(QString div)
 {
     QString message_;
-    if (Settings::getInstance().getUseEmoticons())
-         message_ = SmileyPack::getInstance().smileyfied(toHtmlChars(message));
-    else
-         message_ = toHtmlChars(message);
 
-    // parse URL(s)
-    message_ = Widget::parseURLs(message_);
+    // parse message
+    message_ = Widget::parseMessage(message);
 
     // detect text quotes
     QStringList messageLines = message_.split("\n");

--- a/src/widget/tool/chatactions/messageaction.cpp
+++ b/src/widget/tool/chatactions/messageaction.cpp
@@ -17,6 +17,7 @@
 #include "messageaction.h"
 #include "src/misc/smileypack.h"
 #include "src/misc/settings.h"
+#include "src/widget/widget.h"
 #include <QTextTable>
 
 MessageAction::MessageAction(const QString &author, const QString &message, const QString &date, const bool &me) :
@@ -34,29 +35,8 @@ QString MessageAction::getMessage(QString div)
     else
          message_ = toHtmlChars(message);
 
-    // detect urls
-    QRegExp exp("(?:\\b)(www\\.|http[s]?:\\/\\/|ftp:\\/\\/|tox:\\/\\/|tox:)\\S+");
-    int offset = 0;
-    while ((offset = exp.indexIn(message_, offset)) != -1)
-    {
-        QString url = exp.cap();
-
-        // If there's a trailing " it's a HTML attribute, e.g. a smiley img's title=":tox:"
-        if (url == "tox:\"")
-        {
-            offset += url.length();
-            continue;
-        }
-
-        // add scheme if not specified
-        if (exp.cap(1) == "www.")
-            url.prepend("http://");
-
-        QString htmledUrl = QString("<a href=\"%1\">%1</a>").arg(url);
-        message_.replace(offset, exp.cap().length(), htmledUrl);
-
-        offset += htmledUrl.length();
-    }
+    // parse URL(s)
+    message_ = Widget::parseURLs(message_);
 
     // detect text quotes
     QStringList messageLines = message_.split("\n");

--- a/src/widget/tool/chatactions/systemmessageaction.cpp
+++ b/src/widget/tool/chatactions/systemmessageaction.cpp
@@ -15,6 +15,7 @@
 */
 
 #include "systemmessageaction.h"
+#include "src/widget/widget.h"
 
 SystemMessageAction::SystemMessageAction(const QString &message, const QString &type, const QString &date) :
     ChatAction(false, QString(), date),
@@ -25,5 +26,5 @@ SystemMessageAction::SystemMessageAction(const QString &message, const QString &
 
 QString SystemMessageAction::getMessage()
 {
-    return QString("<table width=100%><tr><td align=center><div class=" + type + ">" + toHtmlChars(message) + "</td><tr></div></table>");
+    return QString("<table width=100%><tr><td align=center><div class=" + type + ">" + Widget::toHtmlChars(message) + "</td><tr></div></table>");
 }

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1274,7 +1274,7 @@ void Widget::reloadTheme()
         g->getGroupWidget()->reloadTheme();
 }
 
-QString Widget::parseURLs(QString message)
+QString Widget::parseURLs(QString message, int maxLength)
 {
     // detect urls
     QRegExp exp("(?:\\b)(www\\.|http[s]?:\\/\\/|ftp:\\/\\/|tox:\\/\\/|tox:)\\S+");
@@ -1294,10 +1294,26 @@ QString Widget::parseURLs(QString message)
         if (exp.cap(1) == "www.")
             url.prepend("http://");
 
-        QString htmledUrl = QString("<a href=\"%1\">%1</a>").arg(url);
+        QString htmledUrl;
+
+        if (maxLength == -1)
+            htmledUrl = QString("<a href=\"%1\">%1</a>").arg(url);
+        else
+            htmledUrl = QString("<a href=\"%1\">%2</a>").arg(url, url.left(maxLength));
+
         message.replace(offset, exp.cap().length(), htmledUrl);
 
         offset += htmledUrl.length();
+
+        if (maxLength == -1)
+            continue;
+
+        maxLength -= url.length();
+
+        if (maxLength <= 0)
+            // If we aren't allowed to use any more characters, it makes 
+            // no sense to continue, so just return the message as-is here.
+            return message;
     }
 
     return message;

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1299,21 +1299,22 @@ QString Widget::parseURLs(QString message, int maxLength)
         if (maxLength == -1)
             htmledUrl = QString("<a href=\"%1\">%1</a>").arg(url);
         else
-            htmledUrl = QString("<a href=\"%1\">%2</a>").arg(url, url.left(maxLength));
+            htmledUrl = QString("<a href=\"%1\">%2</a>").arg(url, url.left(maxLength-offset));
 
         message.replace(offset, exp.cap().length(), htmledUrl);
 
         offset += htmledUrl.length();
 
-        if (maxLength == -1)
-            continue;
+        if (maxLength != -1 && maxLength < offset)
+            maxLength = offset;
+    }
 
-        maxLength -= url.length();
-
-        if (maxLength <= 0)
-            // If we aren't allowed to use any more characters, it makes 
-            // no sense to continue, so just return the message as-is here.
-            return message;
+    if (maxLength != -1 && message.length() != maxLength + 1)
+    {
+        if (maxLength < offset)
+            return message.left(offset);
+        else
+            return message.left(maxLength);
     }
 
     return message;

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1273,3 +1273,32 @@ void Widget::reloadTheme()
     for (Group* g : GroupList::getAllGroups())
         g->getGroupWidget()->reloadTheme();
 }
+
+QString Widget::parseURLs(QString message)
+{
+    // detect urls
+    QRegExp exp("(?:\\b)(www\\.|http[s]?:\\/\\/|ftp:\\/\\/|tox:\\/\\/|tox:)\\S+");
+    int offset = 0;
+    while ((offset = exp.indexIn(message, offset)) != -1)
+    {
+        QString url = exp.cap();
+
+        // If there's a trailing " it's a HTML attribute, e.g. a smiley img's title=":tox:"
+        if (url == "tox:\"")
+        {
+            offset += url.length();
+            continue;
+        }
+
+        // add scheme if not specified
+        if (exp.cap(1) == "www.")
+            url.prepend("http://");
+
+        QString htmledUrl = QString("<a href=\"%1\">%1</a>").arg(url);
+        message.replace(offset, exp.cap().length(), htmledUrl);
+
+        offset += htmledUrl.length();
+    }
+
+    return message;
+}

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -78,6 +78,8 @@ public:
 
     void reloadTheme();
 
+    static QString parseURLs(QString message);
+
 public slots:
     void onSettingsClicked();
     void setWindowTitle(const QString& title);

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -79,7 +79,7 @@ public:
     void reloadTheme();
 
     static QString toHtmlChars(const QString &str);
-    static QString parseMessage(QString message, int maxLength = -1);
+    static QString parseMessage(QString message, bool parseURLs = true, int maxLength = -1);
 
 public slots:
     void onSettingsClicked();

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -78,7 +78,7 @@ public:
 
     void reloadTheme();
 
-    static QString parseURLs(QString message);
+    static QString parseURLs(QString message, int maxLength = -1);
 
 public slots:
     void onSettingsClicked();

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -78,7 +78,8 @@ public:
 
     void reloadTheme();
 
-    static QString parseURLs(QString message, int maxLength = -1);
+    static QString toHtmlChars(const QString &str);
+    static QString parseMessage(QString message, int maxLength = -1);
 
 public slots:
     void onSettingsClicked();


### PR DESCRIPTION
Windows Live Messager. Those were the days, right? So yes, this pull request adds support for URLs and smileys in nicknames/status messages in chats/friend list.

However, IT IS NOT COMPLETE. Please do NOT consider merging this yet. I'm making this pull request in the hope of getting some support to fix the last issues:
- [ ] Messages ending on a link do not get ellipsis

![snapshot142](https://cloud.githubusercontent.com/assets/1885159/5891669/8149f764-a4a3-11e4-8897-c0a40225c662.png)
- [ ] Images get broken if there is not enough space for them

![snapshot142](https://cloud.githubusercontent.com/assets/1885159/5891675/a5bc09d4-a4a3-11e4-8186-72b7e94c59ea.png)
- [ ] Disabling/enabling emoticons doesn't instantly hide/show them in the friend list
- [ ] The code is ugly :(

Other discussion-worthy questions:
- Do we want to allow URLs in nicknames?
- This breaks editing group chat titles by clicking on them which are completely URL because the URL gets opened. Is this to be considered a regression? Should this be solved? If so, how? (Please note that you can still change the title by right-clicking it in the friend list and selecting "Set Title...")
