### PR TITLE
Make qTox build again

### DIFF
--- a/src/toxme.cpp
+++ b/src/toxme.cpp
@@ -1,5 +1,6 @@
 #include "toxme.h"
 #include "core.h"
+#include <QtDebug>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QCoreApplication>


### PR DESCRIPTION
Without this #include, qWarning() cannot be streamed to (in Qt 5.4)
