### PR TITLE
Fix activity sorting out of bounds, update activity category when changed

### DIFF
--- a/src/widget/friendlistwidget.cpp
+++ b/src/widget/friendlistwidget.cpp
@@ -53,7 +53,7 @@ bool last7DaysWasLastMonth()
     return QDate::currentDate().addDays(-7).month() == QDate::currentDate().month();
 }
 
-Time getTime(const QDate date)
+Time getTime(const QDate& date)
 {
     if (date == QDate())
         return Never;
@@ -231,12 +231,15 @@ void FriendListWidget::setMode(Mode mode)
         activityLayout->addWidget(categoryLastWeek);
 
         QDate currentDate = QDate::currentDate();
-        if (last7DaysWasLastMonth())
+        //if (last7DaysWasLastMonth())
         {
             CategoryWidget* categoryThisMonth = new CategoryWidget(this);
             categoryThisMonth->setName(tr("This month", "Category for sorting friends by activity"));
             activityLayout->addWidget(categoryThisMonth);
-            currentDate = currentDate.addMonths(-1);
+            categoryThisMonth->setVisible(last7DaysWasLastMonth());
+
+            if (categoryThisMonth->isVisible())
+                currentDate = currentDate.addMonths(-1);
         }
 
         CategoryWidget* categoryLast1Month = new CategoryWidget(this);
@@ -276,8 +279,6 @@ void FriendListWidget::setMode(Mode mode)
         {
             QDate activityDate = getDateFriend(contact);
             Time time = getTime(activityDate);
-            if (!last7DaysWasLastMonth())
-                time = static_cast<Time>(time-1);
             CategoryWidget* categoryWidget = dynamic_cast<CategoryWidget*>(activityLayout->itemAt(time)->widget());
             categoryWidget->addFriendWidget(contact->getFriendWidget(), contact->getStatus());
         }
@@ -647,6 +648,17 @@ void FriendListWidget::moveWidget(FriendWidget* w, Status s, bool add)
         categoryWidget->addFriendWidget(contact->getFriendWidget(), contact->getStatus());
         categoryWidget->show();
     }
+}
+
+void FriendListWidget::updateActivityDate(const QDate& date)
+{
+    if (mode != Activity)
+        return;
+
+    CategoryWidget* categoryWidget = static_cast<CategoryWidget*>(activityLayout->itemAt(getTime(date))->widget());
+    categoryWidget->updateStatus();
+
+    categoryWidget->setVisible(categoryWidget->hasChatrooms());
 }
 
 // update widget after add/delete/hide/show

--- a/src/widget/friendlistwidget.h
+++ b/src/widget/friendlistwidget.h
@@ -60,6 +60,7 @@ public:
     void cycleContacts(GenericChatroomWidget* activeChatroomWidget, bool forward);
     QVector<CircleWidget*> getAllCircles();
 
+    void updateActivityDate(const QDate& date);
     void reDraw();
 
 signals:

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -907,8 +907,11 @@ void Widget::updateFriendActivity(Friend *frnd)
     QDate date = Settings::getInstance().getFriendActivity(frnd->getToxId());
     if (date != QDate::currentDate())
     {
+        // Update old activity before after new one. Store old date first.
+        QDate oldDate = Settings::getInstance().getFriendActivity(frnd->getToxId());
         Settings::getInstance().setFriendActivity(frnd->getToxId(), QDate::currentDate());
         contactListWidget->moveWidget(frnd->getFriendWidget(), frnd->getStatus());
+        contactListWidget->updateActivityDate(oldDate);
     }
 }
 


### PR DESCRIPTION
The PR that fixes #1948 segfault. This is an easier fix.

Also fixes #1944.
