### PR TITLE
Codecleanup

### DIFF
--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -190,10 +190,7 @@ void Settings::loadGlobal()
     s.endGroup();
 
     s.beginGroup("GUI");
-        enableSmoothAnimation = s.value("smoothAnimation", true).toBool();
         smileyPack = s.value("smileyPack", ":/smileys/TwitterEmojiSVG/emoticons.xml").toString();
-        customEmojiFont = s.value("customEmojiFont", true).toBool();
-        emojiFontFamily = s.value("emojiFontFamily", "DejaVu Sans").toString();
         emojiFontPointSize = s.value("emojiFontPointSize", 16).toInt();
         firstColumnHandlePos = s.value("firstColumnHandlePos", 50).toInt();
         secondColumnHandlePosFromRight = s.value("secondColumnHandlePosFromRight", 50).toInt();
@@ -202,7 +199,6 @@ void Settings::loadGlobal()
         minimizeOnClose = s.value("minimizeOnClose", false).toBool();
         minimizeToTray = s.value("minimizeToTray", false).toBool();
         lightTrayIcon = s.value("lightTrayIcon", false).toBool();
-        useNativeStyle = s.value("nativeStyle", false).toBool();
         useEmoticons = s.value("useEmoticons", true).toBool();
         statusChangeNotificationEnabled = s.value("statusChangeNotificationEnabled", false).toBool();
         themeColor = s.value("themeColor", 0).toInt();
@@ -372,14 +368,10 @@ void Settings::saveGlobal()
     const QList<QString> widgetNames = widgetSettings.keys();
     for (const QString& name : widgetNames)
         s.setValue(name, widgetSettings.value(name));
-
     s.endGroup();
 
     s.beginGroup("GUI");
-        s.setValue("smoothAnimation", enableSmoothAnimation);
         s.setValue("smileyPack", smileyPack);
-        s.setValue("customEmojiFont", customEmojiFont);
-        s.setValue("emojiFontFamily", emojiFontFamily);
         s.setValue("emojiFontPointSize", emojiFontPointSize);
         s.setValue("firstColumnHandlePos", firstColumnHandlePos);
         s.setValue("secondColumnHandlePosFromRight", secondColumnHandlePosFromRight);
@@ -388,7 +380,6 @@ void Settings::saveGlobal()
         s.setValue("minimizeOnClose", minimizeOnClose);
         s.setValue("minimizeToTray", minimizeToTray);
         s.setValue("lightTrayIcon", lightTrayIcon);
-        s.setValue("nativeStyle", useNativeStyle);
         s.setValue("useEmoticons", useEmoticons);
         s.setValue("themeColor", themeColor);
         s.setValue("style", style);
@@ -927,18 +918,6 @@ QByteArray Settings::getWidgetData(const QString& uniqueName) const
     return widgetSettings.value(uniqueName);
 }
 
-bool Settings::isAnimationEnabled() const
-{
-    QMutexLocker locker{&bigLock};
-    return enableSmoothAnimation;
-}
-
-void Settings::setAnimationEnabled(bool newValue)
-{
-    QMutexLocker locker{&bigLock};
-    enableSmoothAnimation = newValue;
-}
-
 QString Settings::getSmileyPack() const
 {
     QMutexLocker locker{&bigLock};
@@ -950,19 +929,6 @@ void Settings::setSmileyPack(const QString &value)
     QMutexLocker locker{&bigLock};
     smileyPack = value;
     emit smileyPackChanged();
-}
-
-bool Settings::isCurstomEmojiFont() const
-{
-    QMutexLocker locker{&bigLock};
-    return customEmojiFont;
-}
-
-void Settings::setCurstomEmojiFont(bool value)
-{
-    QMutexLocker locker{&bigLock};
-    customEmojiFont = value;
-    emit emojiFontChanged();
 }
 
 int Settings::getEmojiFontPointSize() const
@@ -1024,31 +990,6 @@ void Settings::setDateFormat(const QString &format)
 {
     QMutexLocker locker{&bigLock};
     dateFormat = format;
-}
-
-QString Settings::getEmojiFontFamily() const
-{
-    QMutexLocker locker{&bigLock};
-    return emojiFontFamily;
-}
-
-void Settings::setEmojiFontFamily(const QString &value)
-{
-    QMutexLocker locker{&bigLock};
-    emojiFontFamily = value;
-    emit emojiFontChanged();
-}
-
-bool Settings::getUseNativeStyle() const
-{
-    QMutexLocker locker{&bigLock};
-    return useNativeStyle;
-}
-
-void Settings::setUseNativeStyle(bool value)
-{
-    QMutexLocker locker{&bigLock};
-    useNativeStyle = value;
 }
 
 QByteArray Settings::getWindowGeometry() const

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -174,9 +174,6 @@ public:
     bool isCurstomEmojiFont() const;
     void setCurstomEmojiFont(bool value);
 
