### PR TITLE
Made the 'remove friend dialog' user-friendly again

### DIFF
--- a/src/widget/form/removefrienddialog.ui
+++ b/src/widget/form/removefrienddialog.ui
@@ -46,7 +46,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::No|QDialogButtonBox::Yes</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>

--- a/src/widget/form/removefrienddialog.ui
+++ b/src/widget/form/removefrienddialog.ui
@@ -7,8 +7,14 @@
     <x>0</x>
     <y>0</y>
     <width>300</width>
-    <height>180</height>
+    <height>110</height>
    </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>300</width>
+    <height>110</height>
+   </size>
   </property>
   <property name="windowTitle">
    <string>Remove friend</string>
@@ -28,19 +34,6 @@
     </widget>
    </item>
    <item>
-    <widget class="QLineEdit" name="yes">
-     <property name="text">
-      <string/>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
-     </property>
-     <property name="placeholderText">
-      <string>YES</string>
-     </property>
-    </widget>
-   </item>
-   <item>
     <widget class="QCheckBox" name="removeHistory">
      <property name="text">
       <string>Also remove chat history</string>
@@ -53,7 +46,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::No|QDialogButtonBox::Yes</set>
      </property>
     </widget>
    </item>

--- a/src/widget/tool/removefrienddialog.cpp
+++ b/src/widget/tool/removefrienddialog.cpp
@@ -10,7 +10,9 @@ RemoveFriendDialog::RemoveFriendDialog(QWidget *parent, const Friend *f)
     ui.setupUi(this);
     ui.label->setText(ui.label->text().replace("&lt;name&gt;", f->getDisplayedName()));
     auto removeButton = ui.buttonBox->button(QDialogButtonBox::Ok);
+    auto cancelButton = ui.buttonBox->button(QDialogButtonBox::Cancel);
     removeButton->setText(tr("Remove"));
+    cancelButton->setDefault(true);
     adjustSize();
     connect(ui.buttonBox, &QDialogButtonBox::accepted, this, &RemoveFriendDialog::onAccepted);
     connect(ui.buttonBox, &QDialogButtonBox::rejected, this, &RemoveFriendDialog::close);

--- a/src/widget/tool/removefrienddialog.cpp
+++ b/src/widget/tool/removefrienddialog.cpp
@@ -9,10 +9,7 @@ RemoveFriendDialog::RemoveFriendDialog(QWidget *parent, const Friend *f)
     setAttribute(Qt::WA_QuitOnClose, false);
     ui.setupUi(this);
     ui.label->setText(ui.label->text().replace("&lt;name&gt;", f->getDisplayedName()));
-    auto removeButton = ui.buttonBox->button(QDialogButtonBox::Ok);
-    removeButton->setEnabled(false);
-    removeButton->setText(tr("Remove"));
-    connect(ui.yes, &QLineEdit::textChanged, this, &RemoveFriendDialog::onTextChanged);
+    adjustSize();
     connect(ui.buttonBox, &QDialogButtonBox::accepted, this, &RemoveFriendDialog::onAccepted);
     connect(ui.buttonBox, &QDialogButtonBox::rejected, this, &RemoveFriendDialog::close);
     setFocus();
@@ -23,9 +20,3 @@ void RemoveFriendDialog::onAccepted()
     _accepted = true;
     close();
 }
-
-void RemoveFriendDialog::onTextChanged(QString text)
-{
-    ui.buttonBox->button(QDialogButtonBox::Ok)->setEnabled(text == ui.yes->placeholderText());
-}
-

--- a/src/widget/tool/removefrienddialog.cpp
+++ b/src/widget/tool/removefrienddialog.cpp
@@ -9,6 +9,8 @@ RemoveFriendDialog::RemoveFriendDialog(QWidget *parent, const Friend *f)
     setAttribute(Qt::WA_QuitOnClose, false);
     ui.setupUi(this);
     ui.label->setText(ui.label->text().replace("&lt;name&gt;", f->getDisplayedName()));
+    auto removeButton = ui.buttonBox->button(QDialogButtonBox::Ok);
+    removeButton->setText(tr("Remove"));
     adjustSize();
     connect(ui.buttonBox, &QDialogButtonBox::accepted, this, &RemoveFriendDialog::onAccepted);
     connect(ui.buttonBox, &QDialogButtonBox::rejected, this, &RemoveFriendDialog::close);

--- a/src/widget/tool/removefrienddialog.h
+++ b/src/widget/tool/removefrienddialog.h
@@ -25,7 +25,6 @@ public:
 
 public slots:
     void onAccepted();
-    void onTextChanged(QString text);
 
 protected:
     Ui_RemoveFriendDialog ui;


### PR DESCRIPTION
#1961 changed the friend removal dialog in a way that hurts the UX, this pull request fixes that.

Here's what it will look like:

<img src="https://impy.me/i/275513.png"/>
- 'No' does not take any action at all.
- 'No' is focused by default, making accidental deletion harder.
- 'Yes' removes the friend from the friend list but also removes chat history if the checkbox is checked.

This should also fix #2281.
