### PR TITLE
Make call tooltips depend on status, grey out vol and mic settings when not in call

### DIFF
--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -274,7 +274,7 @@ void ChatForm::onAvInvite(int FriendId, int CallId, bool video)
         callButton->setObjectName("grey");
         callButton->setToolTip("");
         videoButton->setObjectName("yellow");
-        videoButton->setToolTip(tr("Accept/Decline video call"));
+        videoButton->setToolTip(tr("Accept video call"));
         connect(videoButton, &QPushButton::clicked, this, &ChatForm::onAnswerCallTriggered);
     }
     else
@@ -286,7 +286,7 @@ void ChatForm::onAvInvite(int FriendId, int CallId, bool video)
         connect(callConfirm, &CallConfirmWidget::rejected, this, &ChatForm::onRejectCallTriggered);
 
         callButton->setObjectName("yellow");
-        callButton->setToolTip(tr("Accept/Decline audio call"));
+        callButton->setToolTip(tr("Accept audio call"));
         videoButton->setObjectName("grey");
         videoButton->setToolTip("");
         connect(callButton, &QPushButton::clicked, this, &ChatForm::onAnswerCallTriggered);

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -272,7 +272,9 @@ void ChatForm::onAvInvite(int FriendId, int CallId, bool video)
         connect(callConfirm, &CallConfirmWidget::rejected, this, &ChatForm::onRejectCallTriggered);
 
         callButton->setObjectName("grey");
+        callButton->setToolTip("");
         videoButton->setObjectName("yellow");
+        videoButton->setToolTip(tr("Accept/Decline video call"));
         connect(videoButton, &QPushButton::clicked, this, &ChatForm::onAnswerCallTriggered);
     }
     else
@@ -284,7 +286,9 @@ void ChatForm::onAvInvite(int FriendId, int CallId, bool video)
         connect(callConfirm, &CallConfirmWidget::rejected, this, &ChatForm::onRejectCallTriggered);
 
         callButton->setObjectName("yellow");
+        callButton->setToolTip(tr("Accept/Decline audio call"));
         videoButton->setObjectName("grey");
+        videoButton->setToolTip("");
         connect(callButton, &QPushButton::clicked, this, &ChatForm::onAnswerCallTriggered);
     }
     callButton->style()->polish(callButton);
@@ -317,7 +321,9 @@ void ChatForm::onAvStart(int FriendId, int CallId, bool video)
     if (video)
     {
         callButton->setObjectName("grey");
+        callButton->setToolTip("");
         videoButton->setObjectName("red");
+        videoButton->setToolTip(tr("End video call"));
         connect(videoButton, SIGNAL(clicked()),
                 this, SLOT(onHangupCallTriggered()));
 
@@ -326,12 +332,26 @@ void ChatForm::onAvStart(int FriendId, int CallId, bool video)
     else
     {
         callButton->setObjectName("red");
+        callButton->setToolTip(tr("End audio call"));
         videoButton->setObjectName("grey");
+        videoButton->setToolTip("");
         connect(callButton, SIGNAL(clicked()),
                 this, SLOT(onHangupCallTriggered()));
     }
     callButton->style()->polish(callButton);
     videoButton->style()->polish(videoButton);
+
+    micButton->setObjectName("green");
+    micButton->style()->polish(micButton);
+    micButton->setToolTip(tr("Mute microphone"));
+    volButton->setObjectName("green");
+    volButton->style()->polish(volButton);
+    volButton->setToolTip(tr("Mute call"));
+
+    connect(micButton, SIGNAL(clicked()),
+            this, SLOT(onMicMuteToggle()));
+    connect(volButton, SIGNAL(clicked()),
+            this, SLOT(onVolMuteToggle()));
     
     startCounter();
 }
@@ -386,8 +406,10 @@ void ChatForm::onAvRinging(int FriendId, int CallId, bool video)
     {
         callButton->setObjectName("grey");
         callButton->style()->polish(callButton);
+        callButton->setToolTip("");
         videoButton->setObjectName("yellow");
         videoButton->style()->polish(videoButton);
+        videoButton->setToolTip(tr("Cancel video call"));
         connect(videoButton, SIGNAL(clicked()),
                 this, SLOT(onCancelCallTriggered()));
     }
@@ -395,8 +417,10 @@ void ChatForm::onAvRinging(int FriendId, int CallId, bool video)
     {
         callButton->setObjectName("yellow");
         callButton->style()->polish(callButton);
+        callButton->setToolTip(tr("Cancel audio call"));
         videoButton->setObjectName("grey");
         videoButton->style()->polish(videoButton);
+        videoButton->setToolTip("");
         connect(callButton, SIGNAL(clicked()),
                 this, SLOT(onCancelCallTriggered()));
     }
