### PR TITLE
Add OpenSUSE to simple_make.sh

### DIFF
--- a/simple_make.sh
+++ b/simple_make.sh
@@ -19,12 +19,20 @@ elif which dnf; then
         openal-soft-devel libXScrnSaver-devel qrencode-devel \
         opus-devel libvpx-devel qt5-qttools-devel glib2-devel \
         gdk-pixbuf2-devel gtk2-devel
+elif which zypper; then
+    sudo zypper in \
+	git patterns-openSUSE-devel_basis libqt5-qtbase-common-devel \
+	libqt5-qtsvg-devel libqt5-linguist libQt5Network-devel \
+	libQt5OpenGL-devel libQt5Concurrent-devel libQt5Xml-devel \
+	libQt5Sql-devel openal-soft-devel qrencode-devel \
+	libXScrnSaver-devel libQt5Sql5-sqlite libffmpeg-devel \
+	libsodium-devel libvpx-devel libopus-devel patterns-openSUSE-devel_basis
 else
     echo "Unknown package manager, attempting to compile anyways"
 fi
 
 ./bootstrap.sh
-if [ -e /etc/redhat-release ]; then
+if [ -e /etc/redhat-release -o -e /etc/zypp ]; then
     qmake-qt5
 else
     qmake


### PR DESCRIPTION
Not too happy with: " -e /etc/redhat-release -o -e /etc/zypp " for the qmake-qt5. 
Something similar could be done for Arch and _maybe_ Void. I'll add to this when i get an Arch and a Void install up and running.
