### PR TITLE
Friend request and group invite buttons

### DIFF
--- a/qtox.pro
+++ b/qtox.pro
@@ -493,7 +493,8 @@ SOURCES += \
     src/widget/genericchatitemwidget.cpp \
     src/widget/friendlistlayout.cpp \
     src/widget/genericchatitemlayout.cpp \
-    src/widget/categorywidget.cpp
+    src/widget/categorywidget.cpp \
+    src/widget/form/groupinviteform.cpp
 
 HEADERS += \
     src/audio/audio.h \
@@ -536,4 +537,5 @@ HEADERS += \
     src/widget/genericchatitemwidget.h \
     src/widget/friendlistlayout.h \
     src/widget/genericchatitemlayout.h \
-    src/widget/categorywidget.h
+    src/widget/categorywidget.h \
+    src/widget/form/groupinviteform.h

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -1062,19 +1062,24 @@ void Core::groupInviteFriend(uint32_t friendId, int groupId)
     tox_invite_friend(tox, friendId, groupId);
 }
 
-void Core::createGroup(uint8_t type)
+int Core::createGroup(uint8_t type)
 {
     if (type == TOX_GROUPCHAT_TYPE_TEXT)
     {
-        emit emptyGroupCreated(tox_add_groupchat(tox));
+        int group = tox_add_groupchat(tox);
+        emit emptyGroupCreated(group);
+        return group;
     }
     else if (type == TOX_GROUPCHAT_TYPE_AV)
     {
-        emit emptyGroupCreated(toxav_add_av_groupchat(tox, &Audio::playGroupAudioQueued, this));
+        int group = toxav_add_av_groupchat(tox, &Audio::playGroupAudioQueued, this);
+        emit emptyGroupCreated(group);
+        return group;
     }
     else
     {
         qWarning() << "createGroup: Unknown type "<<type;
+        return -1;
     }
 }
 

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -105,7 +105,7 @@ public slots:
     void acceptFriendRequest(const QString& userId);
     void requestFriendship(const QString& friendAddress, const QString& message);
     void groupInviteFriend(uint32_t friendId, int groupId);
-    void createGroup(uint8_t type = TOX_GROUPCHAT_TYPE_AV);
+    int createGroup(uint8_t type = TOX_GROUPCHAT_TYPE_AV);
 
     void removeFriend(uint32_t friendId, bool fake = false);
     void removeGroup(int groupId, bool fake = false);

