### PR TITLE
Code consistency fixes → 's/ToxID/ToxId/'

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -1080,20 +1080,20 @@ QString Core::getGroupPeerName(int groupId, int peerId) const
     return name;
 }
 
-ToxId Core::getGroupPeerToxID(int groupId, int peerId) const
+ToxId Core::getGroupPeerToxId(int groupId, int peerId) const
 {
-    ToxId peerToxID;
+    ToxId peerToxId;
 
     uint8_t rawID[TOX_PUBLIC_KEY_SIZE];
     int res = tox_group_peer_pubkey(tox, groupId, peerId, rawID);
     if (res == -1)
     {
-        qWarning() << "getGroupPeerToxID: Unknown error";
-        return peerToxID;
+        qWarning() << "getGroupPeerToxId: Unknown error";
+        return peerToxId;
     }
 
-    peerToxID = ToxId(CUserId::toString(rawID));
-    return peerToxID;
+    peerToxId = ToxId(CUserId::toString(rawID));
+    return peerToxId;
 }
 
 QList<QString> Core::getGroupPeerNames(int groupId) const

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -61,9 +61,9 @@ public:
     QVector<uint32_t> getFriendList() const; ///< Returns the list of friendIds in our friendlist, an empty list on error
     int getGroupNumberPeers(int groupId) const; ///< Return the number of peers in the group chat on success, or -1 on failure
     QString getGroupPeerName(int groupId, int peerId) const; ///< Get the name of a peer of a group
-    ToxId getGroupPeerToxID(int groupId, int peerId) const; ///< Get the ToxID of a peer of a group
+    ToxId getGroupPeerToxId(int groupId, int peerId) const; ///< Get the public key of a peer of a group
     QList<QString> getGroupPeerNames(int groupId) const; ///< Get the names of the peers of a group
-    QString getFriendAddress(uint32_t friendId) const; ///< Get the full address if known, or Tox ID of a friend
+    QString getFriendAddress(uint32_t friendId) const; ///< Get the full address if known, or public key of a friend
     QString getFriendUsername(uint32_t friendId) const; ///< Get the username of a friend
     bool isFriendOnline(uint32_t friendId) const; ///< Check if a friend is online. Unknown friends are considered offline.
     bool hasFriendWithAddress(const QString &addr) const; ///< Check if we have a friend by address

--- a/src/friend.cpp
+++ b/src/friend.cpp
@@ -93,7 +93,7 @@ QString Friend::getDisplayedName() const
     return userAlias;
 }
 
-const ToxId &Friend::getToxID() const
+const ToxId &Friend::getToxId() const
 {
     return userID;
 }

--- a/src/friend.h
+++ b/src/friend.h
@@ -44,7 +44,7 @@ public:
     void setEventFlag(int f);
     int getEventFlag() const;
 
-    const ToxId &getToxID() const;
+    const ToxId &getToxId() const;
     uint32_t getFriendID() const;
 
     void setStatus(Status s);

--- a/src/friendlist.cpp
+++ b/src/friendlist.cpp
@@ -54,7 +54,7 @@ void FriendList::removeFriend(int friendId, bool fake)
     if (f_it != friendList.end())
     {
         if (!fake)
-            Settings::getInstance().removeFriendSettings(f_it.value()->getToxID());
+            Settings::getInstance().removeFriendSettings(f_it.value()->getToxId());
         friendList.erase(f_it);
     }
 }
@@ -74,7 +74,7 @@ Friend* FriendList::findFriend(const ToxId& userId)
         Friend *f = findFriend(*id);
         if (!f)
             return nullptr;
