### PR TITLE
Q_OS_LINUX -> Q_OS_UNIX: *nixes should behave similarly to Linux

### DIFF
--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -72,7 +72,7 @@ ChatLog::ChatLog(QWidget* parent)
     connect(copyAction, &QAction::triggered, this, [this]() { copySelectedText(); });
     addAction(copyAction);
 
-#ifdef Q_OS_LINUX
+#ifdef Q_OS_UNIX
     // Ctrl+Insert shortcut
     QShortcut* copyCtrlInsShortcut = new QShortcut(QKeySequence(Qt::CTRL + Qt::Key_Insert), this);
     connect(copyCtrlInsShortcut, &QShortcut::activated, this, [this]() { copySelectedText(); });
@@ -103,7 +103,7 @@ ChatLog::ChatLog(QWidget* parent)
     // selection
     connect(this, &ChatLog::selectionChanged, this, [this]() {
         copyAction->setEnabled(hasTextToBeCopied());
-#ifdef Q_OS_LINUX
+#ifdef Q_OS_UNIX
         copySelectedText(true);
 #endif
     });

--- a/src/platform/camera/v4l2.h
+++ b/src/platform/camera/v4l2.h
@@ -24,8 +24,12 @@
 #include <QPair>
 #include "src/video/videomode.h"
 
-#ifndef Q_OS_LINUX
-#error "This file is only meant to be compiled for Linux targets"
+#if defined(Q_OS_UNIX) && !defined(__APPLE__)
+#define TOX_USE_V4L
+#endif
+
+#ifndef TOX_USE_V4L
+#error "This file is only meant to be compiled for Linux and Unix-like targets"
 #endif
 
 namespace v4l2

--- a/src/video/cameradevice.cpp
+++ b/src/video/cameradevice.cpp
@@ -31,7 +31,7 @@ extern "C" {
 #ifdef Q_OS_WIN
 #include "src/platform/camera/directshow.h"
 #endif
-#ifdef Q_OS_LINUX
+#ifdef TOX_USE_V4L
 #include "src/platform/camera/v4l2.h"
 #endif
 
@@ -105,7 +105,7 @@ CameraDevice* CameraDevice::open(QString devName, VideoMode mode)
 
     AVDictionary* options = nullptr;
     if (!iformat);
-#ifdef Q_OS_LINUX
+#ifdef TOX_USE_V4L
     else if (devName.startsWith("x11grab#"))
     {
         QSize screen;
@@ -141,7 +141,7 @@ CameraDevice* CameraDevice::open(QString devName, VideoMode mode)
         av_dict_set(&options, "framerate", QString().setNum(mode.FPS).toStdString().c_str(), 0);
     }
 #endif
-#ifdef Q_OS_LINUX
+#ifdef TOX_USE_V4L
     else if (iformat->name == QString("video4linux2,v4l2") && mode)
     {
         av_dict_set(&options, "video_size", QString("%1x%2").arg(mode.width).arg(mode.height).toStdString().c_str(), 0);
@@ -299,7 +299,7 @@ QVector<VideoMode> CameraDevice::getVideoModes(QString devName)
     else if (iformat->name == QString("dshow"))
         return DirectShow::getDeviceModes(devName);
 #endif
-#ifdef Q_OS_LINUX
+#ifdef TOX_USE_V4L
     else if (iformat->name == QString("video4linux2,v4l2"))
         return v4l2::getDeviceModes(devName);
 #endif
@@ -319,7 +319,7 @@ bool CameraDevice::getDefaultInputFormat()
     avdevice_register_all();
 
     // Desktop capture input formats
-#ifdef Q_OS_LINUX
+#ifdef TOX_USE_V4L
     idesktopFormat = av_find_input_format("x11grab");
 #endif
 #ifdef Q_OS_WIN
@@ -327,7 +327,7 @@ bool CameraDevice::getDefaultInputFormat()
 #endif
 
     // Webcam input formats
-#ifdef Q_OS_LINUX
+#ifdef TOX_USE_V4L
     if ((iformat = av_find_input_format("v4l2")))
         return true;
 #endif


### PR DESCRIPTION
Resubmitting (see https://github.com/tux3/qTox/pull/2005)

New logic is Q_OS_UNIX && !MACOS

Reason: FreeBSD and other BSDs should be included.
