### PR TITLE
Add ability to cycle through the contacts list.

### DIFF
--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -169,22 +169,10 @@ GenericChatForm::GenericChatForm(QWidget *parent)
     connect(emoteButton, &QPushButton::clicked, this, &GenericChatForm::onEmoteButtonClicked);
     connect(chatWidget, &ChatLog::customContextMenuRequested, this, &GenericChatForm::onChatContextMenuRequested);
 
-    new QShortcut(Qt::CTRL + Qt::Key_PageUp, this, SLOT(previousContact()));
-    new QShortcut(Qt::CTRL + Qt::Key_PageDown, this, SLOT(nextContact()));
     new QShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_L, this, SLOT(clearChatArea()));
 
     chatWidget->setStyleSheet(Style::getStylesheet(":/ui/chatArea/chatArea.css"));
     headWidget->setStyleSheet(Style::getStylesheet(":/ui/chatArea/chatHead.css"));
-}
-
-void GenericChatForm::previousContact()
-{
-    parent->previousContact();
-}
-
-void GenericChatForm::nextContact()
-{
-    parent->nextContact();
 }
 
 bool GenericChatForm::isEmpty()

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -76,8 +76,6 @@ protected slots:
     void clearChatArea(bool);
     void clearChatArea();
     void onSelectAllClicked();
-    void previousContact();
-    void nextContact();
 
 protected:
     QString resolveToxID(const ToxID &id);

--- a/src/widget/friendlistwidget.cpp
+++ b/src/widget/friendlistwidget.cpp
@@ -61,6 +61,32 @@ QVBoxLayout* FriendListWidget::getFriendLayout(Status s)
     return layouts[static_cast<int>(Status::Online)];
 }
 
+QList<GenericChatroomWidget*> FriendListWidget::getAllFriends()
+{
+    QList<GenericChatroomWidget*> friends;
+
+    for (int i = 0; i < mainLayout->count(); ++i)
+    {
+        QLayout* subLayout = mainLayout->itemAt(i)->layout();
+
+        if(!subLayout)
+            continue;
+
+        for (int j = 0; j < subLayout->count(); ++j)
+        {
+            GenericChatroomWidget* widget =
+                reinterpret_cast<GenericChatroomWidget*>(subLayout->itemAt(j)->widget());
+
+            if(!widget)
+                continue;
+
+            friends.append(widget);
+        }
+    }
+
+    return friends;
+}
+
 void FriendListWidget::moveWidget(QWidget *w, Status s, int hasNewEvents)
 {
     mainLayout->removeWidget(w);

--- a/src/widget/friendlistwidget.h
+++ b/src/widget/friendlistwidget.h
@@ -19,7 +19,9 @@
 
 #include <QWidget>
 #include <QHash>
+#include <QList>
 #include "src/corestructs.h"
+#include "src/widget/genericchatroomwidget.h"
 
 class QVBoxLayout;
 class QGridLayout;
@@ -34,6 +36,8 @@ public:
     QVBoxLayout* getGroupLayout();
     QVBoxLayout* getFriendLayout(Status s);
     void moveWidget(QWidget *w, Status s, int hasNewEvents);
+
+    QList<GenericChatroomWidget*> getAllFriends();
 
 signals:
 

--- a/src/widget/tool/chattextedit.cpp
+++ b/src/widget/tool/chattextedit.cpp
@@ -25,12 +25,17 @@ ChatTextEdit::ChatTextEdit(QWidget *parent) :
 }
 
 void ChatTextEdit::keyPressEvent(QKeyEvent * event)
-{    
+{
     int key = event->key();
     if ((key == Qt::Key_Enter || key == Qt::Key_Return) && !(event->modifiers() & Qt::ShiftModifier))
         emit enterPressed();
     else if (key == Qt::Key_Tab)
-        emit tabPressed();
+    {
+        if (event->modifiers())
+            event->ignore();
+        else
+            emit tabPressed();
+    }
     else if (key == Qt::Key_Up && this->toPlainText().isEmpty())
     {
         this->setText(lastMessage);

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -47,6 +47,7 @@
 #include <QBuffer>
 #include <QPainter>
 #include <QMouseEvent>
+#include <QShortcut>
 #include <QClipboard>
 #include <QThread>
 #include <QDialogButtonBox>
@@ -196,6 +197,12 @@ void Widget::init()
     connect(offlineMsgTimer, &QTimer::timeout, this, &Widget::processOfflineMsgs);
 
     addFriendForm->show(*ui);
+
+    new QShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_Tab, this, SLOT(previousContact()));
+    new QShortcut(Qt::CTRL + Qt::Key_Tab, this, SLOT(nextContact()));
+
+    new QShortcut(Qt::CTRL + Qt::Key_PageUp, this, SLOT(previousContact()));
+    new QShortcut(Qt::CTRL + Qt::Key_PageDown, this, SLOT(nextContact()));
 
 #if (AUTOUPDATE_ENABLED)
     if (Settings::getInstance().getCheckUpdates())

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1162,6 +1162,23 @@ void Widget::onSplitterMoved(int pos, int index)
     saveSplitterGeometry();
 }
 
+void Widget::cycleContacts(int offset)
+{
+    if (!activeChatroomWidget)
+        return;
+
+    FriendListWidget* friendList = static_cast<FriendListWidget*>(ui->friendList->widget());
+    QList<GenericChatroomWidget*> friends = friendList->getAllFriends();
+
+    int activeIndex = friends.indexOf(activeChatroomWidget);
+    int bounded = (activeIndex + offset) % friends.length();
+
+    if(bounded < 0)
+        bounded += friends.length();
+
+    emit friends[bounded]->chatroomWidgetClicked(friends[bounded]);
+}
+
 void Widget::processOfflineMsgs()
 {
     if (OfflineMsgEngine::globalMutex.tryLock())
@@ -1203,13 +1220,12 @@ void Widget::reloadTheme()
 
 void Widget::nextContact()
 {
-    // dont know how to get current/previous/next contact from friendlistwidget
-    qDebug() << "next contact";
+    cycleContacts(1);
 }
 
 void Widget::previousContact()
 {
-    qDebug() << "previous contact";
+    cycleContacts(-1);
 }
 
 QString Widget::getStatusIconPath(Status status)

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -158,6 +158,7 @@ private:
     void removeGroup(Group* g, bool fake = false);
     void saveWindowGeometry();
     void saveSplitterGeometry();
+    void cycleContacts(int offset);
     SystemTrayIcon *icon;
     QMenu *trayMenu;
     QAction *statusOnline,


### PR DESCRIPTION
I've added the ability to cycle through the contacts list with Ctrl+Tab and Ctrl+Shift+Tab. See commits for discussion of the implementation. I haven't tested this on friends lists with just one friend but my calculator says it should work.

The last commit may conflict with #1449 if they fix the shortcuts for the chat system.
This should work with #1371 as it walks the widgets rather than using internal structure.
Improves #997 and #1019 by adding these keybinds.
