### PR TITLE
Redesign draft for settings pane and proper UX for Mac

### DIFF
--- a/qtox.pro
+++ b/qtox.pro
@@ -437,7 +437,8 @@ SOURCES += \
     src/widget/tool/screengrabberchooserrectitem.cpp \
     src/widget/tool/screengrabberoverlayitem.cpp \
     src/widget/tool/toolboxgraphicsitem.cpp \
-    src/widget/tool/flyoutoverlaywidget.cpp
+    src/widget/tool/flyoutoverlaywidget.cpp \
+    src/widget/form/settings/verticalonlyscroller.cpp
 
 
 HEADERS += \
@@ -468,4 +469,5 @@ HEADERS += \
     src/widget/tool/screengrabberchooserrectitem.h \
     src/widget/tool/screengrabberoverlayitem.h \
     src/widget/tool/toolboxgraphicsitem.h \
-    src/widget/tool/flyoutoverlaywidget.h
+    src/widget/tool/flyoutoverlaywidget.h \
+    src/widget/form/settings/verticalonlyscroller.h

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -144,7 +144,7 @@ int main(int argc, char *argv[])
     cvSetErrMode(CV_ErrModeParent);
     cvRedirectError(opencvErrorHandler);
 
-#ifdef Q_OS_MACX
+#if defined(Q_OS_MACX) && defined(QT_RELEASE)
     if (qApp->applicationDirPath() != "/Applications/qtox.app/Contents/MacOS") {
         qDebug() << "OS X: Not in Applications folder";
 

--- a/src/widget/form/settings/advancedsettings.ui
+++ b/src/widget/form/settings/advancedsettings.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QScrollArea" name="scrollArea">
+    <widget class="VerticalOnlyScroller" name="scrollArea">
      <property name="widgetResizable">
       <bool>true</bool>
      </property>
@@ -24,8 +24,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>380</width>
-        <height>280</height>
+        <width>374</width>
+        <height>302</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -114,6 +114,14 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>VerticalOnlyScroller</class>
+   <extends>QScrollArea</extends>
+   <header>src/widget/form/settings/verticalonlyscroller.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/widget/form/settings/avsettings.ui
+++ b/src/widget/form/settings/avsettings.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
-    <widget class="QScrollArea" name="scrollArea">
+    <widget class="VerticalOnlyScroller" name="scrollArea">
      <property name="autoFillBackground">
       <bool>true</bool>
      </property>
@@ -30,8 +30,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>824</width>
-        <height>489</height>
+        <width>818</width>
+        <height>510</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -242,6 +242,14 @@ which may lead to problems with video calls.</string>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>VerticalOnlyScroller</class>
+   <extends>QScrollArea</extends>
+   <header>src/widget/form/settings/verticalonlyscroller.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/widget/form/settings/generalsettings.ui
+++ b/src/widget/form/settings/generalsettings.ui
@@ -40,7 +40,7 @@
         <x>0</x>
         <y>0</y>
         <width>653</width>
-        <height>1080</height>
+        <height>1154</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,0,0,1">
@@ -106,7 +106,7 @@
             </property>
             <layout class="QHBoxLayout" name="horizontalLayout_2">
              <item>
-              <layout class="QVBoxLayout" name="verticalLayout_6">
+              <layout class="QVBoxLayout" name="trayOptionsLayout">
                <item>
                 <widget class="QCheckBox" name="startInTray">
                  <property name="sizePolicy">
@@ -193,49 +193,8 @@ instead of system taskbar.</string>
            </widget>
           </item>
           <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_3">
+           <layout class="QHBoxLayout" name="autoAwayLayout">
             <item>
-             <layout class="QVBoxLayout" name="verticalLayout_8">
-              <item>
-               <widget class="QCheckBox" name="cbAutorun">
-                <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Start qTox on operating system startup (current profile).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-                <property name="text">
-                 <string>Autostart</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QCheckBox" name="checkUpdates">
-                <property name="text">
-                 <string>Check for updates on startup</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_3">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QGridLayout" name="autoLayout">
-            <property name="topMargin">
-             <number>0</number>
-            </property>
-            <item row="0" column="0" colspan="2">
              <widget class="QLabel" name="autoAwayLabel">
               <property name="toolTip">
                <string>Your status is changed to Away after set period of inactivity.</string>
@@ -248,7 +207,7 @@ instead of system taskbar.</string>
               </property>
              </widget>
             </item>
-            <item row="0" column="1">
+            <item>
              <widget class="QSpinBox" name="autoAwaySpinBox">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -273,7 +232,35 @@ instead of system taskbar.</string>
               </property>
              </widget>
             </item>
-            <item row="1" column="0">
+           </layout>
+          </item>
+          <item>
+           <layout class="QVBoxLayout" name="startupLayout">
+            <item>
+             <widget class="QCheckBox" name="cbAutorun">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Start qTox on operating system startup (current profile).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>Autostart</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkUpdates">
+              <property name="text">
+               <string>Check for updates on startup</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="autoacceptLayout">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <item>
              <widget class="QCheckBox" name="autoacceptFiles">
               <property name="toolTip">
                <string comment="autoaccept cb tooltip">You can set this on a per-friend basis by right clicking them.</string>
@@ -283,7 +270,7 @@ instead of system taskbar.</string>
               </property>
              </widget>
             </item>
-            <item row="1" column="1">
+            <item>
              <widget class="QPushButton" name="autoSaveFilesDir">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -308,58 +295,53 @@ instead of system taskbar.</string>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_7">
           <item>
-           <layout class="QHBoxLayout" name="onMessageLayout">
+           <layout class="QVBoxLayout" name="newMessagesLayout">
             <property name="topMargin">
              <number>0</number>
             </property>
             <item>
-             <widget class="QLabel" name="label">
-              <property name="text">
+             <widget class="QGroupBox" name="newMessages">
+              <property name="title">
                <string>On new message:</string>
               </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_2">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QCheckBox" name="showWindow">
-              <property name="toolTip">
-               <string comment="tooltip for Show window setting">Show qTox's window when you receive new message.</string>
-              </property>
-              <property name="text">
-               <string>Show window</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QCheckBox" name="showInFront">
-              <property name="toolTip">
-               <string comment="toolTip for Focus window setting">Focus qTox when you receive message.</string>
-              </property>
-              <property name="text">
-               <string>Focus window</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QCheckBox" name="notifySound">
-              <property name="toolTip">
-               <string comment="toolTip for Notify sound setting">Play a sound when you recieve message.</string>
-              </property>
-              <property name="text">
-               <string>Play sound</string>
-              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_10">
+               <item>
+                <widget class="QCheckBox" name="notifySound">
+                 <property name="toolTip">
+                  <string comment="toolTip for Notify sound setting">Play a sound when you recieve message.</string>
+                 </property>
+                 <property name="text">
+                  <string>Play sound</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="showInFront">
+                 <property name="toolTip">
+                  <string comment="toolTip for Focus window setting">Focus qTox when you receive message.</string>
+                 </property>
+                 <property name="text">
+                  <string>Focus window</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="showWindow">
+                 <property name="toolTip">
+                  <string comment="tooltip for Show window setting">Show qTox's window when you receive new message.</string>
+                 </property>
+                 <property name="text">
+                  <string>Show window</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+              <zorder>showWindow</zorder>
+              <zorder>showInFront</zorder>
+              <zorder>notifySound</zorder>
+              <zorder>showWindow</zorder>
+              <zorder>showInFront</zorder>
+              <zorder>notifySound</zorder>
              </widget>
             </item>
            </layout>
@@ -457,10 +439,26 @@ will be sent to them when they appear online to you.</string>
              </widget>
             </item>
             <item row="1" column="0" colspan="2">
-             <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0,0,0">
+             <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0,0,0,0">
               <property name="sizeConstraint">
                <enum>QLayout::SetDefaultConstraint</enum>
               </property>
+              <item>
+               <spacer name="horizontalSpacer_2">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeType">
+                 <enum>QSizePolicy::Fixed</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>120</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
               <item alignment="Qt::AlignTop">
                <widget class="QLabel" name="smile1">
                 <property name="toolTip">
@@ -468,6 +466,9 @@ will be sent to them when they appear online to you.</string>
                 </property>
                 <property name="text">
                  <string/>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
                 </property>
                </widget>
               </item>
@@ -479,6 +480,9 @@ will be sent to them when they appear online to you.</string>
                 <property name="text">
                  <string/>
                 </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
                </widget>
               </item>
               <item alignment="Qt::AlignTop">
@@ -488,6 +492,9 @@ will be sent to them when they appear online to you.</string>
                 </property>
                 <property name="text">
                  <string/>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
                 </property>
                </widget>
               </item>
@@ -499,6 +506,9 @@ will be sent to them when they appear online to you.</string>
                 <property name="text">
                  <string/>
                 </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
                </widget>
               </item>
               <item alignment="Qt::AlignTop">
@@ -508,6 +518,9 @@ will be sent to them when they appear online to you.</string>
                 </property>
                 <property name="text">
                  <string/>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
                 </property>
                </widget>
               </item>
@@ -764,13 +777,8 @@ will be sent to them when they appear online to you.</string>
  <tabstops>
   <tabstop>scrollArea</tabstop>
   <tabstop>transComboBox</tabstop>
-  <tabstop>autoacceptFiles</tabstop>
-  <tabstop>autoSaveFilesDir</tabstop>
-  <tabstop>autoAwaySpinBox</tabstop>
   <tabstop>groupAlwaysNotify</tabstop>
   <tabstop>statusChanges</tabstop>
-  <tabstop>showWindow</tabstop>
-  <tabstop>showInFront</tabstop>
   <tabstop>useEmoticons</tabstop>
   <tabstop>smileyPackBrowser</tabstop>
   <tabstop>emoticonSize</tabstop>
@@ -786,18 +794,18 @@ will be sent to them when they appear online to you.</string>
  <resources/>
  <connections>
   <connection>
-   <sender>showSystemTray</sender>
+   <sender>showWindow</sender>
    <signal>toggled(bool)</signal>
-   <receiver>startInTray</receiver>
+   <receiver>showInFront</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>105</x>
-     <y>144</y>
+     <x>329</x>
+     <y>349</y>
     </hint>
     <hint type="destinationlabel">
-     <x>119</x>
-     <y>177</y>
+     <x>451</x>
+     <y>349</y>
     </hint>
    </hints>
   </connection>
@@ -834,18 +842,18 @@ will be sent to them when they appear online to you.</string>
    </hints>
   </connection>
   <connection>
-   <sender>showWindow</sender>
+   <sender>showSystemTray</sender>
    <signal>toggled(bool)</signal>
-   <receiver>showInFront</receiver>
+   <receiver>startInTray</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>329</x>
-     <y>349</y>
+     <x>105</x>
+     <y>144</y>
     </hint>
     <hint type="destinationlabel">
-     <x>451</x>
-     <y>349</y>
+     <x>119</x>
+     <y>177</y>
     </hint>
    </hints>
   </connection>

--- a/src/widget/form/settings/generalsettings.ui
+++ b/src/widget/form/settings/generalsettings.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>573</width>
-    <height>644</height>
+    <width>673</width>
+    <height>1100</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -27,7 +27,7 @@
     <number>9</number>
    </property>
    <item>
-    <widget class="QScrollArea" name="scrollArea">
+    <widget class="VerticalOnlyScroller" name="scrollArea">
      <property name="widgetResizable">
       <bool>true</bool>
      </property>
@@ -38,14 +38,14 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-214</y>
-        <width>539</width>
-        <height>838</height>
+        <y>0</y>
+        <width>653</width>
+        <height>1080</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,0,0,1">
        <property name="spacing">
-        <number>9</number>
+        <number>32</number>
        </property>
        <property name="topMargin">
         <number>9</number>
@@ -104,76 +104,80 @@
             <property name="alignment">
              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
             </property>
-            <layout class="QGridLayout" name="gridLayout_2">
-             <item row="0" column="0">
-              <widget class="QCheckBox" name="showSystemTray">
-               <property name="text">
-                <string>Show system tray icon</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QCheckBox" name="lightTrayIcon">
-               <property name="toolTip">
-                <string comment="toolTip for light icon setting">Enable light tray icon.</string>
-               </property>
-               <property name="text">
-                <string>Light icon</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="0">
-              <widget class="QCheckBox" name="startInTray">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="toolTip">
-                <string comment="toolTip for Start in tray setting">qTox will start minimized in tray.</string>
-               </property>
-               <property name="text">
-                <string>Start in tray</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="1">
-              <widget class="QCheckBox" name="closeToTray">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="toolTip">
-                <string comment="toolTip for close to tray setting">After pressing close (X) qTox will minimize to tray,
+            <layout class="QHBoxLayout" name="horizontalLayout_2">
+             <item>
+              <layout class="QVBoxLayout" name="verticalLayout_6">
+               <item>
+                <widget class="QCheckBox" name="startInTray">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="toolTip">
+                  <string comment="toolTip for Start in tray setting">qTox will start minimized in tray.</string>
+                 </property>
+                 <property name="text">
+                  <string>Start in tray</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="showSystemTray">
+                 <property name="text">
+                  <string>Show system tray icon</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="closeToTray">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="toolTip">
+                  <string comment="toolTip for close to tray setting">After pressing close (X) qTox will minimize to tray,
 instead of closing itself.</string>
-               </property>
-               <property name="text">
-                <string>Close to tray</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="2">
-              <widget class="QCheckBox" name="minimizeToTray">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="toolTip">
-                <string comment="toolTip for minimize to tray setting">After pressing minimize (_) qTox will minimize itself to tray,
+                 </property>
+                 <property name="text">
+                  <string>Close to tray</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="lightTrayIcon">
+                 <property name="toolTip">
+                  <string comment="toolTip for light icon setting">Enable light tray icon.</string>
+                 </property>
+                 <property name="text">
+                  <string>Light icon</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="minimizeToTray">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="toolTip">
+                  <string comment="toolTip for minimize to tray setting">After pressing minimize (_) qTox will minimize itself to tray,
 instead of system taskbar.</string>
-               </property>
-               <property name="text">
-                <string>Minimize to tray</string>
-               </property>
-              </widget>
+                 </property>
+                 <property name="text">
+                  <string>Minimize to tray</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
              </item>
-             <item row="2" column="3">
-              <spacer name="traySpacer">
+             <item>
+              <spacer name="horizontalSpacer">
                <property name="orientation">
                 <enum>Qt::Horizontal</enum>
                </property>
@@ -189,23 +193,40 @@ instead of system taskbar.</string>
            </widget>
           </item>
           <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_2">
+           <layout class="QHBoxLayout" name="horizontalLayout_3">
             <item>
-             <widget class="QCheckBox" name="cbAutorun">
-              <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Start qTox on operating system startup (current profile).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-              </property>
-              <property name="text">
-               <string>Autostart</string>
-              </property>
-             </widget>
+             <layout class="QVBoxLayout" name="verticalLayout_8">
+              <item>
+               <widget class="QCheckBox" name="cbAutorun">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Start qTox on operating system startup (current profile).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="text">
+                 <string>Autostart</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="checkUpdates">
+                <property name="text">
+                 <string>Check for updates on startup</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
             </item>
             <item>
-             <widget class="QCheckBox" name="checkUpdates">
-              <property name="text">
-               <string>Check for updates on startup</string>
+             <spacer name="horizontalSpacer_3">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
               </property>
-             </widget>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
             </item>
            </layout>
           </item>
@@ -214,40 +235,20 @@ instead of system taskbar.</string>
             <property name="topMargin">
              <number>0</number>
             </property>
-            <item row="1" column="1">
-             <widget class="QLabel" name="autoSaveFilesDirLabel">
+            <item row="0" column="0" colspan="2">
+             <widget class="QLabel" name="autoAwayLabel">
               <property name="toolTip">
-               <string>Set where files will be saved.</string>
+               <string>Your status is changed to Away after set period of inactivity.</string>
+              </property>
+              <property name="layoutDirection">
+               <enum>Qt::LeftToRight</enum>
               </property>
               <property name="text">
-               <string>Save to:</string>
+               <string>Auto away after (0 to disable):</string>
               </property>
              </widget>
             </item>
-            <item row="1" column="0">
-             <widget class="QCheckBox" name="autoacceptFiles">
-              <property name="toolTip">
-               <string comment="autoaccept cb tooltip">You can set this on a per-friend basis by right clicking them.</string>
-              </property>
-              <property name="text">
-               <string>Autoaccept files</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="2">
-             <widget class="QPushButton" name="autoSaveFilesDir">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="toolTip">
-               <string>Set where files will be saved.</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="2">
+            <item row="0" column="1">
              <widget class="QSpinBox" name="autoAwaySpinBox">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -272,16 +273,26 @@ instead of system taskbar.</string>
               </property>
              </widget>
             </item>
-            <item row="0" column="0" colspan="2">
-             <widget class="QLabel" name="autoAwayLabel">
+            <item row="1" column="0">
+             <widget class="QCheckBox" name="autoacceptFiles">
               <property name="toolTip">
-               <string>Your status is changed to Away after set period of inactivity.</string>
-              </property>
-              <property name="layoutDirection">
-               <enum>Qt::LeftToRight</enum>
+               <string comment="autoaccept cb tooltip">You can set this on a per-friend basis by right clicking them.</string>
               </property>
               <property name="text">
-               <string>Auto away after (0 to disable):</string>
+               <string>Autoaccept and save files:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QPushButton" name="autoSaveFilesDir">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="toolTip">
+               <string>Set where files will be saved.</string>
               </property>
              </widget>
             </item>
@@ -295,36 +306,32 @@ instead of system taskbar.</string>
          <property name="title">
           <string>Chat</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout" columnstretch="0,0,0">
-          <item row="3" column="0">
-           <widget class="QCheckBox" name="groupAlwaysNotify">
-            <property name="toolTip">
-             <string comment="toolTip for Group chat always notify">Always notify about new messages in groupchats.</string>
-            </property>
-            <property name="text">
-             <string>Group chats always notify</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QCheckBox" name="statusChanges">
-            <property name="text">
-             <string>Show contacts' status changes</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label">
-            <property name="text">
-             <string>On new message:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
+         <layout class="QVBoxLayout" name="verticalLayout_7">
+          <item>
            <layout class="QHBoxLayout" name="onMessageLayout">
             <property name="topMargin">
              <number>0</number>
             </property>
+            <item>
+             <widget class="QLabel" name="label">
+              <property name="text">
+               <string>On new message:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
             <item>
              <widget class="QCheckBox" name="showWindow">
               <property name="toolTip">
@@ -357,20 +364,34 @@ instead of system taskbar.</string>
             </item>
            </layout>
           </item>
-          <item row="1" column="2">
-           <spacer name="chatSpacer">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
+          <item>
+           <widget class="QCheckBox" name="statusChanges">
+            <property name="text">
+             <string>Show contacts' status changes</string>
             </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
+           </widget>
           </item>
-          <item row="2" column="1">
+          <item>
+           <widget class="QCheckBox" name="groupAlwaysNotify">
+            <property name="toolTip">
+             <string comment="toolTip for Group chat always notify">Always notify about new messages in groupchats.</string>
+            </property>
+            <property name="text">
+             <string>Group chats always notify</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="cbGroupchatPosition">
+            <property name="toolTip">
+             <string comment="toolTip for groupchat positioning">If checked, groupchats will be placed at the top of the friends list, otherwise, they'll be placed below online friends.</string>
+            </property>
+            <property name="text">
+             <string>Place groupchats at top of friend list</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QCheckBox" name="cbFauxOfflineMessaging">
             <property name="toolTip">
              <string comment="toolTip for Faux offline messaging setting">Messages you are trying to send to your friends when they are not online
@@ -381,23 +402,13 @@ will be sent to them when they appear online to you.</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
+          <item>
            <widget class="QCheckBox" name="cbCompactLayout">
             <property name="toolTip">
              <string comment="toolTip for compact layout setting">Your contact list will be shown in compact mode.</string>
             </property>
             <property name="text">
              <string>Compact contact list</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QCheckBox" name="cbGroupchatPosition">
-            <property name="toolTip">
-             <string comment="toolTip for groupchat positioning">If checked, groupchats will be placed at the top of the friends list, otherwise, they'll be placed below online friends.</string>
-            </property>
-            <property name="text">
-             <string>Place groupchats at top of friend list</string>
             </property>
            </widget>
           </item>
@@ -710,11 +721,28 @@ will be sent to them when they appear online to you.</string>
            </layout>
           </item>
           <item>
-           <widget class="QPushButton" name="reconnectButton">
-            <property name="text">
-             <string comment="reconnect button">Reconnect</string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="horizontalLayout_4">
+            <item>
+             <spacer name="horizontalSpacer_4">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QPushButton" name="reconnectButton">
+              <property name="text">
+               <string comment="reconnect button">Reconnect</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
          </layout>
         </widget>
@@ -725,16 +753,17 @@ will be sent to them when they appear online to you.</string>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>VerticalOnlyScroller</class>
+   <extends>QScrollArea</extends>
+   <header>src/widget/form/settings/verticalonlyscroller.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>scrollArea</tabstop>
   <tabstop>transComboBox</tabstop>
-  <tabstop>showSystemTray</tabstop>
-  <tabstop>lightTrayIcon</tabstop>
-  <tabstop>startInTray</tabstop>
-  <tabstop>closeToTray</tabstop>
-  <tabstop>minimizeToTray</tabstop>
-  <tabstop>cbAutorun</tabstop>
-  <tabstop>checkUpdates</tabstop>
   <tabstop>autoacceptFiles</tabstop>
   <tabstop>autoSaveFilesDir</tabstop>
   <tabstop>autoAwaySpinBox</tabstop>
@@ -742,8 +771,6 @@ will be sent to them when they appear online to you.</string>
   <tabstop>statusChanges</tabstop>
   <tabstop>showWindow</tabstop>
   <tabstop>showInFront</tabstop>
-  <tabstop>cbFauxOfflineMessaging</tabstop>
-  <tabstop>cbCompactLayout</tabstop>
   <tabstop>useEmoticons</tabstop>
   <tabstop>smileyPackBrowser</tabstop>
   <tabstop>emoticonSize</tabstop>
@@ -755,7 +782,6 @@ will be sent to them when they appear online to you.</string>
   <tabstop>proxyType</tabstop>
   <tabstop>proxyAddr</tabstop>
   <tabstop>proxyPort</tabstop>
-  <tabstop>reconnectButton</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/widget/form/settings/generalsettings.ui
+++ b/src/widget/form/settings/generalsettings.ui
@@ -40,7 +40,7 @@
         <x>0</x>
         <y>0</y>
         <width>653</width>
-        <height>1154</height>
+        <height>1150</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,0,0,1">
@@ -339,9 +339,6 @@ instead of system taskbar.</string>
               <zorder>showWindow</zorder>
               <zorder>showInFront</zorder>
               <zorder>notifySound</zorder>
-              <zorder>showWindow</zorder>
-              <zorder>showInFront</zorder>
-              <zorder>notifySound</zorder>
              </widget>
             </item>
            </layout>
@@ -438,94 +435,6 @@ will be sent to them when they appear online to you.</string>
               </property>
              </widget>
             </item>
-            <item row="1" column="0" colspan="2">
-             <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0,0,0,0">
-              <property name="sizeConstraint">
-               <enum>QLayout::SetDefaultConstraint</enum>
-              </property>
-              <item>
-               <spacer name="horizontalSpacer_2">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeType">
-                 <enum>QSizePolicy::Fixed</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>120</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item alignment="Qt::AlignTop">
-               <widget class="QLabel" name="smile1">
-                <property name="toolTip">
-                 <string notr="true">:)</string>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item alignment="Qt::AlignTop">
-               <widget class="QLabel" name="smile2">
-                <property name="toolTip">
-                 <string notr="true">;)</string>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item alignment="Qt::AlignTop">
-               <widget class="QLabel" name="smile3">
-                <property name="toolTip">
-                 <string notr="true">:p</string>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item alignment="Qt::AlignTop">
-               <widget class="QLabel" name="smile4">
-                <property name="toolTip">
-                 <string notr="true">:O</string>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item alignment="Qt::AlignTop">
-               <widget class="QLabel" name="smile5">
-                <property name="toolTip">
-                 <string notr="true">:'(</string>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
             <item row="2" column="0">
              <widget class="QLabel" name="emoticonSizeLabel">
               <property name="text">
