### PR TITLE
Fix keypad enter not sending message

### DIFF
--- a/src/widget/tool/chattextedit.cpp
+++ b/src/widget/tool/chattextedit.cpp
@@ -27,7 +27,7 @@ ChatTextEdit::ChatTextEdit(QWidget *parent) :
 void ChatTextEdit::keyPressEvent(QKeyEvent * event)
 {    
     int key = event->key();
-    if ((key == Qt::Key_Enter || key == Qt::Key_Return) && !(event->modifiers() && Qt::ShiftModifier))
+    if ((key == Qt::Key_Enter || key == Qt::Key_Return) && !(event->modifiers() & Qt::ShiftModifier))
         emit enterPressed();
     else if (key == Qt::Key_Tab)
         emit tabPressed();


### PR DESCRIPTION
Issue #1068

This fixes the issue when you press the keypad enter the message was not sent because keypad enter sends a modifier, and if any modifier was present it would not send the message.
