### PR TITLE
Load user status from data file

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -838,6 +838,11 @@ QString Core::getStatusMessage() const
     return sname;
 }
 
+Status Core::getStatus() const
+{
+    return (Status)tox_self_get_status(tox);
+}
+
 void Core::setStatusMessage(const QString& message)
 {
     CString cMessage(message);

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -77,6 +77,7 @@ public:
     QString getIDString() const; ///< Get the 12 first characters of our Tox ID
 
     QString getUsername() const; ///< Returns our username, or an empty string on failure
+    Status getStatus() const; ///< Returns our user status
     QString getStatusMessage() const; ///< Returns our status message, or an empty string on failure
     ToxId getSelfId() const; ///< Returns our Tox ID
     QPair<QByteArray, QByteArray> getKeypair() const; ///< Returns our public and private keys

--- a/src/widget/form/settings/generalform.cpp
+++ b/src/widget/form/settings/generalform.cpp
@@ -360,10 +360,15 @@ void GeneralForm::onUseProxyUpdated()
 void GeneralForm::onReconnectClicked()
 {
     if (Core::getInstance()->anyActiveCalls())
+    {
         QMessageBox::warning(this, tr("Call active", "popup title"),
                         tr("You can't disconnect while a call is active!", "popup text"));
+    }
     else
+    {
+        emit Core::getInstance()->statusSet(Status::Offline);
         Nexus::getProfile()->restartCore();
+    }
 }
 
 void GeneralForm::reloadSmiles()

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -499,15 +499,11 @@ void Widget::onSelfAvatarLoaded(const QPixmap& pic)
 void Widget::onConnected()
 {
     ui->statusButton->setEnabled(true);
-    if (beforeDisconnect == Status::Offline)
-        emit statusSet(Status::Online);
-    else
-        emit statusSet(beforeDisconnect);
+    emit statusSet(Nexus::getCore()->getStatus());
 }
 
 void Widget::onDisconnected()
 {
-    beforeDisconnect = getStatusFromString(ui->statusButton->property("status").toString());
     ui->statusButton->setEnabled(false);
     emit statusSet(Status::Offline);
 }

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -253,7 +253,6 @@ private:
     MaskablePixmapWidget *profilePicture;
     bool notify(QObject *receiver, QEvent *event);
     bool autoAwayActive = false;
-    Status beforeDisconnect = Status::Offline;
     QTimer *timer, *offlineMsgTimer;
     QRegExp nameMention, sanitizedNameMention;
     bool eventFlag;


### PR DESCRIPTION
Toxcore saves the user status, let's make use of that.

This also fixes a small issue where the status icon wouldn't be changed to offline when 'Reconnect' is pressed.
