### PR TITLE
Correct screenshot 2nd monitor

### DIFF
--- a/src/widget/tool/screenshotgrabber.cpp
+++ b/src/widget/tool/screenshotgrabber.cpp
@@ -178,8 +178,12 @@ void ScreenshotGrabber::adjustWindowSize()
     this->overlay->setRect(systemScreenRect);
 }
 
-QPixmap ScreenshotGrabber::grabScreen() {
-    return QApplication::primaryScreen()->grabWindow(QApplication::desktop()->winId());
+QPixmap ScreenshotGrabber::grabScreen()
+{
+    QRect systemScreenRect = getSystemScreenRect();
+    return QApplication::primaryScreen()->grabWindow(QApplication::desktop()->winId(),0,0,
+                                                       systemScreenRect.width(),
+                                                       systemScreenRect.height());
 }
 
 void ScreenshotGrabber::beginRectChooser(QGraphicsSceneMouseEvent* event)


### PR DESCRIPTION
but only if a second monitor on the right side
I did not find it possible to determine on which side of the monitor
Correct: #1698, #1595
Tested in Win7x32
