### PR TITLE
Fixing clang build on OSX

### DIFF
--- a/src/widget/tool/screengrabberchooserrectitem.cpp
+++ b/src/widget/tool/screengrabberchooserrectitem.cpp
@@ -16,6 +16,8 @@
 
 #include "screengrabberchooserrectitem.h"
 
+#include <complex>
+
 #include <QGraphicsSceneMouseEvent>
 #include <QGraphicsScene>
 #include <QPainter>

--- a/src/widget/tool/screengrabberchooserrectitem.cpp
+++ b/src/widget/tool/screengrabberchooserrectitem.cpp
@@ -16,7 +16,7 @@
 
 #include "screengrabberchooserrectitem.h"
 
-#include <complex>
+#include <cstdlib>
 
 #include <QGraphicsSceneMouseEvent>
 #include <QGraphicsScene>


### PR DESCRIPTION
std::abs() is function from <complex>, current HEAD doesn't build on OSX with latest clang because of missing include. This commit fixes the build.
