### PR TITLE
Align file bubbles better

### DIFF
--- a/src/chatlog/chatlinecontentproxy.cpp
+++ b/src/chatlog/chatlinecontentproxy.cpp
@@ -30,7 +30,9 @@ ChatLineContentProxy::ChatLineContentProxy(QWidget* widget, int minWidth, float 
 
 QRectF ChatLineContentProxy::boundingRect() const
 {
-    return proxy->boundingRect();
+    QRectF result = proxy->boundingRect();
+    result.setHeight(result.height() + 5);
+    return result;
 }
 
 void ChatLineContentProxy::paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget)
@@ -41,7 +43,7 @@ void ChatLineContentProxy::paint(QPainter *painter, const QStyleOptionGraphicsIt
 
 qreal ChatLineContentProxy::getAscent() const
 {
-    return 0;
+    return 7.0;
 }
 
 QWidget *ChatLineContentProxy::getWidget() const


### PR DESCRIPTION
File bubbles were misaligned with the username. This patch changes the alignment of a ChatLineContentProxy so it looks better aligned. I added a margin of 5 to the bounding rect to add a bit space between the bubble and the selection rectangle.
This should fix #1178.
