### PR TITLE
fixing problem with +1 lines in msg edit

### DIFF
--- a/src/widget/tool/chattextedit.cpp
+++ b/src/widget/tool/chattextedit.cpp
@@ -25,32 +25,17 @@ ChatTextEdit::ChatTextEdit(QWidget *parent) :
 }
 
 void ChatTextEdit::keyPressEvent(QKeyEvent * event)
-{
+{    
     int key = event->key();
     if ((key == Qt::Key_Enter || key == Qt::Key_Return) && !(event->modifiers() && Qt::ShiftModifier))
         emit enterPressed();
     else if (key == Qt::Key_Tab)
         emit tabPressed();
-    /**
-    If message box is empty, it will paste previous message on arrow up
-    if message box is not empty,
-    it will copy current(2) text and paste previous(1) message,
-    to paste previous message(2) press arrow down,
-    press arrow down twice to clear mesage box,
-    only previous message(1) is available to paste now.
-      */
     else if (key == Qt::Key_Up && this->toPlainText().isEmpty())
-        this->setText(lastMessage);
-    else if (key == Qt::Key_Up && !this->toPlainText().isEmpty()
-             && lastMessage != this->toPlainText())
     {
-        currentMessage = this->toPlainText();
         this->setText(lastMessage);
-    }
-    else if (key == Qt::Key_Down && !currentMessage.isEmpty())
-    {
-        this->setPlainText(currentMessage);
-        currentMessage.clear();
+        this->setFocus();
+        this->moveCursor(QTextCursor::MoveOperation::End,QTextCursor::MoveMode::MoveAnchor);
     }
     else
     {

--- a/src/widget/tool/chattextedit.h
+++ b/src/widget/tool/chattextedit.h
@@ -31,11 +31,9 @@ signals:
     void enterPressed();
     void tabPressed();
     void keyPressed();
-    
-private:
-    QString lastMessage,
-            currentMessage;
 
+private:
+    QString lastMessage;
 };
 
 #endif // CHATTEXTEDIT_H


### PR DESCRIPTION
This was very buggy when user typed more than one line in msg edit, shourtcut related with Key_Down had to be removed.
