### PR TITLE
Remove call to ProfileLocker::clearAllLocks()

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,7 +25,6 @@
 #include "src/net/autoupdate.h"
 #include "src/persistence/toxsave.h"
 #include "src/persistence/profile.h"
-#include "src/persistence/profilelocker.h"
 #include "src/widget/loginscreen.h"
 #include "src/widget/translator.h"
 #include "src/video/camerasource.h"
@@ -162,13 +161,6 @@ int main(int argc, char *argv[])
     ipc.registerEventHandler("uri", &toxURIEventHandler);
     ipc.registerEventHandler("save", &toxSaveEventHandler);
     ipc.registerEventHandler("activate", &toxActivateEventHandler);
-
-    // If we're the IPC owner and we just started, then
-    // either we're the only running instance or any other instance
-    // is already so frozen it lost ownership.
-    // It's safe to remove any potential stale locks in this situation.
-    if (ipc.isCurrentOwner())
-        ProfileLocker::clearAllLocks();
 
     if (parser.isSet("p"))
     {


### PR DESCRIPTION
Before: `ProfileLocker::clearAllLocks()` deleted all .lock files in `/home/user/.config/tox/` or whatever the alternative is on other platforms. This means the hypothetical file `/home/user/.config/tox/gTox.conf.lock` would be deleted whenever qTox starts.

Now:
- Stale files, caused by a program crashing should be (and are*) deleted. [Docs](http://doc.qt.io/qt-5/qlockfile.html).
- Other programs can use .lock files with out having them deleted by qTox.
- If another client creates a .lock file on a profile then the user tries to open that profile in qTox as well then qTox will inform them that the profile is already in use.

This should allow locks to work between clients so long as they use the same naming convention. Perhaps this could be added to the STS in the future.

*I have tested this and stale files are deleted so long as they take the right form. If the file is empty or the file contains something other than a number on the first line it will never be seen as stale.

This could cause a problem if another client creates a lock file in the wrong form and then crashes.
For reference the right form is PID on the first line, process name on the second and, optionally, hostname on the third line.
E.g.

```
28115
qTox
myCompter
```

or

```
14325
gTox
```

`ProfileLocker::clearAllLocks()` still exists it just isn't called anywhere.