@@ -618,6 +527,91 @@ will be sent to them when they appear online to you.</string>
             </item>
             <item row="6" column="1">
              <widget class="QComboBox" name="dateFormats"/>
+            </item>
+            <item row="1" column="0">
+             <spacer name="horizontalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>80</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="1" column="1">
+             <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0,0,0">
+              <property name="sizeConstraint">
+               <enum>QLayout::SetDefaultConstraint</enum>
+              </property>
+              <item alignment="Qt::AlignTop">
+               <widget class="QLabel" name="smile1">
+                <property name="toolTip">
+                 <string notr="true">:)</string>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item alignment="Qt::AlignTop">
+               <widget class="QLabel" name="smile2">
+                <property name="toolTip">
+                 <string notr="true">;)</string>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item alignment="Qt::AlignTop">
+               <widget class="QLabel" name="smile3">
+                <property name="toolTip">
+                 <string notr="true">:p</string>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item alignment="Qt::AlignTop">
+               <widget class="QLabel" name="smile4">
+                <property name="toolTip">
+                 <string notr="true">:O</string>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item alignment="Qt::AlignTop">
+               <widget class="QLabel" name="smile5">
+                <property name="toolTip">
+                 <string notr="true">:'(</string>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+               </widget>
+              </item>
+             </layout>
             </item>
            </layout>
           </item>

