### PR TITLE
Update profileform.cpp

### DIFF
--- a/src/widget/form/profileform.cpp
+++ b/src/widget/form/profileform.cpp
@@ -243,7 +243,7 @@ void ProfileForm::onAvatarClicked()
     if (bytes.size() > 65535)
     {
         QMessageBox::critical(this, tr("Error"),
-            tr("The supplied image is too large.\nPlease use an image that is less than 64 KiB in size."));
+            tr("The supplied image is too large.\nPlease use another image."));
         return;
     }
 


### PR DESCRIPTION
This fixes several issues caused by a stupid zetok fix.
- Doesn't tell the user to pick an image under 64 KiB when bigger images, quoting tux3, "work 100% of the time", thus, doesn't mislead the user
- Doesn't bother the user with unnecessary technical details
