### PR TITLE
Attempted to make Greentext better.

### DIFF
--- a/src/widget/tool/chatactions/messageaction.cpp
+++ b/src/widget/tool/chatactions/messageaction.cpp
@@ -63,7 +63,7 @@ QString MessageAction::getMessage(QString div)
     message_ = "";
     for (QString& s : messageLines)
     {
-        if (QRegExp("^&gt; .*(\\w{1,}|\\d{1,}).*").exactMatch(s))
+        if (QRegExp("^&gt;.*(\\w{1,}|\\d{1,}).*").exactMatch(s))
             message_ += "<span class=quote>" + s + "</span><br/>";
         else
             message_ += s + "<br/>";

--- a/src/widget/tool/chatactions/messageaction.cpp
+++ b/src/widget/tool/chatactions/messageaction.cpp
@@ -63,7 +63,7 @@ QString MessageAction::getMessage(QString div)
     message_ = "";
     for (QString& s : messageLines)
     {
-        if (QRegExp("^&gt;( |[[]|&gt;|[^_\\d\\W]).*").exactMatch(s))
+        if (QRegExp("^&gt; .*(\\w{1,}|\\d{1,}).*").exactMatch(s))
             message_ += "<span class=quote>" + s + "</span><br/>";
         else
             message_ += s + "<br/>";


### PR DESCRIPTION
If I understand how the strings here work. This should make it so that only text that contains at least 1 'word' or 'diget' character, will be greentexed. allowing for things like >_< to be completely fine, while >What are you talking about   will be greentexted, as well as anything more obscure such as > _Im_not_sure_why_youd_greentext_this     as well.

Please tell me if I've misunderstood how the regex's work, I find them a bit confusing, and I will happily fix this if I've done it wrong.
