### PR TITLE
Copy ToxID into XA_PRIMARY clipboard too to make retrieval easier.

### DIFF
--- a/src/widget/form/profileform.cpp
+++ b/src/widget/form/profileform.cpp
@@ -150,7 +150,9 @@ void ProfileForm::copyIdClicked()
     toxId->selectAll();
     QString txt = toxId->text();
     txt.replace('\n',"");
-    QApplication::clipboard()->setText(txt);
+    QApplication::clipboard()->setText(txt, QClipboard::Clipboard);
+    if (QApplication::clipboard()->supportsSelection())
+      QApplication::clipboard()->setText(txt, QClipboard::Selection);
     toxId->setCursorPosition(0);
 
     if (!hasCheck)


### PR DESCRIPTION
Otherwise I couldn't paste it on dwm.
Both chrome and firefox copy into XA_PRIMARY and XA_CLIPBOARD in "Copy" operation.
