### PR TITLE
Autorun:xdg: create autostart dir if needed

### DIFF
--- a/src/platform/autorun_xdg.cpp
+++ b/src/platform/autorun_xdg.cpp
@@ -26,14 +26,19 @@
 
 namespace Platform
 {
-    QString getAutostartFilePath()
+    QString getAutostartDirPath()
     {
         QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
         QString config = env.value("XDG_CONFIG_HOME");
         if (config.isEmpty())
             config = QDir::homePath() + "/" + ".config";
-        return config + "/" + "autostart/qTox - " +
-               Settings::getInstance().getCurrentProfile() + ".desktop";
+        return config + "/autostart";
+    }
+
+    QString getAutostartFilePath(QString dir)
+    {
+        return dir + "/qTox - " + Settings::getInstance().getCurrentProfile() +
+               ".desktop";
     }
 
     inline QString currentCommandLine()
@@ -45,11 +50,12 @@ namespace Platform
 
 bool Platform::setAutorun(bool on)
 {
-
-    QFile desktop(getAutostartFilePath());
+    QString dirPath = getAutostartDirPath();
+    QFile desktop(getAutostartFilePath(dirPath));
     if (on)
     {
-        if (!desktop.open(QFile::WriteOnly | QFile::Truncate))
+        if (!QDir().mkpath(dirPath) ||
+            !desktop.open(QFile::WriteOnly | QFile::Truncate))
             return false;
         desktop.write("[Desktop Entry]\n");
         desktop.write("Type=Application\n");
@@ -66,7 +72,7 @@ bool Platform::setAutorun(bool on)
 
 bool Platform::getAutorun()
 {
-    return QFile(getAutostartFilePath()).exists();
+    return QFile(getAutostartFilePath(getAutostartDirPath())).exists();
 }
 
 #endif  // defined(Q_OS_UNIX) && !defined(__APPLE__) && !defined(__MACH__)


### PR DESCRIPTION
Hello,

First, thank you for developing and maintaining qTox!

After a fresh installation of Ubuntu, `~/.config/autostart` dir is not available. It is mostly created by `gnome-session-properties` when adding the first extra application which will be launched at startup.

With this modification, `QDir::mkpath("~/.config/autostart")` (= `mkdir -p`) is now used before trying to open a new file in `~/.config/autostart` dir.

It then fixes a bug reported by @363734 to me: "_qTox is launched at startup after having enabled corresponding option from qTox's settings_".
