### PR TITLE
Change dialog buttons to use more meaningful text

### DIFF
--- a/src/widget/gui.cpp
+++ b/src/widget/gui.cpp
@@ -113,8 +113,8 @@ void GUI::showError(const QString& title, const QString& msg)
 }
 
 bool GUI::askQuestion(const QString& title, const QString& msg,
-                            bool defaultAns, bool warning,
-                            bool yesno)
+                      bool defaultAns, bool warning,
+                      bool yesno)
 {
     if (QThread::currentThread() == qApp->thread())
     {
@@ -128,6 +128,25 @@ bool GUI::askQuestion(const QString& title, const QString& msg,
                                   Q_ARG(const QString&, title), Q_ARG(const QString&, msg),
                                   Q_ARG(bool, defaultAns), Q_ARG(bool, warning),
                                   Q_ARG(bool, yesno));
+        return ret;
+    }
+}
+
+bool GUI::askQuestion(const QString& title, const QString& msg,
+                      const QString& button1, const QString& button2,
+                      bool defaultAns, bool warning)
+{
+    if (QThread::currentThread() == qApp->thread())
+    {
+        return getInstance()._askQuestion(title, msg, button1, button2, defaultAns, warning);
+    }
+    else
+    {
+        bool ret;
+        QMetaObject::invokeMethod(&getInstance(), "_askQuestion", Qt::BlockingQueuedConnection,
+                                  Q_RETURN_ARG(bool, ret),
+                                  Q_ARG(const QString&, title), Q_ARG(const QString&, msg),
+                                  Q_ARG(bool, defaultAns), Q_ARG(bool, warning));
         return ret;
     }
 }
@@ -213,8 +232,8 @@ void GUI::_showError(const QString& title, const QString& msg)
 }
 
 bool GUI::_askQuestion(const QString& title, const QString& msg,
-                            bool defaultAns, bool warning,
-                            bool yesno)
+                       bool defaultAns, bool warning,
+                       bool yesno)
 {
     QMessageBox::StandardButton positiveButton = yesno ? QMessageBox::Yes : QMessageBox::Ok;
     QMessageBox::StandardButton negativeButton = yesno ? QMessageBox::No : QMessageBox::Cancel;
@@ -225,6 +244,21 @@ bool GUI::_askQuestion(const QString& title, const QString& msg,
         return QMessageBox::warning(getMainWidget(), title, msg, positiveButton | negativeButton, defButton) == positiveButton;
     else
         return QMessageBox::question(getMainWidget(), title, msg, positiveButton | negativeButton, defButton) == positiveButton;
+}
+
+bool GUI::_askQuestion(const QString& title, const QString& msg,
+                       const QString& button1, const QString& button2,
+                       bool defaultAns, bool warning)
+{
+    QMessageBox box(warning ? QMessageBox::Warning : QMessageBox::Question,
+        title, msg, QMessageBox::NoButton, getMainWidget());
+    QPushButton* pushButton1 = box.addButton(button1, QMessageBox::AcceptRole);
+    QPushButton* pushButton2 = box.addButton(button2, QMessageBox::RejectRole);
+    box.setDefaultButton(defaultAns ? pushButton1 : pushButton2);
+    box.setEscapeButton(pushButton2);
+
+    box.exec();
+    return box.clickedButton() == pushButton1;
 }
 
 QString GUI::_itemInputDialog(QWidget * parent, const QString & title,

--- a/src/widget/gui.h
+++ b/src/widget/gui.h
@@ -35,6 +35,13 @@ public:
     static bool askQuestion(const QString& title, const QString& msg,
                             bool defaultAns = false, bool warning = true,
                             bool yesno = true);
+    /// Asks the user a question, for example in a message box.
+    /// The text for the displayed buttons can be specified.
+    /// If warning is true, we will use a special warning style.
+    /// Returns the answer.
+    static bool askQuestion(const QString& title, const QString& msg,
+                            const QString& button1, const QString& button2,
+                            bool defaultAns = false, bool warning = true);
     /// Asks the user to input text and returns the answer.
     /// The interface is equivalent to QInputDialog::getItem()
     static QString itemInputDialog(QWidget * parent, const QString & title,
@@ -64,8 +71,11 @@ private slots:
     void _showWarning(const QString& title, const QString& msg);
     void _showError(const QString& title, const QString& msg);
     bool _askQuestion(const QString& title, const QString& msg,
-                                bool defaultAns = false, bool warning = true,
-                                bool yesno = true);
+                      bool defaultAns = false, bool warning = true,
+                      bool yesno = true);
+    bool _askQuestion(const QString& title, const QString& msg,
+                      const QString& button1, const QString& button2,
+                      bool defaultAns = false, bool warning = true);
     QString _itemInputDialog(QWidget * parent, const QString & title,
                         const QString & label, const QStringList & items,
                         int current = 0, bool editable = true, bool * ok = 0,


### PR DESCRIPTION
This fixes #1100. The buttons previously had generic names, now they have a more meaningful caption like "decrypt" or "delete".
