### PR TITLE
Allow writing messages in a lonely groupchat

### DIFF
--- a/src/widget/form/groupchatform.cpp
+++ b/src/widget/form/groupchatform.cpp
@@ -101,11 +101,9 @@ void GroupChatForm::onSendTriggered()
     msgEdit->setLastMessage(msg);
     msgEdit->clear();
 
-    bool isAction = msg.startsWith("/me ");
-
     if (group->getPeersCount() != 1)
     {
-        if (isAction)
+        if (msg.startsWith("/me "))
         {
             msg = msg.right(msg.length() - 4);
             emit sendAction(group->getGroupId(), msg);
@@ -114,10 +112,7 @@ void GroupChatForm::onSendTriggered()
             emit sendMessage(group->getGroupId(), msg);
     }
     else
-    {
-        QDateTime timestamp = QDateTime::currentDateTime();
-        addSelfMessage(msg, isAction, timestamp, true);
-    }
+        addSelfMessage(msg, msg.startsWith("/me "), QDateTime::currentDateTime(), true);
 }
 
 void GroupChatForm::onUserListChanged()

--- a/src/widget/form/groupchatform.cpp
+++ b/src/widget/form/groupchatform.cpp
@@ -101,12 +101,22 @@ void GroupChatForm::onSendTriggered()
     msgEdit->setLastMessage(msg);
     msgEdit->clear();
 
-    if (msg.startsWith("/me "))
+    bool isAction = msg.startsWith("/me ");
+
+    if (group->getPeersCount() != 1)
     {
-        msg = msg.right(msg.length() - 4);
-        emit sendAction(group->getGroupId(), msg);
-    } else {
-        emit sendMessage(group->getGroupId(), msg);
+        if (isAction)
+        {
+            msg = msg.right(msg.length() - 4);
+            emit sendAction(group->getGroupId(), msg);
+        }
+        else
+            emit sendMessage(group->getGroupId(), msg);
+    }
+    else
+    {
+        QDateTime timestamp = QDateTime::currentDateTime();
+        addSelfMessage(msg, isAction, timestamp, true);
     }
 }
 


### PR DESCRIPTION
This allows users to write messages if they are alone in a groupchat, before they were rejected because there is noone connected. This should fix #1246.
