### PR TITLE
Revert "Removes chat history of friend when removed, fixes #1486"

### DIFF
--- a/src/historykeeper.cpp
+++ b/src/historykeeper.cpp
@@ -138,24 +138,6 @@ HistoryKeeper::~HistoryKeeper()
     delete db;
 }
 
-void HistoryKeeper::removeFriendHistory(const QString& chat)
-{
-    int chat_id = getChatID(chat, ctSingle).first;
-
-    db->exec("BEGIN TRANSACTION;");
-
-    QString cmd = QString("DELETE FROM chats WHERE name = '%1';").arg(chat);
-    db->exec(cmd);
-    cmd = QString("DELETE FROM aliases WHERE user_id = '%1';").arg(chat);
-    db->exec(cmd);
-    cmd = QString("DELETE FROM sent_status WHERE id IN (SELECT id FROM history WHERE chat_id = '%1');").arg(chat_id);
-    db->exec(cmd);
-    cmd = QString("DELETE FROM history WHERE chat_id = '%1';").arg(chat_id);
-    db->exec(cmd);
-
-    db->exec("COMMIT TRANSACTION;");
-}
-
 qint64 HistoryKeeper::addChatEntry(const QString& chat, const QString& message, const QString& sender, const QDateTime &dt, bool isSent)
 {
     QList<QString> cmds = generateAddChatEntryCmd(chat, message, sender, dt, isSent);

--- a/src/historykeeper.h
+++ b/src/historykeeper.h
@@ -54,7 +54,6 @@ public:
     static bool removeHistory(int encrypted = -1);
     static QList<HistMessage> exportMessagesDeleteFile(int encrypted = -1);
 
-    void removeFriendHistory(const QString& chat);
     qint64 addChatEntry(const QString& chat, const QString& message, const QString& sender, const QDateTime &dt, bool isSent);
     qint64 addGroupChatEntry(const QString& chat, const QString& message, const QString& sender, const QDateTime &dt);
     QList<HistMessage> getChatHistory(ChatType ct, const QString &chat, const QDateTime &time_from, const QDateTime &time_to);

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -866,7 +866,6 @@ void Widget::removeFriend(Friend* f, bool fake)
     }
     FriendList::removeFriend(f->getFriendID(), fake);
     Nexus::getCore()->removeFriend(f->getFriendID(), fake);
-    HistoryKeeper::getInstance()->removeFriendHistory(f->getToxID().publicKey);
     delete f;
     if (ui->mainHead->layout()->isEmpty())
         onAddClicked();


### PR DESCRIPTION
This reverts commit 07ba0c9ae0745cf6ba62724a022e2542c96ab9ff.

Reverted, since it introduces regression that causes removal of user data
when they remove contact.

fixes #1603