--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -368,7 +368,7 @@ QSplitter:handle{
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
-       <layout class="QVBoxLayout" name="verticalLayout_6">
+       <layout class="QVBoxLayout" name="statusLayout">
         <property name="spacing">
          <number>0</number>
         </property>
@@ -1085,7 +1085,7 @@ QSplitter:handle{
              <x>0</x>
              <y>0</y>
              <width>284</width>
-             <height>398</height>
+             <height>393</height>
             </rect>
            </property>
            <layout class="QVBoxLayout" name="verticalLayout_5"/>

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -301,6 +301,21 @@ void Settings::loadPersonnal(Profile* profile)
         ps.endArray();
     ps.endGroup();
 
+    ps.beginGroup("Requests");
+        unreadFriendRequests = ps.value("unread", 0).toUInt();
+        size = ps.beginReadArray("Request");
+        friendLst.reserve(size);
+        for (int i = 0; i < size; i ++)
+        {
+            ps.setArrayIndex(i);
+            QPair<QString, QString> request;
+            request.first = ps.value("addr").toString();
+            request.second = ps.value("message").toString();
+            friendRequests.push_back(request);
+        }
+        ps.endArray();
+    ps.endGroup();
+
     ps.beginGroup("General");
         compactLayout = ps.value("compactLayout", false).toBool();
     ps.endGroup();
@@ -467,7 +482,22 @@ void Settings::savePersonal(QString profileName, QString password)
             if (getEnableLogging())
                 ps.setValue("activity", frnd.activity);
 
-            index++;
+            ++index;
+        }
+        ps.endArray();
+    ps.endGroup();
+
+    ps.beginGroup("Requests");
+        ps.setValue("unread", unreadFriendRequests);
+        ps.beginWriteArray("Request", friendRequests.size());
+        index = 0;
+        for (auto& request : friendRequests)
+        {
+            ps.setArrayIndex(index);
+            ps.setValue("addr", request.first);
+            ps.setValue("message", request.second);
+
+            ++index;
         }
         ps.endArray();
     ps.endGroup();
@@ -1377,6 +1407,48 @@ bool Settings::getCircleExpanded(int id) const
 void Settings::setCircleExpanded(int id, bool expanded)
 {
     circleLst[id].expanded = expanded;
+}
+
+void Settings::addFriendRequest(const QString &friendAddress, const QString &message)
+{
+    QMutexLocker locker{&bigLock};
+    QPair<QString, QString> request(friendAddress, message);
+
+    if (friendRequests.indexOf(request) != -1)
+        return;
+
+    friendRequests.push_back(request);
+    ++unreadFriendRequests;
+}
+
+unsigned int Settings::getUnreadFriendRequests() const
+{
+    QMutexLocker locker{&bigLock};
+    return unreadFriendRequests;
+}
+
+QPair<QString, QString> Settings::getFriendRequest(int index) const
+{
+    QMutexLocker locker{&bigLock};
+    return friendRequests.at(index);
+}
+
+int Settings::getFriendRequestSize() const
+{
+    QMutexLocker locker{&bigLock};
+    return friendRequests.size();
+}
+
+void Settings::clearUnreadFriendRequests()
+{
+    QMutexLocker locker{&bigLock};
+    unreadFriendRequests = 0;
+}
+
+void Settings::removeFriendRequest(int index)
+{
+    QMutexLocker locker{&bigLock};
+    friendRequests.removeAt(index);
 }
 
 int Settings::removeCircle(int id)

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -251,6 +251,13 @@ public:
     bool getCircleExpanded(int id) const;
     void setCircleExpanded(int id, bool expanded);
 
+    void addFriendRequest(const QString &friendAddress, const QString &message);
+    unsigned int getUnreadFriendRequests() const;
+    QPair<QString, QString> getFriendRequest(int index) const;
+    int getFriendRequestSize() const;
+    void clearUnreadFriendRequests();
+    void removeFriendRequest(int index);
+
     // Assume all widgets have unique names
     // Don't use it to save every single thing you want to save, use it
     // for some general purpose widgets, such as MainWindows or Splitters,
@@ -326,6 +333,9 @@ private:
     QHash<QString, QString> autoAccept;
     bool autoSaveEnabled;
     QString globalAutoAcceptDir;
+
+    QList<QPair<QString, QString>> friendRequests;
+    unsigned int unreadFriendRequests;
 
     // GUI
     QString smileyPack;

--- a/src/widget/form/addfriendform.cpp
+++ b/src/widget/form/addfriendform.cpp
@@ -45,14 +45,14 @@ AddFriendForm::AddFriendForm()
 
     retranslateUi();
 
-    tabWidget->addTab(main, tr("Add a friend"));
+    tabWidget->addTab(main, QString());
     QScrollArea* scrollArea = new QScrollArea(tabWidget);
     QWidget* requestWidget = new QWidget(tabWidget);
     scrollArea->setWidget(requestWidget);
     scrollArea->setWidgetResizable(true);
     requestsLayout = new QVBoxLayout(requestWidget);
     requestsLayout->addStretch(1);
-    tabWidget->addTab(scrollArea, tr("Friend requests"));
+    tabWidget->addTab(scrollArea, QString());
 
     main->setLayout(&layout);
     layout.addWidget(&toxIdLabel);
@@ -177,14 +177,15 @@ void AddFriendForm::setIdFromClipboard()
             toxId.setText(id);
     }
 }
-#include <QDebug>
+
 void AddFriendForm::onFriendRequestAccepted(QWidget* friendWidget)
 {
     int index = requestsLayout->indexOf(friendWidget);
     friendWidget->deleteLater();
     requestsLayout->removeWidget(friendWidget);
     emit friendRequestAccepted(Settings::getInstance().getFriendRequest(requestsLayout->count() - index - 1).first);
-    qDebug() << "Accepted:" << requestsLayout->count() - index - 1;
+    Settings::getInstance().removeFriendRequest(requestsLayout->count() - index - 1);
+    Settings::getInstance().savePersonal();
 }
 
 void AddFriendForm::onFriendRequestRejected(QWidget* friendWidget)
