### PR TITLE
Fix audio not working on 64-bit windows with non-latin audio device names

### DIFF
--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -264,7 +264,7 @@ void AVForm::getAudioInDevices()
         while (*pDeviceList)
         {
             int len = strlen(pDeviceList);
-#ifdef Q_OS_WIN32
+#ifdef Q_OS_WIN
             QString inDev = QString::fromUtf8(pDeviceList,len);
 #else
 			QString inDev = QString::fromLocal8Bit(pDeviceList,len);
@@ -298,7 +298,7 @@ void AVForm::getAudioOutDevices()
         while (*pDeviceList)
         {
             int len = strlen(pDeviceList);
-#ifdef Q_OS_WIN32
+#ifdef Q_OS_WIN
             QString outDev = QString::fromUtf8(pDeviceList,len);
 #else
 			QString outDev = QString::fromLocal8Bit(pDeviceList,len);


### PR DESCRIPTION
properly fixes #816
