### PR TITLE
Pasting last message using ↑ arrow

### DIFF
--- a/src/widget/form/groupchatform.cpp
+++ b/src/widget/form/groupchatform.cpp
@@ -98,6 +98,7 @@ void GroupChatForm::onSendTriggered()
     if (msg.isEmpty())
         return;
 
+    msgEdit->setLastMessage(msg);
     msgEdit->clear();
 
     if (msg.startsWith("/me "))


### PR DESCRIPTION
In groupchat, last message is not being stored when a send is triggered, hence pressing ↑ would not work.
This solve the issue [1309](https://github.com/tux3/qTox/issues/1309)
