### PR TITLE
core: TOX_ERR_NEW_LOAD_BAD_FORMAT is non-fatal.

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -232,9 +232,8 @@ void Core::makeTox(QByteArray savedata)
             emit failedToStart();
             return;
         case TOX_ERR_NEW_LOAD_BAD_FORMAT:
-            qCritical() << "bad load data format";
-            emit failedToStart();
-            return;
+            qWarning() << "bad load data format";
+            break;
         default:
             qCritical() << "Tox core failed to start";
             emit failedToStart();


### PR DESCRIPTION
This fixes errors from save migrations between versions and architectures.
