### PR TITLE
make it easier to build on Fedora

### DIFF
--- a/simple_make.sh
+++ b/simple_make.sh
@@ -17,16 +17,16 @@ elif which dnf; then
     sudo dnf install \
         git qt-devel qt-doc qt-creator qt5-qtsvg opencv-devel \
         openal-soft-devel libXScrnSaver-devel qrencode-devel \
-	opus-devel libvpx-devel qt5-qttools-devel glib2-devel \
-	gdk-pixbuf2-devel gtk2-devel
+        opus-devel libvpx-devel qt5-qttools-devel glib2-devel \
+        gdk-pixbuf2-devel gtk2-devel
 else
     echo "Unknown package manager, attempting to compile anyways"
 fi
 
 ./bootstrap.sh
 if [ -e /etc/redhat-release ]; then
-	qmake-qt5
+    qmake-qt5
 else
-	qmake
+    qmake
 fi
 make

--- a/simple_make.sh
+++ b/simple_make.sh
@@ -16,11 +16,17 @@ elif which dnf; then
         "Development Tools"
     sudo dnf install \
         git qt-devel qt-doc qt-creator qt5-qtsvg opencv-devel \
-        openal-soft-devel libXScrnSaver-devel qrencode-devel
+        openal-soft-devel libXScrnSaver-devel qrencode-devel \
+	opus-devel libvpx-devel qt5-qttools-devel glib2-devel \
+	gdk-pixbuf2-devel gtk2-devel
 else
     echo "Unknown package manager, attempting to compile anyways"
 fi
 
 ./bootstrap.sh
-qmake
+if [ -e /etc/redhat-release ]; then
+	qmake-qt5
+else
+	qmake
+fi
 make


### PR DESCRIPTION
Updated some build dependencies for Fedora.  There are more, but they will come later.
Also, make sure the build script uses qmake-qt5 on Fedora. If not, it will use qt4 which will create problems.