@@ -417,8 +441,10 @@ void ChatForm::onAvStarting(int FriendId, int CallId, bool video)
     {
         callButton->setObjectName("grey");
         callButton->style()->polish(callButton);
+        callButton->setToolTip("");
         videoButton->setObjectName("red");
         videoButton->style()->polish(videoButton);
+        videoButton->setToolTip(tr("End video call"));
         connect(videoButton, SIGNAL(clicked()), this, SLOT(onHangupCallTriggered()));
 
         netcam->show(Core::getInstance()->getVideoSourceFromCall(CallId), f->getDisplayedName());
@@ -427,8 +453,10 @@ void ChatForm::onAvStarting(int FriendId, int CallId, bool video)
     {
         callButton->setObjectName("red");
         callButton->style()->polish(callButton);
+        callButton->setToolTip(tr("End audio call"));
         videoButton->setObjectName("grey");
         videoButton->style()->polish(videoButton);
+        videoButton->setToolTip("");
         connect(callButton, SIGNAL(clicked()), this, SLOT(onHangupCallTriggered()));
     }
     
@@ -614,16 +642,20 @@ void ChatForm::enableCallButtons()
     
     micButton->setObjectName("grey");
     micButton->style()->polish(micButton);
+    micButton->setToolTip("");
     micButton->disconnect();    
     volButton->setObjectName("grey");
     volButton->style()->polish(volButton);
+    volButton->setToolTip("");
     volButton->disconnect();
     
     callButton->setObjectName("grey");
     callButton->style()->polish(callButton);
+    callButton->setToolTip("");
     callButton->disconnect();
     videoButton->setObjectName("grey");
     videoButton->style()->polish(videoButton);
+    videoButton->setToolTip("");
     videoButton->disconnect();
     
     if(disableCallButtonsTimer == nullptr)
@@ -642,24 +674,19 @@ void ChatForm::onEnableCallButtons()
     qDebug() << "onEnableCallButtons";
     audioInputFlag = false;
     audioOutputFlag = false;
-    micButton->setObjectName("green");
-    micButton->style()->polish(micButton);
-    volButton->setObjectName("green");
-    volButton->style()->polish(volButton);
+
     callButton->setObjectName("green");
     callButton->style()->polish(callButton);
+    callButton->setToolTip(tr("Start audio call"));
     videoButton->setObjectName("green");
     videoButton->style()->polish(videoButton);
+    videoButton->setToolTip(tr("Start video call"));
     
     connect(callButton, SIGNAL(clicked()),
             this, SLOT(onCallTriggered()));
     connect(videoButton, SIGNAL(clicked()),
             this, SLOT(onVideoCallTriggered()));
-    connect(micButton, SIGNAL(clicked()),
-            this, SLOT(onMicMuteToggle()));
-    connect(volButton, SIGNAL(clicked()),
-            this, SLOT(onVolMuteToggle()));
-    
+
     disableCallButtonsTimer->stop();
     delete disableCallButtonsTimer;
     disableCallButtonsTimer = nullptr;
@@ -671,9 +698,15 @@ void ChatForm::onMicMuteToggle()
     {
         emit micMuteToggle(callId);
         if (micButton->objectName() == "red")
+        {
             micButton->setObjectName("green");
+            micButton->setToolTip(tr("Mute microphone"));
+        }
         else
+        {
             micButton->setObjectName("red");
+            micButton->setToolTip(tr("Unmute microphone"));
+        }
 
         Style::repolish(micButton);
     }
@@ -685,9 +718,15 @@ void ChatForm::onVolMuteToggle()
     {
         emit volMuteToggle(callId);
         if (volButton->objectName() == "red")
+        {
             volButton->setObjectName("green");
+            volButton->setToolTip(tr("Mute call"));
+        }
         else
+        {
             volButton->setObjectName("red");
+            volButton->setToolTip(tr("Unmute call"));
+        }
 
         Style::repolish(volButton);
     }

--- a/src/widget/form/chatform.h
+++ b/src/widget/form/chatform.h
@@ -121,7 +121,7 @@ private:
     void stopCounter();
     QString secondsToDHMS(quint32 duration);
     CallConfirmWidget *callConfirm;
-    void enableCallButtons();    
+    void enableCallButtons();
     bool isTyping;
 };
 

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -79,16 +79,16 @@ GenericChatForm::GenericChatForm(QWidget *parent)
     fileButton->setToolTip(tr("Send file(s)"));
     callButton = new QPushButton();
     callButton->setFixedSize(50,40);
