### PR TITLE
Arrow up to paste previous message

### DIFF
--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -143,6 +143,8 @@ void ChatForm::onSendTriggered()
             rec = Core::getInstance()->sendMessage(f->getFriendID(), qt_msg);
 
         registerReceipt(rec, id, ma);
+        
+        msgEdit->setLastMessage(msg); //set last message only when sending it
     }
 
     msgEdit->clear();

--- a/src/widget/tool/chattextedit.cpp
+++ b/src/widget/tool/chattextedit.cpp
@@ -16,6 +16,7 @@
 
 #include "chattextedit.h"
 #include <QKeyEvent>
+#include <QDebug>
 
 ChatTextEdit::ChatTextEdit(QWidget *parent) :
     QTextEdit(parent)
@@ -31,9 +32,31 @@ void ChatTextEdit::keyPressEvent(QKeyEvent * event)
         emit enterPressed();
     else if (key == Qt::Key_Tab)
         emit tabPressed();
+    else if (key == Qt::Key_Up && this->toPlainText().isEmpty())
+    {
+        this->setText(lastMessage);
+        this->setFocus();
+    }
+    else if (key == Qt::Key_Up && !this->toPlainText().isEmpty())
+    {
+        currentMessage = this->toPlainText();
+        this->setText(lastMessage);
+    }
+    else if (key == Qt::Key_Down && !currentMessage.isEmpty())
+    {
+        this->setPlainText(currentMessage);
+        currentMessage.clear();
+    }
+    else if (key == Qt::Key_Down)
+        this->clear();
     else
     {
         emit keyPressed();
         QTextEdit::keyPressEvent(event);
     }
+}
+
+void ChatTextEdit::setLastMessage(QString lm)
+{
+    lastMessage = lm;
 }

--- a/src/widget/tool/chattextedit.cpp
+++ b/src/widget/tool/chattextedit.cpp
@@ -16,7 +16,6 @@
 
 #include "chattextedit.h"
 #include <QKeyEvent>
-#include <QDebug>
 
 ChatTextEdit::ChatTextEdit(QWidget *parent) :
     QTextEdit(parent)
@@ -33,10 +32,7 @@ void ChatTextEdit::keyPressEvent(QKeyEvent * event)
     else if (key == Qt::Key_Tab)
         emit tabPressed();
     else if (key == Qt::Key_Up && this->toPlainText().isEmpty())
-    {
         this->setText(lastMessage);
-        this->setFocus();
-    }
     else if (key == Qt::Key_Up && !this->toPlainText().isEmpty())
     {
         currentMessage = this->toPlainText();

--- a/src/widget/tool/chattextedit.cpp
+++ b/src/widget/tool/chattextedit.cpp
@@ -31,6 +31,14 @@ void ChatTextEdit::keyPressEvent(QKeyEvent * event)
         emit enterPressed();
     else if (key == Qt::Key_Tab)
         emit tabPressed();
+    /**
+    If message box is empty, it will paste previous message on arrow up
+    if message box is not empty,
+    it will copy current(2) text and paste previous(1) message,
+    to paste previous message(2) press arrow down,
+    press arrow down twice to clear mesage box,
+    only previous message(1) is available to paste now.
+      */
     else if (key == Qt::Key_Up && this->toPlainText().isEmpty())
         this->setText(lastMessage);
     else if (key == Qt::Key_Up && !this->toPlainText().isEmpty())

--- a/src/widget/tool/chattextedit.cpp
+++ b/src/widget/tool/chattextedit.cpp
@@ -41,7 +41,8 @@ void ChatTextEdit::keyPressEvent(QKeyEvent * event)
       */
     else if (key == Qt::Key_Up && this->toPlainText().isEmpty())
         this->setText(lastMessage);
-    else if (key == Qt::Key_Up && !this->toPlainText().isEmpty())
+    else if (key == Qt::Key_Up && !this->toPlainText().isEmpty()
+             && lastMessage != this->toPlainText())
     {
         currentMessage = this->toPlainText();
         this->setText(lastMessage);
@@ -51,8 +52,6 @@ void ChatTextEdit::keyPressEvent(QKeyEvent * event)
         this->setPlainText(currentMessage);
         currentMessage.clear();
     }
-    else if (key == Qt::Key_Down)
-        this->clear();
     else
     {
         emit keyPressed();

--- a/src/widget/tool/chattextedit.h
+++ b/src/widget/tool/chattextedit.h
@@ -25,13 +25,16 @@ class ChatTextEdit : public QTextEdit
 public:
     explicit ChatTextEdit(QWidget *parent = 0);
     virtual void keyPressEvent(QKeyEvent * event) override;
-
+    void setLastMessage(QString lm);
+    
 signals:
     void enterPressed();
     void tabPressed();
     void keyPressed();
-
-public slots:
+    
+private:
+    QString lastMessage,
+            currentMessage;
 
 };
 


### PR DESCRIPTION
If message box is empty, it will paste previous message on arrow up
if message box is not empty, it will copy current(2) text and paste previous(1) message, to paste previous message(2) press arrow down, press arrow down twice to clear mesage box, only previous message(1) is available to paste now.
