### PR TITLE
Fixed settings tabbar style

### DIFF
--- a/ui/settings/mainContent.css
+++ b/ui/settings/mainContent.css
@@ -71,11 +71,6 @@ QTabWidget
     background-color: white;
 }
 
-QTabBar
-{
-    background-color: white;
-}
-
 QScrollArea
 {
     background-color: white;


### PR DESCRIPTION
Current:
![qtox-tab-old-crop](https://cloud.githubusercontent.com/assets/4348610/7576513/0ec972d2-f804-11e4-9183-85f64cbdd432.png)

New:
![qtox-tab-new-crop](https://cloud.githubusercontent.com/assets/4348610/7576512/0ec90e50-f804-11e4-9414-bd3afbbcab34.png)

It should look better for other styles as well, not just Fusion.
