### PR TITLE
Correct_style_filter_combobox

### DIFF
--- a/ui/window/statusPanel.css
+++ b/ui/window/statusPanel.css
@@ -16,7 +16,7 @@ QComboBox {
 }
 
 QComboBox:on {
-    background-color: @themeDark;
+    background-color: @themeMediumDark;
     border-radius: 4px;
 }
 


### PR DESCRIPTION
fix #1681
It was:
![1](https://cloud.githubusercontent.com/assets/6053197/7870085/86a9ffb8-058f-11e5-918c-5e688a267094.png)
It has become:
![default](https://cloud.githubusercontent.com/assets/6053197/7870109/a3a45e06-058f-11e5-85c8-5b45e0bfffce.png)
