### PR TITLE
Add profile file name in profile page

### DIFF
--- a/src/widget/form/profileform.cpp
+++ b/src/widget/form/profileform.cpp
@@ -118,6 +118,12 @@ ProfileForm::ProfileForm(QWidget *parent) :
     Translator::registerHandler(std::bind(&ProfileForm::retranslateUi, this), this);
 }
 
+void ProfileForm::prFileLabelUpdate()
+{
+    Nexus& nexus = Nexus::getInstance();
+    bodyUI->prFileLabel->setText(tr("The name of the current file Profile: ") + nexus.getProfile()->getName() + ".tox");
+}
+
 ProfileForm::~ProfileForm()
 {
     Translator::unregister(this);
@@ -132,6 +138,7 @@ void ProfileForm::show(Ui::MainWindow &ui)
     ui.mainContent->layout()->addWidget(this);
     head->show();
     QWidget::show();
+    prFileLabelUpdate();
     bodyUI->userName->setFocus();
     bodyUI->userName->selectAll();
 }
@@ -258,7 +265,10 @@ void ProfileForm::onRenameClicked()
             GUI::showError(tr("Failed to rename", "rename failed title"),
                              tr("Couldn't rename the profile to \"%1\"").arg(cur));
         else
+        {
+            prFileLabelUpdate();
             break;
+        }
     } while (true);
 }
 

--- a/src/widget/form/profileform.cpp
+++ b/src/widget/form/profileform.cpp
@@ -139,6 +139,10 @@ void ProfileForm::show(Ui::MainWindow &ui)
     head->show();
     QWidget::show();
     prFileLabelUpdate();
+    QString DirPath = QDir(Settings::getInstance().getSettingsDirPath()).path().trimmed();
+    bodyUI->dirPrLink->setText(bodyUI->dirPrLink->text().replace("Dir_Path",DirPath));
+    bodyUI->dirPrLink->setOpenExternalLinks(true);
+    bodyUI->dirPrLink->setTextInteractionFlags(Qt::LinksAccessibleByMouse | Qt::TextSelectableByMouse);
     bodyUI->userName->setFocus();
     bodyUI->userName->selectAll();
 }

--- a/src/widget/form/profileform.cpp
+++ b/src/widget/form/profileform.cpp
@@ -121,7 +121,7 @@ ProfileForm::ProfileForm(QWidget *parent) :
 void ProfileForm::prFileLabelUpdate()
 {
     Nexus& nexus = Nexus::getInstance();
-    bodyUI->prFileLabel->setText(tr("The name of the current file Profile: ") + nexus.getProfile()->getName() + ".tox");
+    bodyUI->prFileLabel->setText(tr("Current profile:") + nexus.getProfile()->getName() + ".tox");
 }
 
 ProfileForm::~ProfileForm()

--- a/src/widget/form/profileform.h
+++ b/src/widget/form/profileform.h
@@ -80,6 +80,7 @@ private slots:
 
 private:
     void retranslateUi();
+    void prFileLabelUpdate();
 
 private:
     void refreshProfiles();

--- a/src/widget/form/profileform.ui
+++ b/src/widget/form/profileform.ui
@@ -156,6 +156,13 @@ Share it with your friends to communicate.</string>
          </property>
          <layout class="QVBoxLayout" name="profilesVLayout">
           <item>
+           <widget class="QLabel" name="prFileLabel">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+          <item>
            <layout class="QHBoxLayout" name="profilesButtonsLayout">
             <item>
              <spacer name="horizontalSpacer">

--- a/src/widget/form/profileform.ui
+++ b/src/widget/form/profileform.ui
@@ -171,7 +171,7 @@ Share it with your friends to communicate.</string>
              <enum>Qt::ClickFocus</enum>
             </property>
             <property name="text">
-             <string>&lt;p&gt;&lt;a href=&quot;file:///Dir_Path\&quot;&gt;&lt;span style=&quot; text-decoration: NONE; color:#000000;&quot;&gt;Directory file Profile:  Dir_Path&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;</string>
+             <string>&lt;p&gt;&lt;a href=&quot;file:///Dir_Path\&quot;&gt;&lt;span style=&quot; text-decoration: NONE; color:#000000;&quot;&gt;Current profile location:  Dir_Path&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;</string>
             </property>
             <property name="textFormat">
              <enum>Qt::RichText</enum>

--- a/src/widget/form/profileform.ui
+++ b/src/widget/form/profileform.ui
@@ -163,6 +163,31 @@ Share it with your friends to communicate.</string>
            </widget>
           </item>
           <item>
+           <widget class="QLabel" name="dirPrLink">
+            <property name="cursor">
+             <cursorShape>PointingHandCursor</cursorShape>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::ClickFocus</enum>
+            </property>
+            <property name="text">
+             <string>&lt;p&gt;&lt;a href=&quot;file:///Dir_Path\&quot;&gt;&lt;span style=&quot; text-decoration: NONE; color:#000000;&quot;&gt;Directory file Profile:  Dir_Path&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::RichText</enum>
+            </property>
+            <property name="wordWrap">
+             <bool>false</bool>
+            </property>
+            <property name="openExternalLinks">
+             <bool>false</bool>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+          <item>
            <layout class="QHBoxLayout" name="profilesButtonsLayout">
             <item>
              <spacer name="horizontalSpacer">


### PR DESCRIPTION
Add profile file name in profile page and Added indication of the profile folder on the profile page
fix #1951
![default](https://cloud.githubusercontent.com/assets/6053197/8617985/1d560f76-2712-11e5-9cd1-8421d1857106.png)

(profile folder is clickable - opens the profile folder)
