### PR TITLE
Correct redraw after filtering

### DIFF
--- a/src/widget/friendlistwidget.cpp
+++ b/src/widget/friendlistwidget.cpp
@@ -130,3 +130,11 @@ void FriendListWidget::moveWidget(QWidget *w, Status s)
     }
     l->addWidget(w);
 }
+
+// update widget after add/delete/hide/show
+void FriendListWidget::reDraw()
+{
+    hide();
+    show();
+    resize(QSize()); //lifehack
+}

--- a/src/widget/friendlistwidget.h
+++ b/src/widget/friendlistwidget.h
@@ -34,7 +34,7 @@ public:
     QVBoxLayout* getFriendLayout(Status s);
 
     QList<GenericChatroomWidget*> getAllFriends();
-
+    void reDraw();
 signals:
 
 public slots:

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -889,8 +889,7 @@ void Widget::removeFriend(Friend* f, bool fake)
     if (ui->mainHead->layout()->isEmpty())
         onAddClicked();
 
-    contactListWidget->hide();
-    contactListWidget->show();
+    contactListWidget->reDraw();
 }
 
 void Widget::removeFriend(int friendId)
@@ -1040,8 +1039,7 @@ void Widget::removeGroup(Group* g, bool fake)
     if (ui->mainHead->layout()->isEmpty())
         onAddClicked();
 
-    contactListWidget->hide();
-    contactListWidget->show();
+    contactListWidget->reDraw();
 }
 
 void Widget::removeGroup(int groupId)
@@ -1445,8 +1443,7 @@ void Widget::searchContacts()
             return;
     }
 
-    contactListWidget->hide();
-    contactListWidget->show();
+    contactListWidget->reDraw();
 }
 
 void Widget::hideFriends(QString searchString, Status status, bool hideAll)


### PR DESCRIPTION
fix #1757
It looks a bit strange, but a redraw on another call fails. Moreover, order calling functions radically changes the behavior of the widget