--- a/src/widget/form/settings/privacysettings.ui
+++ b/src/widget/form/settings/privacysettings.ui
@@ -27,7 +27,7 @@
     <number>9</number>
    </property>
    <item>
-    <widget class="QScrollArea" name="scrollArea">
+    <widget class="VerticalOnlyScroller" name="scrollArea">
      <property name="widgetResizable">
       <bool>true</bool>
      </property>
@@ -37,7 +37,7 @@
         <x>0</x>
         <y>0</y>
         <width>380</width>
-        <height>280</height>
+        <height>391</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -131,14 +131,14 @@ Save format changes are possible, which may result in data loss.</string>
        </item>
        <item alignment="Qt::AlignTop">
         <widget class="QGroupBox" name="nospamGroup">
-         <property name="title">
-          <string>Nospam</string>
-         </property>
          <property name="toolTip">
           <string comment="toolTip for nospam">Nospam is part of your Tox ID.
 It is there to help you change your Tox ID when you feel like you are getting too much spam friend requests.
 When you change nospam, your current contacts still can communicate with you,
 but new contacts need to know your new Tox ID to be able to add you.</string>
+         </property>
+         <property name="title">
+          <string>Nospam</string>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_4">
           <item>
@@ -181,6 +181,14 @@ but new contacts need to know your new Tox ID to be able to add you.</string>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>VerticalOnlyScroller</class>
+   <extends>QScrollArea</extends>
+   <header>src/widget/form/settings/verticalonlyscroller.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/widget/form/settings/verticalonlyscroller.cpp
+++ b/src/widget/form/settings/verticalonlyscroller.cpp
@@ -1,0 +1,31 @@
+/*
+    Copyright (C) 2014 by Project Tox <https://tox.im>
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    This program is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+    See the COPYING file for more details.
+*/
+
+#include <QResizeEvent>
+
+#include "verticalonlyscroller.h"
+
+VerticalOnlyScroller::VerticalOnlyScroller(QWidget *parent) :
+    QScrollArea(parent)
+{
+}
+
+void VerticalOnlyScroller::resizeEvent(QResizeEvent *event)
+{
+    QScrollArea::resizeEvent(event);
+    if (widget())
+        widget()->setMaximumWidth(event->size().width());
+}