@@ -194,7 +195,6 @@ void AddFriendForm::onFriendRequestRejected(QWidget* friendWidget)
     requestsLayout->removeWidget(friendWidget);
     Settings::getInstance().removeFriendRequest(requestsLayout->count() - index - 1);
     Settings::getInstance().savePersonal();
-    qDebug() << "Rejected:" << requestsLayout->count() - index - 1;
 }
 
 void AddFriendForm::onCurrentChanged(int index)
@@ -216,6 +216,9 @@ void AddFriendForm::retranslateUi()
     message.setPlaceholderText(tr("%1 here! Tox me maybe?",
                 "Default message in friend requests if the field is left blank. Write something appropriate!")
                 .arg(lastUsername));
+
+    tabWidget->setTabText(0, tr("Add a friend"));
+    tabWidget->setTabText(1, tr("Friend requests"));
 }
 
 void AddFriendForm::addFriendRequestWidget(const QString &friendAddress, const QString &message)
@@ -226,7 +229,7 @@ void AddFriendForm::addFriendRequestWidget(const QString &friendAddress, const Q
     horLayout->setMargin(0);
     friendLayout->addLayout(horLayout);
     CroppingLabel* friendLabel = new CroppingLabel(friendWidget);
-    friendLabel->setText("<b>" "12345678901234567890" "</b>");
+    friendLabel->setText("<b>" + friendAddress + "</b>");
     horLayout->addWidget(friendLabel);
     QLabel* messageLabel = new QLabel(message);
     messageLabel->setWordWrap(true);

--- a/src/widget/form/addfriendform.cpp
+++ b/src/widget/form/addfriendform.cpp
@@ -23,6 +23,8 @@
 #include <QMessageBox>
 #include <QErrorMessage>
 #include <QClipboard>
+#include <QTabWidget>
+#include <QSignalMapper>
 #include <tox/tox.h>
 #include "ui_mainwindow.h"
 #include "src/nexus.h"
@@ -35,12 +37,22 @@
 
 AddFriendForm::AddFriendForm()
 {
-    main = new QWidget(), head = new QWidget();
+    tabWidget = new QTabWidget();
+    main = new QWidget(tabWidget), head = new QWidget();
     QFont bold;
     bold.setBold(true);
     headLabel.setFont(bold);
 
     retranslateUi();
+
+    tabWidget->addTab(main, tr("Add a friend"));
+    QScrollArea* scrollArea = new QScrollArea(tabWidget);
+    QWidget* requestWidget = new QWidget(tabWidget);
+    scrollArea->setWidget(requestWidget);
+    scrollArea->setWidgetResizable(true);
+    requestsLayout = new QVBoxLayout(requestWidget);
+    requestsLayout->addStretch(1);
+    tabWidget->addTab(scrollArea, tr("Friend requests"));
 
     main->setLayout(&layout);
     layout.addWidget(&toxIdLabel);
@@ -52,25 +64,38 @@ AddFriendForm::AddFriendForm()
     head->setLayout(&headLayout);
     headLayout.addWidget(&headLabel);
 
+    connect(tabWidget, &QTabWidget::currentChanged, this, &AddFriendForm::onCurrentChanged);
     connect(&toxId,&QLineEdit::returnPressed, this, &AddFriendForm::onSendTriggered);
     connect(&sendButton, SIGNAL(clicked()), this, SLOT(onSendTriggered()));
     connect(Nexus::getCore(), &Core::usernameSet, this, &AddFriendForm::onUsernameSet);
 
     Translator::registerHandler(std::bind(&AddFriendForm::retranslateUi, this), this);
+
+    acceptMapper = new QSignalMapper(requestWidget);
+    rejectMapper = new QSignalMapper(requestWidget);
+    connect(acceptMapper, SIGNAL(mapped(QWidget*)), this, SLOT(onFriendRequestAccepted(QWidget*)));
+    connect(rejectMapper, SIGNAL(mapped(QWidget*)), this, SLOT(onFriendRequestRejected(QWidget*)));
+    int size = Settings::getInstance().getFriendRequestSize();
+
+    for (int i = 0; i < size; ++i)
+    {
+        QPair<QString, QString> request = Settings::getInstance().getFriendRequest(i);
+        addFriendRequestWidget(request.first, request.second);
+    }
 }
 
 AddFriendForm::~AddFriendForm()
 {
     Translator::unregister(this);
     head->deleteLater();
-    main->deleteLater();
+    tabWidget->deleteLater();
 }
 
 void AddFriendForm::show(Ui::MainWindow &ui)
 {
-    ui.mainContent->layout()->addWidget(main);
+    ui.mainContent->layout()->addWidget(tabWidget);
     ui.mainHead->layout()->addWidget(head);
-    main->show();
+    tabWidget->show();
     head->show();
     setIdFromClipboard();
     toxId.setFocus();
@@ -80,6 +105,18 @@ QString AddFriendForm::getMessage() const
 {
     const QString msg = message.toPlainText();
     return !msg.isEmpty() ? msg : message.placeholderText();
+}
+
+void AddFriendForm::setMode(Mode mode)
+{
+    tabWidget->setCurrentIndex(mode);
+}
+
+void AddFriendForm::addFriendRequest(const QString &friendAddress, const QString &message)
+{
+    addFriendRequestWidget(friendAddress, message);
+    Settings::getInstance().addFriendRequest(friendAddress, message);
+    onCurrentChanged(tabWidget->currentIndex());
 }
 
 void AddFriendForm::onUsernameSet(const QString& username)
@@ -140,6 +177,35 @@ void AddFriendForm::setIdFromClipboard()
             toxId.setText(id);
     }
 }
