### PR TITLE
Use QImage scaling and base64 encoding for sharper previews

### DIFF
--- a/src/chatlog/content/filetransferwidget.cpp
+++ b/src/chatlog/content/filetransferwidget.cpp
@@ -24,6 +24,7 @@
 #include <QMouseEvent>
 #include <QFileDialog>
 #include <QFile>
+#include <QBuffer>
 #include <QMessageBox>
 #include <QDesktopServices>
 #include <QDesktopWidget>
@@ -451,22 +452,13 @@ void FileTransferWidget::showPreview(const QString &filename)
         ui->previewLabel->setPixmap(pmap);
         ui->previewLabel->show();
 
-        // Show preview, but make sure it's not larger than 50% of the screen width/height
-        QRect maxSize = QApplication::desktop()->screenGeometry();
-        maxSize.setWidth(0.5*maxSize.width());
-        maxSize.setHeight(0.5*maxSize.height());
-
-        QImage image = QImage(filename);
-        QSize imageSize(image.width(), image.height());
-        if (imageSize.width() > maxSize.width() || imageSize.height() > maxSize.height())
-        {
-            imageSize.scale(maxSize.width(), maxSize.height(), Qt::KeepAspectRatio);
-            ui->previewLabel->setToolTip("<html><img src="+QUrl::toPercentEncoding(filename)+" width="+QString::number(imageSize.width())+" height="+QString::number(imageSize.height())+"/></html>");
-        }
-        else
-        {
-            ui->previewLabel->setToolTip("<html><img src"+QUrl::toPercentEncoding(filename)+"/></html>");
-        }
+        // Show mouseover preview, but make sure it's not larger than 50% of the screen width/height
+        QRect desktopSize = QApplication::desktop()->screenGeometry();
+        QImage image = QImage(filename).scaled(0.5*desktopSize.width(), 0.5*desktopSize.height(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
+        QByteArray imageData;
+        QBuffer buffer(&imageData);
+        image.save(&buffer, "PNG");
+        ui->previewLabel->setToolTip("<img src=data:image/png;base64," + imageData.toBase64() + "/>");
     }
 }
 


### PR DESCRIPTION
Before:
![before](https://cloud.githubusercontent.com/assets/1885159/6426832/16b721a8-bf6d-11e4-88a7-8bbb7eaee648.png)

After:
![after](https://cloud.githubusercontent.com/assets/1885159/6547372/24b2c3ec-c5d6-11e4-9750-93caa3c92efe.png)
