### PR TITLE
Added chatroom status to window title

### DIFF
--- a/src/widget/form/settings/generalform.cpp
+++ b/src/widget/form/settings/generalform.cpp
@@ -174,7 +174,7 @@ GeneralForm::GeneralForm(SettingsWidget *myParent) :
     connect(bodyUI->cbFauxOfflineMessaging, &QCheckBox::stateChanged, this, &GeneralForm::onFauxOfflineMessaging);
     connect(bodyUI->cbCompactLayout, &QCheckBox::stateChanged, this, &GeneralForm::onCompactLayout);
     connect(bodyUI->cbGroupchatPosition, &QCheckBox::stateChanged, this, &GeneralForm::onGroupchatPositionChanged);
-    
+
     // prevent stealing mouse whell scroll
     // scrolling event won't be transmitted to comboboxes or qspinboxes when scrolling
     // you can scroll through general settings without accidentially chaning theme/skin/icons etc.

--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -168,6 +168,24 @@ void FriendWidget::updateStatusLight()
         statusPic.setMargin(0);
 }
 
+QString FriendWidget::getStatusString()
+{
+    Friend* f = FriendList::findFriend(friendId);
+    Status status = f->getStatus();
+
+    if (f->getEventFlag() == 1)
+        return tr("New message");
+    else if (status == Status::Online)
+        return tr("Online");
+    else if (status == Status::Away)
+        return tr("Away");
+    else if (status == Status::Busy)
+        return tr("Busy");
+    else if (status == Status::Offline)
+        return tr("Offline");
+    return QString::null;
+}
+
 void FriendWidget::setChatForm(Ui::MainWindow &ui)
 {
     Friend* f = FriendList::findFriend(friendId);

--- a/src/widget/friendwidget.h
+++ b/src/widget/friendwidget.h
@@ -35,6 +35,7 @@ public:
     void updateStatusLight();
     void setChatForm(Ui::MainWindow &);
     void resetEventFlags();
+    QString getStatusString();
 
 signals:
     void friendWidgetClicked(FriendWidget* widget);

--- a/src/widget/genericchatroomwidget.h
+++ b/src/widget/genericchatroomwidget.h
@@ -41,6 +41,7 @@ public:
     virtual void updateStatusLight(){;}
     virtual void setChatForm(Ui::MainWindow &){;}
     virtual void resetEventFlags(){;}
+    virtual QString getStatusString(){return QString::null;}
 
     bool isActive();
     void setActive(bool active);

--- a/src/widget/groupwidget.cpp
+++ b/src/widget/groupwidget.cpp
@@ -119,6 +119,16 @@ void GroupWidget::updateStatusLight()
     }
 }
 
+QString GroupWidget::getStatusString()
+{
+    Group *g = GroupList::findGroup(groupId);
+
+    if (!g->getEventFlag())
+        return "Online";
+    else
+        return "New Message";
+}
+
 void GroupWidget::setChatForm(Ui::MainWindow &ui)
 {
     Group* g = GroupList::findGroup(groupId);

--- a/src/widget/groupwidget.h
+++ b/src/widget/groupwidget.h
@@ -33,6 +33,7 @@ public:
     void setChatForm(Ui::MainWindow &);
     void resetEventFlags();
     void setName(const QString& name);
+    QString getStatusString();
 
 signals:
     void groupWidgetClicked(GroupWidget* widget);

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -661,7 +661,14 @@ void Widget::onFriendStatusChanged(int friendId, Status status)
 
     f->setStatus(status);
     f->getFriendWidget()->updateStatusLight();
-    
+    if(f->getFriendWidget()->isActive())
+    {
+        QString windowTitle = f->getFriendWidget()->getName();
+        if (!f->getFriendWidget()->getStatusString().isNull())
+            windowTitle += " (" + f->getFriendWidget()->getStatusString() + ")";
+        setWindowTitle(windowTitle);
+    }
+
     //won't print the message if there were no messages before
     if (!f->getChatForm()->isEmpty()
             && Settings::getInstance().getStatusChangeNotificationEnabled())
@@ -722,9 +729,13 @@ void Widget::onChatroomWidgetClicked(GenericChatroomWidget *widget)
     }
     activeChatroomWidget = widget;
     widget->setAsActiveChatroom();
-    setWindowTitle(widget->getName());
     widget->resetEventFlags();
     widget->updateStatusLight();
+    QString windowTitle = widget->getName();
+    if (!widget->getStatusString().isNull())
+        windowTitle += " (" + widget->getStatusString() + ")";
+    setWindowTitle(windowTitle);
+
 }
 
 void Widget::onFriendMessageReceived(int friendId, const QString& message, bool isAction)
@@ -742,6 +753,13 @@ void Widget::onFriendMessageReceived(int friendId, const QString& message, bool 
     f->setEventFlag(f->getFriendWidget() != activeChatroomWidget);
     newMessageAlert(f->getFriendWidget());
     f->getFriendWidget()->updateStatusLight();
+    if (f->getFriendWidget()->isActive())
+    {
+        QString windowTitle = f->getFriendWidget()->getName();
+        if (!f->getFriendWidget()->getStatusString().isNull())
+            windowTitle += " (" + f->getFriendWidget()->getStatusString() + ")";
+        setWindowTitle(windowTitle);
+    }
 }
 
 void Widget::onReceiptRecieved(int friendId, int receipt)
@@ -902,6 +920,13 @@ void Widget::onGroupMessageReceived(int groupnumber, int peernumber, const QStri
         g->setMentionedFlag(true); // useful for highlighting line or desktop notifications
 
     g->getGroupWidget()->updateStatusLight();
+    if (g->getGroupWidget()->isActive())
+    {
+        QString windowTitle = g->getGroupWidget()->getName();
+        if (!g->getGroupWidget()->getStatusString().isNull())
+            windowTitle += " (" + g->getGroupWidget()->getStatusString() + ")";
+        setWindowTitle(windowTitle);
+    }
 }
 
 void Widget::onGroupNamelistChanged(int groupnumber, int peernumber, uint8_t Change)
@@ -1027,6 +1052,10 @@ bool Widget::event(QEvent * e)
             {
                 activeChatroomWidget->resetEventFlags();
                 activeChatroomWidget->updateStatusLight();
+                QString windowTitle = activeChatroomWidget->getName();
+                if (!activeChatroomWidget->getStatusString().isNull())
+                    windowTitle += " (" + activeChatroomWidget->getStatusString() + ")";
+                setWindowTitle(windowTitle);
             }
             if (eventFlag)
             {


### PR DESCRIPTION
I thought that the status of active chat room in the window title would be nice. The status strings displayed are same as that in the Status class and when there's a new message (New Message) is displayed instead of status.
![screenshot](https://cloud.githubusercontent.com/assets/5618578/6698918/30cc162a-cd23-11e4-9810-e2375ddcaba3.png)
