### PR TITLE
Possible Fix for Tray Icon Detection

### DIFF
--- a/src/widget/systemtrayicon.cpp
+++ b/src/widget/systemtrayicon.cpp
@@ -28,7 +28,7 @@
 
 SystemTrayIcon::SystemTrayIcon()
 {
-    QString desktop = getenv("XDG_CURRENT_DESKTOP");
+    QString desktop = getenv("XDG_SESSION_DESKTOP");
     if (desktop.isEmpty())
         desktop = getenv("DESKTOP_SESSION");
     desktop = desktop.toLower();

--- a/src/widget/systemtrayicon.cpp
+++ b/src/widget/systemtrayicon.cpp
@@ -28,7 +28,7 @@
 
 SystemTrayIcon::SystemTrayIcon()
 {
-    QString desktop = getenv("XDG_SESSION_DESKTOP");
+    QString desktop = getenv("XDG_CURRENT_DESKTOP");
     if (desktop.isEmpty())
         desktop = getenv("DESKTOP_SESSION");
     desktop = desktop.toLower();
@@ -60,7 +60,7 @@ SystemTrayIcon::SystemTrayIcon()
     }
     #endif
     #ifdef ENABLE_SYSTRAY_GTK_BACKEND
-    else if (desktop == "xfce" || desktop.contains("gnome") || desktop == "mate")
+    else if (desktop == "XFCE" || desktop.contains("GNOME") || desktop == "MATE")
     {
         qDebug() << "Using GTK backend";
         backendType = SystrayBackendType::GTK;
@@ -95,7 +95,7 @@ SystemTrayIcon::SystemTrayIcon()
     }
     #endif
     #ifdef ENABLE_SYSTRAY_STATUSNOTIFIER_BACKEND
-    else if (desktop == "kde"
+    else if (desktop == "KDE"
             && getenv("KDE_SESSION_VERSION") == QString("5"))
     {
         qDebug() << "Using Status Notifier backend";


### PR DESCRIPTION
Call it a hunch, but XDG_SESSION_DESKTOP and XDG_CURRENT_DESKTOP aren't as interchangeable as they may have seemed. Notably, the XDG_CURRENT_DESKTOP environment variable in Ubuntu GNOME 15.04 (systemd woo) is set like this:

XDG_SESSION_DESKTOP=gnome

which is a variable qtox is expecting from XDG_CURRENT_DESKTOP. On the other hand:

XDG_CURRENT_DESKTOP=GNOME

The casing is different, obviously. Two solutions emerge: change the casing in those if statements, or change the environment variable we're checking. I've done the former.

Even if this solution doesn't work at all, my guess as to why the tray icons for all this time is this environment variable setup. Also to be noted is that XDG_SESSION_DESKTOP takes one item, whereas XDG_CURRENT_DESKTOP takes a colon-seperated list.

Some stuff about XDG_SESSION_DESKTOP is over here:

http://www.freedesktop.org/software/systemd/man/pam_systemd.html
