### PR TITLE
Fix displaying Pub key when name empty

### DIFF
--- a/src/friend.cpp
+++ b/src/friend.cpp
@@ -58,6 +58,9 @@ void Friend::loadHistory()
 
 void Friend::setName(QString name)
 {
+   if (name.isEmpty())
+       name = userID.publicKey;
+
     userName = name;
     if (userAlias.size() == 0)
     {


### PR DESCRIPTION
When friend name is empty it display the public key instead
