### PR TITLE
Move the identity settings tab into its own dedicated profile page (fixes #1012)

### DIFF
--- a/qtox.pro
+++ b/qtox.pro
@@ -315,10 +315,10 @@ contains(ENABLE_SYSTRAY_GTK_BACKEND, NO) {
         src/widget/form/settingswidget.h \
         src/widget/form/settings/genericsettings.h \
         src/widget/form/settings/generalform.h \
-        src/widget/form/settings/identityform.h \
         src/widget/form/settings/privacyform.h \
         src/widget/form/settings/avform.h \
         src/widget/form/filesform.h \
+        src/widget/form/profileform.h \
         src/widget/tool/chattextedit.h \
         src/widget/tool/friendrequestdialog.h \
         src/widget/friendwidget.h \
@@ -343,9 +343,9 @@ contains(ENABLE_SYSTRAY_GTK_BACKEND, NO) {
         src/widget/form/addfriendform.cpp \
         src/widget/form/settingswidget.cpp \
         src/widget/form/settings/generalform.cpp \
-        src/widget/form/settings/identityform.cpp \
         src/widget/form/settings/privacyform.cpp \
         src/widget/form/settings/avform.cpp \
+        src/widget/form/profileform.cpp \
         src/widget/form/filesform.cpp \
         src/widget/tool/chattextedit.cpp \
         src/widget/tool/friendrequestdialog.cpp \

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -855,6 +855,9 @@ QSplitter:handle{
                    <bold>true</bold>
                   </font>
                  </property>
+                 <property name="cursor">
+                  <cursorShape>PointingHandCursor</cursorShape>
+                 </property>
                  <property name="text">
                   <string>Your name</string>
                  </property>
@@ -1037,8 +1040,8 @@ QSplitter:handle{
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>284</width>
-             <height>399</height>
+             <width>285</width>
+             <height>381</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_5"/>
@@ -1779,7 +1782,7 @@ QSplitter:handle{
      <x>0</x>
      <y>0</y>
      <width>775</width>
-     <height>20</height>
+     <height>22</height>
     </rect>
    </property>
   </widget>

--- a/src/widget/form/profileform.cpp
+++ b/src/widget/form/profileform.cpp
@@ -111,7 +111,7 @@ ProfileForm::ProfileForm(QWidget *parent) :
 ProfileForm::~ProfileForm()
 {
     delete bodyUI;
-    delete head;
+    head->deleteLater();
 }
 
 void ProfileForm::show(Ui::MainWindow &ui)

--- a/src/widget/form/profileform.cpp
+++ b/src/widget/form/profileform.cpp
@@ -36,6 +36,16 @@
 #include <QBuffer>
 
 
+void ProfileForm::refreshProfiles()
+{
+    bodyUI->profiles->clear();
+    for (QString profile : Settings::getInstance().searchProfiles())
+        bodyUI->profiles->addItem(profile);
+    QString current = Settings::getInstance().getCurrentProfile();
+    if (current != "")
+        bodyUI->profiles->setCurrentText(current);
+}
+
 ProfileForm::ProfileForm(QWidget *parent) :
     QWidget(parent)
 {
@@ -317,4 +327,10 @@ void ProfileForm::enableSwitching()
         bodyUI->loadButton->setEnabled(true);
         bodyUI->newButton->setEnabled(true);
     }
+}
+
+void ProfileForm::showEvent(QShowEvent *event)
+{
+    refreshProfiles();
+    QWidget::showEvent(event);
 }

--- a/src/widget/form/profileform.cpp
+++ b/src/widget/form/profileform.cpp
@@ -15,9 +15,11 @@
 */
 
 #include "src/core.h"
+#include "src/nexus.h"
 #include "ui_identitysettings.h"
-#include "identityform.h"
+#include "profileform.h"
 #include "src/widget/form/settingswidget.h"
+#include "src/widget/maskablepixmapwidget.h"
 #include "src/misc/settings.h"
 #include "src/widget/croppinglabel.h"
 #include "src/widget/widget.h"
@@ -26,13 +28,16 @@
 #include "src/misc/style.h"
 #include <QLabel>
 #include <QLineEdit>
+#include <QGroupBox>
 #include <QApplication>
 #include <QClipboard>
 #include <QInputDialog>
 #include <QFileDialog>
+#include <QBuffer>
 
-IdentityForm::IdentityForm() :
-    GenericForm(tr("Identity"), QPixmap(":/img/settings/identity.png"))
+
+ProfileForm::ProfileForm(QWidget *parent) :
+    QWidget(parent)
 {
     bodyUI = new Ui::IdentitySettings;
     bodyUI->setupUi(this);
@@ -46,42 +51,50 @@ IdentityForm::IdentityForm() :
     
     bodyUI->toxGroup->layout()->addWidget(toxId);
 
+    profilePicture = new MaskablePixmapWidget(this, QSize(64, 64), ":/img/avatar_mask.png");
+    profilePicture->setPixmap(QPixmap(":/img/contact_dark.png"));
+    profilePicture->setClickable(true);
+    connect(profilePicture, SIGNAL(clicked()), this, SLOT(onAvatarClicked()));
+    QHBoxLayout *publicGrouplayout = qobject_cast<QHBoxLayout*>(bodyUI->publicGroup->layout());
+    publicGrouplayout->insertWidget(0, profilePicture);
+    publicGrouplayout->insertSpacing(1, 7);
+
     timer.setInterval(750);
     timer.setSingleShot(true);
     connect(&timer, &QTimer::timeout, this, [=]() {bodyUI->toxIdLabel->setText(bodyUI->toxIdLabel->text().replace(" ✔", "")); hasCheck = false;});
     
     connect(bodyUI->toxIdLabel, SIGNAL(clicked()), this, SLOT(copyIdClicked()));
     connect(toxId, SIGNAL(clicked()), this, SLOT(copyIdClicked()));
-    connect(core, &Core::idSet, this, &IdentityForm::setToxId);
+    connect(core, &Core::idSet, this, &ProfileForm::setToxId);
     connect(bodyUI->userName, SIGNAL(editingFinished()), this, SLOT(onUserNameEdited()));
     connect(bodyUI->statusMessage, SIGNAL(editingFinished()), this, SLOT(onStatusMessageEdited()));
-    connect(bodyUI->loadButton, &QPushButton::clicked, this, &IdentityForm::onLoadClicked);
-    connect(bodyUI->renameButton, &QPushButton::clicked, this, &IdentityForm::onRenameClicked);
-    connect(bodyUI->exportButton, &QPushButton::clicked, this, &IdentityForm::onExportClicked);
-    connect(bodyUI->deleteButton, &QPushButton::clicked, this, &IdentityForm::onDeleteClicked);
-    connect(bodyUI->importButton, &QPushButton::clicked, this, &IdentityForm::onImportClicked);
-    connect(bodyUI->newButton, &QPushButton::clicked, this, &IdentityForm::onNewClicked);
+    connect(bodyUI->loadButton, &QPushButton::clicked, this, &ProfileForm::onLoadClicked);
+    connect(bodyUI->renameButton, &QPushButton::clicked, this, &ProfileForm::onRenameClicked);
+    connect(bodyUI->exportButton, &QPushButton::clicked, this, &ProfileForm::onExportClicked);
+    connect(bodyUI->deleteButton, &QPushButton::clicked, this, &ProfileForm::onDeleteClicked);
+    connect(bodyUI->importButton, &QPushButton::clicked, this, &ProfileForm::onImportClicked);
+    connect(bodyUI->newButton, &QPushButton::clicked, this, &ProfileForm::onNewClicked);
 
-    connect(core, &Core::avStart, this, &IdentityForm::disableSwitching);
-    connect(core, &Core::avStarting, this, &IdentityForm::disableSwitching);
-    connect(core, &Core::avInvite, this, &IdentityForm::disableSwitching);
-    connect(core, &Core::avRinging, this, &IdentityForm::disableSwitching);
-    connect(core, &Core::avCancel, this, &IdentityForm::enableSwitching);
-    connect(core, &Core::avEnd, this, &IdentityForm::enableSwitching);
-    connect(core, &Core::avEnding, this, &IdentityForm::enableSwitching);
-    connect(core, &Core::avPeerTimeout, this, &IdentityForm::enableSwitching);
-    connect(core, &Core::avRequestTimeout, this, &IdentityForm::enableSwitching);
+    connect(core, &Core::avStart, this, &ProfileForm::disableSwitching);
+    connect(core, &Core::avStarting, this, &ProfileForm::disableSwitching);
+    connect(core, &Core::avInvite, this, &ProfileForm::disableSwitching);
+    connect(core, &Core::avRinging, this, &ProfileForm::disableSwitching);
+    connect(core, &Core::avCancel, this, &ProfileForm::enableSwitching);
+    connect(core, &Core::avEnd, this, &ProfileForm::enableSwitching);
+    connect(core, &Core::avEnding, this, &ProfileForm::enableSwitching);
+    connect(core, &Core::avPeerTimeout, this, &ProfileForm::enableSwitching);
+    connect(core, &Core::avRequestTimeout, this, &ProfileForm::enableSwitching);
 
     connect(core, &Core::usernameSet, this, [=](const QString& val) { bodyUI->userName->setText(val); });
     connect(core, &Core::statusMessageSet, this, [=](const QString& val) { bodyUI->statusMessage->setText(val); });
 }
 
-IdentityForm::~IdentityForm()
+ProfileForm::~ProfileForm()
 {
     delete bodyUI;
 }
 
-void IdentityForm::copyIdClicked()
+void ProfileForm::copyIdClicked()
 {
     toxId->selectAll();
     QString txt = toxId->text();
@@ -97,38 +110,75 @@ void IdentityForm::copyIdClicked()
     timer.start();
 }
 
-void IdentityForm::onUserNameEdited()
+void ProfileForm::onUserNameEdited()
 {
     Core::getInstance()->setUsername(bodyUI->userName->text());
 }
 
-void IdentityForm::onStatusMessageEdited()
+void ProfileForm::onStatusMessageEdited()
 {
     Core::getInstance()->setStatusMessage(bodyUI->statusMessage->text());
 }
 
-void IdentityForm::present()
+void ProfileForm::onSelfAvatarLoaded(const QPixmap& pic)
 {
-    toxId->setText(Core::getInstance()->getSelfId().toString());
-    toxId->setCursorPosition(0);
-    bodyUI->profiles->clear();
-    for (QString profile : Settings::getInstance().searchProfiles())
-        bodyUI->profiles->addItem(profile);
-    QString current = Settings::getInstance().getCurrentProfile();
-    if (current != "")
-        bodyUI->profiles->setCurrentText(current);
-
-    bodyUI->userName->setText(Core::getInstance()->getUsername());
-    bodyUI->statusMessage->setText(Core::getInstance()->getStatusMessage());
+    profilePicture->setPixmap(pic);
 }
 
-void IdentityForm::setToxId(const QString& id)
+void ProfileForm::setToxId(const QString& id)
 {
     toxId->setText(id);
     toxId->setCursorPosition(0);
 }
 
-void IdentityForm::onLoadClicked()
+void ProfileForm::onAvatarClicked()
+{
+    QString filename = QFileDialog::getOpenFileName(this,
+        tr("Choose a profile picture"),
+        QDir::homePath(),
+        Nexus::getSupportedImageFilter());
+    if (filename.isEmpty())
+        return;
+    QFile file(filename);
+    file.open(QIODevice::ReadOnly);
+    if (!file.isOpen())
+    {
+        QMessageBox::critical(this, tr("Error"), tr("Unable to open this file"));
+        return;
+    }
+
+    QPixmap pic;
+    if (!pic.loadFromData(file.readAll()))
+    {
+        QMessageBox::critical(this, tr("Error"), tr("Unable to read this image"));
+        return;
+    }
+
+    QByteArray bytes;
+    QBuffer buffer(&bytes);
+    buffer.open(QIODevice::WriteOnly);
+    pic.save(&buffer, "PNG");
+    buffer.close();
+
+    if (bytes.size() >= TOX_AVATAR_MAX_DATA_LENGTH)
+    {
+        pic = pic.scaled(64,64, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+        bytes.clear();
+        buffer.open(QIODevice::WriteOnly);
+        pic.save(&buffer, "PNG");
+        buffer.close();
+    }
+
+    if (bytes.size() >= TOX_AVATAR_MAX_DATA_LENGTH)
+    {
+        QMessageBox::critical(this, tr("Error"), tr("This image is too big"));
+        return;
+    }
+
+    Nexus::getCore()->setAvatar(TOX_AVATAR_FORMAT_PNG, bytes);
+}
+
+void ProfileForm::onLoadClicked()
 {
     if (bodyUI->profiles->currentText() != Settings::getInstance().getCurrentProfile())
     {
@@ -141,7 +191,7 @@ void IdentityForm::onLoadClicked()
     }
 }
 
-void IdentityForm::onRenameClicked()
+void ProfileForm::onRenameClicked()
 {
     QString cur = bodyUI->profiles->currentText();
     QString title = tr("Rename \"%1\"", "renaming a profile").arg(cur);
@@ -169,7 +219,7 @@ void IdentityForm::onRenameClicked()
     } while (true);
 }
 
-void IdentityForm::onExportClicked()
+void ProfileForm::onExportClicked()
 {
     QString current = bodyUI->profiles->currentText() + Core::TOX_EXT;
     QString path = QFileDialog::getSaveFileName(this, tr("Export profile", "save dialog title"),
@@ -194,7 +244,7 @@ void IdentityForm::onExportClicked()
     }
 }
 
-void IdentityForm::onDeleteClicked()
+void ProfileForm::onDeleteClicked()
 {
     if (Settings::getInstance().getCurrentProfile() == bodyUI->profiles->currentText())
     {
@@ -219,7 +269,7 @@ void IdentityForm::onDeleteClicked()
     }
 }
 
-void IdentityForm::onImportClicked()
+void ProfileForm::onImportClicked()
 {
     QString path = QFileDialog::getOpenFileName(this,
                                                 tr("Import profile", "import dialog title"),
@@ -249,18 +299,18 @@ void IdentityForm::onImportClicked()
     bodyUI->profiles->addItem(profile);
 }
 
-void IdentityForm::onNewClicked()
+void ProfileForm::onNewClicked()
 {
     emit Widget::getInstance()->changeProfile(QString());
 }
 
-void IdentityForm::disableSwitching()
+void ProfileForm::disableSwitching()
 {
     bodyUI->loadButton->setEnabled(false);
     bodyUI->newButton->setEnabled(false);
 }
 
-void IdentityForm::enableSwitching()
+void ProfileForm::enableSwitching()
 {
     if (!core->anyActiveCalls())
     {

--- a/src/widget/form/profileform.cpp
+++ b/src/widget/form/profileform.cpp
@@ -85,6 +85,7 @@ ProfileForm::ProfileForm(QWidget *parent) :
     connect(bodyUI->toxIdLabel, SIGNAL(clicked()), this, SLOT(copyIdClicked()));
     connect(toxId, SIGNAL(clicked()), this, SLOT(copyIdClicked()));
     connect(core, &Core::idSet, this, &ProfileForm::setToxId);
+    connect(core, &Core::statusSet, this, &ProfileForm::onStatusSet);
     connect(bodyUI->userName, SIGNAL(editingFinished()), this, SLOT(onUserNameEdited()));
     connect(bodyUI->statusMessage, SIGNAL(editingFinished()), this, SLOT(onStatusMessageEdited()));
     connect(bodyUI->loadButton, &QPushButton::clicked, this, &ProfileForm::onLoadClicked);
@@ -324,6 +325,11 @@ void ProfileForm::onImportClicked()
 
     QFile::copy(path, profilePath);
     bodyUI->profiles->addItem(profile);
+}
+
+void ProfileForm::onStatusSet(Status status)
+{
+    refreshProfiles();
 }
 
 void ProfileForm::onNewClicked()

--- a/src/widget/form/profileform.cpp
+++ b/src/widget/form/profileform.cpp
@@ -18,6 +18,7 @@
 #include "src/nexus.h"
 #include "ui_identitysettings.h"
 #include "profileform.h"
+#include "ui_mainwindow.h"
 #include "src/widget/form/settingswidget.h"
 #include "src/widget/maskablepixmapwidget.h"
 #include "src/misc/settings.h"
@@ -52,6 +53,14 @@ ProfileForm::ProfileForm(QWidget *parent) :
     bodyUI = new Ui::IdentitySettings;
     bodyUI->setupUi(this);
     core = Core::getInstance();
+
+    head = new QWidget();
+    QFont bold;
+    bold.setBold(true);
+    head->setLayout(&headLayout);
+    headLabel.setText(tr("User Profile"));
+    headLabel.setFont(bold);
+    headLayout.addWidget(&headLabel);
 
     // tox
     toxId = new ClickableTE();
@@ -102,6 +111,14 @@ ProfileForm::ProfileForm(QWidget *parent) :
 ProfileForm::~ProfileForm()
 {
     delete bodyUI;
+    delete head;
+}
+
+void ProfileForm::show(Ui::MainWindow &ui)
+{
+    ui.mainHead->layout()->addWidget(head);
+    head->show();
+    QWidget::show();
 }
 
 void ProfileForm::copyIdClicked()

--- a/src/widget/form/profileform.cpp
+++ b/src/widget/form/profileform.cpp
@@ -327,7 +327,7 @@ void ProfileForm::onImportClicked()
     bodyUI->profiles->addItem(profile);
 }
 
-void ProfileForm::onStatusSet(Status status)
+void ProfileForm::onStatusSet(Status)
 {
     refreshProfiles();
 }

--- a/src/widget/form/profileform.h
+++ b/src/widget/form/profileform.h
@@ -69,7 +69,11 @@ private slots:
     void disableSwitching();
     void enableSwitching();
 
+protected:
+    virtual void showEvent(QShowEvent *);
+
 private:
+    void refreshProfiles();
     Ui::IdentitySettings* bodyUI;
     MaskablePixmapWidget* profilePicture;
     Core* core;

--- a/src/widget/form/profileform.h
+++ b/src/widget/form/profileform.h
@@ -20,6 +20,7 @@
 #include <QLineEdit>
 #include <QLabel>
 #include <QTimer>
+#include <QVBoxLayout>
 
 class CroppingLabel;
 class Core;
@@ -27,6 +28,7 @@ class MaskablePixmapWidget;
 
 namespace Ui {
 class IdentitySettings;
+class MainWindow;
 }
 
 class ClickableTE : public QLineEdit
@@ -46,6 +48,7 @@ class ProfileForm : public QWidget
 public:
     ProfileForm(QWidget *parent = nullptr);
     ~ProfileForm();
+    void show(Ui::MainWindow &ui);
 
 signals:
     void userNameChanged(QString);
@@ -76,6 +79,9 @@ private:
     void refreshProfiles();
     Ui::IdentitySettings* bodyUI;
     MaskablePixmapWidget* profilePicture;
+    QWidget *head;
+    QLabel headLabel;
+    QVBoxLayout headLayout;
     Core* core;
     QTimer timer;
     bool hasCheck = false;

--- a/src/widget/form/profileform.h
+++ b/src/widget/form/profileform.h
@@ -21,6 +21,7 @@
 #include <QLabel>
 #include <QTimer>
 #include <QVBoxLayout>
+#include "src/core.h"
 
 class CroppingLabel;
 class Core;
@@ -56,6 +57,7 @@ signals:
 
 public slots:
     void onSelfAvatarLoaded(const QPixmap &pic);
+    void onStatusSet(Status status);
 
 private slots:
     void setToxId(const QString& id);

--- a/src/widget/form/profileform.h
+++ b/src/widget/form/profileform.h
@@ -17,15 +17,13 @@
 #ifndef IDENTITYFORM_H
 #define IDENTITYFORM_H
 
-#include "genericsettings.h"
-#include <QGroupBox>
-#include <QTextEdit>
 #include <QLineEdit>
 #include <QLabel>
 #include <QTimer>
 
 class CroppingLabel;
 class Core;
+class MaskablePixmapWidget;
 
 namespace Ui {
 class IdentitySettings;
@@ -42,22 +40,24 @@ protected:
     void mouseReleaseEvent(QMouseEvent*) {emit clicked();}    
 };
 
-class IdentityForm : public GenericForm
+class ProfileForm : public QWidget
 {
     Q_OBJECT
 public:
-    IdentityForm();
-    ~IdentityForm();
-
-    virtual void present();
+    ProfileForm(QWidget *parent = nullptr);
+    ~ProfileForm();
 
 signals:
     void userNameChanged(QString);
     void statusMessageChanged(QString);
 
+public slots:
+    void onSelfAvatarLoaded(const QPixmap &pic);
+
 private slots:
     void setToxId(const QString& id);
     void copyIdClicked();
+    void onAvatarClicked();
     void onUserNameEdited();
     void onStatusMessageEdited();
     void onLoadClicked();
@@ -71,6 +71,7 @@ private slots:
 
 private:
     Ui::IdentitySettings* bodyUI;
+    MaskablePixmapWidget* profilePicture;
     Core* core;
     QTimer timer;
     bool hasCheck = false;

--- a/src/widget/form/settings/identitysettings.ui
+++ b/src/widget/form/settings/identitysettings.ui
@@ -47,43 +47,47 @@
        <property name="spacing">
         <number>9</number>
        </property>
-       <item alignment="Qt::AlignTop">
+       <item>
         <widget class="QGroupBox" name="publicGroup">
          <property name="title">
           <string>Public Information</string>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_2">
+         <layout class="QHBoxLayout" name="horizontalLayout_2">
           <item>
-           <widget class="QLabel" name="userNameLabel">
-            <property name="text">
-             <string>Name</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLineEdit" name="userName"/>
-          </item>
-          <item>
-           <widget class="QLabel" name="statusMessageLabel">
-            <property name="text">
-             <string>Status</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLineEdit" name="statusMessage"/>
+           <layout class="QVBoxLayout" name="publicFieldsLayout">
+            <item>
+             <widget class="QLabel" name="userNameLabel">
+              <property name="text">
+               <string>Name</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="userName"/>
+            </item>
+            <item>
+             <widget class="QLabel" name="statusMessageLabel">
+              <property name="text">
+               <string>Status</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="statusMessage"/>
+            </item>
+           </layout>
           </item>
          </layout>
         </widget>
        </item>
        <item alignment="Qt::AlignTop">
         <widget class="QGroupBox" name="toxGroup">
-         <property name="title">
-          <string>Tox ID</string>
-         </property>
          <property name="toolTip">
           <string comment="Tox ID tooltip">This bunch of characters tells other Tox clients how to contact you.
 Share it with your friends to communicate.</string>
+         </property>
+         <property name="title">
+          <string>Tox ID</string>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_3">
           <item>
@@ -113,14 +117,14 @@ Share it with your friends to communicate.</string>
             </item>
             <item>
              <widget class="QComboBox" name="profiles">
-              <property name="toolTip">
-               <string comment="toolTip for currently set profile">Currently selected profile.</string>
-              </property>
               <property name="sizePolicy">
                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
                 <horstretch>0</horstretch>
                 <verstretch>0</verstretch>
                </sizepolicy>
+              </property>
+              <property name="toolTip">
+               <string comment="toolTip for currently set profile">Currently selected profile.</string>
               </property>
              </widget>
             </item>
@@ -140,22 +144,22 @@ Share it with your friends to communicate.</string>
             </item>
             <item>
              <widget class="QPushButton" name="renameButton">
-              <property name="text">
-               <string comment="rename profile button">Rename</string>
-              </property>
               <property name="toolTip">
                <string comment="tooltip for renaming profile button">Rename selected profile.</string>
+              </property>
+              <property name="text">
+               <string comment="rename profile button">Rename</string>
               </property>
              </widget>
             </item>
             <item>
              <widget class="QPushButton" name="exportButton">
-              <property name="text">
-               <string comment="export profile button">Export</string>
-              </property>
               <property name="toolTip">
                <string comment="tooltip for profile exporting button">Allows you to export your Tox profile to a file.
 Profile does not contain your history.</string>
+              </property>
+              <property name="text">
+               <string comment="export profile button">Export</string>
               </property>
              </widget>
             </item>
@@ -175,11 +179,11 @@ Profile does not contain your history.</string>
            <layout class="QHBoxLayout" name="profilesButtonsLayout2">
             <item>
              <widget class="QPushButton" name="importButton">
-              <property name="text">
-               <string comment="import profile button">Import a profile</string>
-              </property>
               <property name="toolTip">
                <string comment="tooltip for importing profile button">Import Tox profile from a .tox file.</string>
+              </property>
+              <property name="text">
+               <string comment="import profile button">Import a profile</string>
               </property>
              </widget>
             </item>

--- a/src/widget/form/settingswidget.cpp
+++ b/src/widget/form/settingswidget.cpp
@@ -19,7 +19,6 @@
 #include "ui_mainwindow.h"
 #include "src/video/camera.h"
 #include "src/widget/form/settings/generalform.h"
-#include "src/widget/form/settings/identityform.h"
 #include "src/widget/form/settings/privacyform.h"
 #include "src/widget/form/settings/avform.h"
 #include "src/widget/form/settings/advancedform.h"
@@ -52,12 +51,11 @@ SettingsWidget::SettingsWidget(QWidget* parent)
     bodyLayout->addWidget(settingsWidgets);
 
     GeneralForm* gfrm = new GeneralForm(this);
-    IdentityForm* ifrm = new IdentityForm;
     PrivacyForm* pfrm = new PrivacyForm;
     AVForm* avfrm = new AVForm;
     AdvancedForm *expfrm = new AdvancedForm;
 
-    GenericForm* cfgForms[] = { gfrm, ifrm, pfrm, avfrm, expfrm };
+    GenericForm* cfgForms[] = { gfrm, pfrm, avfrm, expfrm };
     for (GenericForm* cfgForm : cfgForms)
         settingsWidgets->addTab(cfgForm, cfgForm->getFormIcon(), cfgForm->getFormName());
 

--- a/src/widget/form/settingswidget.h
+++ b/src/widget/form/settingswidget.h
@@ -24,7 +24,6 @@
 class Camera;
 class GenericForm;
 class GeneralForm;
-class IdentityForm;
 class PrivacyForm;
 class AVForm;
 class QLabel;

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -550,7 +550,7 @@ void Widget::showProfile()
 {
     hideMainForms();
     ui->mainContent->layout()->addWidget(profileForm);
-    profileForm->show();
+    profileForm->show(*ui);
     setWindowTitle(tr("Profile"));
     activeChatroomWidget = nullptr;
 }

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -23,7 +23,7 @@
 #include <QFileInfo>
 #include "form/addfriendform.h"
 #include "form/settingswidget.h"
-#include "form/settings/identityform.h"
+#include "form/profileform.h"
 #include "form/filesform.h"
 #include "src/corestructs.h"
 
@@ -77,6 +77,7 @@ public:
 
     void reloadTheme();
 
+    void showProfile();
 public slots:
     void onSettingsClicked();
     void setWindowTitle(const QString& title);
@@ -120,6 +121,7 @@ private slots:
     void onGroupClicked();
     void onTransferClicked();
     void onAvatarClicked();
+    void onUsernameClicked();
     void onUsernameChanged(const QString& newUsername, const QString& oldUsername);
     void onStatusMessageChanged(const QString& newStatusMessage, const QString& oldStatusMessage);
     void onChatroomWidgetClicked(GenericChatroomWidget *);
@@ -157,6 +159,7 @@ private:
     QSplitter *centralLayout;
     QPoint dragPosition;
     AddFriendForm* addFriendForm;
+    ProfileForm* profileForm;
     SettingsWidget* settingsWidget;
     FilesForm* filesForm;
     static Widget* instance;


### PR DESCRIPTION
Make the page directly accessible from the main screen by clicking the avatar or the username. Changing the avatar or the username are now possible only from the profile page.
#1012 for the discussion

This is what it would look like
![qtox-profile](https://cloud.githubusercontent.com/assets/991166/6471626/550db9fa-c1f5-11e4-821e-5da25fa38dcc.png)