-    callButton->setToolTip(tr("Audio call: RED means you're on a call"));
+    callButton->setToolTip(tr("Start an audio call"));
     videoButton = new QPushButton();
     videoButton->setFixedSize(50,40);
-    videoButton->setToolTip(tr("Video call: RED means you're on a call"));
+    videoButton->setToolTip(tr("Start a video call"));
     volButton = new QPushButton();
     //volButton->setFixedSize(25,20);
-    volButton->setToolTip(tr("Toggle speakers volume: RED is OFF"));
+    volButton->setToolTip("");
     micButton = new QPushButton();
     // micButton->setFixedSize(25,20);
-    micButton->setToolTip(tr("Toggle microphone: RED is OFF"));
+    micButton->setToolTip("");
 
     footButtonsSmall->setSpacing(2);
 
@@ -107,11 +107,11 @@ GenericChatForm::GenericChatForm(QWidget *parent)
     videoButton->setStyleSheet(Style::getStylesheet(":/ui/videoButton/videoButton.css"));
 
     QString volButtonStylesheet = Style::getStylesheet(":/ui/volButton/volButton.css");
-    volButton->setObjectName("green");
+    volButton->setObjectName("grey");
     volButton->setStyleSheet(volButtonStylesheet);
 
     QString micButtonStylesheet = Style::getStylesheet(":/ui/micButton/micButton.css");
-    micButton->setObjectName("green");
+    micButton->setObjectName("grey");
     micButton->setStyleSheet(micButtonStylesheet);
 
     setLayout(mainLayout);

--- a/src/widget/form/groupchatform.cpp
+++ b/src/widget/form/groupchatform.cpp
@@ -151,11 +151,13 @@ void GroupChatForm::onMicMuteToggle()
         {
             Core::getInstance()->enableGroupCallMic(group->getGroupId());
             micButton->setObjectName("green");
+            micButton->setToolTip(tr("Mute microphone"));
         }
         else
         {
             Core::getInstance()->disableGroupCallMic(group->getGroupId());
             micButton->setObjectName("red");
+            micButton->setToolTip(tr("Unmute microphone"));
         }
 
         Style::repolish(micButton);
@@ -170,11 +172,13 @@ void GroupChatForm::onVolMuteToggle()
         {
             Core::getInstance()->enableGroupCallVol(group->getGroupId());
             volButton->setObjectName("green");
+            volButton->setToolTip(tr("Mute call"));
         }
         else
         {
             Core::getInstance()->disableGroupCallVol(group->getGroupId());
             volButton->setObjectName("red");
+            volButton->setToolTip(tr("Unmute call"));
         }
 
         Style::repolish(volButton);
@@ -190,6 +194,13 @@ void GroupChatForm::onCallClicked()
         audioOutputFlag = true;
         callButton->setObjectName("red");
         callButton->style()->polish(callButton);
+        callButton->setToolTip(tr("End audio call"));
+        micButton->setObjectName("green");
+        micButton->style()->polish(micButton);
+        micButton->setToolTip(tr("Mute microphone"));
+        volButton->setObjectName("green");
+        volButton->style()->polish(volButton);
+        volButton->setToolTip(tr("Mute call"));
         inCall = true;
     }
     else
@@ -197,12 +208,15 @@ void GroupChatForm::onCallClicked()
         Core::getInstance()->leaveGroupCall(group->getGroupId());
         audioInputFlag = false;
         audioOutputFlag = false;
-        micButton->setObjectName("green");
-        micButton->style()->polish(micButton);
-        volButton->setObjectName("green");
-        volButton->style()->polish(volButton);
         callButton->setObjectName("green");
         callButton->style()->polish(callButton);
+        callButton->setToolTip(tr("Start audio call"));
+        micButton->setObjectName("grey");
+        micButton->style()->polish(micButton);
+        micButton->setToolTip("");
+        volButton->setObjectName("grey");
+        volButton->style()->polish(volButton);
+        volButton->setToolTip("");
         inCall = false;
     }
 }


### PR DESCRIPTION
Now qTox finally properly states what the call buttons will do on click when hovering over them. It also greys out the volume and microphone toggles when not in a call.

These two changes will hopefully alleviate much of the issues in #823.

![1](https://cloud.githubusercontent.com/assets/1885159/6320002/12420d5c-bad3-11e4-89c1-953aa6766b12.png)
![3](https://cloud.githubusercontent.com/assets/1885159/6320012/9a99edd2-bad3-11e4-9e9f-3211890dcd5a.png)

(Note: I only screenshot the call button now, but all call-related buttons have been fixed to clearly state what clicking them will do)
