### PR TITLE
Add support for playback audio slider setting

### DIFF
--- a/src/audio.cpp
+++ b/src/audio.cpp
@@ -41,6 +41,7 @@ ALCdevice* Audio::alInDev{nullptr};
 ALCdevice* Audio::alOutDev{nullptr};
 ALCcontext* Audio::alContext{nullptr};
 ALuint Audio::alMainSource{0};
+float Audio::outputVolume{1.0};
 
 void audioDebugLog(QString msg)
 {
@@ -261,7 +262,10 @@ void Audio::playGroupAudio(int group, int peer, const int16_t* data,
         return;
 
     if (!call.alSources.contains(peer))
+    {
         alGenSources(1, &call.alSources[peer]);
+        alSourcef(call.alSources[peer], AL_GAIN, outputVolume);
+    }
 
     playAudioBuffer(call.alSources[peer], data, samples, channels, sample_rate);
 }
@@ -301,6 +305,7 @@ void Audio::playAudioBuffer(ALuint alSource, const int16_t *data, int samples, u
 
     ALint state;
     alGetSourcei(alSource, AL_SOURCE_STATE, &state);
+    alSourcef(alSource, AL_GAIN, outputVolume);
     if (state != AL_PLAYING)
         alSourcePlay(alSource);
 }

--- a/src/audio.h
+++ b/src/audio.h
@@ -73,6 +73,7 @@ public:
     static QThread* audioThread;
     static ALCcontext* alContext;
     static ALuint alMainSource;
+    static float outputVolume;
 
 private:
     explicit Audio()=default;

--- a/src/coreav.cpp
+++ b/src/coreav.cpp
@@ -559,6 +559,7 @@ void Core::playAudioBuffer(ALuint alSource, const int16_t *data, int samples, un
 
     ALint state;
     alGetSourcei(alSource, AL_SOURCE_STATE, &state);
+    alSourcef(alSource, AL_GAIN, Audio::outputVolume);
     if (state != AL_PLAYING)
     {
         alSourcePlay(alSource);

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -47,6 +47,7 @@ AVForm::AVForm() :
     connect(bodyUI->outDevCombobox, qcomboboxIndexChanged, this, &AVForm::onOutDevChanged);
     connect(bodyUI->filterAudio, SIGNAL(toggled(bool)), this, SLOT(onFilterAudioToggled(bool)));
     connect(bodyUI->rescanButton, &QPushButton::clicked, this, [=](){getAudioInDevices(); getAudioOutDevices();});
+    bodyUI->playbackSlider->setValue(100);
 }
 
 AVForm::~AVForm()
@@ -257,4 +258,9 @@ void AVForm::on_SaturationSlider_valueChanged(int value)
 void AVForm::on_ContrastSlider_valueChanged(int value)
 {
     Camera::getInstance()->setProp(Camera::CONTRAST, value / 100.0);
+}
+
+void AVForm::on_playbackSlider_valueChanged(int value)
+{
+    Audio::getInstance().outputVolume = value / 100.0;
 }

--- a/src/widget/form/settings/avform.h
+++ b/src/widget/form/settings/avform.h
@@ -53,6 +53,7 @@ private slots:
     void onInDevChanged(const QString& deviceDescriptor);
     void onOutDevChanged(const QString& deviceDescriptor);
     void onFilterAudioToggled(bool filterAudio);
+    void on_playbackSlider_valueChanged(int value);
 
     // camera
     void onPropProbingFinished(Camera::Prop prop, double val);

--- a/src/widget/form/settings/avsettings.ui
+++ b/src/widget/form/settings/avsettings.ui
@@ -61,8 +61,7 @@
              <enum>Qt::Horizontal</enum>
             </property>
             <property name="toolTip">
-             <string>Use slider to set volume of your speakers.
-WARNING: slider is not supposed to work yet.</string>
+             <string>Use slider to set volume of your speakers.</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
This adds the support to change the sliders for the playback audio in the settings. There might be a better way to do this. This does work however, from what I've tested.
#1074
