### PR TITLE
Disable the call button when there's nobody else in a groupchat

### DIFF
--- a/src/widget/form/groupchatform.cpp
+++ b/src/widget/form/groupchatform.cpp
@@ -152,6 +152,22 @@ void GroupChatForm::onUserListChanged()
             label->setText(label->text() + ", ");
         namesListLayout->addWidget(label);
     }
+
+    // Enable or disable call button
+    if (group->getPeersCount() != 1)
+    {
+        callButton->setEnabled(true);
+        callButton->setObjectName("green");
+        callButton->style()->polish(callButton);
+        callButton->setToolTip(tr("Start audio call"));
+    }
+    else
+    {
+        callButton->setEnabled(false);
+        callButton->setObjectName("grey");
+        callButton->style()->polish(callButton);
+        callButton->setToolTip("");
+    }
 }
 
 void GroupChatForm::peerAudioPlaying(int peer)


### PR DESCRIPTION
The call button was enabled when there was only one person in  a groupchat. Clicking on it only generated errors in the console so it should be disabled.
