### PR TITLE
optionally hide all qTox windows in screenshot

### DIFF
--- a/src/widget/tool/screenshotgrabber.cpp
+++ b/src/widget/tool/screenshotgrabber.cpp
@@ -37,22 +37,24 @@
 
 ScreenshotGrabber::ScreenshotGrabber(QObject* parent)
     : QObject(parent)
+    , scene(0)
 {
-    scene = new QGraphicsScene;
     window = new QGraphicsView (scene); // Top-level widget
-    setupWindow();
-    setupScene(scene);
+    window->setAttribute(Qt::WA_DeleteOnClose);
+    window->setWindowFlags(Qt::FramelessWindowHint | Qt::BypassWindowManagerHint);
+    window->setContentsMargins(0, 0, 0, 0);
+    window->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    window->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    window->setFrameShape(QFrame::NoFrame);
+    window->installEventFilter(this);
 
+    setupScene();
     installEventFilter(this);
 }
 
 void ScreenshotGrabber::reInit()
 {
-    delete scene;
-    scene = new QGraphicsScene;
-    window = new QGraphicsView(scene); // Top-level widget
-    setupWindow();
-    setupScene(scene);
+    setupScene();
     showGrabber();
     blocked = false;
 }
@@ -120,28 +122,18 @@ void ScreenshotGrabber::acceptRegion()
     if (rect.width() < 1 || rect.height() < 1)
         return;
 
-    //
     qDebug() << "Screenshot accepted, chosen region" << rect;
     emit screenshotTaken(this->screenGrab.copy(rect));
     this->window->close();
     Widget::getInstance()->setVisible(true); // show window if it was hidden
 }
 
-void ScreenshotGrabber::setupWindow()
+void ScreenshotGrabber::setupScene()
 {
-    this->window->setWindowFlags(Qt::FramelessWindowHint | Qt::X11BypassWindowManagerHint);
-    this->window->setAttribute(Qt::WA_DeleteOnClose);
-    this->window->setContentsMargins(0, 0, 0, 0);
-    this->window->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-    this->window->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-    this->window->setFrameShape(QFrame::NoFrame);
+    delete scene;
+    scene = new QGraphicsScene;
+    window->setScene(scene);
 
-    connect(this->window, &QObject::destroyed, this, &QObject::deleteLater);
-    this->window->installEventFilter(this);
-}
-
-void ScreenshotGrabber::setupScene(QGraphicsScene* scene)
-{
     this->overlay = new ScreenGrabberOverlayItem(this);
     this->helperToolbox = new ToolBoxGraphicsItem;
 

--- a/src/widget/tool/screenshotgrabber.cpp
+++ b/src/widget/tool/screenshotgrabber.cpp
@@ -19,15 +19,16 @@
 
 #include "screenshotgrabber.h"
 
-#include <QGraphicsSceneMouseEvent>
+#include <QApplication>
+#include <QDebug>
+#include <QDesktopWidget>
 #include <QGraphicsPixmapItem>
 #include <QGraphicsRectItem>
-#include <QDesktopWidget>
+#include <QGraphicsSceneMouseEvent>
 #include <QGraphicsView>
-#include <QApplication>
 #include <QMouseEvent>
 #include <QScreen>
-#include <QDebug>
+#include <QTimer>
 
 #include "screengrabberchooserrectitem.h"
 #include "screengrabberoverlayitem.h"

--- a/src/widget/tool/screenshotgrabber.cpp
+++ b/src/widget/tool/screenshotgrabber.cpp
@@ -38,6 +38,7 @@
 ScreenshotGrabber::ScreenshotGrabber(QObject* parent)
     : QObject(parent)
     , scene(0)
+    , mQToxVisible(true)
 {
     window = new QGraphicsView (scene); // Top-level widget
     window->setAttribute(Qt::WA_DeleteOnClose);
@@ -206,6 +207,29 @@ QPixmap ScreenshotGrabber::grabScreen()
                               rec.y(),
                               rec.width(),
                               rec.height());
+}
+
+void ScreenshotGrabber::hideVisibleWindows()
+{
+    foreach(QWidget* w, qApp->topLevelWidgets()) {
+        if (w != window && w->isVisible()) {
+            mHiddenWindows << w;
+            w->setVisible(false);
+        }
+    }
+
+    mQToxVisible = false;
+}
+
+void ScreenshotGrabber::restoreHiddenWindows()
+{
+    foreach(QWidget* w, mHiddenWindows) {
+        if (w)
+            w->setVisible(true);
+    }
+
+    mHiddenWindows.clear();
+    mQToxVisible = true;
 }
 
 void ScreenshotGrabber::beginRectChooser(QGraphicsSceneMouseEvent* event)

