### PR TITLE
Added add friend on window on first start

### DIFF
--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -197,6 +197,7 @@ void Widget::init()
     connect(offlineMsgTimer, &QTimer::timeout, this, &Widget::processOfflineMsgs);
 
     addFriendForm->show(*ui);
+    setWindowTitle(tr("Add friend"));
 
     connect(settingsWidget, &SettingsWidget::groupchatPositionToggled, contactListWidget, &FriendListWidget::onGroupchatPositionChanged);
 #if (AUTOUPDATE_ENABLED)


### PR DESCRIPTION
When qTox starts it shows the 'Add friend' widget but it was not reflected in the title.
