### PR TITLE
OSX main menu bar

### DIFF
--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -1085,7 +1085,7 @@ QSplitter:handle{
              <x>0</x>
              <y>0</y>
              <width>284</width>
-             <height>353</height>
+             <height>398</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_5"/>
@@ -1841,20 +1841,6 @@ QSplitter:handle{
     </item>
    </layout>
   </widget>
-  <widget class="QMenuBar" name="menubar">
-   <property name="enabled">
-    <bool>true</bool>
-   </property>
-   <property name="geometry">
-    <rect>
-     <x>0</x>
-     <y>0</y>
-     <width>775</width>
-     <height>22</height>
-    </rect>
-   </property>
-  </widget>
-  <widget class="QStatusBar" name="statusbar"/>
   <action name="actionClose">
    <property name="text">
     <string>Close</string>

--- a/src/nexus.cpp
+++ b/src/nexus.cpp
@@ -39,6 +39,11 @@
 #include <QDesktopWidget>
 #endif
 
+#ifdef Q_OS_MAC
+#include <QWindow>
+#include <QMenuBar>
+#endif
+
 static Nexus* nexus{nullptr};
 
 Nexus::Nexus(QObject *parent) :
@@ -60,6 +65,9 @@ Nexus::~Nexus()
     delete loginScreen;
     delete profile;
     Settings::getInstance().saveGlobal();
+#ifdef Q_OS_MAC
+    delete globalMenuBar;
+#endif
 }
 
 void Nexus::start()
@@ -80,6 +88,25 @@ void Nexus::start()
     qRegisterMetaType<ToxFile>("ToxFile");
     qRegisterMetaType<ToxFile::FileDirection>("ToxFile::FileDirection");
     qRegisterMetaType<std::shared_ptr<VideoFrame>>("std::shared_ptr<VideoFrame>");
+
+#ifdef Q_OS_MAC
+    globalMenuBar = new QMenuBar(0);
+
+    windowMenu = globalMenuBar->addMenu(tr("Window"));
+    globalMenuBar->addAction(windowMenu->menuAction());
+
+    QAction* minimizeAction = Nexus::getInstance().windowMenu->addAction(tr("Minimize"));
+    minimizeAction->setShortcut(Qt::CTRL + Qt::Key_M);
+    connect(minimizeAction, &QAction::triggered, [minimizeAction]()
+    {
+        QApplication::focusWindow()->showMinimized();
+    });
+    Nexus::getInstance().windowMenu->addSeparator();
+
+    QAction* quitAction = new QAction(globalMenuBar);
+    quitAction->setMenuRole(QAction::QuitRole);
+    connect(quitAction, &QAction::triggered, qApp, &QApplication::quit);
+#endif
 
     loginScreen = new LoginScreen();
 

--- a/src/nexus.h
+++ b/src/nexus.h
@@ -29,6 +29,11 @@ class Profile;
 class LoginScreen;
 class Core;
 
+#ifdef Q_OS_MAC
+class QMenuBar;
+class QMenu;
+#endif
+
 /// This class is in charge of connecting various systems together
 /// and forwarding signals appropriately to the right objects
 /// It is in charge of starting the GUI and the Core
@@ -51,6 +56,11 @@ public:
     static Widget* getDesktopGUI(); ///< Will return 0 if not started
     static QString getSupportedImageFilter();
     static bool tryRemoveFile(const QString& filepath); ///< Dangerous way to find out if a path is writable
+
+#ifdef Q_OS_MAC
+    QMenuBar* globalMenuBar;
+    QMenu* windowMenu;
+#endif
 
 private:
     explicit Nexus(QObject *parent = 0);

--- a/src/widget/form/settingswidget.cpp
+++ b/src/widget/form/settingswidget.cpp
@@ -81,6 +81,11 @@ void SettingsWidget::setBodyHeadStyle(QString style)
     body->setStyle(QStyleFactory::create(style));
 }
 
+void SettingsWidget::showAbout()
+{
+    onTabChanged(settingsWidgets->count() - 1);
+}
+
 void SettingsWidget::show(Ui::MainWindow& ui)
 {
     ui.mainContent->layout()->addWidget(body);

--- a/src/widget/form/settingswidget.h
+++ b/src/widget/form/settingswidget.h
@@ -45,6 +45,8 @@ public:
     void show(Ui::MainWindow &ui);
     void setBodyHeadStyle(QString style);
 
+    void showAbout();
+
 signals:
     void setShowSystemTray(bool newValue);
     void compactToggled(bool compact);

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -303,11 +303,13 @@ void Widget::init()
     QAction* addContactAction = contactMenu->menu()->addAction(tr("Add Contact..."));
     connect(addContactAction, &QAction::triggered, this, &Widget::onAddClicked);
 
-    QAction* nextConversationAction = Nexus::getInstance().windowMenu->addAction(tr("Next Conversation"));
+    QAction* nextConversationAction = new QAction(tr("Next Conversation"), this);
+    Nexus::getInstance().windowMenu->addAction(nextConversationAction);
     nextConversationAction->setShortcut(QKeySequence::SelectNextPage);
     connect(nextConversationAction, &QAction::triggered, this, &Widget::nextContact);
 
-    QAction* previousConversationAction = Nexus::getInstance().windowMenu->addAction(tr("Previous Conversation"));
+    QAction* previousConversationAction = new QAction(tr("Previous Conversation"), this);
+    Nexus::getInstance().windowMenu->addAction(previousConversationAction);
     previousConversationAction->setShortcut(QKeySequence::SelectPreviousPage);
     connect(previousConversationAction, &QAction::triggered, this, &Widget::previousContact);
 
@@ -415,11 +417,6 @@ Widget::~Widget()
     delete trayMenu;
     delete ui;
     instance = nullptr;
-
-#ifdef Q_OS_MAC
-    //Nexus::getInstance().globalMenuBar->clear();
-    //Nexus::getInstance().globalMenuBar->addMenu(Nexus::getInstance().windowMenu);
-#endif
 }
 
 Widget* Widget::getInstance()

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -160,6 +160,11 @@ private slots:
     void processOfflineMsgs();
     void friendListContextMenu(const QPoint &pos);
 
+#ifdef Q_OS_MAC
+    void bringAllToFront();
+    void toggleFullscreen();
+#endif
+
 private:
     enum ActiveToolMenuButton {
         AddButton,
@@ -236,6 +241,11 @@ private:
     bool eventFlag;
     bool eventIcon;
     bool wasMaximized = false;
+
+#ifdef Q_OS_MAC
+    QMenuBar* mainMenu;
+    QAction* fullscreenAction;
+#endif
 };
 
 bool toxActivateEventHandler(const QByteArray& data);

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -243,7 +243,6 @@ private:
     bool wasMaximized = false;
 
 #ifdef Q_OS_MAC
-    QMenuBar* mainMenu;
     QAction* fullscreenAction;
 #endif
 };


### PR DESCRIPTION
Adds a global menu bar for OS X instead of having an empty one. Includes common OS X shortcuts/menus, including preferences, about and quit, as well as a few window-based shortcuts.

This does not include some actions such as cut/copy/paste because they're a little bit harder to implement for OS X. It would require signals on each widget which is tedious work and will likely be a different PR.
