### PR TITLE
Don't quote with action messages

### DIFF
--- a/src/chatlog/chatmessage.cpp
+++ b/src/chatlog/chatmessage.cpp
@@ -46,8 +46,6 @@ ChatMessage::Ptr ChatMessage::createChatMessage(const QString &sender, const QSt
     if (Settings::getInstance().getUseEmoticons())
         text = SmileyPack::getInstance().smileyfied(text);
 
-    //quotes (green text)
-    text = detectQuotes(detectAnchors(text));
 
     switch(type)
     {
@@ -57,9 +55,13 @@ ChatMessage::Ptr ChatMessage::createChatMessage(const QString &sender, const QSt
         msg->setAsAction();
         break;
     case ALERT:
+        // quotes should not be available for action messages ↑
+        text = detectQuotes(detectAnchors(text)); //quotes (green text)
         text = wrapDiv(text, "alert");
         break;
     default:
+        // quotes should not be avaialble for action messages
+        text = detectQuotes(detectAnchors(text)); //quotes (green text)
         text = wrapDiv(text, "msg");
     }
 


### PR DESCRIPTION
Quoting with action messages produces badly looking messages,
where nick is blue coloured, while rest of text that is preceded
by '> ' is green. To avoid that, quoting should not be triggered
in action messages.

Without fix:
![before](https://cloud.githubusercontent.com/assets/3148759/7786258/60b98cc2-01b8-11e5-8580-7807be93acbf.png)

With fix:
![after](https://cloud.githubusercontent.com/assets/3148759/7786263/6d05cb26-01b8-11e5-986d-bcc65633e927.png)
