### PR TITLE
Enable high DPI support

### DIFF
--- a/qtox.pro
+++ b/qtox.pro
@@ -5,7 +5,7 @@
 #-------------------------------------------------
 
 
-#    Copyright (C) 2014 by Project Tox <https://tox.im>
+#    Copyright (C) 2015 by Project Tox <https://tox.im>
 #
 #    This file is part of qTox, a Qt-based graphical interface for Tox.
 #
@@ -98,6 +98,11 @@ contains(DISABLE_FILTER_AUDIO, YES) {
 
 } else {
      DEFINES += QTOX_FILTER_AUDIO
+}
+
+contains(HIGH_DPI, YES) {
+    QT_DEVICE_PIXEL_RATIO= auto
+    DEFINES += HIGH_DPI
 }
 
 contains(JENKINS,YES) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,6 +62,10 @@ int main(int argc, char *argv[])
     a.setApplicationName("qTox");
     a.setOrganizationName("Tox");
     a.setApplicationVersion("\nGit commit: " + QString(GIT_VERSION));
+    
+#ifdef HIGH_DPI
+    a.setAttribute(Qt::AA_UseHighDpiPixmaps, true);
+#endif
 
     // Process arguments
     QCommandLineParser parser;

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -471,6 +471,7 @@ void Widget::onStatusSet(Status status)
 void Widget::setWindowTitle(const QString& title)
 {
     QString tmp = title;
+    /// <[^>]*> Regexp to remove HTML tags, in case someone used them in title
     QMainWindow::setWindowTitle("qTox - " + tmp.remove(QRegExp("<[^>]*>")));
 }
 

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -470,7 +470,8 @@ void Widget::onStatusSet(Status status)
 
 void Widget::setWindowTitle(const QString& title)
 {
-    QMainWindow::setWindowTitle("qTox - " + title);
+    QString tmp = title;
+    QMainWindow::setWindowTitle("qTox - " + tmp.remove(QRegExp("<[^>]*>")));
 }
 
 void Widget::forceShow()


### PR DESCRIPTION
This basically makes things using pixels scale up like they do on a Mac, so on high resolution displays (muh 5k) things are actually readable and you can tell what you're looking at.

In some cases it reduces CPU usage because pixmaps on high DPI displays are horribly inefficient.

Also, _slight_ chance this isn't supported by Linux, but I can't test it because Linux on the desktop is broken ootb.

Depends on Qt 5.4+ so it's behind a define, just enable HIGH_DPI.

Sorry about the commit spam, used the web UI to do it quickly because I don't have my pgp key on hand but actually verified it worked in production™
