### PR TITLE
Notification edge marker

### DIFF
--- a/qtox.pro
+++ b/qtox.pro
@@ -481,7 +481,9 @@ SOURCES += \
     src/core/toxid.cpp \
     src/persistence/profile.cpp \
     src/widget/translator.cpp \
-    src/persistence/settingsserializer.cpp
+    src/persistence/settingsserializer.cpp \
+    src/widget/notificationscrollarea.cpp \
+    src/widget/notificationedgewidget.cpp
 
 HEADERS += \
     src/audio/audio.h \
@@ -517,4 +519,6 @@ HEADERS += \
     src/core/toxid.h \
     src/persistence/profile.h \
     src/widget/translator.h \
-    src/persistence/settingsserializer.h
+    src/persistence/settingsserializer.h \
+    src/widget/notificationscrollarea.h \
+    src/widget/notificationedgewidget.h

--- a/res.qrc
+++ b/res.qrc
@@ -119,5 +119,6 @@
         <file>ui/rejectCall/rejectCall.svg</file>
         <file>ui/volButton/volButtonDisabled.png</file>
         <file>img/login_logo.svg</file>
+        <file>ui/notificationEdge/notificationEdge.css</file>
     </qresource>
 </RCC>

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -1045,7 +1045,7 @@ QSplitter:handle{
          </widget>
         </item>
         <item>
-         <widget class="AdjustingScrollArea" name="friendList">
+         <widget class="NotificationScrollArea" name="friendList">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
             <horstretch>0</horstretch>
@@ -1072,8 +1072,8 @@ QSplitter:handle{
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>284</width>
-             <height>359</height>
+             <width>292</width>
+             <height>353</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_5"/>
@@ -1838,7 +1838,7 @@ QSplitter:handle{
      <x>0</x>
      <y>0</y>
      <width>775</width>
-     <height>19</height>
+     <height>22</height>
     </rect>
    </property>
   </widget>
@@ -1859,9 +1859,9 @@ QSplitter:handle{
    <header location="global">src/widget/tool/croppinglabel.h</header>
   </customwidget>
   <customwidget>
-   <class>AdjustingScrollArea</class>
+   <class>NotificationScrollArea</class>
    <extends>QScrollArea</extends>
-   <header location="global">src/widget/tool/adjustingscrollarea.h</header>
+   <header location="global">src/widget/notificationscrollarea.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/widget/notificationedgewidget.cpp
+++ b/src/widget/notificationedgewidget.cpp
@@ -32,7 +32,7 @@ NotificationEdgeWidget::NotificationEdgeWidget(Position position, QWidget *paren
     QHBoxLayout* layout = new QHBoxLayout(this);
     layout->addStretch();
 
-    QLabel* textLabel = new QLabel(tr("Unread message(s)"), this);
+    textLabel = new QLabel(this);
     textLabel->setMinimumHeight(textLabel->sizeHint().height()); // Prevent cut-off text.
     layout->addWidget(textLabel);
 
@@ -47,6 +47,11 @@ NotificationEdgeWidget::NotificationEdgeWidget(Position position, QWidget *paren
     layout->addStretch();
 
     setCursor(Qt::PointingHandCursor);
+}
+
+void NotificationEdgeWidget::updateNotificationCount(int count)
+{
+    textLabel->setText(tr("Unread message(s)", "", count));
 }
 
 void NotificationEdgeWidget::mouseReleaseEvent(QMouseEvent *event)

--- a/src/widget/notificationedgewidget.cpp
+++ b/src/widget/notificationedgewidget.cpp
@@ -1,0 +1,56 @@
+/*
+    Copyright © 2015 by The qTox Project
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "notificationedgewidget.h"
+#include "style.h"
+#include <QLabel>
+#include <QBoxLayout>
+
+#include <QDebug>
+
+NotificationEdgeWidget::NotificationEdgeWidget(Position position, QWidget *parent)
+    : QWidget(parent)
+{
+    setAttribute(Qt::WA_StyledBackground); // Show background.
+    setStyleSheet(Style::getStylesheet(":/ui/notificationEdge/notificationEdge.css"));
+    QHBoxLayout* layout = new QHBoxLayout(this);
+    layout->addStretch();
+
+    QLabel* textLabel = new QLabel(tr("Unread message(s)"), this);
+    textLabel->setMinimumHeight(textLabel->sizeHint().height()); // Prevent cut-off text.
+    layout->addWidget(textLabel);
+
+    QLabel* arrowLabel = new QLabel(this);
+
+    if (position == Top)
+        arrowLabel->setPixmap(QPixmap("://ui/chatArea/scrollBarUpArrow.svg"));
+    else
+        arrowLabel->setPixmap(QPixmap("://ui/chatArea/scrollBarDownArrow.svg"));
+
+    layout->addWidget(arrowLabel);
+    layout->addStretch();
+
+    setCursor(Qt::PointingHandCursor);
+}
+
+void NotificationEdgeWidget::mouseReleaseEvent(QMouseEvent *event)
+{
+    emit clicked();
+    QWidget::mousePressEvent(event);
+}

--- a/src/widget/notificationedgewidget.h
+++ b/src/widget/notificationedgewidget.h
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2014 by The qTox Project
+    Copyright © 2015 by The qTox Project
 
     This file is part of qTox, a Qt-based graphical interface for Tox.
 
@@ -17,20 +17,28 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef ADJUSTINGSCROLLAREA_H
-#define ADJUSTINGSCROLLAREA_H
+#ifndef NOTIFICATIONEDGEWIDGET_H
+#define NOTIFICATIONEDGEWIDGET_H
 
-#include <QScrollArea>
+#include <QWidget>
 
-class AdjustingScrollArea : public QScrollArea
+class NotificationEdgeWidget final : public QWidget
 {
     Q_OBJECT
 public:
-    explicit AdjustingScrollArea(QWidget *parent = 0);
+    enum Position : uint8_t
+    {
+        Top,
+        Bottom
+    };
+
+    explicit NotificationEdgeWidget(Position position, QWidget *parent = 0);
+
+signals:
+    void clicked();
 
 protected:
-    virtual void resizeEvent(QResizeEvent *ev) override;
-    virtual QSize sizeHint() const final override;
+    void mouseReleaseEvent(QMouseEvent* event) final override;
 };
 
-#endif // ADJUSTINGSCROLLAREA_H
+#endif // NOTIFICATIONEDGEWIDGET_H

--- a/src/widget/notificationedgewidget.h
+++ b/src/widget/notificationedgewidget.h
@@ -22,6 +22,8 @@
 
 #include <QWidget>
 
+class QLabel;
+
 class NotificationEdgeWidget final : public QWidget
 {
     Q_OBJECT
@@ -33,12 +35,16 @@ public:
     };
 
     explicit NotificationEdgeWidget(Position position, QWidget *parent = 0);
+    void updateNotificationCount(int count);
 
 signals:
     void clicked();
 
 protected:
     void mouseReleaseEvent(QMouseEvent* event) final override;
+
+private:
+    QLabel* textLabel;
 };
 
 #endif // NOTIFICATIONEDGEWIDGET_H

--- a/src/widget/notificationscrollarea.cpp
+++ b/src/widget/notificationscrollarea.cpp
@@ -1,0 +1,204 @@
+/*
+    Copyright © 2015 by The qTox Project
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+#include "notificationscrollarea.h"
+#include "notificationedgewidget.h"
+#include "genericchatroomwidget.h"
+#include <QScrollBar>
+#include <cassert>
+
+#include <QDebug>
+#include <QTimer>
+
+NotificationScrollArea::NotificationScrollArea(QWidget* parent)
+    : AdjustingScrollArea(parent)
+{
+    connect(verticalScrollBar(), &QAbstractSlider::valueChanged, this, &NotificationScrollArea::updateTracking);
+}
+
+void NotificationScrollArea::trackWidget(GenericChatroomWidget* widget)
+{
+    if (trackedWidgets.find(widget) != trackedWidgets.end())
+        return;
+
+    Visibility visibility = widgetVisible(widget);
+    if (visibility != Visible)
+    {
+        if (visibility == Above)
+        {
+            if (referencesAbove++ == 0)
+            {
+                assert(topEdge == nullptr);
+                topEdge = new NotificationEdgeWidget(NotificationEdgeWidget::Top, this);
+                connect(topEdge, &NotificationEdgeWidget::clicked, this, &NotificationScrollArea::findPreviousWidget);
+                recalculateTopEdge();
+                topEdge->show();
+            }
+        }
+        else
+        {
+            if (referencesBelow++ == 0)
+            {
+                assert(bottomEdge == nullptr);
+                bottomEdge = new NotificationEdgeWidget(NotificationEdgeWidget::Bottom, this);
+                connect(bottomEdge, &NotificationEdgeWidget::clicked, this, &NotificationScrollArea::findNextWidget);
+                recalculateBottomEdge();
+                bottomEdge->show();
+            }
+        }
+
+        trackedWidgets.insert(widget, visibility);
+    }
+    qDebug() << "VISIBLE?" << visibility;
+}
+
+void NotificationScrollArea::updateTracking()
+{
+    QHash<GenericChatroomWidget*, Visibility>::iterator i = trackedWidgets.begin();
+    while (i != trackedWidgets.end())
+    {
+        if (widgetVisible(i.key()) == Visible)
+        {
+            if (i.value() == Above)
+            {
+                if (--referencesAbove == 0)
+                {
+                    delete topEdge;
+                    topEdge = nullptr;
+                }
+            }
+            else
+            {
+                if (--referencesBelow == 0)
+                {
+                    delete bottomEdge;
+                    bottomEdge = nullptr;
+                }
+            }
+            i = trackedWidgets.erase(i);
+            continue;
+        }
+        ++i;
+    }
+}
+
+void NotificationScrollArea::resizeEvent(QResizeEvent *event)
+{
+    if (topEdge != nullptr)
+        recalculateTopEdge();
+    if (bottomEdge != nullptr)
+        recalculateBottomEdge();
+
+    AdjustingScrollArea::resizeEvent(event);
+}
+
+void NotificationScrollArea::findNextWidget()
+{
+    GenericChatroomWidget* next = nullptr;
+    int value;
+    QHash<GenericChatroomWidget*, Visibility>::iterator i = trackedWidgets.begin();
+
+    // Find the first next, to avoid nullptr.
+    for (; i != trackedWidgets.end(); ++i)
+    {
+        if (i.value() == Below)
+        {
+            next = i.key();
+            value = next->mapTo(viewport(), QPoint()).y();
+            break;
+        }
+    }
+
+    // Try finding a closer one.
+    for (; i != trackedWidgets.end(); ++i)
+    {
+        if (i.value() == Below)
+        {
+            int y = i.key()->mapTo(viewport(), QPoint()).y();
+            if (y < value)
+            {
+                next = i.key();
+                value = y;
+            }
+        }
+    }
+
+    if (next != nullptr)
+        ensureWidgetVisible(next, 0, referencesBelow != 1 ? bottomEdge->height() : 0);
+}
+
+void NotificationScrollArea::findPreviousWidget()
+{
+    GenericChatroomWidget* next = nullptr;
+    int value;
+    QHash<GenericChatroomWidget*, Visibility>::iterator i = trackedWidgets.begin();
+
+    // Find the first next, to avoid nullptr.
+    for (; i != trackedWidgets.end(); ++i)
+    {
+        if (i.value() == Above)
+        {
+            next = i.key();
+            value = next->mapTo(viewport(), QPoint()).y();
+            break;
+        }
+    }
+
+    // Try finding a closer one.
+    for (; i != trackedWidgets.end(); ++i)
+    {
+        if (i.value() == Above)
+        {
+            int y = i.key()->mapTo(viewport(), QPoint()).y();
+            if (y > value)
+            {
+                next = i.key();
+                value = y;
+            }
+        }
+    }
+
+    if (next != nullptr)
+        ensureWidgetVisible(next, 0, referencesAbove != 1 ? topEdge->height() : 0);
+}
+
+NotificationScrollArea::Visibility NotificationScrollArea::widgetVisible(QWidget *widget) const
+{
+    int y = widget->mapTo(viewport(), QPoint()).y();
+
+    if (y < 0)
+        return Above;
+    else if (y + widget->height() > viewport()->height())
+        return Below;
+
+    return Visible;
+}
+
+void NotificationScrollArea::recalculateTopEdge()
+{
+    topEdge->move(viewport()->pos());
+    topEdge->resize(viewport()->width(), topEdge->height());
+}
+
+void NotificationScrollArea::recalculateBottomEdge()
+{
+    QPoint position = viewport()->pos();
+    position.setY(position.y() + viewport()->height() - bottomEdge->height());
+    bottomEdge->move(position);
+    bottomEdge->resize(viewport()->width(), bottomEdge->height());
+}

--- a/src/widget/notificationscrollarea.cpp
+++ b/src/widget/notificationscrollarea.cpp
@@ -77,7 +77,7 @@ void NotificationScrollArea::updateTracking()
             {
                 if (--referencesAbove == 0)
                 {
-                    delete topEdge;
+                    topEdge->deleteLater();
                     topEdge = nullptr;
                 }
                 else
@@ -89,7 +89,7 @@ void NotificationScrollArea::updateTracking()
             {
                 if (--referencesBelow == 0)
                 {
-                    delete bottomEdge;
+                    bottomEdge->deleteLater();
                     bottomEdge = nullptr;
                 }
                 else

--- a/src/widget/notificationscrollarea.cpp
+++ b/src/widget/notificationscrollarea.cpp
@@ -47,6 +47,7 @@ void NotificationScrollArea::trackWidget(GenericChatroomWidget* widget)
                 recalculateTopEdge();
                 topEdge->show();
             }
+            topEdge->updateNotificationCount(referencesAbove);
         }
         else
         {
@@ -58,6 +59,7 @@ void NotificationScrollArea::trackWidget(GenericChatroomWidget* widget)
                 recalculateBottomEdge();
                 bottomEdge->show();
             }
+            bottomEdge->updateNotificationCount(referencesBelow);
         }
 
         trackedWidgets.insert(widget, visibility);
@@ -78,6 +80,10 @@ void NotificationScrollArea::updateTracking()
                     delete topEdge;
                     topEdge = nullptr;
                 }
+                else
+                {
+                    topEdge->updateNotificationCount(referencesAbove);
+                }
             }
             else
             {
@@ -85,6 +91,10 @@ void NotificationScrollArea::updateTracking()
                 {
                     delete bottomEdge;
                     bottomEdge = nullptr;
+                }
+                else
+                {
+                    bottomEdge->updateNotificationCount(referencesBelow);
                 }
             }
             i = trackedWidgets.erase(i);

--- a/src/widget/notificationscrollarea.cpp
+++ b/src/widget/notificationscrollarea.cpp
@@ -22,13 +22,11 @@
 #include <QScrollBar>
 #include <cassert>
 
-#include <QDebug>
-#include <QTimer>
-
 NotificationScrollArea::NotificationScrollArea(QWidget* parent)
     : AdjustingScrollArea(parent)
 {
     connect(verticalScrollBar(), &QAbstractSlider::valueChanged, this, &NotificationScrollArea::updateTracking);
+    connect(verticalScrollBar(), &QAbstractSlider::rangeChanged, this, &NotificationScrollArea::updateTracking);
 }
 
 void NotificationScrollArea::trackWidget(GenericChatroomWidget* widget)
@@ -64,7 +62,6 @@ void NotificationScrollArea::trackWidget(GenericChatroomWidget* widget)
 
         trackedWidgets.insert(widget, visibility);
     }
-    qDebug() << "VISIBLE?" << visibility;
 }
 
 void NotificationScrollArea::updateTracking()
@@ -183,7 +180,7 @@ NotificationScrollArea::Visibility NotificationScrollArea::widgetVisible(QWidget
 
     if (y < 0)
         return Above;
-    else if (y + widget->height() > viewport()->height())
+    else if (y + widget->height() - 1 > viewport()->height())
         return Below;
 
     return Visible;

--- a/src/widget/notificationscrollarea.h
+++ b/src/widget/notificationscrollarea.h
@@ -1,0 +1,63 @@
+/*
+    Copyright © 2015 by The qTox Project
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef NOTIFICATIONSCROLLAREA_H
+#define NOTIFICATIONSCROLLAREA_H
+
+#include "tool/adjustingscrollarea.h"
+#include <QHash>
+
+class GenericChatroomWidget;
+class NotificationEdgeWidget;
+
+class NotificationScrollArea final : public AdjustingScrollArea
+{
+public:
+    NotificationScrollArea(QWidget* parent = 0);
+
+public slots:
+    void trackWidget(GenericChatroomWidget* widget);
+    void updateTracking();
+
+protected:
+    void resizeEvent(QResizeEvent *event) final override;
+
+private slots:
+    void findNextWidget();
+    void findPreviousWidget();
+
+private:
+    enum Visibility : uint8_t
+    {
+        Visible,
+        Above,
+        Below
+    };
+    Visibility widgetVisible(QWidget* widget) const;
+    void recalculateTopEdge();
+    void recalculateBottomEdge();
+
+    QHash<GenericChatroomWidget*, Visibility> trackedWidgets;
+    NotificationEdgeWidget* topEdge = nullptr;
+    NotificationEdgeWidget* bottomEdge = nullptr;
+    size_t referencesAbove = 0;
+    size_t referencesBelow = 0;
+};
+
+#endif // NOTIFICATIONSCROLLAREA_H

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -800,7 +800,8 @@ void Widget::newMessageAlert(GenericChatroomWidget* chat)
         Audio::playMono16Sound(sndData);
     }
 
-    ui->friendList->trackWidget(chat);
+    if (activeChatroomWidget != chat)
+        ui->friendList->trackWidget(chat);
 }
 
 void Widget::playRingtone()

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -799,6 +799,8 @@ void Widget::newMessageAlert(GenericChatroomWidget* chat)
 
         Audio::playMono16Sound(sndData);
     }
+
+    ui->friendList->trackWidget(chat);
 }
 
 void Widget::playRingtone()

--- a/ui/notificationEdge/notificationEdge.css
+++ b/ui/notificationEdge/notificationEdge.css
@@ -1,0 +1,9 @@
+NotificationEdgeWidget
+{
+    background-color: #6bc260;
+}
+
+NotificationEdgeWidget > QLabel
+{
+    color: white;
+}


### PR DESCRIPTION
This pull request adds notification edge markers as those described by #1747

It works by checking whether the chatroom that received a notification is on the screen or not, and if not, it adds an edge marker accordingly. Even if we have a recent list, a notification edge marker is still useful, such as when the recent list is long. Edge markers are removed when each chatroom is on the screen. Alternatively, users may click on them and the scroll area will move to the closest chatroom towards their chosen direction (and is not removed until all chatrooms have been seen).

Note, that this does not affect group chats unless alerts for group chats are enabled.
