### PR TITLE
Add missing ffmpeg libs and set correct depency order of them

### DIFF
--- a/qtox.pro
+++ b/qtox.pro
@@ -165,12 +165,12 @@ win32 {
             contains(STATICPKG, YES) {
                 target.path = /usr/bin
                 INSTALLS += target
-                LIBS += -L$$PWD/libs/lib/ -lopus -lvpx -lopenal -Wl,-Bstatic -ltoxcore -ltoxav -ltoxencryptsave -ltoxdns -lsodium -lavformat -lavdevice -lavcodec -lavutil -lswscale -lz -Wl,-Bdynamic
+                LIBS += -L$$PWD/libs/lib/ -lopus -lvpx -lopenal -Wl,-Bstatic -ltoxcore -ltoxav -ltoxencryptsave -ltoxdns -lsodium -lavdevice -lavfilter -lswscale -lpostproc -lavformat -lavcodec -lswresample -lavutil -lz -Wl,-Bdynamic
                 LIBS += -Wl,-Bstatic -ljpeg -ltiff -lpng -ljasper -lIlmImf -lIlmThread -lIex -ldc1394 -lraw1394 -lHalf -lz -llzma -ljbig
                 LIBS += -Wl,-Bdynamic -lv4l1 -lv4l2 -lavformat -lavcodec -lavutil -lswscale -lusb-1.0
                 LIBS += -lqrencode
             } else {
-                LIBS += -L$$PWD/libs/lib/ -ltoxcore -ltoxav -ltoxencryptsave -ltoxdns -lvpx -lsodium -lopenal -lavformat -lavdevice -lavcodec -lavutil -lswscale
+                LIBS += -L$$PWD/libs/lib/ -ltoxcore -ltoxav -ltoxencryptsave -ltoxdns -lvpx -lsodium -lopenal -lavdevice -lavfilter -lswscale -lpostproc -lavformat -lavcodec -lswresample -lavutil
                 LIBS += -lqrencode
             }
 


### PR DESCRIPTION
Add missing ffmpeg libs and set correct depency order of them (for static build). This fixes link errors like:

```
ld: warning: libavfilter.so.5, needed by /usr/lib/tox/libavdevice.so, not found
ld: warning: libswresample.so.1, needed by /usr/lib/tox/libavcodec.so, not found
```
