### PR TITLE
More consistent translation strings in groupchatform.cpp

### DIFF
--- a/src/widget/form/groupchatform.cpp
+++ b/src/widget/form/groupchatform.cpp
@@ -164,7 +164,7 @@ void GroupChatForm::onSendTriggered()
 
 void GroupChatForm::onUserListChanged()
 {
-    nusersLabel->setText(tr("%1 users in chat").arg(group->getPeersCount()));
+    nusersLabel->setText(tr("%1 users in chat", "Number of users in chat").arg(group->getPeersCount()));
 
     QLayoutItem *child;
     while ((child = namesListLayout->takeAt(0)))
@@ -367,5 +367,5 @@ void GroupChatForm::keyReleaseEvent(QKeyEvent* ev)
 
 void GroupChatForm::retranslateUi()
 {
-    nusersLabel->setText(GroupChatForm::tr("%1 users in chat","Number of users in chat").arg(group->getPeersCount()));
+    nusersLabel->setText(GroupChatForm::tr("%1 users in chat", "Number of users in chat").arg(group->getPeersCount()));
 }


### PR DESCRIPTION
It should not be able to be translated differently as one update when the number of user in the group chat change and the other is when language change, so it should be translated together.

https://github.com/tux3/qTox/blob/f8352d63ff17bbb551fc575252b747ac95208b99/src/widget/form/groupchatform.cpp#L167
https://github.com/tux3/qTox/blob/f8352d63ff17bbb551fc575252b747ac95208b99/src/widget/form/groupchatform.cpp#L370
