### PR TITLE
ver.2 System menu translation

### DIFF
--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -59,6 +59,7 @@
 #include <QList>
 #include <QDesktopServices>
 #include <QProcess>
+#include <qlibraryinfo.h>
 #include <tox/tox.h>
 
 #ifdef Q_OS_ANDROID
@@ -217,7 +218,20 @@ void Widget::setTranslation()
         return;
 
     if (translator->load(locale, ":translations/"))
+    {
         qDebug() << "Loaded translation" << locale;
+
+        // system menu translation
+        QTranslator *qtTranslator = new QTranslator();
+        QString s_locale = "qt_"+locale;
+        if ( qtTranslator->load(s_locale, QLibraryInfo::location(QLibraryInfo::TranslationsPath)) )
+        {
+            QApplication::installTranslator(qtTranslator);
+            qDebug() << "System translation loaded" << locale;
+        }
+        else
+            qDebug() << "System translation not loaded" << locale;
+    }
     else
         qDebug() << "Error loading translation" << locale;
     QCoreApplication::installTranslator(translator);


### PR DESCRIPTION
Does not work with all languages, but takes into account the user's settings.
In the future, you need to fix an array of "locales" in the file "generalform.cpp" according to the names of available locales in QT.
I did not find this information.
