### PR TITLE
correct screenshot tooltip

### DIFF
--- a/src/widget/tool/toolboxgraphicsitem.cpp
+++ b/src/widget/tool/toolboxgraphicsitem.cpp
@@ -29,7 +29,7 @@ ToolBoxGraphicsItem::ToolBoxGraphicsItem()
     this->opacityAnimation->setKeyValueAt(1, this->activeOpacity);
     this->opacityAnimation->setDuration(this->fadeTimeMs);
 
-    setOpacity(this->idleOpacity);
+    setOpacity(this->activeOpacity);
 }
 
 ToolBoxGraphicsItem::~ToolBoxGraphicsItem()
@@ -39,13 +39,13 @@ ToolBoxGraphicsItem::~ToolBoxGraphicsItem()
 
 void ToolBoxGraphicsItem::hoverEnterEvent(QGraphicsSceneHoverEvent* event)
 {
-    startAnimation(QAbstractAnimation::Forward);
+    startAnimation(QAbstractAnimation::Backward);
     QGraphicsItemGroup::hoverEnterEvent(event);
 }
 
 void ToolBoxGraphicsItem::hoverLeaveEvent(QGraphicsSceneHoverEvent* event)
 {
-    startAnimation(QAbstractAnimation::Backward);
+    startAnimation(QAbstractAnimation::Forward);
     QGraphicsItemGroup::hoverLeaveEvent(event);
 }
 

--- a/src/widget/tool/toolboxgraphicsitem.h
+++ b/src/widget/tool/toolboxgraphicsitem.h
@@ -43,7 +43,7 @@ private:
     void startAnimation(QAbstractAnimation::Direction direction);
 
     QPropertyAnimation* opacityAnimation;
-    qreal idleOpacity = 0.7f;
+    qreal idleOpacity = 0.0f;
     qreal activeOpacity = 1.0f;
     int fadeTimeMs = 300;
 };


### PR DESCRIPTION
fix #2267
has made the message disappears when the cursor is over it
