### PR TITLE
[qtox.pro] add more INCLUDEPATH for GTK deps

### DIFF
--- a/qtox.pro
+++ b/qtox.pro
@@ -206,14 +206,17 @@ contains(ENABLE_SYSTRAY_STATUSNOTIFIER_BACKEND, NO) {
 
 	INCLUDEPATH += "/usr/include/gtk-2.0"
 	INCLUDEPATH += "/usr/include/glib-2.0"
+	INCLUDEPATH += "/usr/lib/glib-2.0/include"
 	INCLUDEPATH += "/usr/lib/x86_64-linux-gnu/glib-2.0/include"
 	INCLUDEPATH += "/usr/lib/i386-linux-gnu/glib-2.0/include"
+	INCLUDEPATH += "/usr/lib/gtk-2.0/include"
 	INCLUDEPATH += "/usr/lib/x86_64-linux-gnu/gtk-2.0/include"
 	INCLUDEPATH += "/usr/lib/i386-linux-gnu/gtk-2.0/include"
+	INCLUDEPATH += "/usr/include/atk-1.0"
 	INCLUDEPATH += "/usr/include/gdk-pixbuf-2.0"
 	INCLUDEPATH += "/usr/include/cairo"
 	INCLUDEPATH += "/usr/include/pango-1.0"
-	INCLUDEPATH += "/usr/include/atk-1.0"
+
 
 	LIBS += -lglib-2.0 -lgdk_pixbuf-2.0 -lgio-2.0 -lcairo -lgtk-x11-2.0 -lgdk-x11-2.0 -lgobject-2.0
 


### PR DESCRIPTION
On some distributions there is no /usr/lib/{x86_64-linux-gnu,i386-linux-gnu}

fixes #1262
