### PR TITLE
Display correclty what the user write and open correctly link with 'http://'

### DIFF
--- a/src/chatlog/chatmessage.cpp
+++ b/src/chatlog/chatmessage.cpp
@@ -204,10 +204,12 @@ QString ChatMessage::detectAnchors(const QString &str)
                 offset += url.length();
                 continue;
             }
+            QString htmledUrl;
             // add scheme if not specified
             if (exp.cap(2) == "www.")
-                url.prepend("http://");
-            QString htmledUrl = QString("<a href=\"%1\">%1</a>").arg(url);
+                htmledUrl = QString("<a href=\"http://%1\">%1</a>").arg(url);
+            else
+                htmledUrl = QString("<a href=\"%1\">%1</a>").arg(url);
             out.replace(offset, exp.cap().length(), htmledUrl);
             offset += htmledUrl.length();
         }


### PR DESCRIPTION
I think if user write www.example.com it display www.example.com but it create the link 'http://www.example.com'.
Can someone check if this is right?
