### PR TITLE
Persistent friends aliases, finally resolves #697

### DIFF
--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -250,6 +250,7 @@ void FriendWidget::setAlias(const QString& _alias)
     Friend* f = FriendList::findFriend(friendId);
     f->setAlias(alias);
     Settings::getInstance().setFriendAlias(f->getToxID(), alias);
+    Settings::getInstance().save(true);
     hide();
     show();
 }


### PR DESCRIPTION
I discovered that the problem of temporary aliasing (which is a bug, according to #697) lied in the wrong config workflow: alias is being written to config object in memory, but not recorded to config file. This patch makes sure that new alias will get rendered in config file.