--- a/src/widget/form/settings/verticalonlyscroller.cpp
+++ b/src/widget/form/settings/verticalonlyscroller.cpp
@@ -15,6 +15,7 @@
 */
 
 #include <QResizeEvent>
+#include <QShowEvent>
 
 #include "verticalonlyscroller.h"
 
@@ -28,4 +29,11 @@ void VerticalOnlyScroller::resizeEvent(QResizeEvent *event)
     QScrollArea::resizeEvent(event);
     if (widget())
         widget()->setMaximumWidth(event->size().width());
+}
+
+void VerticalOnlyScroller::showEvent(QShowEvent *event)
+{
+    QScrollArea::showEvent(event);
+    if (widget())
+        widget()->setMaximumWidth(size().width());
 }

--- a/src/widget/form/settings/verticalonlyscroller.cpp
+++ b/src/widget/form/settings/verticalonlyscroller.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014 by Project Tox <https://tox.im>
+    Copyright (C) 2015 by Project Tox <https://tox.im>
 
     This file is part of qTox, a Qt-based graphical interface for Tox.
 

--- a/src/widget/form/settings/verticalonlyscroller.h
+++ b/src/widget/form/settings/verticalonlyscroller.h
@@ -1,0 +1,34 @@
+/*
+    Copyright (C) 2014 by Project Tox <https://tox.im>
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    This program is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+    See the COPYING file for more details.
+*/
+
+#ifndef VERTICALONLYSCROLLER_H
+#define VERTICALONLYSCROLLER_H
+
+#include <QScrollArea>
+
+class QResizeEvent;
+
+class VerticalOnlyScroller : public QScrollArea
+{
+    Q_OBJECT
+public:
+    explicit VerticalOnlyScroller(QWidget *parent = 0);
+
+protected:
+    void resizeEvent(QResizeEvent *event);
+};
+
+#endif // VERTICALONLYSCROLLER_H

