### PR TITLE
Make `Change password` dialog ~consistent with login page password form

### DIFF
--- a/src/widget/form/setpassworddialog.cpp
+++ b/src/widget/form/setpassworddialog.cpp
@@ -26,14 +26,14 @@ const double SetPasswordDialog::reasonablePasswordLength = 8.;
 SetPasswordDialog::SetPasswordDialog(QString body, QString extraButton, QWidget* parent)
     : QDialog(parent)
     , ui(new Ui::SetPasswordDialog)
-    , body(body+"\n")
+    , body(body + "\n\n")
 {
     ui->setupUi(this);
 
     connect(ui->  passwordlineEdit, SIGNAL(textChanged(QString)), this, SLOT(onPasswordEdit()));
     connect(ui->repasswordlineEdit, SIGNAL(textChanged(QString)), this, SLOT(onPasswordEdit()));
 
-    ui->body->setText(body + "\n" + tr("The passwords don't match."));
+    ui->body->setText(body + "\n\n");
     ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
 
     if (!extraButton.isEmpty())
@@ -70,7 +70,7 @@ void SetPasswordDialog::onPasswordEdit()
         ui->body->setText(body);
     }
 
-    ui->strengthBar->setValue(getPasswordStrength(pswd));
+    ui->passStrengthMeter->setValue(getPasswordStrength(pswd));
 }
 
 int SetPasswordDialog::getPasswordStrength(QString pass)

--- a/src/widget/form/setpassworddialog.ui
+++ b/src/widget/form/setpassworddialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>325</width>
+    <width>255</width>
     <height>160</height>
    </rect>
   </property>
@@ -25,20 +25,20 @@
      <item row="4" column="0">
       <widget class="QLabel" name="label_2">
        <property name="alignment">
-        <set>Qt::AlignRight</set>
+        <set>Qt::AlignLeft</set>
        </property>
        <property name="text">
-        <string>Repeat password</string>
+        <string>Confirm:</string>
        </property>
       </widget>
      </item>
      <item row="2" column="0">
       <widget class="QLabel" name="label">
        <property name="alignment">
-        <set>Qt::AlignRight</set>
+        <set>Qt::AlignLeft</set>
        </property>
        <property name="text">
-        <string>Type password</string>
+        <string>Password:</string>
        </property>
       </widget>
      </item>
@@ -56,23 +56,13 @@
        </property>
       </widget>
      </item>
-     <item row="6" column="0">
-      <widget class="QLabel" name="label_3">
-       <property name="alignment">
-        <set>Qt::AlignRight</set>
-       </property>
-       <property name="text">
-        <string>Password strength</string>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="1">
-      <widget class="QProgressBar" name="strengthBar">
+     <item row="6" column="0" colspan="2">
+      <widget class="QProgressBar" name="passStrengthMeter">
        <property name="value">
         <number>0</number>
        </property>
        <property name="format">
-        <string/>
+        <string>Password strength: %p%</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Make text about password not matching appear only when passwords don't match.

Change width of dialog window, to make it look better.

fixes points 1 and 2 from issue #2337 
# 

Before:
![before1](https://cloud.githubusercontent.com/assets/3148759/10412567/8e3e7bee-6f81-11e5-89f7-8c8f1fbff4e6.png) ![before2](https://cloud.githubusercontent.com/assets/3148759/10412569/9989c242-6f81-11e5-98af-0b9ad406318d.png)

Change:
![change1](https://cloud.githubusercontent.com/assets/3148759/10412571/ad481568-6f81-11e5-8577-571a3adfbe31.png) ![change1](https://cloud.githubusercontent.com/assets/3148759/10412573/b29c6ff0-6f81-11e5-8ca8-281815a937e2.png)
