### PR TITLE
Temporary removal of link to tox.im repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ qTox
 <h5>qTox is a powerful Tox client that follows the Tox design guidelines while running on all major platforms:</h5>
 
 * **Windows**:
-  - [**64 bit download**](https://tux3-dev.tox.im/jenkins/job/qTox-win64-nsis/lastSuccessfulBuild/artifact/setup-qtox64.exe)
-  - [**32 bit download** (for older hardware)](https://tux3-dev.tox.im/jenkins/job/qTox-win32-nsis/lastSuccessfulBuild/artifact/setup-qtox32.exe)
+  - (coming soon)
 * **Linux**:
   - [**binary**](#) - Currently unmaintained
   - [**packages**](/INSTALL.md#simple-install)


### PR DESCRIPTION
As it was stated in recent blog post on https://blog.tox.chat/2015/07/current-situation-3/
"Unfortunately, Sean refuses to take responsibility for what he has done, and seems to carry the attitude that what he did was perfectly acceptable. Despite our having spent a great deal of time and effort trying to engage with him, giving him opportunities to pay us back and redeem himself (which is part of the reason why we have waited this long to make an official post about it), he has shown no remorse for his actions, and continues to hold some of our infrastructure “hostage”. This includes the tox.im, toxme.se, and libtoxcore.so domains. For this reason, we have also been forced to disassociate ourselves with the aforementioned domains and begin again from scratch with a new domain, tox.chat"
