### PR TITLE
Group audio not being reset

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -759,7 +759,7 @@ void Core::setAvatar(const QByteArray& data)
     pic.loadFromData(data);
     Settings::getInstance().saveAvatar(pic, getSelfId().toString());
     emit selfAvatarChanged(pic);
-    
+
     AvatarBroadcaster::setAvatar(data);
     AvatarBroadcaster::enableAutoBroadcast();
 }
@@ -1325,7 +1325,13 @@ void Core::setNospam(uint32_t nospam)
 void Core::resetCallSources()
 {
     for (ToxGroupCall& call : groupCalls)
+    {
+        for (QPair<int, ALuint> alSources : alSources)
+        {
+            alDeleteSources(1, alSources.second);
+        }
         call.alSources.clear();
+    }
 
     for (ToxCall& call : calls)
     {

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -1326,10 +1326,8 @@ void Core::resetCallSources()
 {
     for (ToxGroupCall& call : groupCalls)
     {
-        for (QPair<int, ALuint> alSources : alSources)
-        {
+        for (QPair<int, ALuint> alSources : call)
             alDeleteSources(1, alSources.second);
-        }
         call.alSources.clear();
     }
 

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -1330,8 +1330,8 @@ void Core::resetCallSources()
 {
     for (ToxGroupCall& call : groupCalls)
     {
-        for (QPair<int, ALuint> alSources : call)
-            alDeleteSources(1, alSources.second);
+        for (QHash<int, ALuint>::iterator i = call.alSources.begin(); i != call.alSources.end(); ++i)
+            alDeleteSources(1, &i.value());
         call.alSources.clear();
     }
 

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -1330,8 +1330,8 @@ void Core::resetCallSources()
 {
     for (ToxGroupCall& call : groupCalls)
     {
-        for (QHash<int, ALuint>::iterator i = call.alSources.begin(); i != call.alSources.end(); ++i)
-            alDeleteSources(1, &i.value());
+        for (ALuint source : call.alSources)
+            alDeleteSources(1, &source);
         call.alSources.clear();
     }
 

--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -629,8 +629,8 @@ void Core::leaveGroupCall(int groupId)
     groupCalls[groupId].active = false;
     disconnect(groupCalls[groupId].sendAudioTimer,0,0,0);
     groupCalls[groupId].sendAudioTimer->stop();
-    for (QPair<int, ALuint> alSources : groupCalls[groupId])
-        alDeleteSources(1, alSources.second);
+    for (QHash<int, ALuint>::iterator i = groupCalls[groupId].alSources.begin(); i != groupCalls[groupId].alSources.end(); ++i)
+        alDeleteSources(1, &i.value());
     groupCalls[groupId].alSources.clear();
     Audio::unsuscribeInput();
     delete groupCalls[groupId].sendAudioTimer;

--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -629,8 +629,8 @@ void Core::leaveGroupCall(int groupId)
     groupCalls[groupId].active = false;
     disconnect(groupCalls[groupId].sendAudioTimer,0,0,0);
     groupCalls[groupId].sendAudioTimer->stop();
-    for (QHash<int, ALuint>::iterator i = groupCalls[groupId].alSources.begin(); i != groupCalls[groupId].alSources.end(); ++i)
-        alDeleteSources(1, &i.value());
+    for (ALuint source : groupCalls[groupId].alSources)
+        alDeleteSources(1, &source);
     groupCalls[groupId].alSources.clear();
     Audio::unsuscribeInput();
     delete groupCalls[groupId].sendAudioTimer;

--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -629,6 +629,8 @@ void Core::leaveGroupCall(int groupId)
     groupCalls[groupId].active = false;
     disconnect(groupCalls[groupId].sendAudioTimer,0,0,0);
     groupCalls[groupId].sendAudioTimer->stop();
+    for (QPair<int, ALuint> alSources : groupCalls[groupId])
+        alDeleteSources(1, alSources.second);
     groupCalls[groupId].alSources.clear();
     Audio::unsuscribeInput();
     delete groupCalls[groupId].sendAudioTimer;


### PR DESCRIPTION
Small fix. Group audio was not being reset. Originally, sources were lost forever (but still existed) because the reference to them was being removed without actually removing them. Recreating them here is useless unlike the non-group calls because they recreated on playGroupAudio().