--- a/src/widget/tool/screenshotgrabber.cpp
+++ b/src/widget/tool/screenshotgrabber.cpp
@@ -51,7 +51,6 @@ ScreenshotGrabber::ScreenshotGrabber(QObject* parent)
     window->installEventFilter(this);
 
     setupScene();
-    installEventFilter(this);
 }
 
 void ScreenshotGrabber::reInit()

--- a/src/widget/tool/screenshotgrabber.h
+++ b/src/widget/tool/screenshotgrabber.h
@@ -56,8 +56,7 @@ signals:
 
 private:
     friend class ScreenGrabberOverlayItem;
-    // for exception multiple handling during switching window
-    bool blocked = false;
+    bool mKeysBlocked;
 
     void setupScene();
 

--- a/src/widget/tool/screenshotgrabber.h
+++ b/src/widget/tool/screenshotgrabber.h
@@ -21,6 +21,7 @@
 #define SCREENSHOTGRABBER_H
 
 #include <QPixmap>
+#include <QPointer>
 
 class QGraphicsSceneMouseEvent;
 class QGraphicsPixmapItem;
@@ -70,8 +71,12 @@ private:
 
     QPixmap grabScreen();
 
+    void hideVisibleWindows();
+    void restoreHiddenWindows();
+
     void beginRectChooser(QGraphicsSceneMouseEvent* event);
 
+private:
     QPixmap screenGrab;
     QGraphicsScene* scene;
     QGraphicsView* window;
@@ -80,6 +85,9 @@ private:
     ScreenGrabberChooserRectItem* chooserRect;
     ToolBoxGraphicsItem* helperToolbox;
     QGraphicsTextItem* helperTooltip;
+
+    bool mQToxVisible;
+    QVector< QPointer<QWidget> >   mHiddenWindows;
 };
 
 

--- a/src/widget/tool/screenshotgrabber.h
+++ b/src/widget/tool/screenshotgrabber.h
@@ -43,9 +43,9 @@ public:
 
     bool eventFilter(QObject* object, QEvent* event) override;
 
-public slots:
-
     void showGrabber();
+
+public slots:
     void acceptRegion();
     void reInit();
 

--- a/src/widget/tool/screenshotgrabber.h
+++ b/src/widget/tool/screenshotgrabber.h
@@ -58,8 +58,7 @@ private:
     // for exception multiple handling during switching window
     bool blocked = false;
 
-    void setupWindow();
-    void setupScene(QGraphicsScene* scene);
+    void setupScene();
 
     void useNothingSelectedTooltip();
     void useRegionSelectedTooltip();

--- a/src/widget/tool/screenshotgrabber.h
+++ b/src/widget/tool/screenshotgrabber.h
@@ -20,20 +20,18 @@
 #ifndef SCREENSHOTGRABBER_H
 #define SCREENSHOTGRABBER_H
 
-#include <QWidget>
 #include <QPixmap>
-#include <QPoint>
-#include <QTimer>
 
-class ScreenGrabberChooserRectItem;
 class QGraphicsSceneMouseEvent;
-class ScreenGrabberOverlayItem;
 class QGraphicsPixmapItem;
-class ToolBoxGraphicsItem;
 class QGraphicsRectItem;
 class QGraphicsTextItem;
 class QGraphicsScene;
 class QGraphicsView;
+class QKeyEvent;
+class ScreenGrabberChooserRectItem;
+class ScreenGrabberOverlayItem;
+class ToolBoxGraphicsItem;
 
 class ScreenshotGrabber : public QObject
 {


### PR DESCRIPTION
fixes #2303

There's an occasional problem, that the main window reappears. Probably `FriendListWidget::setMode` makes the main window re-visible on a mode change.

@agilob Here you are. :smile: Reparenting the `Widget` class had not the desired effect as well. Instead, I set up a stack of currently visible widgets to restore them. Further fixed some other related bugs here.
