### PR TITLE
Add image preview on mouseover

### DIFF
--- a/src/chatlog/content/filetransferwidget.cpp
+++ b/src/chatlog/content/filetransferwidget.cpp
@@ -26,6 +26,7 @@
 #include <QFile>
 #include <QMessageBox>
 #include <QDesktopServices>
+#include <QDesktopWidget>
 #include <QPainter>
 #include <QVariantAnimation>
 #include <QDebug>
@@ -449,6 +450,23 @@ void FileTransferWidget::showPreview(const QString &filename)
         QPixmap pmap = QPixmap(filename).scaled(QSize(size, size), Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation);
         ui->previewLabel->setPixmap(pmap);
         ui->previewLabel->show();
+
+        // Show preview, but make sure it's not larger than 50% of the screen width/height
+        QRect maxSize = QApplication::desktop()->screenGeometry();
+        maxSize.setWidth(0.5*maxSize.width());
+        maxSize.setHeight(0.5*maxSize.height());
+
+        QImage image = QImage(filename);
+        QSize imageSize(image.width(), image.height());
+        if (imageSize.width() > maxSize.width() || imageSize.height() > maxSize.height())
+        {
+            imageSize.scale(maxSize.width(), maxSize.height(), Qt::KeepAspectRatio);
+            ui->previewLabel->setToolTip("<html><img src="+filename+" width="+QString::number(imageSize.width())+" height="+QString::number(imageSize.height())+"/></html>");
+        }
+        else
+        {
+            ui->previewLabel->setToolTip("<html><img src"+filename+"/></html>");
+        }
     }
 }
 


### PR DESCRIPTION
On placing your mouse onto the image preview in a file transfer, a tooltip will pop up, showing the image. If the image is too large, it is scaled down to make sure it never takes more than 50% of the screen.
![qtox_preview](https://cloud.githubusercontent.com/assets/1885159/6426832/16b721a8-bf6d-11e4-88a7-8bbb7eaee648.png)

fixes #980 