-        if (f->getToxID() == userId)
+        if (f->getToxId() == userId)
             return f;
     }
 

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -66,7 +66,7 @@ void Group::removePeer(int peerId)
 
 void Group::updatePeer(int peerId, QString name)
 {
-    ToxId id = Core::getInstance()->getGroupPeerToxID(groupId, peerId);
+    ToxId id = Core::getInstance()->getGroupPeerToxId(groupId, peerId);
     QString toxid = id.publicKey;
     peers[peerId] = name;
     toxids[toxid] = name;
@@ -97,7 +97,7 @@ void Group::regeneratePeerList()
     nPeers = peers.size();
     for (int i = 0; i < nPeers; i++)
     {
-        ToxId id = Core::getInstance()->getGroupPeerToxID(groupId, i);
+        ToxId id = Core::getInstance()->getGroupPeerToxId(groupId, i);
         if (id.isActiveProfile())
             selfPeerNum = i;
 
@@ -170,7 +170,7 @@ int Group::getMentionedFlag() const
     return userWasMentioned;
 }
 
-QString Group::resolveToxID(const ToxId &id) const
+QString Group::resolveToxId(const ToxId &id) const
 {
     QString key = id.publicKey;
     auto it = toxids.find(key);

--- a/src/group.h
+++ b/src/group.h
@@ -57,7 +57,7 @@ public:
     void updatePeer(int peerId, QString newName);
     void setName(const QString& name);
 
-    QString resolveToxID(const ToxId &id) const;
+    QString resolveToxId(const ToxId &id) const;
 
 private:
     GroupWidget* widget;

--- a/src/toxdns.cpp
+++ b/src/toxdns.cpp
@@ -289,7 +289,7 @@ ToxId ToxDNS::resolveToxAddress(const QString &address, bool silent)
         else
         {
 #if TOX1_SILENT_FALLBACK
-            toxId = ToxID::fromString(queryTox1(address, silent));
+            toxId = ToxId::fromString(queryTox1(address, silent));
 #elif TOX1_ASK_FALLBACK
             QMessageBox::StandardButton btn = QMessageBox::warning(nullptr, "qTox", tr("It appears that qTox has to use the old tox1 protocol to access DNS record of your friend's Tox ID.\n\
 Unfortunately tox1 is not secure, and you are at risk of someone hijacking what is sent between you and ToxDNS service.\n\

--- a/src/toxdns.h
+++ b/src/toxdns.h
@@ -43,7 +43,7 @@ public:
     };
 
 public:
-    /// Tries to map a text string to a ToxID struct, will query Tox DNS records if necessary
+    /// Tries to map a text string to a ToxId struct, will query Tox DNS records if necessary
     static ToxId resolveToxAddress(const QString& address, bool silent=true);
 
     static QString queryTox1(const QString& record, bool silent=true); ///< Record should look like user@domain.tld. Do *NOT* use tox1 without a good reason, it's unsafe.

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -203,7 +203,7 @@ void ChatForm::onFileRecvRequest(ToxFile file)
     }
 
     QString name;
-    ToxId friendId = f->getToxID();
+    ToxId friendId = f->getToxId();
     if (friendId != previousId)
     {
         name = f->getDisplayedName();
@@ -213,7 +213,7 @@ void ChatForm::onFileRecvRequest(ToxFile file)
     ChatMessage::Ptr msg = ChatMessage::createFileTransferMessage(name, file, false, QDateTime::currentDateTime());
     insertChatMessage(msg);
 
-    if (!Settings::getInstance().getAutoAcceptDir(f->getToxID()).isEmpty()
+    if (!Settings::getInstance().getAutoAcceptDir(f->getToxId()).isEmpty()
             || Settings::getInstance().getAutoSaveEnabled())
     {
         ChatLineContentProxy* proxy = dynamic_cast<ChatLineContentProxy*>(msg->getContent(1));
@@ -222,7 +222,7 @@ void ChatForm::onFileRecvRequest(ToxFile file)
             FileTransferWidget* tfWidget = dynamic_cast<FileTransferWidget*>(proxy->getWidget());
 
             if (tfWidget)
-                tfWidget->autoAcceptTransfer(Settings::getInstance().getAutoAcceptDir(f->getToxID()));
+                tfWidget->autoAcceptTransfer(Settings::getInstance().getAutoAcceptDir(f->getToxId()));
         }
     }
 }
@@ -792,7 +792,7 @@ void ChatForm::loadHistory(QDateTime since, bool processUndelivered)
         }
     }
 
-    auto msgs = HistoryKeeper::getInstance()->getChatHistory(HistoryKeeper::ctSingle, f->getToxID().publicKey, since, now);
+    auto msgs = HistoryKeeper::getInstance()->getChatHistory(HistoryKeeper::ctSingle, f->getToxId().publicKey, since, now);
 
     ToxId storedPrevId = previousId;
     ToxId prevId;
@@ -814,7 +814,7 @@ void ChatForm::loadHistory(QDateTime since, bool processUndelivered)
 
         // Show each messages
         ToxId authorId = ToxId(it.sender);
-        QString authorStr = authorId.isActiveProfile() ? Core::getInstance()->getUsername() : resolveToxID(authorId);
+        QString authorStr = authorId.isActiveProfile() ? Core::getInstance()->getUsername() : resolveToxId(authorId);
         bool isAction = it.message.startsWith("/me ", Qt::CaseInsensitive);
 
         ChatMessage::Ptr msg = ChatMessage::createChatMessage(authorStr,
@@ -1015,7 +1015,7 @@ void ChatForm::SendMessageStr(QString msg)
 
         bool status = !Settings::getInstance().getFauxOfflineMessaging();
 
-        int id = HistoryKeeper::getInstance()->addChatEntry(f->getToxID().publicKey, qt_msg_hist,
+        int id = HistoryKeeper::getInstance()->addChatEntry(f->getToxId().publicKey, qt_msg_hist,
                                                             Core::getInstance()->getSelfId().publicKey, timestamp, status);
 
         ChatMessage::Ptr ma = addSelfMessage(msg, isAction, timestamp, false);

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -248,7 +248,7 @@ void GenericChatForm::onChatContextMenuRequested(QPoint pos)
 ChatMessage::Ptr GenericChatForm::addMessage(const ToxId& author, const QString &message, bool isAction,
                                              const QDateTime &datetime, bool isSent)
 {
-    QString authorStr = author.isActiveProfile() ? Core::getInstance()->getUsername() : resolveToxID(author);
+    QString authorStr = author.isActiveProfile() ? Core::getInstance()->getUsername() : resolveToxId(author);
 
     ChatMessage::Ptr msg;
     if (isAction)
@@ -281,7 +281,7 @@ ChatMessage::Ptr GenericChatForm::addSelfMessage(const QString &message, bool is
 
 void GenericChatForm::addAlertMessage(const ToxId &author, QString message, QDateTime datetime)
 {
-    QString authorStr = resolveToxID(author);
+    QString authorStr = resolveToxId(author);
     ChatMessage::Ptr msg = ChatMessage::createChatMessage(authorStr, message, ChatMessage::ALERT, author.isActiveProfile(), datetime);
     insertChatMessage(msg);
 
@@ -388,7 +388,7 @@ void GenericChatForm::onSelectAllClicked()
     chatWidget->selectAll();
 }
 
-QString GenericChatForm::resolveToxID(const ToxId &id)
+QString GenericChatForm::resolveToxId(const ToxId &id)
 {
     Friend *f = FriendList::findFriend(id);
     if (f)
@@ -399,7 +399,7 @@ QString GenericChatForm::resolveToxID(const ToxId &id)
     {
         for (auto it : GroupList::getAllGroups())
         {
-            QString res = it->resolveToxID(id);
+            QString res = it->resolveToxId(id);
             if (res.size())
                 return res;
         }

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -80,7 +80,7 @@ protected slots:
     void hideFileMenu();
 
 protected:
-    QString resolveToxID(const ToxId &id);
+    QString resolveToxId(const ToxId &id);
     void insertChatMessage(ChatMessage::Ptr msg);
     void hideEvent(QHideEvent* event);
     void resizeEvent(QResizeEvent* event);

--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -51,7 +51,7 @@ FriendWidget::FriendWidget(int FriendId, QString id)
 void FriendWidget::contextMenuEvent(QContextMenuEvent * event)
 {
     QPoint pos = event->globalPos();
-    ToxId id = FriendList::findFriend(friendId)->getToxID();
+    ToxId id = FriendList::findFriend(friendId)->getToxId();
     QString dir = Settings::getInstance().getAutoAcceptDir(id);
     QMenu menu;
     QMenu* inviteMenu = menu.addMenu(tr("Invite to group","Menu to invite a friend to a groupchat"));
@@ -247,7 +247,7 @@ void FriendWidget::setAlias(const QString& _alias)
     alias = alias.left(128); // same as TOX_MAX_NAME_LENGTH
     Friend* f = FriendList::findFriend(friendId);
     f->setAlias(alias);
-    Settings::getInstance().setFriendAlias(f->getToxID(), alias);
+    Settings::getInstance().setFriendAlias(f->getToxId(), alias);
     Settings::getInstance().save(true);
     hide();
     show();

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -769,10 +769,10 @@ void Widget::onFriendMessageReceived(int friendId, const QString& message, bool 
         return;
 
     QDateTime timestamp = QDateTime::currentDateTime();
-    f->getChatForm()->addMessage(f->getToxID(), message, isAction, timestamp, true);
+    f->getChatForm()->addMessage(f->getToxId(), message, isAction, timestamp, true);
 
-    HistoryKeeper::getInstance()->addChatEntry(f->getToxID().publicKey, isAction ? "/me " + f->getDisplayedName() + " " + message : message,
-                                               f->getToxID().publicKey, timestamp, true);
+    HistoryKeeper::getInstance()->addChatEntry(f->getToxId().publicKey, isAction ? "/me " + f->getDisplayedName() + " " + message : message,
+                                               f->getToxId().publicKey, timestamp, true);
 
     f->setEventFlag(f->getFriendWidget() != activeChatroomWidget);
     newMessageAlert(f->getFriendWidget());
@@ -871,7 +871,7 @@ void Widget::removeFriend(Friend* f, bool fake)
         if (removeFriendMB == QMessageBox::Cancel)
                return;
         else if (removeFriendMB == QMessageBox::Yes)
-            HistoryKeeper::getInstance()->removeFriendHistory(f->getToxID().publicKey);
+            HistoryKeeper::getInstance()->removeFriendHistory(f->getToxId().publicKey);
     }
         
     f->getFriendWidget()->setAsInactiveChatroom();
@@ -945,7 +945,7 @@ void Widget::onGroupMessageReceived(int groupnumber, int peernumber, const QStri
     if (!g)
         return;
 
-    ToxId author = Core::getInstance()->getGroupPeerToxID(groupnumber, peernumber);
+    ToxId author = Core::getInstance()->getGroupPeerToxId(groupnumber, peernumber);
     bool targeted = !author.isActiveProfile() && (message.contains(nameMention) || message.contains(sanitizedNameMention));
     if (targeted && !isAction)
         g->getChatForm()->addAlertMessage(author, message, QDateTime::currentDateTime());


### PR DESCRIPTION
Since consistency in code is most important, 'ToxId' is used
for code, whereas 'Tox ID' anywhere outside of code.

Also fixed wrong comments in core.h:
- qTox gets only public key of a grouchat peer, not their
  Tox ID
- qTox tries to return full address (Tox ID) or public key
