### PR TITLE
Remove StatusNotifier dependency

### DIFF
--- a/src/widget/systemtrayicon.cpp
+++ b/src/widget/systemtrayicon.cpp
@@ -227,8 +227,8 @@ void SystemTrayIcon::setContextMenu(QMenu* menu)
             g_signal_connect(item, "activate", G_CALLBACK(callback), a);
             gtk_widget_show(item);
         }
-        void (*callbackMenu)(StatusNotifier*, gint, gint, gpointer) =
-                [](StatusNotifier*, gint, gint, gpointer data)
+        void (*callbackMenu)(GtkMenu*, gint, gint, gpointer) =
+                [](GtkMenu*, gint, gint, gpointer data)
         {
             gtk_widget_show_all(((SystemTrayIcon*)data)->gtkMenu);
             gtk_menu_popup(GTK_MENU(((SystemTrayIcon*)data)->gtkMenu), 0, 0, 0, 0, 3, gtk_get_current_event_time());


### PR DESCRIPTION
Helps when compiling under these conditions:

qmake-qt5 \
ENABLE_SYSTRAY_STATUSNOTIFIER_BACKEND=NO \
ENABLE_SYSTRAY_UNITY_BACKEND=NO \
ENABLE_SYSTRAY_GTK_BACKEND=YES
