### PR TITLE
Allow user to open all transferred files, but warn for executable files

### DIFF
--- a/src/chatlog/content/filetransferwidget.cpp
+++ b/src/chatlog/content/filetransferwidget.cpp
@@ -19,6 +19,7 @@
 
 #include "src/core.h"
 #include "src/misc/style.h"
+#include "src/widget/widget.h"
 
 #include <QMouseEvent>
 #include <QFileDialog>
@@ -326,7 +327,6 @@ void FileTransferWidget::onFileTransferFinished(ToxFile file)
 
     ui->topButton->setIcon(QIcon(":/ui/fileTransferInstance/yes.svg"));
     ui->topButton->setObjectName("ok");
-    ui->topButton->setEnabled(openExtensions.contains(QFileInfo(file.fileName).suffix()));
     ui->topButton->show();
 
     ui->bottomButton->setIcon(QIcon(":/ui/fileTransferInstance/dir.svg"));
@@ -431,11 +431,12 @@ void FileTransferWidget::handleButton(QPushButton *btn)
 
     if(btn->objectName() == "ok")
     {
-        QDesktopServices::openUrl(QUrl("file://" + fileInfo.filePath, QUrl::TolerantMode));
+        if (Widget::confirmExecutableOpen(QFileInfo(fileInfo.filePath)))
+            QDesktopServices::openUrl(QUrl("file://" + fileInfo.filePath, QUrl::TolerantMode));
     }
     else if (btn->objectName() == "dir")
     {
-        QString dirPath = QDir(QFileInfo(fileInfo.filePath).dir()).path();
+        QString dirPath = QFileInfo(fileInfo.filePath).dir().path();
         QDesktopServices::openUrl(QUrl("file://" + dirPath, QUrl::TolerantMode));
     }
 

