### PR TITLE
Another fix for settings tabbar style

### DIFF
--- a/src/widget/form/settingswidget.cpp
+++ b/src/widget/form/settingswidget.cpp
@@ -48,6 +48,10 @@ SettingsWidget::SettingsWidget(QWidget* parent)
     settingsWidgets = new QTabWidget(this);
     settingsWidgets->setTabPosition(QTabWidget::North);
 
+    // Originally had some CSS for this (QTabBar { background-color: white; }), but it removed
+    // borders and didn't look quite right.
+    const_cast<QTabBar*>(settingsWidgets->tabBar())->setPalette(QPalette(Qt::white));
+
     bodyLayout->addWidget(settingsWidgets);
 
     GeneralForm* gfrm = new GeneralForm(this);

--- a/ui/settings/mainContent.css
+++ b/ui/settings/mainContent.css
@@ -71,11 +71,6 @@ QTabWidget
     background-color: white;
 }
 
-QTabBar
-{
-    background-color: white;
-}
-
 QScrollArea
 {
     background-color: white;


### PR DESCRIPTION
So I set a dark system theme and replicated the issue @agilob was having with pull request #1629. While Qt's CSS is a bit weird/unexpected in how it displays, setting a white QPalette to the QTabBar seemed to work for all styles except GTK+ with a dark system theme.
