### PR TITLE
Make dropdown menus look better on high dpi

### DIFF
--- a/src/widget/form/settings/generalsettings.ui
+++ b/src/widget/form/settings/generalsettings.ui
@@ -406,12 +406,6 @@ will be sent to them when they appear online to you.</string>
        </item>
        <item>
         <widget class="QGroupBox" name="themeGroup">
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>232</height>
-          </size>
-         </property>
          <property name="title">
           <string>Theme</string>
          </property>


### PR DESCRIPTION
This is what it now looks like on 125 dpi

![screenshot_2015-05-04_02-08-45](https://cloud.githubusercontent.com/assets/9732486/7447627/48b0bc46-f203-11e4-82a8-1346c88b9dfb.png)
