### PR TITLE
qlabels will not support richtext, plaintext only

### DIFF
--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -57,7 +57,8 @@ ChatForm::ChatForm(Friend* chatFriend)
     statusMessageLabel->setObjectName("statusLabel");
     statusMessageLabel->setFont(Style::getFont(Style::Medium));
     statusMessageLabel->setMinimumHeight(Style::getFont(Style::Medium).pixelSize());
-
+    statusMessageLabel->setTextFormat(Qt::PlainText);
+    
     callConfirm = nullptr;
     offlineEngine = new OfflineMsgEngine(f);
 

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -49,10 +49,11 @@ GenericChatForm::GenericChatForm(QWidget *parent)
     nameLabel->setObjectName("nameLabel");
     nameLabel->setMinimumHeight(Style::getFont(Style::Medium).pixelSize());
     nameLabel->setEditable(true);
+    nameLabel->setTextFormat(Qt::PlainText);   
 
     avatar = new MaskablePixmapWidget(this, QSize(40,40), ":/img/avatar_mask.png");
     QHBoxLayout *headLayout = new QHBoxLayout(),
-            *mainFootLayout = new QHBoxLayout();
+                *mainFootLayout = new QHBoxLayout();
     
     QVBoxLayout *mainLayout = new QVBoxLayout(),
                 *footButtonsSmall = new QVBoxLayout(),

--- a/src/widget/form/groupchatform.cpp
+++ b/src/widget/form/groupchatform.cpp
@@ -63,9 +63,15 @@ GroupChatForm::GroupChatForm(Group* chatGroup)
 
     namesListLayout = new FlowLayout(0,5,0);
     QStringList names(group->getPeerList());
+    QLabel *l;
+    
     for (const QString& name : names)
-        namesListLayout->addWidget(new QLabel(name));
-
+    {
+        l = new QLabel(name);
+        l->setTextFormat(Qt::PlainText);
+        namesListLayout->addWidget(l);
+    }
+    
     headTextLayout->addWidget(nusersLabel);
     headTextLayout->addLayout(namesListLayout);
     headTextLayout->addStretch();
@@ -124,6 +130,7 @@ void GroupChatForm::onUserListChanged()
             nameStr+=", ";
         QLabel* nameLabel = new QLabel(nameStr);
         nameLabel->setObjectName("peersLabel");
+        nameLabel->setTextFormat(Qt::PlainText);
         namesListLayout->addWidget(nameLabel);
     }
 }

--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -45,6 +45,8 @@ FriendWidget::FriendWidget(int FriendId, QString id)
     avatar->setPixmap(QPixmap(":img/contact.png"), Qt::transparent);
     statusPic.setPixmap(QPixmap(":img/status/dot_away.png"));
     nameLabel->setText(id);
+    nameLabel->setTextFormat(Qt::PlainText);
+    statusMessageLabel->setTextFormat(Qt::PlainText);
 }
 
 void FriendWidget::contextMenuEvent(QContextMenuEvent * event)

--- a/src/widget/genericchatroomwidget.cpp
+++ b/src/widget/genericchatroomwidget.cpp
@@ -44,6 +44,8 @@ GenericChatroomWidget::GenericChatroomWidget(QWidget *parent)
     // name text
     nameLabel = new CroppingLabel(this);
     nameLabel->setObjectName("name");
+    nameLabel->setTextFormat(Qt::PlainText);
+    statusMessageLabel->setTextFormat(Qt::PlainText);
 
     onCompactChanged(property("compact").toBool());
 


### PR DESCRIPTION
removes support for HTML, QML, JS and CSS in username/status labels

this commit closes #1298(bug) #1295(bug) and #1224(feature request)

![](https://i.imgur.com/KvB9j9k.png)
