### PR TITLE
Change warning message to less confusing one

### DIFF
--- a/src/toxdns.cpp
+++ b/src/toxdns.cpp
@@ -220,8 +220,10 @@ fallbackOnTox1:
 #if TOX1_SILENT_FALLBACK
     toxIdStr = queryTox1(record, silent);
 #elif TOX1_ASK_FALLBACK
-    QMessageBox::StandardButton btn = QMessageBox::warning(nullptr, "qTox", tr("It appears that qTox has to use the old tox1 protocol.\n\
-Unfortunately tox1 is not secure. Should it be used anyway?"), QMessageBox::Yes|QMessageBox::No, QMessageBox::No);
+    QMessageBox::StandardButton btn = QMessageBox::warning(nullptr, "qTox", tr("It appears that qTox has to use the old tox1 protocol to access DNS record of your friend's Tox ID.\n\
+Unfortunately tox1 is not secure, and you are at risk of someone hijacking what is sent between you and ToxDNS service.\n\
+Should tox1 be used anyway?\n\
+If unsure, press “No”, so that request to ToxDNS service will not be made using unsecure protocol."), QMessageBox::Yes|QMessageBox::No, QMessageBox::No);
     if (btn == QMessageBox::Yes)
         queryTox1(record, silent);
 #endif
@@ -264,8 +266,10 @@ ToxID ToxDNS::resolveToxAddress(const QString &address, bool silent)
 #if TOX1_SILENT_FALLBACK
             toxId = ToxID::fromString(queryTox1(address, silent));
 #elif TOX1_ASK_FALLBACK
-            QMessageBox::StandardButton btn = QMessageBox::warning(nullptr, "qTox", tr("It appears that qTox has to use the old tox1 protocol.\n\
-Unfortunately tox1 is not secure. Should it be used anyway?"), QMessageBox::Ok|QMessageBox::No, QMessageBox::No);
+            QMessageBox::StandardButton btn = QMessageBox::warning(nullptr, "qTox", tr("It appears that qTox has to use the old tox1 protocol to access DNS record of your friend's Tox ID.\n\
+Unfortunately tox1 is not secure, and you are at risk of someone hijacking what is sent between you and ToxDNS service.\n\
+Should tox1 be used anyway?\n\
+If unsure, press “No”, so that request to ToxDNS service will not be made using unsecure protocol."), QMessageBox::Ok|QMessageBox::No, QMessageBox::No);
             if (btn == QMessageBox::Ok)
                 toxId = ToxID::fromString(queryTox1(address, silent));
 #else


### PR DESCRIPTION
Previous message without context causes confusion about security of Tox
