### PR TITLE
Fix quoting; everything after '>' is a quote

### DIFF
--- a/src/chatlog/chatmessage.cpp
+++ b/src/chatlog/chatmessage.cpp
@@ -211,7 +211,7 @@ QString ChatMessage::detectQuotes(const QString& str, MessageType type)
         // don't quote first line in action message. This makes co-existence of
         // quotes and action messages possible, since only first line can cause
         // problems in case where there is quote in it used.
-        if (QRegExp("^(&gt;|＞)( |[[]|&gt;|[^_\\d\\W]).*").exactMatch(messageLines[i])) {
+        if (QRegExp("^(&gt;|＞).*").exactMatch(messageLines[i])) {
             if (i > 0 || type != ACTION)
                 quotedText += "<span class=quote>" + messageLines[i] + "</span>";
             else


### PR DESCRIPTION
Plenty of people voiced their opinion that everything after '>' should be a
quote. Trying to conform to anything other brings only chaos and makes
situation worse, since it is impossible to catch every exception.

There are already plenty of cases where regexp simply can't work with unicode.

In the future, qTox should have easy to use r-click options for 'Paste text as
 a quote' and 'Copy as a quote', which makes it a must to have quote detection
as simple as possible, to avoid situation where user wants to paste something
as a quote, and suddenly it doesn't seem to work.

Fixes #1059 #1099 #1173
Continuation of #1332 

If you want examples of things that can't be done with regexp, just read related issues / previous PR.
