### PR TITLE
Fixing tray icon visibility issue on OS X

### DIFF
--- a/src/widget/systemtrayicon.cpp
+++ b/src/widget/systemtrayicon.cpp
@@ -4,6 +4,8 @@
 #include <QMenu>
 #include <QFile>
 #include <QDebug>
+#include <QPainter>
+#include <QBitmap>
 #include "src/misc/settings.h"
 
 SystemTrayIcon::SystemTrayIcon()
@@ -388,6 +390,16 @@ void SystemTrayIcon::setIcon(QIcon &icon)
     #endif
     else if (backendType == SystrayBackendType::Qt)
     {
+        #ifdef Q_OS_MAC
+            // Since Qt doesn't render SVG tray icons for OSX
+            // we are forced to do this sort of a workaround!
+            QPixmap quirk(64, 64);
+            quirk.fill(Qt::transparent);
+            QPainter quirker(&quirk);
+            icon.paint(&quirker, 0, 0, 64, 64);
+            icon = QIcon(quirk);
+        #endif
+
         qtIcon->setIcon(icon);
     }
 }

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -489,6 +489,11 @@ void Widget::onIconClick(QSystemTrayIcon::ActivationReason reason)
     {
         case QSystemTrayIcon::Trigger:
         {
+            #if defined(Q_OS_MAC)
+                // We don't want to raise/minimize a window on icon click in OS X
+                break;
+            #endif
+
             if (isHidden())
             {
                 show();

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -301,7 +301,7 @@ void Widget::updateIcons()
     if (ico.isNull())
     {
         QString color = Settings::getInstance().getLightTrayIcon() ? "light" : "dark";
-        ico = QIcon(":img/taskbar/" + color + "/taskbar_" + status + ".svg");
+        ico = QIcon(":/img/taskbar/" + color + "/taskbar_" + status + ".svg");
     }
 
     setWindowIcon(ico);


### PR DESCRIPTION
Some quirking since Qt doesn't render SVG tray icons on OS X. It won't leave a significant footprint on general performance and we can leave it as it is till the proper fix from the Qt's side.

Related issue: #1594
