### PR TITLE
Save file transfer accept default directory

### DIFF
--- a/src/chatlog/content/filetransferwidget.cpp
+++ b/src/chatlog/content/filetransferwidget.cpp
@@ -24,6 +24,7 @@
 #include "src/core/core.h"
 #include "src/widget/style.h"
 #include "src/widget/widget.h"
+#include "src/persistence/settings.h"
 
 #include <QMouseEvent>
 #include <QFileDialog>
@@ -143,6 +144,8 @@ void FileTransferWidget::acceptTransfer(const QString &filepath)
 
     //everything ok!
     Core::getInstance()->acceptFileRecvRequest(fileInfo.friendId, fileInfo.fileNum, filepath);
+
+    Settings::getInstance().setSaveFileDirectory(QDir(filepath).path());
 }
 
 void FileTransferWidget::setBackgroundColor(const QColor &c, bool whiteFont)
@@ -472,7 +475,7 @@ void FileTransferWidget::handleButton(QPushButton *btn)
             Core::getInstance()->pauseResumeFileRecv(fileInfo.friendId, fileInfo.fileNum);
         else if (btn->objectName() == "accept")
         {
-            QString path = QFileDialog::getSaveFileName(0, tr("Save a file","Title of the file saving dialog"), QDir::home().filePath(fileInfo.fileName));
+            QString path = QFileDialog::getSaveFileName(0, tr("Save a file","Title of the file saving dialog"), QDir(Settings::getInstance().getSaveFileDirectory()).filePath(fileInfo.fileName));
             acceptTransfer(path);
         }
     }

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -174,6 +174,7 @@ void Settings::loadGlobal()
         globalAutoAcceptDir = s.value("globalAutoAcceptDir",
                                       QStandardPaths::locate(QStandardPaths::HomeLocation, QString(), QStandardPaths::LocateDirectory)
                                       ).toString();
+        saveFileDirectory = s.value("saveFileDirectory", QDir::home().path()).toString();
         groupchatPosition = s.value("groupchatPosition", true).toBool();
     s.endGroup();
 
@@ -378,6 +379,7 @@ void Settings::saveGlobal()
         s.setValue("fauxOfflineMessaging", fauxOfflineMessaging);
         s.setValue("groupchatPosition", groupchatPosition);
         s.setValue("autoSaveEnabled", autoSaveEnabled);
+        s.setValue("saveFileDirectory", saveFileDirectory);
         s.setValue("globalAutoAcceptDir", globalAutoAcceptDir);
     s.endGroup();
 
@@ -943,6 +945,18 @@ void Settings::setGlobalAutoAcceptDir(const QString& newValue)
 {
     QMutexLocker locker{&bigLock};
     globalAutoAcceptDir = newValue;
+}
+
+QString Settings::getSaveFileDirectory() const
+{
+    QMutexLocker locker{&bigLock};
+    return saveFileDirectory;
+}
+
+void Settings::setSaveFileDirectory(const QString& newValue)
+{
+    QMutexLocker locker{&bigLock};
+    saveFileDirectory = newValue;
 }
 
 void Settings::setWidgetData(const QString& uniqueName, const QByteArray& data)

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -184,6 +184,9 @@ public:
     QString getGlobalAutoAcceptDir() const;
     void setGlobalAutoAcceptDir(const QString& dir);
 
+    QString getSaveFileDirectory() const;
+    void setSaveFileDirectory(const QString& file);
+
     // ChatView
     int getFirstColumnHandlePos() const;
     void setFirstColumnHandlePos(const int pos);
@@ -326,6 +329,7 @@ private:
     QHash<QString, QString> autoAccept;
     bool autoSaveEnabled;
     QString globalAutoAcceptDir;
+    QString saveFileDirectory;
 
     // GUI
     QString smileyPack;


### PR DESCRIPTION
@Chiitoo requested on IRC that he would like the last used file transfer directory to be saved instead of having the directory always show the home directory. This small commit adds that functionality.
