### PR TITLE
INSTALL.md clarified per distro.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -29,8 +29,9 @@ Easy qTox install is provided for variety of distributions:
 * [Gentoo](#gentoo)
 * [Slackware](#slackware)
 
+* [Fedora] (#fedora)
 
-#### Arch
+
 
 **Please note that installing toxcore/qTox from AUR is not supported**, although installing other dependencies, provided that they met requirements, should be fine, unless you are installing cryptography library from AUR, which should rise red flags by itself…
 


### PR DESCRIPTION
--- Using https://gist.github.com/linux-modder/8fa5bbac30cf83b8e252 as a template  making  a  non external linked (or links but not need to  compile merely check that  its utd (e.g. filter_audio  the git checkout **tags/1.0.3** part(s) but can be  compiled without jumping around.  While this is not entirely uncommon for a veteran compiler it is increasingly borking  / confusing new comers to the space.

---Again using gist (above) as template make a  "quick compile lookaside"   per  Distro to increase readability / clarity.
