### PR TITLE
Add open directory option to completed file transfers

### DIFF
--- a/src/chatlog/content/filetransferwidget.cpp
+++ b/src/chatlog/content/filetransferwidget.cpp
@@ -429,13 +429,12 @@ void FileTransferWidget::handleButton(QPushButton *btn)
 
     if(btn->objectName() == "ok")
     {
-        QDesktopServices::openUrl(QUrl("file:///" + fileInfo.filePath, QUrl::TolerantMode));
+        QDesktopServices::openUrl(QUrl("file://" + fileInfo.filePath, QUrl::TolerantMode));
     }
     else if (btn->objectName() == "dir")
     {
-        QString dirName = fileInfo.filePath;
-        dirName.chop(fileInfo.fileName.length());
-        QDesktopServices::openUrl(QUrl("file:///" + dirName, QUrl::TolerantMode));
+        QString dirPath = QDir(QFileInfo(fileInfo.filePath).dir()).path();
+        QDesktopServices::openUrl(QUrl("file://" + dirPath, QUrl::TolerantMode));
     }
 
 }


### PR DESCRIPTION
This adds a button to open the directory a file was saved in on a completed file transfer.
![opendirectory](https://cloud.githubusercontent.com/assets/1885159/6235154/acc6826e-b6e0-11e4-8828-a9002be82e5e.png)

As usual, I understand if this code has imperfections that make you prefer to do it yourself, but it's still useful for me as a learning experience and hopefully to point you to an easy way to add this functionality :)

dir.svg in modified directly from browse.svg.
