### PR TITLE
Add Dutch translation

### DIFF
--- a/res.qrc
+++ b/res.qrc
@@ -54,6 +54,7 @@
         <file>translations/fi.qm</file>
         <file>translations/fr.qm</file>
         <file>translations/it.qm</file>
+        <file>translations/nl.qm</file>
         <file>translations/lt.qm</file>
         <file>translations/mannol.qm</file>
         <file>translations/pirate.qm</file>

--- a/translations/i18n.pri
+++ b/translations/i18n.pri
@@ -6,6 +6,7 @@ TRANSLATIONS = translations/es.ts \
                translations/fi.ts \
                translations/fr.ts \
                translations/it.ts \
+               translations/nl.ts \
                translations/lt.ts \
                translations/mannol.ts \
                translations/pirate.ts \

--- a/translations/nl.ts
+++ b/translations/nl.ts
@@ -1,0 +1,1967 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="nl_NL">
+<context>
+    <name>AVForm</name>
+    <message>
+        <location filename="../src/widget/form/settings/avform.cpp" line="35"/>
+        <source>Audio/Video</source>
+        <translation>Audio/Video</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/avform.cpp" line="77"/>
+        <source>Initializing Camera...</source>
+        <translation>Camera initialiseren...</translation>
+    </message>
+</context>
+<context>
+    <name>AVSettings</name>
+    <message>
+        <location filename="../src/widget/form/settings/avsettings.ui" line="41"/>
+        <source>Audio Settings</source>
+        <translation>Audio Instellingen</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/avsettings.ui" line="47"/>
+        <source>Microphone</source>
+        <translation>Microfoonvolume</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/avsettings.ui" line="54"/>
+        <source>Playback</source>
+        <translation>Afspeelvolume</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/avsettings.ui" line="64"/>
+        <source>Use slider to set volume of your speakers.</source>
+        <translation>Gebruik de slider om het volume van de speakers in te stellen.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/avsettings.ui" line="74"/>
+        <source>Use slider to set volume of your microphone.
+WARNING: slider is not supposed to work yet.</source>
+        <translation>Gebruik de slider om de volume van je microfoon in te stellen
+LET OP: deze slider hoort nog niet te werken.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/avsettings.ui" line="82"/>
+        <source>Playback device</source>
+        <translation>Afspeelapparaat</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/avsettings.ui" line="89"/>
+        <source>Capture device</source>
+        <translation>Microfoon</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/avsettings.ui" line="102"/>
+        <source>Rescan audio devices</source>
+        <translation>Zoek audio apparaten</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/avsettings.ui" line="109"/>
+        <source>Filter audio</source>
+        <translation>Filter audio</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/avsettings.ui" line="112"/>
+        <source>Filter sound from your microphone, so that people hearing you would get better sound.</source>
+        <translation>Filter het geluid van je microfoon, zo dat anderen je beter kunnen horen.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/avsettings.ui" line="122"/>
+        <source>Video Settings</source>
+        <translation>Video Instellingen</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/avsettings.ui" line="133"/>
+        <source>Resolution</source>
+        <translation>Resolutie</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/avsettings.ui" line="136"/>
+        <location filename="../src/widget/form/settings/avsettings.ui" line="153"/>
+        <source>Set resolution of your camera.
+The higher values, the better video quality your friends may get.
+Note though that with better video quality there is needed better internet connection.
+Sometimes your connection may not be good enough to handle higher video quality,
+which may lead to problems with video calls.</source>
+        <translation>Stel de resolutie van je camera in.
+Hoe hoger de resolutie, des de beter de video kwaliteit die je vrienden te zijn krijgen.
+Let er echter op dat een hogere resolutie meer bandbreedte gebruikt.
+Het kan mogelijk zijn dat je internetverbinding niet snel genoeg is om een hogere video kwaliteit te ondersteunen,
+wat tot problemen kan leiden met videogesprekken.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/avsettings.ui" line="164"/>
+        <source>Hue</source>
+        <translation>Tint</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/avsettings.ui" line="178"/>
+        <source>Brightness</source>
+        <translation>Helderheid</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/avsettings.ui" line="192"/>
+        <source>Saturation</source>
+        <translation>Verzadiging</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/avsettings.ui" line="206"/>
+        <source>Contrast</source>
+        <translation>Contrast</translation>
+    </message>
+</context>
+<context>
+    <name>AddFriendForm</name>
+    <message>
+        <location filename="../src/widget/form/addfriendform.cpp" line="34"/>
+        <source>Add Friends</source>
+        <translation>Voeg vrienden toe</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/addfriendform.cpp" line="37"/>
+        <source>Tox ID</source>
+        <comment>Tox ID of the person you&apos;re sending a friend request to</comment>
+        <translation>Tox ID</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/addfriendform.cpp" line="38"/>
+        <source>Message</source>
+        <comment>The message you send in friend requests</comment>
+        <translation>Bericht</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/addfriendform.cpp" line="39"/>
+        <source>Send friend request</source>
+        <translation>Verstuur vriend verzoek</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/addfriendform.cpp" line="40"/>
+        <source>Tox me maybe?</source>
+        <comment>Default message in friend requests if the field is left blank. Write something appropriate!</comment>
+        <translation>Tox met me!</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/addfriendform.cpp" line="89"/>
+        <source>Please fill in a valid Tox ID</source>
+        <comment>Tox ID of the friend you&apos;re sending a friend request to</comment>
+        <translation>Vul alstublieft een geldig Tox ID in</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/addfriendform.cpp" line="92"/>
+        <source>You can&apos;t add yourself as a friend!</source>
+        <comment>When trying to add your own Tox ID as friend</comment>
+        <translation>Je kunt jezelf niet als vriend toevoegen!</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/addfriendform.cpp" line="100"/>
+        <source>qTox needs to use the Tox DNS, but can&apos;t do it through a proxy.
+Ignore the proxy and connect to the Internet directly?</source>
+        <translation>qTox moet gebruik maken van Tox DNS, maar kan dit niet via een proxy doen.
+Proxy omzeilen en een directe internetverbinding gebruiken?</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/addfriendform.cpp" line="110"/>
+        <source>This Tox ID does not exist</source>
+        <comment>DNS error</comment>
+        <translation>Deze Tox ID bestaat niet</translation>
+    </message>
+</context>
+<context>
+    <name>AdvancedForm</name>
+    <message>
+        <location filename="../src/widget/form/settings/advancedform.cpp" line="25"/>
+        <source>Advanced</source>
+        <translation>Gevorderd</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/advancedform.cpp" line="35"/>
+        <source>FULL - very safe, slowest (recommended)</source>
+        <translation>VOLLEDIG - zeer veilig, het langzaamst (aangeraden)</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/advancedform.cpp" line="36"/>
+        <source>NORMAL - almost as safe as FULL, about 20% faster than FULL</source>
+        <translation>NORMAAL - bijna zo veilig als VOLLEDIG, ongeveer 20% sneller dan VOLLEDIG</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/advancedform.cpp" line="37"/>
+        <source>OFF - disables all safety, when something goes wrong your history may be lost, fastest (not recommended)</source>
+        <translation>UIT - schakeld alle veiligheid uit, als iets mis gaat kan de complete geschiedenis verloren gaan, het snelste (niet aangeraden)</translation>
+    </message>
+</context>
+<context>
+    <name>AdvancedSettings</name>
+    <message>
+        <location filename="../src/widget/form/settings/advancedsettings.ui" line="14"/>
+        <source>Form</source>
+        <translation>Formulier</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/advancedsettings.ui" line="35"/>
+        <source>Save settings to the working directory instead of the usual conf dir</source>
+        <extracomment>describes makeToxPortable checkbox</extracomment>
+        <translation>Sla instellingen op in de map waarin qTox draait in plaats van de normale configuratielocatie</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/advancedsettings.ui" line="38"/>
+        <source>Make Tox portable</source>
+        <translation>Maak Tox draagbaar</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/advancedsettings.ui" line="45"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; color:#ff0000;&quot;&gt;IMPORTANT NOTE&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;Unless you &lt;/span&gt;&lt;span style=&quot; font-weight:600; color:#ff0000;&quot;&gt;really&lt;/span&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt; know what you are doing, please do &lt;/span&gt;&lt;span style=&quot; font-weight:600; color:#ff0000;&quot;&gt;not&lt;/span&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt; change anything here. Changes made here may lead to problems with qTox, and even to loss of your data, e.g. history.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;ody&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; color:#ff0000;&quot;&gt;BELANGRIJKE MELDING&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;Tenzij je &lt;/span&gt;&lt;span style=&quot; font-weight:600; color:#ff0000;&quot;&gt;echt&lt;/span&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt; weet wat je doet, verander hier alsjeblieft &lt;/span&gt;&lt;span style=&quot; font-weight:600; color:#ff0000;&quot;&gt;geen&lt;/span&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt; instellingen. Veranderingen hier kunnen tot problemen met qTox leiden of zelfs tot dataverlies van bijvoorbeeld chatgeschiedenis.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/advancedsettings.ui" line="61"/>
+        <source>Reset to default settings</source>
+        <translation>Herstel standaardinstellingen</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/advancedsettings.ui" line="68"/>
+        <source>Chat history</source>
+        <translation>Chatgeschiedenis</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/advancedsettings.ui" line="76"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;http://www.sqlite.org/pragma.html#pragma_synchronous&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Synchronous writing to DB&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;http://www.sqlite.org/pragma.html#pragma_synchronous&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Synchroon schrijven naar de database&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>Android</name>
+    <message>
+        <location filename="../src/android.ui" line="14"/>
+        <source>Form</source>
+        <translation>Formulier</translation>
+    </message>
+    <message>
+        <location filename="../src/android.ui" line="531"/>
+        <source>Your name</source>
+        <translation>Naam</translation>
+    </message>
+    <message>
+        <location filename="../src/android.ui" line="616"/>
+        <source>Your status</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <location filename="../src/android.ui" line="767"/>
+        <source>Add friends</source>
+        <translation>Voeg vrienden toe</translation>
+    </message>
+    <message>
+        <location filename="../src/android.ui" line="805"/>
+        <source>Create a group chat</source>
+        <translation>Maak een groepsgesprek aan</translation>
+    </message>
+    <message>
+        <location filename="../src/android.ui" line="840"/>
+        <source>View completed file transfers</source>
+        <translation>Bekijk voltooide bestandsoverdrachten</translation>
+    </message>
+    <message>
+        <location filename="../src/android.ui" line="872"/>
+        <source>Change your settings</source>
+        <translation>Verander je instellingen</translation>
+    </message>
+</context>
+<context>
+    <name>AndroidGUI</name>
+    <message>
+        <location filename="../src/widget/androidgui.cpp" line="45"/>
+        <source>Online</source>
+        <comment>Button to set your status to &apos;Online&apos;</comment>
+        <translation>Online</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/androidgui.cpp" line="47"/>
+        <source>Away</source>
+        <comment>Button to set your status to &apos;Away&apos;</comment>
+        <translation>Afwezig</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/androidgui.cpp" line="49"/>
+        <source>Busy</source>
+        <comment>Button to set your status to &apos;Busy&apos;</comment>
+        <translation>Bezet</translation>
+    </message>
+</context>
+<context>
+    <name>ChatForm</name>
+    <message>
+        <location filename="../src/widget/form/chatform.cpp" line="83"/>
+        <source>Load chat history...</source>
+        <translation>Laad chatgeschiedenis...</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/chatform.cpp" line="181"/>
+        <source>Send a file</source>
+        <translation>Verstuur een bestand</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/chatform.cpp" line="189"/>
+        <location filename="../src/widget/form/chatform.cpp" line="760"/>
+        <source>File not read</source>
+        <translation>Bestand niet gelezen</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/chatform.cpp" line="189"/>
+        <location filename="../src/widget/form/chatform.cpp" line="760"/>
+        <source>qTox wasn&apos;t able to open %1</source>
+        <translation>qTox kan %1 niet openen</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/chatform.cpp" line="194"/>
+        <location filename="../src/widget/form/chatform.cpp" line="765"/>
+        <source>Bad Idea</source>
+        <translation>Slecht idee</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/chatform.cpp" line="194"/>
+        <location filename="../src/widget/form/chatform.cpp" line="765"/>
+        <source>You&apos;re trying to send a special (sequential) file, that&apos;s not going to work!</source>
+        <translation>Je probeert een speciaal (sequentieel) bestand te versturen, dat zal niet werken!</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/chatform.cpp" line="312"/>
+        <source>%1 is calling</source>
+        <translation>%1 belt je</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/chatform.cpp" line="374"/>
+        <source>%1 stopped calling</source>
+        <translation>%1 heeft opgelegd</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/chatform.cpp" line="423"/>
+        <source>Calling to %1</source>
+        <translation>%1 bellen</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/chatform.cpp" line="516"/>
+        <source>Call rejected</source>
+        <translation>Gesprek geweigerd</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/chatform.cpp" line="732"/>
+        <source>Failed to send file &quot;%1&quot;</source>
+        <translation>Kon bestand %1 niet verzenden</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/chatform.cpp" line="880"/>
+        <source>Call with %1 ended. %2</source>
+        <translation>Gesprek met %1 beëindigd. %2</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/chatform.cpp" line="900"/>
+        <source>Call duration: </source>
+        <translation>Gesprekstijd: </translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/chatform.cpp" line="923"/>
+        <source>is typing...</source>
+        <translation>is aan het typen...</translation>
+    </message>
+</context>
+<context>
+    <name>ChatTextEdit</name>
+    <message>
+        <location filename="../src/widget/tool/chattextedit.cpp" line="23"/>
+        <source>Type your message here...</source>
+        <translation>Typ je bericht hier...</translation>
+    </message>
+</context>
+<context>
+    <name>Core</name>
+    <message>
+        <location filename="../src/core.cpp" line="260"/>
+        <source>Toxing on qTox</source>
+        <translation>Toxt met qTox</translation>
+    </message>
+    <message>
+        <location filename="../src/core.cpp" line="261"/>
+        <source>qTox User</source>
+        <translation>qTox gebruiker</translation>
+    </message>
+    <message>
+        <location filename="../src/core.cpp" line="763"/>
+        <source>Friend is already added</source>
+        <translation>Vriend is al toegevoegd</translation>
+    </message>
+    <message>
+        <location filename="../src/core.cpp" line="779"/>
+        <source>/me offers friendship.</source>
+        <translation>/me bied vriendschap aan.</translation>
+    </message>
+    <message>
+        <location filename="../src/core.cpp" line="781"/>
+        <source>/me offers friendship, &quot;%1&quot;</source>
+        <translation>/me bied vriendschap aap, &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../src/coreencryption.cpp" line="168"/>
+        <source>Encryption error</source>
+        <translation>Versleutelingsfout</translation>
+    </message>
+    <message>
+        <location filename="../src/coreencryption.cpp" line="168"/>
+        <source>The .tox file is encrypted, but encryption was not checked, continuing regardless.</source>
+        <translatorcomment>FIXME: Likely broken translation.</translatorcomment>
+        <translation>Het .tox bestand is versleuteld, maar de versleutel optie staat niet aan, we gaan toch door.</translation>
+    </message>
+    <message>
+        <location filename="../src/coreencryption.cpp" line="171"/>
+        <source>Please enter the password for the %1 profile.</source>
+        <comment>used in load() when no pw is already set</comment>
+        <translation>Gelieve het wachtwoord voor profiel %1 in te voeren.</translation>
+    </message>
+    <message>
+        <location filename="../src/coreencryption.cpp" line="172"/>
+        <location filename="../src/coreencryption.cpp" line="227"/>
+        <source>The previous password is incorrect; please try again:</source>
+        <comment>used on retries in load()</comment>
+        <translation>Het vorige wachtwoord was incorrect; probeer het alsjeblieft opnieuw:</translation>
+    </message>
+    <message>
+        <location filename="../src/coreencryption.cpp" line="183"/>
+        <source>The profile password failed. Please try another?</source>
+        <comment>used only when pw set before load() doesn&apos;t work</comment>
+        <translatorcomment>FIXME: Weird translation</translatorcomment>
+        <translation>Het profiel wachtwoord is fout. Gelieve een ander wachtwoord te proberen.</translation>
+    </message>
+    <message>
+        <location filename="../src/coreencryption.cpp" line="193"/>
+        <source>Change profile</source>
+        <translation>Profiel wijzigen</translation>
+    </message>
+    <message>
+        <location filename="../src/coreencryption.cpp" line="219"/>
+        <source>Encrypted chat history</source>
+        <translation>Versleutelde chatgeschiedenis</translation>
+    </message>
+    <message>
+        <location filename="../src/coreencryption.cpp" line="219"/>
+        <source>No encrypted chat history file found, or it was corrupted.
+History will be disabled!</source>
+        <translation>Er kon geen versleutelde chatgeschiedenis gevonden worden, of deze is corrupt geraakt.
+Chatgeschiedenis zal uitgeschakeld worden!</translation>
+    </message>
+    <message>
+        <location filename="../src/coreencryption.cpp" line="226"/>
+        <source>Please enter the password for the chat history for the %1 profile.</source>
+        <comment>used in load() when no hist pw set</comment>
+        <translation>Gelieve het wachtwoord voor de chatgeschiedenis van het %1 profiel in te voeren.</translation>
+    </message>
+    <message>
+        <location filename="../src/coreencryption.cpp" line="228"/>
+        <source>
+Disabling chat history now will leave the encrypted history intact (but not usable); if you later remember the password, you may re-enable encryption from the Privacy tab with the correct password to use the history.</source>
+        <comment>part of history password dialog</comment>
+        <translation>
+Het uitschakelen van de chatgeschiedenis zal de versleutelde geschiedenis bewaren maar onbruikbaar maken. Indien je je het wachtwoord later weer herinnerd, kun je versluiteling opnieuw aanzetten in het Privacy tabblad met het correcte wachtwoord om deze geschiedenis te herstellen.</translation>
+    </message>
+    <message>
+        <location filename="../src/coreencryption.cpp" line="235"/>
+        <source>The chat history password failed. Please try another?</source>
+        <comment>used only when pw set before load() doesn&apos;t work</comment>
+        <translation>Het wachtwoord voor de versleuteling van chatgeschiedenis was incorrect. Gelieve een ander wachtwoord te proberen.</translation>
+    </message>
+    <message>
+        <location filename="../src/coreencryption.cpp" line="255"/>
+        <source>Disable chat history</source>
+        <translation>Chatgeschiedenis uitschakelen</translation>
+    </message>
+    <message>
+        <location filename="../src/coreencryption.cpp" line="306"/>
+        <source>NO Password</source>
+        <translation>Geen wachtwoord</translation>
+    </message>
+    <message>
+        <location filename="../src/coreencryption.cpp" line="306"/>
+        <source>Encryption is enabled, but there is no password! Encryption will be disabled.</source>
+        <translation>Versleuteling is ingeschakeld, maar er is geen wachtwoord! Versleuteling zal uitgeschakeld worden.</translation>
+    </message>
+</context>
+<context>
+    <name>FileTransferInstance</name>
+    <message>
+        <location filename="../src/filetransferinstance.cpp" line="239"/>
+        <source>Save a file</source>
+        <comment>Title of the file saving dialog</comment>
+        <translation>Sla een bestand op</translation>
+    </message>
+    <message>
+        <location filename="../src/filetransferinstance.cpp" line="248"/>
+        <source>Location not writable</source>
+        <comment>Title of permissions popup</comment>
+        <translation>Locatie niet schrijfbaar</translation>
+    </message>
+    <message>
+        <location filename="../src/filetransferinstance.cpp" line="249"/>
+        <source>You do not have permission to write that location. Choose another, or cancel the save dialog.</source>
+        <comment>text of permissions popup</comment>
+        <translation>Je hebt geen toepassing om een bestand op deze locatie op te slaan. Kies een andere locatie of annuleer het opslaan.</translation>
+    </message>
+    <message>
+        <location filename="../src/filetransferinstance.cpp" line="425"/>
+        <source>ETA</source>
+        <translatorcomment>NOTE: I couldn&apos;t think of a short Dutch word for this. Do we have one?</translatorcomment>
+        <translation>ETA</translation>
+    </message>
+</context>
+<context>
+    <name>FilesForm</name>
+    <message>
+        <location filename="../src/widget/form/filesform.cpp" line="30"/>
+        <source>Transfered Files</source>
+        <comment>&quot;Headline&quot; of the window</comment>
+        <translation>Overgedragen Bestanden</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/filesform.cpp" line="38"/>
+        <source>Downloads</source>
+        <translation>Downloads</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/filesform.cpp" line="39"/>
+        <source>Uploads</source>
+        <translation>Uploads</translation>
+    </message>
+</context>
+<context>
+    <name>FriendRequestDialog</name>
+    <message>
+        <location filename="../src/widget/tool/friendrequestdialog.cpp" line="31"/>
+        <source>Friend request</source>
+        <comment>Title of the window to aceept/deny a friend request</comment>
+        <translation>Vriendverzoek</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/tool/friendrequestdialog.cpp" line="33"/>
+        <source>Someone wants to make friends with you</source>
+        <translation>Iemand wil je als vriend toevoegen</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/tool/friendrequestdialog.cpp" line="34"/>
+        <source>User ID:</source>
+        <translation>Gebruiker ID:</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/tool/friendrequestdialog.cpp" line="38"/>
+        <source>Friend request message:</source>
+        <translation>Vriendverzoeksbericht:</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/tool/friendrequestdialog.cpp" line="45"/>
+        <source>Accept</source>
+        <comment>Accept a friend request</comment>
+        <translation>Accepteren</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/tool/friendrequestdialog.cpp" line="46"/>
+        <source>Reject</source>
+        <comment>Reject a friend request</comment>
+        <translation>Afwijzen</translation>
+    </message>
+</context>
+<context>
+    <name>FriendWidget</name>
+    <message>
+        <location filename="../src/widget/friendwidget.cpp" line="55"/>
+        <source>Invite to group</source>
+        <comment>Menu to invite a friend to a groupchat</comment>
+        <translation>Stuur uitnodiging voor groep</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/friendwidget.cpp" line="56"/>
+        <source>Copy friend ID</source>
+        <comment>Menu to copy the Tox ID of that friend</comment>
+        <translation>Kopieer vriend ID</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/friendwidget.cpp" line="68"/>
+        <source>Set alias...</source>
+        <translation>Stel alias in...</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/friendwidget.cpp" line="71"/>
+        <source>Auto accept files from this friend</source>
+        <comment>context menu entry</comment>
+        <translation>Accepteer bestandsoverdrachten van deze vriend automatisch</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/friendwidget.cpp" line="76"/>
+        <source>Remove friend</source>
+        <comment>Menu to remove the friend from our friendlist</comment>
+        <translation>Verwijder vriend</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/friendwidget.cpp" line="109"/>
+        <source>Choose an auto accept directory</source>
+        <comment>popup title</comment>
+        <translation>Kies een locatie om automatisch geaccepteerde bestanden op te slaan</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/friendwidget.cpp" line="238"/>
+        <source>User alias</source>
+        <translation>Gebruikersalias</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/friendwidget.cpp" line="238"/>
+        <source>You can also set this by clicking the chat form name.
+Alias:</source>
+        <translation>Je kan dit ook instellen door op de naam in het chatvenster te klikken.
+Alias:</translation>
+    </message>
+</context>
+<context>
+    <name>GUI</name>
+    <message>
+        <location filename="../src/widget/gui.cpp" line="249"/>
+        <source>Enter your password</source>
+        <translation>Voer je wachtwoord in</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/gui.cpp" line="251"/>
+        <source>Decrypt</source>
+        <translation>Ontsleutel</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/gui.cpp" line="293"/>
+        <source>You must enter a non-empty password:</source>
+        <translation>Je moet een niet leeg wachtwoord invoeren:</translation>
+    </message>
+</context>
+<context>
+    <name>GeneralForm</name>
+    <message>
+        <location filename="../src/widget/form/settings/generalform.cpp" line="39"/>
+        <source>General</source>
+        <translation>Algemeen</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalform.cpp" line="86"/>
+        <location filename="../src/widget/form/settings/generalform.cpp" line="92"/>
+        <source>None</source>
+        <translation>Geen</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalform.cpp" line="250"/>
+        <source>Choose an auto accept directory</source>
+        <comment>popup title</comment>
+        <translation>Kies een locatie om automatisch geaccepteerde bestanden op te slaan</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalform.cpp" line="307"/>
+        <source>Call active</source>
+        <comment>popup title</comment>
+        <translation>In gesprek</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalform.cpp" line="308"/>
+        <source>You can&apos;t disconnect while a call is active!</source>
+        <comment>popup text</comment>
+        <translation>Je kan niet offline gaan terwijl je in een gesprek zit!</translation>
+    </message>
+</context>
+<context>
+    <name>GeneralSettings</name>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="56"/>
+        <source>General Settings</source>
+        <translation>Algemene Instellingen</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="64"/>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="80"/>
+        <source>The translation may not load until qTox restarts.</source>
+        <translation>De vertaling zal niet laden totdat qTox herstart.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="67"/>
+        <source>Language:</source>
+        <translation>Taal:</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="102"/>
+        <source>System tray</source>
+        <translation>Systeemvak</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="111"/>
+        <source>Show system tray icon</source>
+        <translation>Laat icoon in systeemvak zien</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="118"/>
+        <source>Enable light tray icon.</source>
+        <comment>toolTip for light icon setting</comment>
+        <translation>Gebruik een licht icoon in het systeemvak.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="121"/>
+        <source>Light icon</source>
+        <translation>Licht icoon</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="134"/>
+        <source>qTox will start minimized in tray.</source>
+        <comment>toolTip for Start in tray setting</comment>
+        <translation>qTox zal geminimaliseerd naar het systeemvak starten.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="137"/>
+        <source>Start in tray</source>
+        <translation>Start in systeemvak</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="150"/>
+        <source>After pressing close (X) qTox will minimize to tray,
+instead of closing itself.</source>
+        <comment>toolTip for close to tray setting</comment>
+        <translation>Indien je op sluiten (X) klikt, zal qTox naar het systeemvak minimaliseren,
+in plaats van af te sluiten.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="154"/>
+        <source>Close to tray</source>
+        <translation>Sluit naar systeemvak</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="167"/>
+        <source>After pressing minimize (_) qTox will minimize itself to tray,
+instead of system taskbar.</source>
+        <comment>toolTip for minimize to tray setting</comment>
+        <translation>Indien je op minimaliseren (_) klikt, zal qTox naar het systeemvak minimaliseren,
+in plaats van naar de taakbalk.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="171"/>
+        <source>Minimize to tray</source>
+        <translation>Minimaliseer naar systeemvak</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="196"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Start qTox on operating system startup (current profile).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Start qTox als het besturingssysteem op start (met het huidige profiel).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="199"/>
+        <source>Start automatically</source>
+        <translation>Start automatisch</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="206"/>
+        <source>Check for updates on startup</source>
+        <translation>Zoek naar updates bij start</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="220"/>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="246"/>
+        <source>Set where files will be saved.</source>
+        <translation>Stel in waar bestanden opgeslagen worden.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="223"/>
+        <source>Save to:</source>
+        <translation>Sla op in:</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="230"/>
+        <source>You can set this on a per-friend basis by right clicking them.</source>
+        <comment>autoaccept cb tooltip</comment>
+        <translation>Je kan dit per vriend instellen door met de rechtermuisknop op een vriend te klikken.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="233"/>
+        <source>Autoaccept files</source>
+        <translation>Accepteer bestanden automatisch</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="249"/>
+        <source>PushButton</source>
+        <translatorcomment>NOTE: Does it even make sense to translate this?</translatorcomment>
+        <translation>DrukKnop</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="262"/>
+        <source>Set to 0 to disable</source>
+        <translation>Zet naar 0 om uit te schakelen</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="268"/>
+        <source> minutes</source>
+        <translation> minuten</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="281"/>
+        <source>Your status is changed to Away after set period of inactivity.</source>
+        <translation>Je status zal automatisch naar afwezig gezet worden na een bepaalde periode van inactiviteit.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="287"/>
+        <source>Auto away after (0 to disable):</source>
+        <translation>Automatisch afwezig na (0 om uit te schakelen):</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="299"/>
+        <source>Chat</source>
+        <translation>Chat</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="305"/>
+        <source>Always notify about new messages in groupchats.</source>
+        <comment>toolTip for Group chat always notify</comment>
+        <translation>Stuur altijd een notificatie voor nieuwe berichten in een groepsgesprek.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="308"/>
+        <source>Group chats always notify</source>
+        <translation>Notificatie voor alle berichten in een groepsgesprek</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="315"/>
+        <source>Show contacts&apos; status changes</source>
+        <translation>Laat statusverandering van contacten zien</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="322"/>
+        <source>On new message:</source>
+        <translation>Bij een nieuw bericht:</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="334"/>
+        <source>Show qTox&apos;s window when you receive new message.</source>
+        <comment>tooltip for Show window setting</comment>
+        <translation>Laat qTox&apos; venster zijn bij het ontvangen van een nieuw bericht.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="337"/>
+        <source>Show window</source>
+        <translation>Laat venster zien</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="344"/>
+        <source>Focus qTox when you receive message.</source>
+        <comment>toolTip for Focus window setting</comment>
+        <translation>Focus qTox&apos; venster zijn bij het ontvangen van een nieuw bericht.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="347"/>
+        <source>Focus window</source>
+        <translation>Focus venster</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="369"/>
+        <source>Messages you are trying to send to your friends when they are not online
+will be sent to them when they will appear online to you.</source>
+        <comment>toolTip for Faux offline messaging setting</comment>
+        <translation>Berichten die je probeert te versturen naar vrienden terwijl ze offline zijn
+zullen naar ze verstuurd worden zodra deze online komen.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="373"/>
+        <source>Faux offline messaging</source>
+        <translation>Faux offline berichten</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="380"/>
+        <source>Your contact list will be shown in compact mode.
+qTox&apos;s restart needed.</source>
+        <comment>toolTip for compact layout setting</comment>
+        <translation>De vriendenlist zal in compacte modus getoond worden.
+qTox herstart benodigd.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="384"/>
+        <source>Compact contact list</source>
+        <translation>Compacte vriendenlijst</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="400"/>
+        <source>Theme</source>
+        <translation>Thema</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="406"/>
+        <source>Use emoticons</source>
+        <translation>Gebruik emoticons</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="424"/>
+        <source>Smiley Pack:</source>
+        <extracomment>Text on smiley pack label</extracomment>
+        <translation>Smiley pakket:</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="498"/>
+        <source>Emoticon size:</source>
+        <translation>Emoticon grootte:</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="514"/>
+        <source> px</source>
+        <translation> px</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="530"/>
+        <source>Style:</source>
+        <translation>Stijl:</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="547"/>
+        <source>Theme color:</source>
+        <translation>Themakleur:</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="564"/>
+        <source>Timestamp format:</source>
+        <translation>Tijdsaanduiding:</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="586"/>
+        <source>Connection Settings</source>
+        <translation>Verbindingsinstellingen</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="600"/>
+        <source>Disabling this allows, e.g., toxing over Tor. It adds load to the Tox network however, so uncheck only when necessary.</source>
+        <extracomment>force tcp checkbox tooltip</extracomment>
+        <translation>Door dit uit te schakelen kun je bijvoorbeeld Tox via Tor gebruiken. Het is wel zwaarder voor het Tox netwerk, dus schakeld dit alleen uit indeen noodzakelijk.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="603"/>
+        <source>Enable UDP (recommended)</source>
+        <extracomment>Text on checkbox to disable UDP</extracomment>
+        <translation>Gebruik UDP (aanbevolen)</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="610"/>
+        <source>Enable IPv6 (recommended)</source>
+        <extracomment>Text on a checkbox to enable IPv6</extracomment>
+        <translation>Gebruik IPv6 (aanbevolen)</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="644"/>
+        <source>Proxy type:</source>
+        <translation>Proxy type:</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="651"/>
+        <source>Address:</source>
+        <extracomment>Text on proxy addr label</extracomment>
+        <translation>Adres:</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="661"/>
+        <source>Port</source>
+        <extracomment>Text on proxy port label</extracomment>
+        <translation>Poort</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="675"/>
+        <source>None</source>
+        <translation>Geen</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="680"/>
+        <source>SOCKS5</source>
+        <translation>SOCKS5</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="685"/>
+        <source>HTTP</source>
+        <translation>HTTP</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/generalsettings.ui" line="695"/>
+        <source>Reconnect</source>
+        <comment>reconnect button</comment>
+        <translation>Opnieuw verbinden</translation>
+    </message>
+</context>
+<context>
+    <name>GenericChatForm</name>
+    <message>
+        <location filename="../src/widget/form/genericchatform.cpp" line="71"/>
+        <source>Send message</source>
+        <translation>Verstuur bericht</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/genericchatform.cpp" line="73"/>
+        <source>Smileys</source>
+        <translation>Smileys</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/genericchatform.cpp" line="77"/>
+        <source>Send file(s)</source>
+        <translation>Verstuur bestand(en)</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/genericchatform.cpp" line="80"/>
+        <source>Audio call: RED means you&apos;re on a call</source>
+        <translation>Audio gesprek: ROOD betekend in gesprek</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/genericchatform.cpp" line="83"/>
+        <source>Video call: RED means you&apos;re on a call</source>
+        <translation>Video gesprek: ROOD betekend in gesprek</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/genericchatform.cpp" line="86"/>
+        <source>Toggle speakers volume: RED is OFF</source>
+        <translation>Schakel speakers in of uit: ROOD is UIT</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/genericchatform.cpp" line="89"/>
+        <source>Toggle microphone: RED is OFF</source>
+        <translation>Schakel microfoon in of uit: ROOD is UIT</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/genericchatform.cpp" line="161"/>
+        <location filename="../src/widget/form/genericchatform.cpp" line="204"/>
+        <source>Save chat log</source>
+        <translation>Sla chatgeschiedenis op</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/genericchatform.cpp" line="162"/>
+        <source>Clear displayed messages</source>
+        <translation>Verwijder getoonde berichten</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/genericchatform.cpp" line="309"/>
+        <source>Cleared</source>
+        <translatorcomment>FIXME: Weird translation</translatorcomment>
+        <translation>Geleegd</translation>
+    </message>
+</context>
+<context>
+    <name>GroupChatForm</name>
+    <message>
+        <location filename="../src/widget/form/groupchatform.cpp" line="57"/>
+        <source>%1 users in chat</source>
+        <comment>Number of users in chat</comment>
+        <translation>%1 gebruikers in de chat</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/groupchatform.cpp" line="108"/>
+        <source>%1 users in chat</source>
+        <translation>%1 gebruikers in de chat</translation>
+    </message>
+</context>
+<context>
+    <name>GroupWidget</name>
+    <message>
+        <location filename="../src/widget/groupwidget.cpp" line="43"/>
+        <location filename="../src/widget/groupwidget.cpp" line="80"/>
+        <source>%1 users in chat</source>
+        <translation>%1 gebruikers in de chat</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/groupwidget.cpp" line="45"/>
+        <location filename="../src/widget/groupwidget.cpp" line="82"/>
+        <source>0 users in chat</source>
+        <translation>0 gebruikers in de chat</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/groupwidget.cpp" line="54"/>
+        <source>Set title...</source>
+        <translation>Stel titel in...</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/groupwidget.cpp" line="55"/>
+        <source>Quit group</source>
+        <comment>Menu to quit a groupchat</comment>
+        <translation>Verlaat groep</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/groupwidget.cpp" line="67"/>
+        <source>Group title</source>
+        <translation>Groepstitel</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/groupwidget.cpp" line="67"/>
+        <source>You can also set this by clicking the chat form name.
+Title:</source>
+        <translation>Je kan dit ook instellen door op de naam in het chatvenster te klikken.
+Titel:</translation>
+    </message>
+</context>
+<context>
+    <name>IdentityForm</name>
+    <message>
+        <location filename="../src/widget/form/settings/identityform.cpp" line="35"/>
+        <source>Identity</source>
+        <translation>Identiteit</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identityform.cpp" line="136"/>
+        <source>Call active</source>
+        <comment>popup title</comment>
+        <translation>In gesprek</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identityform.cpp" line="137"/>
+        <source>You can&apos;t switch profiles while a call is active!</source>
+        <comment>popup text</comment>
+        <translation>Je kan niet van profiel wisselen in een gesprek!</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identityform.cpp" line="147"/>
+        <source>Rename &quot;%1&quot;</source>
+        <comment>renaming a profile</comment>
+        <translation>Hernoem &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identityform.cpp" line="155"/>
+        <source>Profile already exists</source>
+        <comment>rename confirm title</comment>
+        <translation>Profiel bestaat al</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identityform.cpp" line="156"/>
+        <source>A profile named &quot;%1&quot; already exists. Do you want to erase it?</source>
+        <comment>rename confirm text</comment>
+        <translation>Er bestaat al een profiel met de naam &quot;%1&quot;. Wil je deze verwijderen?</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identityform.cpp" line="175"/>
+        <source>Export profile</source>
+        <comment>save dialog title</comment>
+        <translation>Exporteer profiel</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identityform.cpp" line="177"/>
+        <source>Tox save file (*.tox)</source>
+        <comment>save dialog filter</comment>
+        <translation>Tox bestand (*.tox)</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identityform.cpp" line="187"/>
+        <source>Failed to remove file</source>
+        <translation>Kon bestand niet verwijderen</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identityform.cpp" line="187"/>
+        <source>The file you chose to overwrite could not be removed first.</source>
+        <translation>Het bestand dat je hebt gekozen kon niet verwijderd worden.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identityform.cpp" line="193"/>
+        <source>Failed to copy file</source>
+        <translation>Kon bestand niet kopieëren</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identityform.cpp" line="193"/>
+        <source>The file you chose could not be written to.</source>
+        <translation>Het bestand dat je hebt gekozen kan niet geschreven worden.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identityform.cpp" line="201"/>
+        <source>Profile currently loaded</source>
+        <comment>current profile deletion warning title</comment>
+        <translation>Profiel is momenteel geladen</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identityform.cpp" line="201"/>
+        <source>This profile is currently in use. Please load a different profile before deleting this one.</source>
+        <comment>current profile deletion warning text</comment>
+        <translation>Dit profiel is momenteel in gebruik. Schakel naar een ander profiel over voordat je deze verwijderd.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identityform.cpp" line="205"/>
+        <source>Deletion imminent!</source>
+        <comment>deletion confirmation title</comment>
+        <translation>Profiel wordt verwijderd!</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identityform.cpp" line="206"/>
+        <source>Are you sure you want to delete this profile?</source>
+        <comment>deletion confirmation text</comment>
+        <translation>Weet je zeker dat je dit profiel wilt verwijderen?</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identityform.cpp" line="225"/>
+        <source>Import profile</source>
+        <comment>import dialog title</comment>
+        <translation>Importeer profiel</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identityform.cpp" line="227"/>
+        <source>Tox save file (*.tox)</source>
+        <comment>import dialog filter</comment>
+        <translation>Tox bestand (*.tox)</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identityform.cpp" line="237"/>
+        <source>Ignoring non-Tox file</source>
+        <comment>popup title</comment>
+        <translation>Niet-Tox bestand wordt genegeerd</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identityform.cpp" line="238"/>
+        <source>Warning: you&apos;ve chosen a file that is not a Tox save file; ignoring.</source>
+        <comment>popup text</comment>
+        <translation>Let op: je hebt een bestand gekozen dat geen Tox bestand is. Dis bestand wordt genegeerd.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identityform.cpp" line="244"/>
+        <source>Profile already exists</source>
+        <comment>import confirm title</comment>
+        <translation>Profiel bestaat al</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identityform.cpp" line="245"/>
+        <source>A profile named &quot;%1&quot; already exists. Do you want to erase it?</source>
+        <comment>import confirm text</comment>
+        <translation>Er bestaat al een profiel met de naam &quot;%1&quot;. Wil je deze verwijderen?</translation>
+    </message>
+</context>
+<context>
+    <name>IdentitySettings</name>
+    <message>
+        <location filename="../src/widget/form/settings/identitysettings.ui" line="53"/>
+        <source>Public Information</source>
+        <translation>Publieke informatie</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identitysettings.ui" line="59"/>
+        <source>Name</source>
+        <translation>Naam</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identitysettings.ui" line="69"/>
+        <source>Status</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identitysettings.ui" line="82"/>
+        <source>Tox ID</source>
+        <translation>Tox ID</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identitysettings.ui" line="85"/>
+        <source>This bunch of characters tells other Tox clients how to contact you.
+Share it with your friends to communicate.</source>
+        <comment>Tox ID tooltip</comment>
+        <translation>Deze combinatie van tekens verstallen andere Tox programmas hoe ze contact met je op moeten nemen.
+Deel dit met je vrienden om te communiceren.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identitysettings.ui" line="92"/>
+        <source>Your Tox ID (click to copy)</source>
+        <translation>Jouw Tox ID (klik om te kopieëren)</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identitysettings.ui" line="102"/>
+        <source>Profiles</source>
+        <translation>Profielen</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identitysettings.ui" line="110"/>
+        <source>Available profiles:</source>
+        <translation>Beschikbare profielen:</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identitysettings.ui" line="117"/>
+        <source>Currently selected profile.</source>
+        <comment>toolTip for currently set profile</comment>
+        <translation>Momenteel geselecteerd profiel.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identitysettings.ui" line="134"/>
+        <source>Load selected profile and switch to it.</source>
+        <comment>tooltip for loading profile button</comment>
+        <translation>Laat geselecteerd profiel en schakel ernaar over.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identitysettings.ui" line="137"/>
+        <source>Load</source>
+        <comment>load profile button</comment>
+        <translation>Laad</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identitysettings.ui" line="144"/>
+        <source>Rename</source>
+        <comment>rename profile button</comment>
+        <translation>Hernoem</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identitysettings.ui" line="147"/>
+        <source>Rename selected profile.</source>
+        <comment>tooltip for renaming profile button</comment>
+        <translation>Hernoem geselecteerd profiel.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identitysettings.ui" line="154"/>
+        <source>Export</source>
+        <comment>export profile button</comment>
+        <translation>Exporteer</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identitysettings.ui" line="157"/>
+        <source>Allows you to export your Tox profile to a file.
+Profile does not contain your history.</source>
+        <comment>tooltip for profile exporting button</comment>
+        <translation>Exporteer je Tox profiel naar een bestand.
+Dit bestand bevat geen chatgeschiedenis.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identitysettings.ui" line="165"/>
+        <source>Delete selected profile.</source>
+        <comment>delete profile button tooltip</comment>
+        <translation>Verwijder geselecteerde profiel.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identitysettings.ui" line="168"/>
+        <source>Delete</source>
+        <comment>delete profile button</comment>
+        <translation>Verwijder</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identitysettings.ui" line="179"/>
+        <source>Import a profile</source>
+        <comment>import profile button</comment>
+        <translation>Importeer een profiel</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identitysettings.ui" line="182"/>
+        <source>Import Tox profile from a .tox file.</source>
+        <comment>tooltip for importing profile button</comment>
+        <translation>Importeer een profiel uit een .tox bestand.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identitysettings.ui" line="189"/>
+        <source>Create new Tox ID and switch to it.</source>
+        <comment>tooltip for creating new Tox ID button</comment>
+        <translation>Maak nieuw Tox ID en schakel ernaar over.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/identitysettings.ui" line="192"/>
+        <source>New Tox ID</source>
+        <comment>new profile button</comment>
+        <translation>Nieuw Tox ID</translation>
+    </message>
+</context>
+<context>
+    <name>LoadHistoryDialog</name>
+    <message>
+        <location filename="../src/widget/form/loadhistorydialog.ui" line="14"/>
+        <source>Load History Dialog</source>
+        <translation>Geschiedenis laden</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/loadhistorydialog.ui" line="23"/>
+        <source>Load history from:</source>
+        <translation>Laad geschiedenis van:</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../src/mainwindow.ui" line="859"/>
+        <source>Your name</source>
+        <translation>Naam</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="941"/>
+        <source>Your status</source>
+        <translation>Status</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1096"/>
+        <source>Add friends</source>
+        <translation>Voeg vrienden toe</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1134"/>
+        <source>Create a group chat</source>
+        <translation>Maak een groepsgesprek aan</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1169"/>
+        <source>View completed file transfers</source>
+        <translation>Bekijk voltooide bestandsoverdrachten</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1201"/>
+        <source>Change your settings</source>
+        <translation>Verander je instellingen</translation>
+    </message>
+    <message>
+        <location filename="../src/mainwindow.ui" line="1789"/>
+        <source>Close</source>
+        <translation>Sluit</translation>
+    </message>
+</context>
+<context>
+    <name>NetCamView</name>
+    <message>
+        <location filename="../src/widget/netcamview.cpp" line="28"/>
+        <source>Tox video</source>
+        <translation>Tox video</translation>
+    </message>
+</context>
+<context>
+    <name>PrivacyForm</name>
+    <message>
+        <location filename="../src/widget/form/settings/privacyform.cpp" line="31"/>
+        <source>Privacy</source>
+        <translation>Privacy</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/privacyform.cpp" line="78"/>
+        <source>Please set your new chat history password.</source>
+        <translation>Kies een nieuw wachtwoord voor de chatgeschiedenis.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/privacyform.cpp" line="80"/>
+        <source>It appears you have an unused encrypted chat history; if the password matches, it will be added to your current history.</source>
+        <translatorcomment>FIXME: Weird translation</translatorcomment>
+        <translation>Het lijkt erop dat je een oude versleutelde chat geschiedenis hebt. Indien het wachtwoord overeen komt, zal deze aan je momentele chatgeschiedenis toegevoegd worden.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/privacyform.cpp" line="83"/>
+        <source>Use data file password</source>
+        <comment>pushbutton text</comment>
+        <translation>Gebruik wachtwoord voor databestand</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/privacyform.cpp" line="110"/>
+        <source>Successfully decrypted old chat history</source>
+        <comment>popup title</comment>
+        <translation>Oude chatgeschiedenis succesvol ontsleuteld</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/privacyform.cpp" line="110"/>
+        <source>You have succesfully decrypted the old chat history, and it has been added to your current history and re-encrypted.</source>
+        <comment>popup text</comment>
+        <translation>Je heb succesful de oude chatgeschiedenis ontsleuteld. Deze is toegevoegd aan de nieuwe chatgeschiedenis en opnieuw versleuteld.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/privacyform.cpp" line="117"/>
+        <location filename="../src/widget/form/settings/privacyform.cpp" line="118"/>
+        <source>Old encrypted chat history</source>
+        <comment>popup title</comment>
+        <translation>Oude versleutelde chatgeschiedenis</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/privacyform.cpp" line="117"/>
+        <source>There is currently an unused encrypted chat history, but the password you just entered doesn&apos;t match.
+
+If you don&apos;t care about the old history, you may click Ok to delete it and use the password you just entered.
+Otherwise, hit cancel to try again.</source>
+        <comment>This happens when enabling encryption after previously &quot;Disabling History&quot;</comment>
+        <translation>Er is momenteel een oude versluitelde chatgeschiedenis, maar het ingevulde wachtwoord komt niet overeen.
+
+Indien de oude chatgeschiedenis verloren mag geen, druk op Ok om deze te verwijderen en het nieuwe wachtwoord te gebruiken.
+Druk anders op annuleren om het opnieuw te proberen.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/privacyform.cpp" line="118"/>
+        <source>Are you absolutely sure you want to lose the unused encrypted chat history?</source>
+        <comment>secondary popup</comment>
+        <translation>Weet je absoluut zeker dat je de oude versleutelde chatgeschiedenis wilt verwijderen?</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/privacyform.cpp" line="147"/>
+        <location filename="../src/widget/form/settings/privacyform.cpp" line="164"/>
+        <source>Old encrypted chat history</source>
+        <comment>title</comment>
+        <translation>Oude versleutelde chatgeschiedenis</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/privacyform.cpp" line="148"/>
+        <source>Would you like to decrypt your chat history?
+Otherwise it will be deleted.</source>
+        <translation>Wil je de chatgeschiedenis ontsleutelen?
+Anders zal deze worden verwijderd.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/privacyform.cpp" line="165"/>
+        <source>Are you sure you want to lose your entire chat history?</source>
+        <translation>Weet je zeker dat je de oude chatgeschiedenis wilt verwijderen?</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/privacyform.cpp" line="197"/>
+        <source>Please set your new data file password.</source>
+        <translation>Kies een nieuw wachtwoord voor de chatgeschiedenis.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/privacyform.cpp" line="199"/>
+        <source>Use chat history password</source>
+        <comment>pushbutton text</comment>
+        <translation>Gebruik wachtwoord voor chatgeschiedenis</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/privacyform.cpp" line="242"/>
+        <source>Decrypt your data file</source>
+        <comment>title</comment>
+        <translation>Ontsleutel je databestand</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/privacyform.cpp" line="242"/>
+        <source>Would you like to decrypt your data file?</source>
+        <translation>Wil je je databestand ontsleutelen?</translation>
+    </message>
+</context>
+<context>
+    <name>PrivacySettings</name>
+    <message>
+        <location filename="../src/widget/form/settings/privacysettings.ui" line="47"/>
+        <source>Your friends will be able to see when you are typing.</source>
+        <comment>tooltip for typing notifications setting</comment>
+        <translation>Je vrienden kunnen zien wanneer je typt.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/privacysettings.ui" line="50"/>
+        <source>Send Typing Notifications</source>
+        <translation>Verstuur typ notificaties</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/privacysettings.ui" line="57"/>
+        <source>Chat history keeping is still in development.
+Save format changes are possible, which may result in data loss.</source>
+        <comment>toolTip for Keep History setting</comment>
+        <translation>Het opslaan van chatgeschiedenis is nog in ontwikkeling.
+Veranderingen in het formaat om op te slaan zijn mogelijk, welke tot dataverlies kunnen leiden.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/privacysettings.ui" line="61"/>
+        <source>Keep chat history (mostly stable)</source>
+        <translation>Sla chatgeschiedenis op (grotendeels stabiel)</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/privacysettings.ui" line="71"/>
+        <source>Local file encryption</source>
+        <translation>Locale bestandsversleuteling</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/privacysettings.ui" line="77"/>
+        <source>All Tox communications over the internet are encrypted, and this cannot be disabled. However, you may optionally password protect your local Tox files.</source>
+        <translation>Alle online Tox communicatie is versleuteld, en dit kan niet uitgeschakeld worden. Echter, je kan optioneel je locale Tox bestanden met een wachtwoord beschermen.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/privacysettings.ui" line="92"/>
+        <source>Encrypt Tox data file</source>
+        <translation>Versleutel Tox databestand</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/privacysettings.ui" line="99"/>
+        <location filename="../src/widget/form/settings/privacysettings.ui" line="123"/>
+        <source>Change password</source>
+        <translation>Verander wachtwoord</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/privacysettings.ui" line="113"/>
+        <source>Encrypt chat history</source>
+        <translation>Versleutel chatgeschiedenis</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/privacysettings.ui" line="135"/>
+        <source>Nospam</source>
+        <translation>Nospam</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/privacysettings.ui" line="138"/>
+        <source>Nospam is part of your Tox ID.
+It is there to help you change your Tox ID when you feel like you are getting too much spam friend requests.
+When you change nospam, your current contacts still can communicate with you,
+but new contacts need to know your new Tox ID to be able to add you.</source>
+        <comment>toolTip for nospam</comment>
+        <translation>Nospam is deel van je Tox ID.
+Het heeft als doel het veranderen van je Tox ID als je gespamt wordt met vriendverzoeken.
+Wanneer je nospam veranderd, kunnen huidige vrienden nog met je communiceren,
+maar nieuwe vrienden zullen je nieuwe Tox ID moeten wete om te toe te kunnen voegen.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/privacysettings.ui" line="149"/>
+        <source>HHHHHHHH</source>
+        <translatorcomment>Note: WHAT?!</translatorcomment>
+        <translation>HHHHHHHH</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/settings/privacysettings.ui" line="156"/>
+        <source>Generate random nospam</source>
+        <translation>Genereer willekeurige nospam</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/autoupdate.cpp" line="494"/>
+        <source>Update</source>
+        <comment>The title of a message box</comment>
+        <translation>Update</translation>
+    </message>
+    <message>
+        <location filename="../src/autoupdate.cpp" line="495"/>
+        <source>An update is available, do you want to download it now?
+It will be installed when qTox restarts.</source>
+        <translation>Een update is beschikbaar, wil je deze nu downloaden?
+Deze zal geïnstalleerd worden wanneer qTox herstart.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="69"/>
+        <source>Tox URI to parse</source>
+        <translation>Tox URI om te ontleden</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="70"/>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation>Start nieuwe instantie en laad specifiek profiel.</translation>
+    </message>
+    <message>
+        <location filename="../src/main.cpp" line="70"/>
+        <source>profile</source>
+        <translation>profiel</translation>
+    </message>
+    <message>
+        <location filename="../src/misc/style.cpp" line="69"/>
+        <source>Default</source>
+        <translation>Standaard</translation>
+    </message>
+    <message>
+        <location filename="../src/misc/style.cpp" line="69"/>
+        <source>Blue</source>
+        <translation>Blauw</translation>
+    </message>
+    <message>
+        <location filename="../src/misc/style.cpp" line="69"/>
+        <source>Olive</source>
+        <translation>Olijf</translation>
+    </message>
+    <message>
+        <location filename="../src/misc/style.cpp" line="69"/>
+        <source>Red</source>
+        <translation>Rood</translation>
+    </message>
+    <message>
+        <location filename="../src/misc/style.cpp" line="69"/>
+        <source>Violet</source>
+        <translation>Violet</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/callconfirmwidget.cpp" line="28"/>
+        <source>Incoming call...</source>
+        <translation>Incomend gesprek...</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/toxsave.cpp" line="56"/>
+        <source>Ignoring non-Tox file</source>
+        <comment>popup title</comment>
+        <translation>Niet-Tox bestand wordt genegeerd</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/toxsave.cpp" line="57"/>
+        <source>Warning: you&apos;ve chosen a file that is not a Tox save file; ignoring.</source>
+        <comment>popup text</comment>
+        <translation>Let op: je hebt een bestand gekozen dat geen Tox bestand is. Dis bestand wordt genegeerd.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/toxsave.cpp" line="63"/>
+        <source>Profile already exists</source>
+        <comment>import confirm title</comment>
+        <translation>Profiel bestaat al</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/toxsave.cpp" line="64"/>
+        <source>A profile named &quot;%1&quot; already exists. Do you want to erase it?</source>
+        <comment>import confirm text</comment>
+        <translation>Er bestaat al een profiel met de naam &quot;%1&quot;. Wil je deze verwijderen?</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/toxsave.cpp" line="70"/>
+        <source>Profile imported</source>
+        <translation>Profiel geïmporteerd</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/toxsave.cpp" line="70"/>
+        <source>%1.tox was successfully imported</source>
+        <translation>%1.tox was succesvol geïmporteerd</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/toxuri.cpp" line="70"/>
+        <source>Tox me maybe?</source>
+        <comment>Default message in Tox URI friend requests. Write something appropriate!</comment>
+        <translation>Tox met me!</translation>
+    </message>
+</context>
+<context>
+    <name>SetPasswordDialog</name>
+    <message>
+        <location filename="../src/widget/form/setpassworddialog.ui" line="14"/>
+        <source>Set your password</source>
+        <translation>Wachtwoord instellen</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/setpassworddialog.ui" line="31"/>
+        <source>Repeat password</source>
+        <translation>Herhaal wachtwoord</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/setpassworddialog.ui" line="41"/>
+        <source>Type password</source>
+        <translation>Typ wachtword</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/setpassworddialog.ui" line="65"/>
+        <source>Password strength</source>
+        <translation>Wachtwoordsterkte</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/form/setpassworddialog.cpp" line="33"/>
+        <location filename="../src/widget/form/setpassworddialog.cpp" line="61"/>
+        <source>The passwords don&apos;t match.</source>
+        <translation>De wachtwoorden komen niet overeen.</translation>
+    </message>
+</context>
+<context>
+    <name>Settings</name>
+    <message>
+        <location filename="../src/misc/settings.cpp" line="124"/>
+        <source>Choose a profile</source>
+        <translation>Kies een profiel</translation>
+    </message>
+    <message>
+        <location filename="../src/misc/settings.cpp" line="125"/>
+        <source>Please choose which identity to use</source>
+        <translation>Kies een identiteit om te gebruiken</translation>
+    </message>
+</context>
+<context>
+    <name>ToxDNS</name>
+    <message>
+        <location filename="../src/toxdns.cpp" line="64"/>
+        <source>The connection timed out</source>
+        <comment>The DNS gives the Tox ID associated to toxme.se addresses</comment>
+        <translation>De verbinding kreeg een time-out</translation>
+    </message>
+    <message>
+        <location filename="../src/toxdns.cpp" line="70"/>
+        <source>This address does not exist</source>
+        <comment>The DNS gives the Tox ID associated to toxme.se addresses</comment>
+        <translation>Dit adres bestaat niet</translation>
+    </message>
+    <message>
+        <location filename="../src/toxdns.cpp" line="75"/>
+        <source>Error while looking up DNS</source>
+        <comment>The DNS gives the Tox ID associated to toxme.se addresses</comment>
+        <translation>Fout tijdens het opzoeken via DNS</translation>
+    </message>
+    <message>
+        <location filename="../src/toxdns.cpp" line="82"/>
+        <source>No text record found</source>
+        <comment>Error with the DNS</comment>
+        <translation>Geen text records gevonden</translation>
+    </message>
+    <message>
+        <location filename="../src/toxdns.cpp" line="89"/>
+        <source>Unexpected number of values in text record</source>
+        <comment>Error with the DNS</comment>
+        <translation>Onverwachte hoeveelheid waarden in text record</translation>
+    </message>
+    <message>
+        <location filename="../src/toxdns.cpp" line="116"/>
+        <source>The version of Tox DNS used by this server is not supported</source>
+        <comment>Error with the DNS</comment>
+        <translation>De versie van Tox DNS die door deze server gebruikt wordt niet ondersteund</translation>
+    </message>
+    <message>
+        <location filename="../src/toxdns.cpp" line="126"/>
+        <source>The DNS lookup does not contain any Tox ID</source>
+        <comment>Error with the DNS</comment>
+        <translation>De DNS zoekopdracht gaf geen Tox ID terug</translation>
+    </message>
+    <message>
+        <location filename="../src/toxdns.cpp" line="133"/>
+        <location filename="../src/toxdns.cpp" line="140"/>
+        <source>The DNS lookup does not contain a valid Tox ID</source>
+        <comment>Error with the DNS</comment>
+        <translation>De DNS zoekopdracht gaf geen correct Tox ID terug</translation>
+    </message>
+    <message>
+        <location filename="../src/toxdns.cpp" line="223"/>
+        <location filename="../src/toxdns.cpp" line="269"/>
+        <source>It appears that qTox has to use the old tox1 protocol to access DNS record of your friend&apos;s Tox ID.
+Unfortunately tox1 is not secure, and you are at risk of someone hijacking what is sent between you and ToxDNS service.
+Should tox1 be used anyway?
+If unsure, press âNoâ, so that request to ToxDNS service will not be made using unsecure protocol.</source>
+        <translation>Het lijkt erop dat qTox gebruik moet maken van het oude tox1 protocol om het DNS record van je vriend&apos;s Tox ID op te halen.
+Helaas is tox1 niet veilig, en het risico bestaat dat iemand je verkeerde informatie door zal sturen.
+Moet tox1 toch gebruikt worden?
+Indien onzeker, druk op &quot;Nee&quot;, zo dat er geen onveilig verzoek naar de Tox DNS service wordt gedaan.</translation>
+    </message>
+</context>
+<context>
+    <name>ToxURIDialog</name>
+    <message>
+        <location filename="../src/widget/toxuri.cpp" line="80"/>
+        <source>Add a friend</source>
+        <comment>Title of the window to add a friend through Tox URI</comment>
+        <translation>Voeg een vriend toe</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/toxuri.cpp" line="82"/>
+        <source>Do you want to add %1 as a friend?</source>
+        <translation>Wil je %1 als vriend toevoegen?</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/toxuri.cpp" line="83"/>
+        <source>User ID:</source>
+        <translation>Gebruiker ID:</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/toxuri.cpp" line="87"/>
+        <source>Friend request message:</source>
+        <translation>Vriendverzoeksbericht:</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/toxuri.cpp" line="92"/>
+        <source>Send</source>
+        <comment>Send a friend request</comment>
+        <translation>Verstuur</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/toxuri.cpp" line="93"/>
+        <source>Cancel</source>
+        <comment>Don&apos;t send a friend request</comment>
+        <translation>Annuleer</translation>
+    </message>
+</context>
+<context>
+    <name>Widget</name>
+    <message>
+        <location filename="../src/widget/widget.cpp" line="100"/>
+        <source>Online</source>
+        <comment>Button to set your status to &apos;Online&apos;</comment>
+        <translation>Online</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/widget.cpp" line="103"/>
+        <source>Away</source>
+        <comment>Button to set your status to &apos;Away&apos;</comment>
+        <translation>Afwezig</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/widget.cpp" line="106"/>
+        <source>Busy</source>
+        <comment>Button to set your status to &apos;Busy&apos;</comment>
+        <translation>Bezet</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/widget.cpp" line="116"/>
+        <source>&amp;Quit</source>
+        <translatorcomment>NOTE: Can this be safely translated like this?</translatorcomment>
+        <translation>&amp;Sluit</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/widget.cpp" line="347"/>
+        <source>Choose a profile picture</source>
+        <translation>Kies een profielfoto</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/widget.cpp" line="354"/>
+        <location filename="../src/widget/widget.cpp" line="361"/>
+        <location filename="../src/widget/widget.cpp" line="382"/>
+        <source>Error</source>
+        <translation>Fout</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/widget.cpp" line="354"/>
+        <source>Unable to open this file</source>
+        <translation>Kon dit bestand niet openen</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/widget.cpp" line="361"/>
+        <source>Unable to read this image</source>
+        <translation>Kon deze afbeelding niet lezen</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/widget.cpp" line="382"/>
+        <source>This image is too big</source>
+        <translation>Deze afbeelding is te groot</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/widget.cpp" line="422"/>
+        <source>Toxcore failed to start, the application will terminate after you close this message.</source>
+        <translation>Toxcore kon niet opstarten, de applicatie zal afsluiten nadat dit bericht wordt gesloten.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/widget.cpp" line="431"/>
+        <source>toxcore failed to start with your proxy settings. qTox cannot run; please modify your settings and restart.</source>
+        <comment>popup text</comment>
+        <translation>Toxcore kon niet opstarten met deze proxyinstellingen. Hierdoor kan qTox niet starten. Verander je instellingen en herstart.</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/widget.cpp" line="480"/>
+        <source>Add friend</source>
+        <translation>Voeg vriend toe</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/widget.cpp" line="492"/>
+        <source>File transfers</source>
+        <translation>Bestandsoverdrachten</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/widget.cpp" line="537"/>
+        <source>Settings</source>
+        <translation>Instellingen</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/widget.cpp" line="649"/>
+        <source>Couldn&apos;t request friendship</source>
+        <translation>Kon geen vriendschapsverzoek maken</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/widget.cpp" line="677"/>
+        <source>away</source>
+        <comment>contact status</comment>
+        <translation>afwezig</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/widget.cpp" line="679"/>
+        <source>busy</source>
+        <comment>contact status</comment>
+        <translation>bezet</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/widget.cpp" line="681"/>
+        <source>offline</source>
+        <comment>contact status</comment>
+        <translation>offline</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/widget.cpp" line="683"/>
+        <source>online</source>
+        <comment>contact status</comment>
+        <translation>online</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/widget.cpp" line="686"/>
+        <source>%1 is now %2</source>
+        <comment>e.g. &quot;Dubslow is now online&quot;</comment>
+        <translation>%1 is nu %2</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/widget.cpp" line="914"/>
+        <source>&lt;Unknown&gt;</source>
+        <comment>Placeholder when we don&apos;t know someone&apos;s name in a group chat</comment>
+        <translation>&lt;Onbekend&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/widget.cpp" line="939"/>
+        <source>%1 has set the title to %2</source>
+        <translation>%1 heeft de titel naar %2 gezet</translation>
+    </message>
+    <message>
+        <location filename="../src/widget/widget.cpp" line="1095"/>
+        <source>Message failed to send</source>
+        <translation>Bericht kon niet verstuurd worden</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
On this note, someone really ought to clean up qTox' translation stuff. I've had to translate several strings multiple times and some just made no sense at all. Please see the `<translatorcomment>` sections in translations/nl.qm.