--- a/src/widget/form/settings/verticalonlyscroller.h
+++ b/src/widget/form/settings/verticalonlyscroller.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2014 by Project Tox <https://tox.im>
+    Copyright (C) 2015 by Project Tox <https://tox.im>
 
     This file is part of qTox, a Qt-based graphical interface for Tox.
 

--- a/src/widget/form/settings/verticalonlyscroller.h
+++ b/src/widget/form/settings/verticalonlyscroller.h
@@ -20,6 +20,7 @@
 #include <QScrollArea>
 
 class QResizeEvent;
+class QShowEvent;
 
 class VerticalOnlyScroller : public QScrollArea
 {
@@ -29,6 +30,7 @@ public:
 
 protected:
     void resizeEvent(QResizeEvent *event);
+    void showEvent(QShowEvent *event);
 };
 
 #endif // VERTICALONLYSCROLLER_H

--- a/src/widget/form/settingswidget.cpp
+++ b/src/widget/form/settingswidget.cpp
@@ -46,7 +46,7 @@ SettingsWidget::SettingsWidget(QWidget* parent)
     headLayout->addStretch(1);
 
     settingsWidgets = new QTabWidget(this);
-    settingsWidgets->setTabPosition(QTabWidget::South);
+    settingsWidgets->setTabPosition(QTabWidget::North);
 
     bodyLayout->addWidget(settingsWidgets);
 

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -148,10 +148,12 @@ void Widget::init()
         ui->mainContent->setStyle(QStyleFactory::create(Settings::getInstance().getStyle()));
     }
 
