### PR TITLE
Hide is typing status when friend disconnects

### DIFF
--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -901,6 +901,11 @@ QString ChatForm::secondsToDHMS(quint32 duration)
     return cD + res.sprintf("%dd%02dh %02dm %02ds", days, hours, minutes, seconds);
 }
 
+bool ChatForm::getIsTyping()
+{
+    return isTyping;
+}
+
 void ChatForm::setFriendTyping(bool isTyping)
 {
     chatWidget->setTypingNotificationVisible(isTyping);

--- a/src/widget/form/chatform.h
+++ b/src/widget/form/chatform.h
@@ -44,6 +44,7 @@ public:
     void loadHistory(QDateTime since, bool processUndelivered = false);
 
     void dischargeReceipt(int receipt);
+    bool getIsTyping();
     void setFriendTyping(bool isTyping);
     OfflineMsgEngine* getOfflineMsgEngine();
 

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -683,7 +683,9 @@ void Widget::onFriendStatusChanged(int friendId, Status status)
         case Status::Busy:
             fStatus = tr("busy", "contact status"); break;
         case Status::Offline:
-            fStatus = tr("offline", "contact status"); break;
+            fStatus = tr("offline", "contact status");
+            f->getChatForm()->setFriendTyping(false); // Hide the "is typing" message when a friend goes offline
+            break;
         default:
             fStatus = tr("online", "contact status"); break;
         }
@@ -695,6 +697,10 @@ void Widget::onFriendStatusChanged(int friendId, Status status)
     if (isActualChange && status != Status::Offline)
     { // wait a little
         QTimer::singleShot(250, f->getChatForm()->getOfflineMsgEngine(), SLOT(deliverOfflineMsgs()));
+
+        // Send another typing notification if the contact comes back online
+        if (f->getChatForm()->getIsTyping() && Settings::getInstance().isTypingNotificationEnabled())
+            Core::getInstance()->sendTyping(f->getFriendID(), true);
     }
 }
 


### PR DESCRIPTION
Currently, when a contact goes offline, the typing notification remains:
![typingafteroffline](https://cloud.githubusercontent.com/assets/1885159/6247593/9e2b55ae-b776-11e4-8141-299887261c97.png)

This patch fixes that (`src/widget/widget.cpp`, line 687 in this patch)

It should also resend typing notification when a contact comes back online, so that the typing notification message comes back after a reconnect if the contact is still typing (obviously, other clients need to implement this as well, so this would currently only be available on qTox-to-qTox discussions).

The support for this last feature, however, has not been tested as I could not get a second qTox instance to run on TCP-only to play with disconnecting while typing a message. I do, however, see no real reason why this wouldn't work, but would still recommend it to be tested.