--- a/src/chatlog/content/filetransferwidget.cpp
+++ b/src/chatlog/content/filetransferwidget.cpp
@@ -313,8 +313,6 @@ void FileTransferWidget::onFileTransferPaused(ToxFile file)
 
 void FileTransferWidget::onFileTransferFinished(ToxFile file)
 {
-    static const QStringList openExtensions = { "png", "jpeg", "jpg", "gif", "zip", "rar" };
-
     if(fileInfo != file)
         return;
 

--- a/src/chatlog/content/filetransferwidget.cpp
+++ b/src/chatlog/content/filetransferwidget.cpp
@@ -429,8 +429,7 @@ void FileTransferWidget::handleButton(QPushButton *btn)
 
     if(btn->objectName() == "ok")
     {
-        if (Widget::confirmExecutableOpen(QFileInfo(fileInfo.filePath)))
-            QDesktopServices::openUrl(QUrl("file://" + fileInfo.filePath, QUrl::TolerantMode));
+        Widget::confirmExecutableOpen(QFileInfo(fileInfo.filePath));
     }
     else if (btn->objectName() == "dir")
     {

--- a/src/widget/form/filesform.cpp
+++ b/src/widget/form/filesform.cpp
@@ -16,6 +16,7 @@
 
 #include "filesform.h"
 #include "ui_mainwindow.h"
+#include "src/widget/widget.h"
 #include <QFileInfo>
 #include <QUrl>
 #include <QDebug>
@@ -80,6 +81,10 @@ void FilesForm::onFileUploadComplete(const QString& path)
 void FilesForm::onFileActivated(QListWidgetItem* item)
 {
     ListWidgetItem* tmp = dynamic_cast<ListWidgetItem*> (item);
+
+    if (!Widget::confirmExecutableOpen(QFileInfo(tmp->path)))
+        return;
+
     QUrl url = QUrl::fromLocalFile(tmp->path);
     qDebug() << "Opening '" << url << "'";
     QDesktopServices::openUrl(url);

--- a/src/widget/form/filesform.cpp
+++ b/src/widget/form/filesform.cpp
@@ -20,7 +20,6 @@
 #include <QFileInfo>
 #include <QUrl>
 #include <QDebug>
-#include <QDesktopServices>
 
 FilesForm::FilesForm()
     : QObject()
@@ -82,10 +81,5 @@ void FilesForm::onFileActivated(QListWidgetItem* item)
 {
     ListWidgetItem* tmp = dynamic_cast<ListWidgetItem*> (item);
 
-    if (!Widget::confirmExecutableOpen(QFileInfo(tmp->path)))
-        return;
-
-    QUrl url = QUrl::fromLocalFile(tmp->path);
-    qDebug() << "Opening '" << url << "'";
-    QDesktopServices::openUrl(url);
+    Widget::confirmExecutableOpen(QFileInfo(tmp->path));
 }

--- a/src/widget/form/settings/privacyform.cpp
+++ b/src/widget/form/settings/privacyform.cpp
@@ -114,8 +114,8 @@ bool PrivacyForm::setChatLogsPassword()
         }
         else
         {
-            if (GUI::askQuestion(tr("Old encrypted chat history", "popup title"), tr("There is currently an unused encrypted chat history, but the password you just entered doesn't match.\n\nIf you don't care about the old history, you may click Ok to delete it and use the password you just entered.\nOtherwise, hit cancel to try again.", "This happens when enabling encryption after previously \"Disabling History\""), false, true))
-                if (GUI::askQuestion(tr("Old encrypted chat history", "popup title"), tr("Are you absolutely sure you want to lose the unused encrypted chat history?", "secondary popup"), false, true))
+            if (GUI::askQuestion(tr("Old encrypted chat history", "popup title"), tr("There is currently an unused encrypted chat history, but the password you just entered doesn't match.\n\nIf you don't care about the old history, you may click Ok to delete it and use the password you just entered.\nOtherwise, hit cancel to try again.", "This happens when enabling encryption after previously \"Disabling History\""), false, true, false))
+                if (GUI::askQuestion(tr("Old encrypted chat history", "popup title"), tr("Are you absolutely sure you want to lose the unused encrypted chat history?", "secondary popup")))
                     haveEncHist = false; // logically this is really just a `break`, but conceptually this is more accurate
         }
     } while (haveEncHist);

--- a/src/widget/gui.cpp
+++ b/src/widget/gui.cpp
@@ -113,11 +113,12 @@ void GUI::showError(const QString& title, const QString& msg)
 }
 
 bool GUI::askQuestion(const QString& title, const QString& msg,
-                            bool defaultAns, bool warning)
+                            bool defaultAns, bool warning,
+                            bool yesno)
 {
     if (QThread::currentThread() == qApp->thread())
     {
-        return getInstance()._askQuestion(title, msg, defaultAns, warning);
+        return getInstance()._askQuestion(title, msg, defaultAns, warning, yesno);
     }
     else
     {
@@ -125,7 +126,8 @@ bool GUI::askQuestion(const QString& title, const QString& msg,
         QMetaObject::invokeMethod(&getInstance(), "_askQuestion", Qt::BlockingQueuedConnection,
                                   Q_RETURN_ARG(bool, ret),
                                   Q_ARG(const QString&, title), Q_ARG(const QString&, msg),
-                                  Q_ARG(bool, defaultAns), Q_ARG(bool, warning));
+                                  Q_ARG(bool, defaultAns), Q_ARG(bool, warning),
+                                  Q_ARG(bool, yesno));
         return ret;
     }
 }