+#include <QDebug>
+void AddFriendForm::onFriendRequestAccepted(QWidget* friendWidget)
+{
+    int index = requestsLayout->indexOf(friendWidget);
+    friendWidget->deleteLater();
+    requestsLayout->removeWidget(friendWidget);
+    emit friendRequestAccepted(Settings::getInstance().getFriendRequest(requestsLayout->count() - index - 1).first);
+    qDebug() << "Accepted:" << requestsLayout->count() - index - 1;
+}
+
+void AddFriendForm::onFriendRequestRejected(QWidget* friendWidget)
+{
+    int index = requestsLayout->indexOf(friendWidget);
+    friendWidget->deleteLater();
+    requestsLayout->removeWidget(friendWidget);
+    Settings::getInstance().removeFriendRequest(requestsLayout->count() - index - 1);
+    Settings::getInstance().savePersonal();
+    qDebug() << "Rejected:" << requestsLayout->count() - index - 1;
+}
+
+void AddFriendForm::onCurrentChanged(int index)
+{
+    if (index == FriendRequest && Settings::getInstance().getUnreadFriendRequests() != 0)
+    {
+        Settings::getInstance().clearUnreadFriendRequests();
+        Settings::getInstance().savePersonal();
+        emit friendRequestsSeen();
+    }
+}
 
 void AddFriendForm::retranslateUi()
 {
@@ -150,4 +216,28 @@ void AddFriendForm::retranslateUi()
     message.setPlaceholderText(tr("%1 here! Tox me maybe?",
                 "Default message in friend requests if the field is left blank. Write something appropriate!")
                 .arg(lastUsername));
+}
+
+void AddFriendForm::addFriendRequestWidget(const QString &friendAddress, const QString &message)
+{
+    QWidget* friendWidget = new QWidget(tabWidget);
+    QHBoxLayout* friendLayout = new QHBoxLayout(friendWidget);
+    QVBoxLayout* horLayout = new QVBoxLayout();
+    horLayout->setMargin(0);
+    friendLayout->addLayout(horLayout);
+    CroppingLabel* friendLabel = new CroppingLabel(friendWidget);
+    friendLabel->setText("<b>" "12345678901234567890" "</b>");
+    horLayout->addWidget(friendLabel);
+    QLabel* messageLabel = new QLabel(message);
+    messageLabel->setWordWrap(true);
+    horLayout->addWidget(messageLabel, 1);
+    QPushButton* acceptButton = new QPushButton(tr("Accept"));
+    connect(acceptButton, SIGNAL(pressed()), acceptMapper,SLOT(map()));
+    acceptMapper->setMapping(acceptButton, friendWidget);
+    friendLayout->addWidget(acceptButton);
+    QPushButton* rejectButton = new QPushButton(tr("Reject"));
+    connect(rejectButton, SIGNAL(pressed()), rejectMapper,SLOT(map()));
+    rejectMapper->setMapping(rejectButton, friendWidget);
+    friendLayout->addWidget(rejectButton);
+    requestsLayout->insertWidget(0, friendWidget);
 }

