### PR TITLE
Make default friend request message contain nickname

### DIFF
--- a/src/widget/form/addfriendform.cpp
+++ b/src/widget/form/addfriendform.cpp
@@ -21,6 +21,7 @@
 #include <QErrorMessage>
 #include <tox/tox.h>
 #include "ui_mainwindow.h"
+#include "src/nexus.h"
 #include "src/core.h"
 #include "src/misc/cdata.h"
 #include "src/toxdns.h"
@@ -37,7 +38,6 @@ AddFriendForm::AddFriendForm()
     toxIdLabel.setText(tr("Tox ID","Tox ID of the person you're sending a friend request to"));
     messageLabel.setText(tr("Message","The message you send in friend requests"));
     sendButton.setText(tr("Send friend request"));
-    message.setPlaceholderText(tr("Tox me maybe?","Default message in friend requests if the field is left blank. Write something appropriate!"));
 
     main->setLayout(&layout);
     layout.addWidget(&toxIdLabel);
@@ -50,6 +50,7 @@ AddFriendForm::AddFriendForm()
     headLayout.addWidget(&headLabel);
 
     connect(&sendButton, SIGNAL(clicked()), this, SLOT(onSendTriggered()));
+    connect(Nexus::getCore(), &Core::usernameSet, this, &AddFriendForm::onUsernameSet);
 }
 
 AddFriendForm::~AddFriendForm()
@@ -79,6 +80,11 @@ void AddFriendForm::showWarning(const QString &message) const
     warning.setText(message);
     warning.setIcon(QMessageBox::Warning);
     warning.exec();
+}
+
+void AddFriendForm::onUsernameSet(const QString& username)
+{
+    message.setPlaceholderText(tr("%1 here! Tox me maybe?","Default message in friend requests if the field is left blank. Write something appropriate!").arg(username));
 }
 
 void AddFriendForm::onSendTriggered()

--- a/src/widget/form/addfriendform.h
+++ b/src/widget/form/addfriendform.h
@@ -41,6 +41,9 @@ signals:
 protected:
     void showWarning(const QString& message) const;
 
+public slots:
+    void onUsernameSet(const QString& userName);
+
 private slots:
     void onSendTriggered();
 

--- a/src/widget/toxuri.cpp
+++ b/src/widget/toxuri.cpp
@@ -18,6 +18,7 @@
 #include "src/widget/toxuri.h"
 #include "src/toxdns.h"
 #include "src/widget/tool/friendrequestdialog.h"
+#include "src/nexus.h"
 #include "src/core.h"
 #include <QByteArray>
 #include <QString>
@@ -67,7 +68,7 @@ void handleToxURI(const QString &toxURI)
     }
     else
     {
-        ToxURIDialog dialog(0, toxaddr, QObject::tr("Tox me maybe?","Default message in Tox URI friend requests. Write something appropriate!"));
+        ToxURIDialog dialog(0, toxaddr, QObject::tr("%1 here! Tox me maybe?","Default message in Tox URI friend requests. Write something appropriate!").arg(Nexus::getCore()->getUsername()));
         if (dialog.exec() == QDialog::Accepted)
             Core::getInstance()->requestFriendship(toxid, dialog.getRequestMessage());
     }


### PR DESCRIPTION
Make the default friend invite message contain your username. For example, when your username is Testuser, the default message will now be `Testuser here! Tox me maybe?` instead of simply `Tox me maybe?`

The rationale behind this is to make friend requests more user-friendly by allowing friends to recognise each other more easily due to a nickname, which friends will usually know from each other, being included in the friend request message.

![request_send](https://cloud.githubusercontent.com/assets/1885159/6349854/f4fca83a-bc2e-11e4-9fed-2e42406f8f35.png)
![request_receive](https://cloud.githubusercontent.com/assets/1885159/6349862/04bc14fe-bc2f-11e4-9d01-4bdf8380371e.png)