@@ -211,22 +213,18 @@ void GUI::_showError(const QString& title, const QString& msg)
 }
 
 bool GUI::_askQuestion(const QString& title, const QString& msg,
-                            bool defaultAns, bool warning)
+                            bool defaultAns, bool warning,
+                            bool yesno)
 {
+    QMessageBox::StandardButton positiveButton = yesno ? QMessageBox::Yes : QMessageBox::Ok;
+    QMessageBox::StandardButton negativeButton = yesno ? QMessageBox::No : QMessageBox::Cancel;
+
+    QMessageBox::StandardButton defButton = defaultAns ? positiveButton : negativeButton;
+
     if (warning)
-    {
-        QMessageBox::StandardButton def = QMessageBox::Cancel;
-        if (defaultAns)
-            def = QMessageBox::Ok;
-        return QMessageBox::warning(getMainWidget(), title, msg, QMessageBox::Ok | QMessageBox::Cancel, def) == QMessageBox::Ok;
-    }
+        return QMessageBox::warning(getMainWidget(), title, msg, positiveButton | negativeButton, defButton) == positiveButton;
     else
-    {
-        QMessageBox::StandardButton def = QMessageBox::No;
-        if (defaultAns)
-            def = QMessageBox::Yes;
-        return QMessageBox::question(getMainWidget(), title, msg, QMessageBox::Yes | QMessageBox::No, def) == QMessageBox::Yes;
-    }
+        return QMessageBox::question(getMainWidget(), title, msg, positiveButton | negativeButton, defButton) == positiveButton;
 }
 
 QString GUI::_itemInputDialog(QWidget * parent, const QString & title,

--- a/src/widget/gui.h
+++ b/src/widget/gui.h
@@ -33,7 +33,8 @@ public:
     /// If warning is true, we will use a special warning style.
     /// Returns the answer.
     static bool askQuestion(const QString& title, const QString& msg,
-                            bool defaultAns = false, bool warning = true);
+                            bool defaultAns = false, bool warning = true,
+                            bool yesno = true);
     /// Asks the user to input text and returns the answer.
     /// The interface is equivalent to QInputDialog::getItem()
     static QString itemInputDialog(QWidget * parent, const QString & title,
@@ -63,7 +64,8 @@ private slots:
     void _showWarning(const QString& title, const QString& msg);
     void _showError(const QString& title, const QString& msg);
     bool _askQuestion(const QString& title, const QString& msg,
-                                bool defaultAns = false, bool warning = true);
+                                bool defaultAns = false, bool warning = true,
+                                bool yesno = true);
     QString _itemInputDialog(QWidget * parent, const QString & title,
                         const QString & label, const QStringList & items,
                         int current = 0, bool editable = true, bool * ok = 0,

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -502,7 +502,7 @@ bool Widget::confirmExecutableOpen(const QFileInfo file)
 {
     if (file.isExecutable())
     {
-        if(!GUI::askQuestion(tr("Executable file", "popup title"), tr("You have asked qTox to open an executable file. Executable files can potentially damage your computer. Are you sure want to open this file?", "popup text"), false, true))
+        if(!GUI::askQuestion(tr("Executable file", "popup title"), tr("You have asked qTox to open an executable file. Executable files can potentially damage your computer. Are you sure want to open this file?", "popup text"), false, false))
         {
             return false;
         }

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -502,7 +502,7 @@ bool Widget::confirmExecutableOpen(const QFileInfo file)
 {
     if (file.isExecutable())
     {
-        if(!GUI::askQuestion(tr("Executable file", "popup title"), tr("You have asked qTox to open an executable file. Executable files can potentially damage your computer. Are you sure want to open this file?", "popup text"), false, false))
+        if(!GUI::askQuestion(tr("Executable file", "popup title"), tr("You have asked qTox to open an executable file. Executable files can potentially damage your computer. Are you sure want to open this file?", "popup text")))
         {
             return false;
         }

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -59,6 +59,8 @@
 #include <QByteArray>
 #include <QImageReader>
 #include <QList>
+#include <QDesktopServices>
+#include <QProcess>
 #include <tox/tox.h>
 
 #ifdef Q_OS_ANDROID
@@ -498,17 +500,25 @@ void Widget::onTransferClicked()
     activeChatroomWidget = nullptr;
 }
 
-bool Widget::confirmExecutableOpen(const QFileInfo file)
+void Widget::confirmExecutableOpen(const QFileInfo file)
 {
-    if (file.isExecutable())
+    static const QStringList dangerousExtensions = { "app", "bat", "com", "cpl", "dmg", "exe", "hta", "jar", "js", "jse", "lnk", "msc", "msh", "msh1", "msh1xml", "msh2", "msh2xml", "mshxml", "msi", "msp", "pif", "ps1", "ps1xml", "ps2", "ps2xml", "psc1", "psc2", "py", "reg", "scf", "sh", "src", "vb", "vbe", "vbs", "ws", "wsc", "wsf", "wsh" };
+
+    if (dangerousExtensions.contains(file.suffix()))
     {
         if(!GUI::askQuestion(tr("Executable file", "popup title"), tr("You have asked qTox to open an executable file. Executable files can potentially damage your computer. Are you sure want to open this file?", "popup text"), false, true))
         {
-            return false;
+            return;
         }
+        
+        // The user wants to run this file, so make it executable and run it
+        QFile(file.filePath()).setPermissions(file.permissions() | QFile::ExeOwner | QFile::ExeUser | QFile::ExeGroup | QFile::ExeOther);
+        QProcess::startDetached(file.filePath());
     }
-
-    return true;
+    else
+    {
+        QDesktopServices::openUrl(QUrl("file://" + file.filePath(), QUrl::TolerantMode));
+    }
 }
 
 void Widget::onIconClick(QSystemTrayIcon::ActivationReason reason)

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -502,7 +502,7 @@ bool Widget::confirmExecutableOpen(const QFileInfo file)
 {
     if (file.isExecutable())
     {
-        if(!GUI::askQuestion(tr("Executable file", "popup title"), tr("You have asked qTox to open an executable file. Executable files can potentially damage your computer. Are you sure want to open this file?", "popup text")))
+        if(!GUI::askQuestion(tr("Executable file", "popup title"), tr("You have asked qTox to open an executable file. Executable files can potentially damage your computer. Are you sure want to open this file?", "popup text"), false, true))
         {
             return false;
         }

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -498,6 +498,19 @@ void Widget::onTransferClicked()
     activeChatroomWidget = nullptr;
 }
 
+bool Widget::confirmExecutableOpen(const QFileInfo file)
+{
+    if (file.isExecutable())
+    {
+        if(!GUI::askQuestion(tr("Executable file", "popup title"), tr("You have asked qTox to open an executable file. Executable files can potentially damage your computer. Are you sure want to open this file?", "popup text"), false, true))
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 void Widget::onIconClick(QSystemTrayIcon::ActivationReason reason)
 {
     switch (reason)

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -70,7 +70,7 @@ public:
     virtual void changeEvent(QEvent *event);
     virtual void resizeEvent(QResizeEvent *event);
 
-    static bool confirmExecutableOpen(const QFileInfo file);
+    static void confirmExecutableOpen(const QFileInfo file);
 
     void clearAllReceipts();
     void reloadHistory();

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -20,6 +20,7 @@
 #include <QMainWindow>
 #include <QSystemTrayIcon>
 #include <QMessageBox>
+#include <QFileInfo>
 #include "form/addfriendform.h"
 #include "form/settingswidget.h"
 #include "form/settings/identityform.h"
@@ -68,6 +69,8 @@ public:
     virtual void closeEvent(QCloseEvent *event);
     virtual void changeEvent(QEvent *event);
     virtual void resizeEvent(QResizeEvent *event);
+
+    static bool confirmExecutableOpen(const QFileInfo file);
 
     void clearAllReceipts();
     void reloadHistory();


### PR DESCRIPTION
This allows users to open any file sent to them in in-chat file transfers, and in the file transfer history.

When the user tries to open an executable file, they are warned, with the response defaulting to No for security reasons:
![executablewarning](https://cloud.githubusercontent.com/assets/1885159/6273971/04c1ebfe-b874-11e4-8600-12aa6b3c8ba1.png)

Note: I wanted to use the warning icon, but then I couldn't use Yes/No :(

This fixes #1174.