--- a/src/widget/form/addfriendform.h
+++ b/src/widget/form/addfriendform.h
@@ -38,7 +38,8 @@ public:
     enum Mode
     {
         AddFriend = 0,
-        FriendRequest = 1
+        FriendRequest = 1,
+        GroupInvite = 2
     };
 
     AddFriendForm();

--- a/src/widget/form/addfriendform.h
+++ b/src/widget/form/addfriendform.h
@@ -25,9 +25,9 @@
 #include <QLineEdit>
 #include <QTextEdit>
 #include <QPushButton>
+#include <QSet>
 
 class QTabWidget;
-class QSignalMapper;
 
 namespace Ui {class MainWindow;}
 
@@ -63,13 +63,15 @@ public slots:
 
 private slots:
     void onSendTriggered();
-    void onFriendRequestAccepted(QWidget *friendWidget);
-    void onFriendRequestRejected(QWidget *friendWidget);
+    void onFriendRequestAccepted();
+    void onFriendRequestRejected();
     void onCurrentChanged(int index);
 
 private:
     void retranslateUi();
     void addFriendRequestWidget(const QString& friendAddress, const QString& message);
+    void retranslateAcceptButton(QPushButton* acceptButton);
+    void retranslateRejectButton(QPushButton* rejectButton);
 
 private:
     void setIdFromClipboard();
@@ -82,8 +84,8 @@ private:
     QString lastUsername; // Cached username so we can retranslate the invite message
     QTabWidget* tabWidget;
     QVBoxLayout* requestsLayout;
-    QSignalMapper* acceptMapper;
-    QSignalMapper* rejectMapper;
+    QSet<QPushButton*> acceptButtons;
+    QSet<QPushButton*> rejectButtons;
 };
 
 #endif // ADDFRIENDFORM_H

--- a/src/widget/form/addfriendform.h
+++ b/src/widget/form/addfriendform.h
@@ -26,12 +26,21 @@
 #include <QTextEdit>
 #include <QPushButton>
 
+class QTabWidget;
+class QSignalMapper;
+
 namespace Ui {class MainWindow;}
 
 class AddFriendForm : public QObject
 {
     Q_OBJECT
 public:
+    enum Mode
+    {
+        AddFriend = 0,
+        FriendRequest = 1
+    };
+
     AddFriendForm();
     AddFriendForm(const AddFriendForm&) = delete;
     AddFriendForm& operator=(const AddFriendForm&) = delete;
@@ -39,18 +48,27 @@ public:
 
     void show(Ui::MainWindow &ui);
     QString getMessage() const;
+    void setMode(Mode mode);
+
+    void addFriendRequest(const QString& friendAddress, const QString& message);
 
 signals:
     void friendRequested(const QString& friendAddress, const QString& message);
+    void friendRequestAccepted(const QString& friendAddress);
+    void friendRequestsSeen();
 
 public slots:
     void onUsernameSet(const QString& userName);
 
 private slots:
     void onSendTriggered();
+    void onFriendRequestAccepted(QWidget *friendWidget);
+    void onFriendRequestRejected(QWidget *friendWidget);
+    void onCurrentChanged(int index);
 
 private:
     void retranslateUi();
+    void addFriendRequestWidget(const QString& friendAddress, const QString& message);
 
 private:
     void setIdFromClipboard();
@@ -61,6 +79,10 @@ private:
     QVBoxLayout layout, headLayout;
     QWidget *head, *main;
     QString lastUsername; // Cached username so we can retranslate the invite message
+    QTabWidget* tabWidget;
+    QVBoxLayout* requestsLayout;
+    QSignalMapper* acceptMapper;
+    QSignalMapper* rejectMapper;
 };
 
 #endif // ADDFRIENDFORM_H

