### PR TITLE
Simple way to make sure the old name remains known until user intervention

### DIFF
--- a/src/friend.cpp
+++ b/src/friend.cpp
@@ -60,27 +60,24 @@ void Friend::setName(QString name)
 {
     userName = name;
     if (userAlias.size() == 0)
-    {
-        widget->setName(name);
-        chatForm->setName(name);
-
-        if (widget->isActive())
-            GUI::setWindowTitle(name);
-
+    {   setAlias(name); }
+    else
+    {   widget->setName(userAlias, userAlias == userName ? "" : userName);
         emit displayedNameChanged(getFriendWidget(), getStatus(), hasNewEvents);
     }
 }
 
 void Friend::setAlias(QString name)
 {
+    if( name == "" )
+    {   name = userName; }
     userAlias = name;
-    QString dispName = userAlias.size() == 0 ? userName : userAlias;
+    widget->setName(userAlias, userAlias == userName ? "" : userName);
 
-    widget->setName(dispName);
-    chatForm->setName(dispName);
+    chatForm->setName(userAlias);
 
     if (widget->isActive())
-            GUI::setWindowTitle(dispName);
+        GUI::setWindowTitle(userAlias);
 
     emit displayedNameChanged(getFriendWidget(), getStatus(), hasNewEvents);
 }

--- a/src/widget/genericchatroomwidget.cpp
+++ b/src/widget/genericchatroomwidget.cpp
@@ -129,9 +129,9 @@ void GenericChatroomWidget::setActive(bool _active)
     }
 }
 
-void GenericChatroomWidget::setName(const QString &name)
+void GenericChatroomWidget::setName(const QString &name, const QString &minor_name)
 {
-    nameLabel->setText(name);
+    nameLabel->setText(minor_name == "" ? name : (name + " | " + minor_name));
 }
 
 void GenericChatroomWidget::setStatusMsg(const QString &status)

--- a/src/widget/genericchatroomwidget.h
+++ b/src/widget/genericchatroomwidget.h
@@ -51,7 +51,7 @@ public:
     bool isActive();
     void setActive(bool active);
 
-    void setName(const QString& name);
+    void setName(const QString &name, const QString &minor_name="");
     void setStatusMsg(const QString& status);
     QString getStatusMsg() const;
     QString getTitle() const;


### PR DESCRIPTION
Name changes set the alias aswel if the alias is empty. Otherwise, it just sets the name.

Both alias and name are shown, if they differ.  `alias | name` and `name` if they're the same.

Simply by doing strings that way, presumably you want two labels next to each other in that case?

Perhaps we might also want to know why the alias is what it is. If there is an alias and a name due to name change, there could be an "accept name".

Basically it is the idea of #1195, goal is merely to ensure that whenever the name changes, you can see the alias or the older name, so that you can piece it together manually. Keeping histories like #1189 and #659 are relevant, but this isnt intended to take it that far.
