### PR TITLE
UI fixes in general form:

### DIFF
--- a/src/widget/form/profileform.cpp
+++ b/src/widget/form/profileform.cpp
@@ -262,7 +262,7 @@ void ProfileForm::onRenameClicked()
 void ProfileForm::onExportClicked()
 {
     QString current = bodyUI->profiles->currentText() + Core::TOX_EXT;
-    QString path = QFileDialog::getSaveFileName(this, tr("Export profile", "save dialog title"),
+    QString path = QFileDialog::getSaveFileName(0, tr("Export profile", "save dialog title"),
                     QDir::home().filePath(current), 
                     tr("Tox save file (*.tox)", "save dialog filter"));
     if (!path.isEmpty())
@@ -311,7 +311,7 @@ void ProfileForm::onDeleteClicked()
 
 void ProfileForm::onImportClicked()
 {
-    QString path = QFileDialog::getOpenFileName(this,
+    QString path = QFileDialog::getOpenFileName(0,
                                                 tr("Import profile", "import dialog title"),
                                                 QDir::homePath(),
                                                 tr("Tox save file (*.tox)", "import dialog filter"));

--- a/src/widget/form/settings/generalform.cpp
+++ b/src/widget/form/settings/generalform.cpp
@@ -34,7 +34,6 @@ static QStringList locales = {"bg", "de", "en", "es", "fr", "hr", "hu", "it", "l
 static QStringList langs = {"Български", "Deutsch", "English", "Español", "Français", "Hrvatski", "Magyar", "Italiano", "Lietuvių", "mannol", "Nederlands", "Pirate", "Polski", "Português", "Русский", "Slovenščina", "Suomi", "Svenska", "Українська", "简体中文"};
 
 static QStringList timeFormats = {"hh:mm AP", "hh:mm", "hh:mm:ss AP", "hh:mm:ss"};
-
 GeneralForm::GeneralForm(SettingsWidget *myParent) :
     GenericForm(tr("General"), QPixmap(":/img/settings/general.png"))
 {
@@ -66,6 +65,7 @@ GeneralForm::GeneralForm(SettingsWidget *myParent) :
     bodyUI->minimizeToTray->setEnabled(showSystemTray);
     bodyUI->lightTrayIcon->setChecked(Settings::getInstance().getLightTrayIcon());
     bodyUI->lightTrayIcon->setEnabled(showSystemTray);
+    
     bodyUI->statusChanges->setChecked(Settings::getInstance().getStatusChangeNotificationEnabled());
     bodyUI->useEmoticons->setChecked(Settings::getInstance().getUseEmoticons());
     bodyUI->autoacceptFiles->setChecked(Settings::getInstance().getAutoSaveEnabled());
@@ -82,10 +82,10 @@ GeneralForm::GeneralForm(SettingsWidget *myParent) :
     }
     bodyUI->smileyPackBrowser->setCurrentIndex(bodyUI->smileyPackBrowser->findData(Settings::getInstance().getSmileyPack()));
     reloadSmiles();
+    bodyUI->smileyPackBrowser->setEnabled(bodyUI->useEmoticons->isChecked());
 
     bodyUI->styleBrowser->addItem(tr("None"));
     bodyUI->styleBrowser->addItems(QStyleFactory::keys());
-
     if (QStyleFactory::keys().contains(Settings::getInstance().getStyle()))
         bodyUI->styleBrowser->setCurrentText(Settings::getInstance().getStyle());
     else
@@ -107,7 +107,6 @@ GeneralForm::GeneralForm(SettingsWidget *myParent) :
     bodyUI->timestamp->setCurrentText(QString("%1 - %2").arg(Settings::getInstance().getTimestampFormat(),
                                                              QTime::currentTime().toString(Settings::getInstance().getTimestampFormat()))
                                       ); //idiot proof enough?
-
     bodyUI->autoAwaySpinBox->setValue(Settings::getInstance().getAutoAwayTime());
 
     bodyUI->cbEnableUDP->setChecked(!Settings::getInstance().getForceTCP());
@@ -152,6 +151,20 @@ GeneralForm::GeneralForm(SettingsWidget *myParent) :
     connect(bodyUI->reconnectButton, &QPushButton::clicked, this, &GeneralForm::onReconnectClicked);
     connect(bodyUI->cbFauxOfflineMessaging, &QCheckBox::stateChanged, this, &GeneralForm::onFauxOfflineMessaging);
     connect(bodyUI->cbCompactLayout, &QCheckBox::stateChanged, this, &GeneralForm::onCompactLayout);
+    
+    // prevent stealing mouse whell scroll
+    // scrolling event won't be transmitted to comboboxes or qspinboxes when scrolling
+    // you can scroll through general settings without accidentially chaning theme/skin/icons etc.
+    // @see GeneralForm::eventFilter(QObject *o, QEvent *e) at the bottom of this file for more
+    Q_FOREACH(QComboBox *cb, findChildren<QComboBox*>() ) {
+            cb->installEventFilter(this);
+            cb->setFocusPolicy(Qt::StrongFocus);
+    }
+    
+    Q_FOREACH(QSpinBox *sp, findChildren<QSpinBox*>() ) {
+            sp->installEventFilter(this);
+            sp->setFocusPolicy(Qt::WheelFocus);
+    }
 
 #ifndef QTOX_PLATFORM_EXT
     bodyUI->autoAwayLabel->setEnabled(false);   // these don't seem to change the appearance of the widgets,
@@ -184,6 +197,7 @@ void GeneralForm::onSetShowSystemTray()
 {
     Settings::getInstance().setShowSystemTray(bodyUI->showSystemTray->isChecked());
     emit parent->setShowSystemTray(bodyUI->showSystemTray->isChecked());
+    bodyUI->lightTrayIcon->setEnabled(bodyUI->showSystemTray->isChecked());
 }
 
 void GeneralForm::onSetAutostartInTray()
@@ -247,7 +261,8 @@ void GeneralForm::onAutoAcceptFileChange()
 void GeneralForm::onAutoSaveDirChange()
 {
     QString previousDir = Settings::getInstance().getGlobalAutoAcceptDir();
-    QString directory = QFileDialog::getExistingDirectory(0, tr("Choose an auto accept directory","popup title"));
+    QString directory = QFileDialog::getExistingDirectory(0,
+                                                          tr("Choose an auto accept directory","popup title"));
     if (directory.isEmpty())
         directory = previousDir;
 
@@ -258,6 +273,7 @@ void GeneralForm::onAutoSaveDirChange()
 void GeneralForm::onUseEmoticonsChange()
 {
     Settings::getInstance().setUseEmoticons(bodyUI->useEmoticons->isChecked());
+    bodyUI->smileyPackBrowser->setEnabled(bodyUI->useEmoticons->isChecked());
 }
 
 void GeneralForm::onSetStatusChange()
@@ -314,8 +330,6 @@ void GeneralForm::reloadSmiles()
 {
     QList<QStringList> emoticons = SmileyPack::getInstance().getEmoticons();
     QStringList smiles;
-    smiles << ":)" << ";)" << ":p" << ":O" << ":["; //just in case...
-
     for (int i = 0; i < emoticons.size(); i++)
         smiles.push_front(emoticons.at(i).first());
 
@@ -370,4 +384,15 @@ void GeneralForm::onThemeColorChanged(int)
     Settings::getInstance().setThemeColor(index);
     Style::setThemeColor(index);
     Style::applyTheme();
+}
+
+bool GeneralForm::eventFilter(QObject *o, QEvent *e)
+{
+    if ((e->type() == QEvent::Wheel) &&
+         (qobject_cast<QComboBox*>(o) || qobject_cast<QAbstractSpinBox*>(o) ))
+    {
+        e->ignore();
+        return true;
+    }
+    return QWidget::eventFilter(o, e);
 }

--- a/src/widget/form/settings/generalform.h
+++ b/src/widget/form/settings/generalform.h
@@ -65,6 +65,9 @@ private:
     Ui::GeneralSettings *bodyUI;
     void reloadSmiles();
     SettingsWidget *parent;
+
+protected:
+    bool eventFilter(QObject *o, QEvent *e);
 };
 
 #endif

--- a/src/widget/form/settings/generalsettings.ui
+++ b/src/widget/form/settings/generalsettings.ui
@@ -38,9 +38,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>0</y>
-        <width>544</width>
-        <height>785</height>
+        <y>-214</y>
+        <width>539</width>
+        <height>838</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,0,0,1">
@@ -701,6 +701,38 @@ will be sent to them when they will appear online to you.</string>
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>scrollArea</tabstop>
+  <tabstop>transComboBox</tabstop>
+  <tabstop>showSystemTray</tabstop>
+  <tabstop>lightTrayIcon</tabstop>
+  <tabstop>startInTray</tabstop>
+  <tabstop>closeToTray</tabstop>
+  <tabstop>minimizeToTray</tabstop>
+  <tabstop>cbAutorun</tabstop>
+  <tabstop>checkUpdates</tabstop>
+  <tabstop>autoacceptFiles</tabstop>
+  <tabstop>autoSaveFilesDir</tabstop>
+  <tabstop>autoAwaySpinBox</tabstop>
+  <tabstop>groupAlwaysNotify</tabstop>
+  <tabstop>statusChanges</tabstop>
+  <tabstop>showWindow</tabstop>
+  <tabstop>showInFront</tabstop>
+  <tabstop>cbFauxOfflineMessaging</tabstop>
+  <tabstop>cbCompactLayout</tabstop>
+  <tabstop>useEmoticons</tabstop>
+  <tabstop>smileyPackBrowser</tabstop>
+  <tabstop>emoticonSize</tabstop>
+  <tabstop>styleBrowser</tabstop>
+  <tabstop>themeColorCBox</tabstop>
+  <tabstop>timestamp</tabstop>
+  <tabstop>cbEnableUDP</tabstop>
+  <tabstop>cbEnableIPv6</tabstop>
+  <tabstop>proxyType</tabstop>
+  <tabstop>proxyAddr</tabstop>
+  <tabstop>proxyPort</tabstop>
+  <tabstop>reconnectButton</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -679,7 +679,6 @@ void Widget::onFriendUsernameChanged(int friendId, const QString& username)
 
 void Widget::onChatroomWidgetClicked(GenericChatroomWidget *widget)
 {
-    qDebug() << "active chat";
     hideMainForms();
     widget->setChatForm(*ui);
     if (activeChatroomWidget != nullptr)


### PR DESCRIPTION
disable light tray icon if system tray icon is disabled (didn't work for
some reason)

disable emoticons combobox if emoticons are disabled globally

prevent comoboxes and spinboxes stealing mouse scroll event while
scrolling in generalform. Prevents from accidental language/timestamp
format/theme/skin changes while scrolling in the widget.

disable passing CSS to qfiledialog in general form and profileform. qfiledialog will use
default system theme instead of not fully defined from qwidget

fixed tab order in generalsettings