--- a/src/widget/form/groupinviteform.h
+++ b/src/widget/form/groupinviteform.h
@@ -1,0 +1,75 @@
+/*
+    Copyright © 2015 by The qTox Project
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef GROUPINVITEFORM_H
+#define GROUPINVITEFORM_H
+
+#include <QWidget>
+
+class QLabel;
+class QVBoxLayout;
+class QPushButton;
+class QGroupBox;
+class QSignalMapper;
+
+namespace Ui {class MainWindow;}
+
+class GroupInviteForm : public QWidget
+{
+    Q_OBJECT
+public:
+    GroupInviteForm();
+
+    void show(Ui::MainWindow &ui);
+    void addGroupInvite(int32_t friendId, uint8_t type, QByteArray invite);
+
+signals:
+    void groupCreate(uint8_t type);
+    void groupInviteAccepted(int32_t friendId, uint8_t type, QByteArray invite);
+    void groupInvitesSeen();
+
+protected:
+    void showEvent(QShowEvent* event) final override;
+
+private slots:
+    void onGroupInviteAccepted(QWidget* groupWidget);
+    void onGroupInviteRejected(QWidget* groupWidget);
+
+private:
+    void retranslateUi();
+
+private:
+    struct GroupInvite
+    {
+        int32_t friendId;
+        uint8_t type;
+        QByteArray invite;
+    };
+
+    QWidget* headWidget;
+    QLabel* headLabel;
+    QPushButton* createButton;
+    QGroupBox* inviteBox;
+    QVBoxLayout* inviteLayout;
+    QSignalMapper* acceptMapper;
+    QSignalMapper* rejectMapper;
+    QList<GroupInvite> groupInvites;
+};
+
+#endif // GROUPINVITEFORM_H

--- a/src/widget/form/groupinviteform.h
+++ b/src/widget/form/groupinviteform.h
@@ -21,6 +21,7 @@
 #define GROUPINVITEFORM_H
 
 #include <QWidget>
+#include <QSet>
 
 class QLabel;
 class QVBoxLayout;
@@ -48,11 +49,13 @@ protected:
     void showEvent(QShowEvent* event) final override;
 
 private slots:
-    void onGroupInviteAccepted(QWidget* groupWidget);
-    void onGroupInviteRejected(QWidget* groupWidget);
+    void onGroupInviteAccepted();
+    void onGroupInviteRejected();
 
 private:
     void retranslateUi();
+    void retranslateAcceptButton(QPushButton* acceptButton);
+    void retranslateRejectButton(QPushButton* rejectButton);
 
 private:
     struct GroupInvite
@@ -67,8 +70,8 @@ private:
     QPushButton* createButton;
     QGroupBox* inviteBox;
     QVBoxLayout* inviteLayout;
-    QSignalMapper* acceptMapper;
-    QSignalMapper* rejectMapper;
+    QSet<QPushButton*> acceptButtons;
+    QSet<QPushButton*> rejectButtons;
     QList<GroupInvite> groupInvites;
 };
 

--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -68,16 +68,15 @@ void FriendWidget::contextMenuEvent(QContextMenuEvent * event)
     QString dir = Settings::getInstance().getAutoAcceptDir(id);
     QMenu menu;
     QMenu* inviteMenu = menu.addMenu(tr("Invite to group","Menu to invite a friend to a groupchat"));
+    QAction* newGroupAction = inviteMenu->addAction(tr("To new group"));
+    inviteMenu->addSeparator();
     QMap<QAction*, Group*> groupActions;
 
     for (Group* group : GroupList::getAllGroups())
     {
-        QAction* groupAction = inviteMenu->addAction(group->getGroupWidget()->getName());
+        QAction* groupAction = inviteMenu->addAction(tr("Invite to group '%1'").arg(group->getGroupWidget()->getName()));
         groupActions[groupAction] =  group;
     }
-
-    if (groupActions.isEmpty())
-        inviteMenu->setEnabled(false);
 
     int circleId = Settings::getInstance().getFriendCircleID(FriendList::findFriend(friendId)->getToxId());
     CircleWidget *circleWidget = CircleWidget::getFromID(circleId);
@@ -173,6 +172,11 @@ void FriendWidget::contextMenuEvent(QContextMenuEvent * event)
                 qDebug() << "setting auto accept dir for" << friendId << "to" << dir;
                 Settings::getInstance().setAutoAcceptDir(id, dir);
             }
+        }
+        else if (selectedItem == newGroupAction)
+        {
+            int groupId = Core::getInstance()->createGroup();
+            Core::getInstance()->groupInviteFriend(friendId, groupId);
         }
         else if (selectedItem == newCircleAction)
         {

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -336,6 +336,7 @@ void Widget::init()
     addFriendForm->show(*ui);
     setWindowTitle(tr("Add friend"));
     ui->addButton->setCheckable(true);
+    ui->groupButton->setCheckable(true);
     ui->transferButton->setCheckable(true);
     ui->settingsButton->setCheckable(true);
     setActiveToolMenuButton(Widget::AddButton);

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -49,6 +49,7 @@ class FilesForm;
 class ProfileForm;
 class SettingsWidget;
 class AddFriendForm;
+class GroupInviteForm;
 class CircleWidget;
 class QActionGroup;
 class QPushButton;
@@ -112,6 +113,7 @@ public slots:
     void onReceiptRecieved(int friendId, int receipt);
     void onEmptyGroupCreated(int groupId);
     void onGroupInviteReceived(int32_t friendId, uint8_t type, QByteArray invite);
+    void onGroupInviteAccepted(int32_t friendId, uint8_t type, QByteArray invite);
     void onGroupMessageReceived(int groupnumber, int peernumber, const QString& message, bool isAction);
     void onGroupNamelistChanged(int groupnumber, int peernumber, uint8_t change);
     void onGroupTitleChanged(int groupnumber, const QString& author, const QString& title);
@@ -162,6 +164,8 @@ private slots:
     void friendListContextMenu(const QPoint &pos);
     void friendRequestRecieved(const QString& friendAddress, const QString& message);
     void friendRequestsUpdate();
+    void groupInvitesUpdate();
+    void groupInvitesClear();
 
 #ifdef Q_OS_MAC
     void bringAllToFront();
@@ -229,6 +233,7 @@ private:
     QSplitter *centralLayout;
     QPoint dragPosition;
     AddFriendForm *addFriendForm;
+    GroupInviteForm* groupInviteForm;
     ProfileForm *profileForm;
     SettingsWidget *settingsWidget;
     FilesForm *filesForm;
@@ -245,6 +250,8 @@ private:
     bool eventIcon;
     bool wasMaximized = false;
     QPushButton* friendRequestsButton;
+    QPushButton* groupInvitesButton;
+    unsigned int unreadGroupInvites;
 
 #ifdef Q_OS_MAC
     QAction* fullscreenAction;

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -51,6 +51,7 @@ class SettingsWidget;
 class AddFriendForm;
 class CircleWidget;
 class QActionGroup;
+class QPushButton;
 
 class Widget final : public QMainWindow
 {
@@ -159,6 +160,8 @@ private slots:
     void onSplitterMoved(int pos, int index);
     void processOfflineMsgs();
     void friendListContextMenu(const QPoint &pos);
+    void friendRequestRecieved(const QString& friendAddress, const QString& message);
+    void friendRequestsUpdate();
 
 #ifdef Q_OS_MAC
     void bringAllToFront();
@@ -241,6 +244,7 @@ private:
     bool eventFlag;
     bool eventIcon;
     bool wasMaximized = false;
+    QPushButton* friendRequestsButton;
 
 #ifdef Q_OS_MAC
     QAction* fullscreenAction;

--- a/ui/window/statusPanel.css
+++ b/ui/window/statusPanel.css
@@ -25,6 +25,26 @@ QToolButton::menu-indicator {
     image: none
 }
 
+QPushButton#green {
+    background: none;
+    background-color: #6bc260;
+    color: white;
+    border-style: none;
+    border-radius: 4px;
+    padding: 4px;
+    margin: 4px 8px;
+}
+
+QPushButton#green:hover
+{
+    background-color: #79c76f;
+}
+
+QPushButton#green:pressed
+{
+    background-color: #51b244;
+}
+
 /**
   Uncomment this after https://github.com/tux3/qTox/pull/1640
   is merged!
@@ -96,3 +116,4 @@ QListView {
   position: relative;
   bottom: 2px;
 }
+


### PR DESCRIPTION
This PR replaces the current dialogs for friend requests and group invites and adds a button that brings you to a screen that lets you see current requests.

Friend requests are saved, so you can accept or reject a friend any time you want. It is now available under the "Add friend" button.

Group invites are only saved until you close qTox. This can change in the future, e.g. when Toxcore gets new group API merged and groups are persistent. Invites are now viewable under the "Add group" button. To compensate that the "Add group" button now takes you to a new screen instead of adding a new group immediately, I've added new context menus. You can right click on an empty portion of the friends list to create a new group or you can right click on a friend and immediately create and invite them to a group simultaneously.
