### PR TITLE
Fixed #2294

### DIFF
--- a/src/widget/form/settings/generalform.cpp
+++ b/src/widget/form/settings/generalform.cpp
@@ -479,5 +479,7 @@ bool GeneralForm::eventFilter(QObject *o, QEvent *e)
 
 void GeneralForm::retranslateUi()
 {
+    int proxyType = bodyUI->proxyType->currentIndex();
     bodyUI->retranslateUi(this);
+    bodyUI->proxyType->setCurrentIndex(proxyType);
 }


### PR DESCRIPTION
If someone can think of a cleaner way to do this, please tell me.

Note: the same issue as #2294 will occur again if we ever add another combobox with items we want to translate dynamically.
