### PR TITLE
Update Debian dependencies

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -76,12 +76,12 @@ sudo pacman -S --needed base-devel qt5 openal libxss qrencode ffmpeg
 Debian <10 / Ubuntu <15.04:
 **Note that ffmpeg is not included in those distribution version(!).**
 ```bash
-sudo apt-get install build-essential qt5-qmake qt5-default qttools5-dev-tools libqt5opengl5-dev libqt5svg5-dev libopenal-dev libxss-dev qrencode libqrencode-dev
+sudo apt-get install build-essential qt5-qmake qt5-default qttools5-dev-tools libqt5opengl5-dev libqt5svg5-dev libopenal-dev libxss-dev qrencode libqrencode-dev libglib2.0-dev libgdk-pixbuf2.0-dev libgtk2.0-dev
 ```
 
 Debian >=10 / Ubuntu >=15.04:
 ```bash
-sudo apt-get install build-essential qt5-qmake qt5-default qttools5-dev-tools libqt5opengl5-dev libqt5svg5-dev libopenal-dev libxss-dev qrencode libqrencode-dev libavutil-ffmpeg-dev libswresample-ffmpeg-dev libavcodec-ffmpeg-dev libswscale-ffmpeg-dev libavfilter-ffmpeg-dev libavdevice-ffmpeg-dev
+sudo apt-get install build-essential qt5-qmake qt5-default qttools5-dev-tools libqt5opengl5-dev libqt5svg5-dev libopenal-dev libxss-dev qrencode libqrencode-dev libavutil-ffmpeg-dev libswresample-ffmpeg-dev libavcodec-ffmpeg-dev libswscale-ffmpeg-dev libavfilter-ffmpeg-dev libavdevice-ffmpeg-dev libglib2.0-dev libgdk-pixbuf2.0-dev libgtk2.0-dev
 ```
 
 

--- a/simple_make.sh
+++ b/simple_make.sh
@@ -5,7 +5,8 @@ if which apt-get; then
         git build-essential qt5-qmake qt5-default qttools5-dev-tools \
         libqt5opengl5-dev libqt5svg5-dev libopenal-dev libopencv-dev \
         libxss-dev qrencode libqrencode-dev libtool autotools-dev \
-        automake checkinstall check libopus-dev libvpx-dev libsodium-dev
+        automake checkinstall check libopus-dev libvpx-dev libsodium-dev \
+        libglib2.0-dev libgdk-pixbuf2.0-dev libgtk2.0-dev
 elif which pacman; then
     sudo pacman -S --needed \
         git base-devel qt5 opencv openal libxss qrencode opus libvpx \


### PR DESCRIPTION
Ubuntu/Debian now depend on libglib2.0-dev libgdk-pixbuf2.0-dev, and libgtk2.0-dev for systray icon support, which is enabled by default
