### PR TITLE
Login page: make "Create" and "Load" buttons use darker green

### DIFF
--- a/src/loginscreen.ui
+++ b/src/loginscreen.ui
@@ -638,7 +638,7 @@ margin-bottom:45px;</string>
               <string notr="true">border-radius:5px;
 padding:5px;
 color:white;
-background-color:#6cc865;</string>
+background-color:#42a33a;</string>
              </property>
              <property name="text">
               <string>Create Profile</string>
@@ -1003,7 +1003,7 @@ margin-bottom:5px;</string>
               <string notr="true">border-radius:5px;
 padding:5px;
 color:white;
-background-color:#6cc865;</string>
+background-color:#42a33a;</string>
              </property>
              <property name="text">
               <string>Load</string>


### PR DESCRIPTION
Change should make it easier to read text.

fixes #2333

Before:
![before](https://cloud.githubusercontent.com/assets/3148759/10410244/8c8f1b08-6f33-11e5-9176-172f6e647586.png)

Change:
![change](https://cloud.githubusercontent.com/assets/3148759/10410245/9420c2ea-6f33-11e5-9ded-0244be369464.png)

![next to](https://cloud.githubusercontent.com/assets/3148759/10410247/a0993c28-6f33-11e5-918e-31b16924f3df.png)
