### PR TITLE
Properly fix quoting in action messages

### DIFF
--- a/src/chatlog/chatmessage.h
+++ b/src/chatlog/chatmessage.h
@@ -57,7 +57,7 @@ public:
 
 protected:
     static QString detectAnchors(const QString& str);
-    static QString detectQuotes(const QString& str);
+    static QString detectQuotes(const QString& str, MessageType type);
     static QString wrapDiv(const QString& str, const QString& div);
 
 private:


### PR DESCRIPTION
- Allow quoting in action messages if line number is >1.
- Fix regression introduced by 1244d689f6ea1717ce247be4526a4fb72b93853c where
  '\n' was being trimmed in action messages.
- Add comment about typing notifications placeholder that needs to be fixed.

Without fix:
![regression](https://cloud.githubusercontent.com/assets/3148759/7788219/0b4da4fe-022a-11e5-8c76-a7c6efc8d78d.png)

With fix:
![fixed](https://cloud.githubusercontent.com/assets/3148759/7788222/14d8592e-022a-11e5-86b2-887df0727e69.png)

(that black "text" was a normal message)