-    QString getEmojiFontFamily() const;
-    void setEmojiFontFamily(const QString &value);
-
     int getEmojiFontPointSize() const;
     void setEmojiFontPointSize(int value);
 
@@ -210,9 +207,6 @@ public:
     void setTypingNotification(bool enabled);
 
     // State
-    bool getUseNativeStyle() const;
-    void setUseNativeStyle(bool value);
-
     QByteArray getWindowGeometry() const;
     void setWindowGeometry(const QByteArray &value);
 
@@ -319,13 +313,9 @@ private:
     QString globalAutoAcceptDir;
 
     // GUI
-    bool enableSmoothAnimation;
     QString smileyPack;
-    bool customEmojiFont;
-    QString emojiFontFamily;
-    int     emojiFontPointSize;
+    int emojiFontPointSize;
     bool minimizeOnClose;
-    bool useNativeStyle;
     QByteArray windowGeometry;
     QByteArray windowState;
     QByteArray splitterState;

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -225,13 +225,17 @@ void ChatForm::onFileRecvRequest(ToxFile file)
     ChatMessage::Ptr msg = ChatMessage::createFileTransferMessage(name, file, false, QDateTime::currentDateTime());
     insertChatMessage(msg);
 
-    if (!Settings::getInstance().getAutoAcceptDir(f->getToxId()).isEmpty()
-            || Settings::getInstance().getAutoSaveEnabled())
+    if (!Settings::getInstance().getAutoAcceptDir(f->getToxId()).isEmpty()) //per contact autosave
     {
         ChatLineContentProxy* proxy = static_cast<ChatLineContentProxy*>(msg->getContent(1));
         assert(proxy->getWidgetType() == ChatLineContentProxy::FileTransferWidgetType);
         FileTransferWidget* tfWidget = static_cast<FileTransferWidget*>(proxy->getWidget());
         tfWidget->autoAcceptTransfer(Settings::getInstance().getAutoAcceptDir(f->getToxId()));
+    } else if (Settings::getInstance().getAutoSaveEnabled()) { //global autosave to global directory
+        ChatLineContentProxy* proxy = static_cast<ChatLineContentProxy*>(msg->getContent(1));
+        assert(proxy->getWidgetType() == ChatLineContentProxy::FileTransferWidgetType);
+        FileTransferWidget* tfWidget = static_cast<FileTransferWidget*>(proxy->getWidget());
+        tfWidget->autoAcceptTransfer(Settings::getInstance().getGlobalAutoAcceptDir());
     }
 }
 

--- a/src/widget/form/settings/generalform.cpp
+++ b/src/widget/form/settings/generalform.cpp
@@ -160,8 +160,7 @@ GeneralForm::GeneralForm(SettingsWidget *myParent) :
     connect(bodyUI->notifySound, &QCheckBox::stateChanged, this, &GeneralForm::onSetNotifySound);
     connect(bodyUI->groupAlwaysNotify, &QCheckBox::stateChanged, this, &GeneralForm::onSetGroupAlwaysNotify);
     connect(bodyUI->autoacceptFiles, &QCheckBox::stateChanged, this, &GeneralForm::onAutoAcceptFileChange);
-    if (bodyUI->autoacceptFiles->isChecked())
-        connect(bodyUI->autoSaveFilesDir, SIGNAL(clicked()), this, SLOT(onAutoSaveDirChange()));
+    connect(bodyUI->autoSaveFilesDir, SIGNAL(clicked()), this, SLOT(onAutoSaveDirChange()));
     //theme
     connect(bodyUI->useEmoticons, &QCheckBox::stateChanged, this, &GeneralForm::onUseEmoticonsChange);
     connect(bodyUI->smileyPackBrowser, SIGNAL(currentIndexChanged(int)), this, SLOT(onSmileyBrowserIndexChanged(int)));
