### PR TITLE
[qtox.pro] fix building with support for libappindicator

### DIFF
--- a/qtox.pro
+++ b/qtox.pro
@@ -192,18 +192,22 @@ unix:!macx:!android {
 contains(ENABLE_SYSTRAY_UNITY_BACKEND, YES) {
 	DEFINES += ENABLE_SYSTRAY_UNITY_BACKEND
 
-	INCLUDEPATH += "/usr/include/libappindicator-0.1"
-	INCLUDEPATH += "/usr/include/gtk-2.0"
 	INCLUDEPATH += "/usr/include/glib-2.0"
-	INCLUDEPATH += "/usr/lib/x86_64-linux-gnu/glib-2.0/include"
+	INCLUDEPATH += "/usr/lib/glib-2.0/include"
+	INCLUDEPATH += "/usr/lib64/glib-2.0/include"
 	INCLUDEPATH += "/usr/lib/i386-linux-gnu/glib-2.0/include"
-	INCLUDEPATH += "/usr/include/cairo"
-	INCLUDEPATH += "/usr/include/pango-1.0"
-	INCLUDEPATH += "/usr/lib/x86_64-linux-gnu/gtk-2.0/include"
+	INCLUDEPATH += "/usr/lib/x86_64-linux-gnu/glib-2.0/include"
+	INCLUDEPATH += "/usr/include/gtk-2.0"
+	INCLUDEPATH += "/usr/lib/gtk-2.0/include"
+	INCLUDEPATH += "/usr/lib64/gtk-2.0/include"
 	INCLUDEPATH += "/usr/lib/i386-linux-gnu/gtk-2.0/include"
-	INCLUDEPATH += "/usr/include/gdk-pixbuf-2.0"
+	INCLUDEPATH += "/usr/lib/x86_64-linux-gnu/gtk-2.0/include"
 	INCLUDEPATH += "/usr/include/atk-1.0"
+	INCLUDEPATH += "/usr/include/cairo"
+	INCLUDEPATH += "/usr/include/gdk-pixbuf-2.0"
+	INCLUDEPATH += "/usr/include/libappindicator-0.1"
 	INCLUDEPATH += "/usr/include/libdbusmenu-glib-0.4"
+	INCLUDEPATH += "/usr/include/pango-1.0"
 
 	LIBS += -lgobject-2.0 -lappindicator -lgtk-x11-2.0
 }
@@ -215,19 +219,19 @@ contains(ENABLE_SYSTRAY_STATUSNOTIFIER_BACKEND, NO) {
 } else {
 	DEFINES += ENABLE_SYSTRAY_STATUSNOTIFIER_BACKEND
 
-	INCLUDEPATH += "/usr/include/gtk-2.0"
 	INCLUDEPATH += "/usr/include/glib-2.0"
 	INCLUDEPATH += "/usr/lib/glib-2.0/include"
 	INCLUDEPATH += "/usr/lib64/glib-2.0/include"
-	INCLUDEPATH += "/usr/lib/x86_64-linux-gnu/glib-2.0/include"
 	INCLUDEPATH += "/usr/lib/i386-linux-gnu/glib-2.0/include"
+	INCLUDEPATH += "/usr/lib/x86_64-linux-gnu/glib-2.0/include"
+	INCLUDEPATH += "/usr/include/gtk-2.0"
 	INCLUDEPATH += "/usr/lib/gtk-2.0/include"
 	INCLUDEPATH += "/usr/lib64/gtk-2.0/include"
-	INCLUDEPATH += "/usr/lib/x86_64-linux-gnu/gtk-2.0/include"
 	INCLUDEPATH += "/usr/lib/i386-linux-gnu/gtk-2.0/include"
+	INCLUDEPATH += "/usr/lib/x86_64-linux-gnu/gtk-2.0/include"
 	INCLUDEPATH += "/usr/include/atk-1.0"
-	INCLUDEPATH += "/usr/include/gdk-pixbuf-2.0"
 	INCLUDEPATH += "/usr/include/cairo"
+	INCLUDEPATH += "/usr/include/gdk-pixbuf-2.0"
 	INCLUDEPATH += "/usr/include/pango-1.0"
 
 
@@ -250,14 +254,16 @@ contains(ENABLE_SYSTRAY_GTK_BACKEND, NO) {
 } else {
 	DEFINES += ENABLE_SYSTRAY_GTK_BACKEND
 
-	INCLUDEPATH += "/usr/include/gtk-2.0"
 	INCLUDEPATH += "/usr/include/glib-2.0"
 	INCLUDEPATH += "/usr/lib/glib-2.0/include"
-	INCLUDEPATH += "/usr/lib/x86_64-linux-gnu/glib-2.0/include"
+	INCLUDEPATH += "/usr/lib64/glib-2.0/include"
 	INCLUDEPATH += "/usr/lib/i386-linux-gnu/glib-2.0/include"
+	INCLUDEPATH += "/usr/lib/x86_64-linux-gnu/glib-2.0/include"
+	INCLUDEPATH += "/usr/include/gtk-2.0"
 	INCLUDEPATH += "/usr/lib/gtk-2.0/include"
-	INCLUDEPATH += "/usr/lib/x86_64-linux-gnu/gtk-2.0/include"
+	INCLUDEPATH += "/usr/lib64/gtk-2.0/include"
 	INCLUDEPATH += "/usr/lib/i386-linux-gnu/gtk-2.0/include"
+	INCLUDEPATH += "/usr/lib/x86_64-linux-gnu/gtk-2.0/include"
 	INCLUDEPATH += "/usr/include/atk-1.0"
 	INCLUDEPATH += "/usr/include/gdk-pixbuf-2.0"
 	INCLUDEPATH += "/usr/include/cairo"


### PR DESCRIPTION
Changes to appindicator section are necessary to build qTox with support for libappindicator on Gentoo, and possibly on other distros as well.

Someone on IRC confirmed that there is `/usr/lib/x86_64-linux-gnu/libappindicator3.so.1.0.0` on Ubuntu 14.04, so it probably will work (?).

Rest of changes is either cosmetic or should help with eventual building with GTK tray backend on some(?) distros.

I could test only on Gentoo, and whereas compiling works, I encountered a problem. I don't know whether that's due to linking against `libappindicator3`, or whatever, so…

```
$ XDG_CURRENT_DESKTOP="unity" qtox

…

SystemTrayIcon: Using Unity backend

(qtox:2618): Gtk-ERROR **: GTK+ 2.x symbols detected. Using GTK+ 2.x and GTK+ 3 in the same process is not supported

Program received signal SIGTRAP, Trace/breakpoint trap.
g_logv (log_domain=0x7ffff5803c7b "Gtk", log_level=G_LOG_LEVEL_ERROR, format=<optimized out>, args=args@entry=0x7fffffffcca0)
    at /var/tmp/portage/dev-libs/glib-2.40.2/work/glib-2.40.2/glib/gmessages.c:1038
1038    /var/tmp/portage/dev-libs/glib-2.40.2/work/glib-2.40.2/glib/gmessages.c: No such file or directory.
(gdb) bt
#0  g_logv (log_domain=0x7ffff5803c7b "Gtk", log_level=G_LOG_LEVEL_ERROR, format=<optimized out>, args=args@entry=0x7fffffffcca0)
    at /var/tmp/portage/dev-libs/glib-2.40.2/work/glib-2.40.2/glib/gmessages.c:1038
#1  0x00007ffff19ae2bb in g_log (log_domain=log_domain@entry=0x7ffff5803c7b "Gtk", log_level=log_level@entry=G_LOG_LEVEL_ERROR, 
    format=format@entry=0x7ffff58975e0 "GTK+ 2.x symbols detected. Using GTK+ 2.x and GTK+ 3 in the same process is not supported")
    at /var/tmp/portage/dev-libs/glib-2.40.2/work/glib-2.40.2/glib/gmessages.c:1071
#2  0x00007ffff5603832 in do_pre_parse_initialization (argc=0x0, argv=0x0) at /var/tmp/portage/x11-libs/gtk+-2.24.25/work/gtk+-2.24.25/gtk/gtkmain.c:677
#3  pre_parse_hook (context=<optimized out>, group=<optimized out>, data=<optimized out>, error=<optimized out>)
    at /var/tmp/portage/x11-libs/gtk+-2.24.25/work/gtk+-2.24.25/gtk/gtkmain.c:785
#4  0x00007ffff19b3427 in g_option_context_parse (context=context@entry=0x555555e5aa90, argc=argc@entry=0x0, argv=argv@entry=0x0, error=error@entry=0x7fffffffce80)
    at /var/tmp/portage/dev-libs/glib-2.40.2/work/glib-2.40.2/glib/goption.c:1872
#5  0x00007ffff5603b1d in IA__gtk_parse_args (argc=0x0, argv=0x0) at /var/tmp/portage/x11-libs/gtk+-2.24.25/work/gtk+-2.24.25/gtk/gtkmain.c:956
#6  0x00007ffff5603bab in IA__gtk_init_check (argc=<optimized out>, argv=<optimized out>) at /var/tmp/portage/x11-libs/gtk+-2.24.25/work/gtk+-2.24.25/gtk/gtkmain.c:992
#7  0x00007ffff5603c0b in IA__gtk_init (argc=<optimized out>, argv=<optimized out>) at /var/tmp/portage/x11-libs/gtk+-2.24.25/work/gtk+-2.24.25/gtk/gtkmain.c:1042
#8  0x00005555555e9f24 in SystemTrayIcon::SystemTrayIcon (this=0x555555e53090) at src/widget/systemtrayicon.cpp:18
#9  0x00005555555bed41 in Widget::init (this=0x555555d2ac80) at src/widget/widget.cpp:119
#10 0x0000555555672b98 in Nexus::start (this=0x555555d21750) at src/nexus.cpp:76
#11 0x00005555556718d2 in main (argc=3, argv=0x7fffffffdd38) at src/main.cpp:194
```
