### PR TITLE
Reset activeChatroomWidget when switching to addFriendForm

### DIFF
--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -412,6 +412,7 @@ void Widget::onAddClicked()
     hideMainForms();
     addFriendForm->show(*ui);
     setWindowTitle(tr("Add friend"));
+    activeChatroomWidget = nullptr;
 }
 
 void Widget::onGroupClicked()
@@ -705,7 +706,7 @@ void Widget::onFriendMessageReceived(int friendId, const QString& message, bool 
     HistoryKeeper::getInstance()->addChatEntry(f->getToxID().publicKey, isAction ? "/me " + message : message,
                                                f->getToxID().publicKey, timestamp, true);
 
-    f->setEventFlag(static_cast<GenericChatroomWidget*>(f->getFriendWidget()) != activeChatroomWidget);
+    f->setEventFlag(f->getFriendWidget() != activeChatroomWidget);
     newMessageAlert(f->getFriendWidget());
     f->getFriendWidget()->updateStatusLight();
 }


### PR DESCRIPTION
The activeChatroomWidget property wasn't reset to null, when the add friend dialog is opened.
Resetting it fixes #1109.