@@ -291,19 +290,16 @@ void GeneralForm::onAutoAwayChanged()
 void GeneralForm::onAutoAcceptFileChange()
 {
     Settings::getInstance().setAutoSaveEnabled(bodyUI->autoacceptFiles->isChecked());
-
-    if (bodyUI->autoacceptFiles->isChecked() == true)
-        connect(bodyUI->autoSaveFilesDir, &QPushButton::clicked, this, &GeneralForm::onAutoSaveDirChange);
-    else
-        disconnect(bodyUI->autoSaveFilesDir, &QPushButton::clicked, this, &GeneralForm::onAutoSaveDirChange);
 }
 
 void GeneralForm::onAutoSaveDirChange()
 {
     QString previousDir = Settings::getInstance().getGlobalAutoAcceptDir();
     QString directory = QFileDialog::getExistingDirectory(0,
-                                                          tr("Choose an auto accept directory","popup title"));
-    if (directory.isEmpty())
+                                                          tr("Choose an auto accept directory", "popup title"),  //opens in home directory
+                                                             QStandardPaths::locate(QStandardPaths::HomeLocation, QString(), QStandardPaths::LocateDirectory)
+                                                          );
+    if (directory.isEmpty())  // cancel was pressed
         directory = previousDir;
 
     Settings::getInstance().setGlobalAutoAcceptDir(directory);

--- a/src/widget/form/settings/generalsettings.ui
+++ b/src/widget/form/settings/generalsettings.ui
@@ -39,8 +39,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>653</width>
-        <height>1150</height>
+        <width>639</width>
+        <height>1221</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,0,0,1">
@@ -237,6 +237,13 @@ instead of system taskbar.</string>
           <item>
            <layout class="QVBoxLayout" name="startupLayout">
             <item>
+             <widget class="QLabel" name="label_2">
+              <property name="text">
+               <string/>
+              </property>
+             </widget>
+            </item>
+            <item>
              <widget class="QCheckBox" name="cbAutorun">
               <property name="toolTip">
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Start qTox on operating system startup (current profile).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -256,21 +263,11 @@ instead of system taskbar.</string>
            </layout>
           </item>
           <item>
-           <layout class="QHBoxLayout" name="autoacceptLayout">
+           <layout class="QFormLayout" name="formLayout_2">
             <property name="leftMargin">
              <number>0</number>
             </property>
-            <item>
-             <widget class="QCheckBox" name="autoacceptFiles">
-              <property name="toolTip">
-               <string comment="autoaccept cb tooltip">You can set this on a per-friend basis by right clicking them.</string>
-              </property>
-              <property name="text">
-               <string>Autoaccept and save files:</string>
-              </property>
-             </widget>
-            </item>
-            <item>
+            <item row="2" column="1">
              <widget class="QPushButton" name="autoSaveFilesDir">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -280,6 +277,23 @@ instead of system taskbar.</string>
               </property>
               <property name="toolTip">
                <string>Set where files will be saved.</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="label">
+              <property name="text">
+               <string>Default directory to save files</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <widget class="QCheckBox" name="autoacceptFiles">
+              <property name="toolTip">
+               <string comment="autoaccept cb tooltip">You can set this on a per-friend basis by right clicking them.</string>
+              </property>
+              <property name="text">
+               <string>Autoaccept files</string>
               </property>
              </widget>
             </item>

--- a/src/widget/style.cpp
+++ b/src/widget/style.cpp
@@ -77,14 +77,11 @@ QList<QColor> Style::themeColorColors = {QColor(), QColor("#004aa4"), QColor("#9
 
 QString Style::getStylesheet(const QString &filename)
 {
-    if (!Settings::getInstance().getUseNativeStyle())
-    {
-        QFile file(filename);
-        if (file.open(QFile::ReadOnly | QFile::Text))
-            return resolve(file.readAll());
-        else
-            qWarning() << "Stylesheet " << filename << " not found";
-    }
+    QFile file(filename);
+    if (file.open(QFile::ReadOnly | QFile::Text))
+        return resolve(file.readAll());
+    else
+        qWarning() << "Stylesheet " << filename << " not found";
 
     return QString();
 }


### PR DESCRIPTION
fixes issues with global autoaccept:
if per-contact is specified then checks if global autoaccept is enabled, is so, saves to global autoaccept dir.
opens new file chooser in home dir instead in current location of qtox (/home/agilob/projects/qtox/)

removes unused attributes from settings.h
