### PR TITLE
Typing indicator shows up once typing is resumed

### DIFF
--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -89,7 +89,10 @@ ChatForm::ChatForm(Friend* chatFriend)
     connect(volButton, SIGNAL(clicked()), this, SLOT(onVolMuteToggle()));
     connect(Core::getInstance(), &Core::fileSendFailed, this, &ChatForm::onFileSendFailed);
     connect(this, SIGNAL(chatAreaCleared()), getOfflineMsgEngine(), SLOT(removeAllReciepts()));
-    connect(&typingTimer, &QTimer::timeout, this, [=]{Core::getInstance()->sendTyping(f->getFriendID(), false);});
+    connect(&typingTimer, &QTimer::timeout, this, [=]{
+        Core::getInstance()->sendTyping(f->getFriendID(), false);
+        isTyping = false;
+    } );
     connect(nameLabel, &CroppingLabel::textChanged, this, [=](QString text, QString orig) {
         if (text != orig) emit aliasChanged(text);
     } );


### PR DESCRIPTION
Earlier once typing was stopped for more than 3 seconds the indicator vanished and didn't show up even when typing was resumed.