+#ifndef Q_OS_MAC
     ui->mainHead->setStyleSheet(Style::getStylesheet(":ui/settings/mainHead.css"));
     ui->mainContent->setStyleSheet(Style::getStylesheet(":ui/settings/mainContent.css"));
-
     ui->statusHead->setStyleSheet(Style::getStylesheet(":/ui/window/statusPanel.css"));
+    ui->statusPanel->setStyleSheet(Style::getStylesheet(":/ui/window/statusPanel.css"));
+#endif
 
     contactListWidget = new FriendListWidget(0, Settings::getInstance().getGroupchatPosition());
     ui->friendList->setWidget(contactListWidget);


### PR DESCRIPTION
This pull request is capable of:
- **Repairing settings UX on Mac (#1594)**
- **Turning scroll areas in settings panes to vertical scrolling only**
- **Proposing a redesign of settings pane (#1069)**

Here are some neat screenshots:

![screen shot 2015-05-11 at 12 28 50 am](https://cloud.githubusercontent.com/assets/934682/7556397/d867e18e-f776-11e4-90ee-e98d814b38bf.png)
![screen shot 2015-05-11 at 12 39 27 am](https://cloud.githubusercontent.com/assets/934682/7556398/d8690f3c-f776-11e4-8050-b21f107d743e.png)
![screen shot 2015-05-11 at 12 39 46 am](https://cloud.githubusercontent.com/assets/934682/7556399/d883226e-f776-11e4-9d56-c002c904d6dd.png)

Disclaimer: I am still not sure about possible regressions on Linux/Windows, since I haven't got an occasion to test this patch out on these platforms.
