### PR TITLE
finish #2094 (Audio Improvements)

### DIFF
--- a/qtox.pro
+++ b/qtox.pro
@@ -494,12 +494,13 @@ SOURCES += \
     src/widget/friendlistlayout.cpp \
     src/widget/genericchatitemlayout.cpp \
     src/widget/categorywidget.cpp \
-    src/widget/tool/removefrienddialog.cpp \
     src/widget/contentlayout.cpp \
     src/widget/contentdialog.cpp \
+    src/video/genericnetcamview.cpp \
     src/widget/tool/activatedialog.cpp \
     src/widget/tool/movablewidget.cpp \
-    src/video/genericnetcamview.cpp \
+    src/widget/tool/micfeedbackwidget.cpp \
+    src/widget/tool/removefrienddialog.cpp \
     src/video/groupnetcamview.cpp
 
 HEADERS += \
@@ -547,6 +548,7 @@ HEADERS += \
     src/widget/contentlayout.h \
     src/widget/contentdialog.h \
     src/widget/tool/activatedialog.h \
+    src/widget/tool/micfeedbackwidget.h \
     src/widget/tool/removefrienddialog.h \
     src/widget/tool/movablewidget.h \
     src/video/genericnetcamview.h \

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -199,7 +199,7 @@ void Audio::openInput(const QString& inDevDescr)
 
 }
 
-void Audio::openOutput(const QString& outDevDescr)
+bool Audio::openOutput(const QString& outDevDescr)
 {
     QMutexLocker lock(audioOutLock);
     auto* tmp = alOutDev;
@@ -212,6 +212,7 @@ void Audio::openOutput(const QString& outDevDescr)
     if (!alOutDev)
     {
         qWarning() << "Cannot open output audio device " + outDevDescr;
+        return false;
     }
     else
     {
@@ -226,6 +227,7 @@ void Audio::openOutput(const QString& outDevDescr)
         {
             qWarning() << "Cannot create output audio context";
             alcCloseDevice(alOutDev);
+            return false;
         }
         else
         {
@@ -239,6 +241,8 @@ void Audio::openOutput(const QString& outDevDescr)
     Core* core = Core::getInstance();
     if (core)
         core->resetCallSources(); // Force to regen each group call's sources
+
+    return true;
 }
 
 void Audio::closeInput()
@@ -278,8 +282,12 @@ void Audio::closeOutput()
 void Audio::playMono16Sound(const QByteArray& data)
 {
     QMutexLocker lock(audioOutLock);
+
     if (!alOutDev)
-        openOutput(Settings::getInstance().getOutDev());
+    {
+        if (!openOutput(Settings::getInstance().getOutDev()))
+            return;
+    }
 
     ALuint buffer;
     alGenBuffers(1, &buffer);
@@ -325,6 +333,9 @@ void Audio::playGroupAudio(int group, int peer, const int16_t* data,
 
     QMutexLocker lock(audioOutLock);
 
+    if (!alOutDev)
+        return;
+
     ToxGroupCall& call = Core::groupCalls[group];
 
     if (!call.active || call.muteVol)
@@ -351,6 +362,9 @@ void Audio::playAudioBuffer(ALuint alSource, const int16_t *data, int samples, u
     assert(channels == 1 || channels == 2);
 
     QMutexLocker lock(audioOutLock);
+
+    if (!alOutDev)
+        return;
 
     ALuint bufid;
     ALint processed = 0, queued = 16;

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -38,6 +38,9 @@
 
 Audio* Audio::instance{nullptr};
 
+/**
+Returns the singleton's instance. Will construct on first call.
+*/
 Audio& Audio::getInstance()
 {
     if (!instance)
@@ -89,6 +92,9 @@ float Audio::getOutputVolume()
     return getInstance().GetOutputVolume();
 }
 
+/**
+Returns the current output volume, between 0 and 1
+*/
 qreal Audio::GetOutputVolume()
 {
     QMutexLocker locker(&audioOutLock);
@@ -100,6 +106,9 @@ void Audio::setOutputVolume(float volume)
     getInstance().SetOutputVolume(volume);
 }
 
+/**
+The volume must be between 0 and 1
+*/
 void Audio::SetOutputVolume(qreal volume)
 {
     QMutexLocker locker(&audioOutLock);
@@ -122,6 +131,9 @@ void Audio::SetOutputVolume(qreal volume)
     }
 }
 
+/**
+The volume must be between 0 and 2
+*/
 void Audio::setInputVolume(float volume)
 {
     getInstance().SetInputVolume(volume);
@@ -139,6 +151,9 @@ void Audio::suscribeInput()
     inst.SubscribeInput();
 }
 
+/**
+ Call when you need to capture sound from the open input device.
+*/
 void Audio::SubscribeInput()
 {
     assert(userCount >= 0);
@@ -170,6 +185,9 @@ void Audio::unsuscribeInput()
     inst.UnSubscribeInput();
 }
 
+/**
+Call once you don't need to capture on the open input device anymore.
+*/
 void Audio::UnSubscribeInput()
 {
     assert(userCount > 0);
@@ -194,6 +212,9 @@ void Audio::openInput(const QString& inDevDescr)
     getInstance().OpenInput(inDevDescr);
 }
 
+/**
+Open an input device, use before suscribing
+*/
 void Audio::OpenInput(const QString& inDevDescr)
 {
     QMutexLocker lock(&audioInLock);
@@ -238,6 +259,9 @@ bool Audio::openOutput(const QString& outDevDescr)
     return getInstance().OpenOutput(outDevDescr);
 }
 
+/**
+Open an output device
+*/
 bool Audio::OpenOutput(const QString &outDevDescr)
 {
     QMutexLocker lock(&audioOutLock);
@@ -288,6 +312,9 @@ void Audio::closeInput()
     getInstance().CloseInput();
 }
 
+/**
+Close an input device, please don't use unless everyone's unsuscribed
+*/
 void Audio::CloseInput()
 {
     qDebug() << "Closing input";
@@ -311,6 +338,9 @@ void Audio::closeOutput()
     getInstance().CloseOutput();
 }
 
+/**
+Close an output device
+*/
 void Audio::CloseOutput()
 {
     qDebug() << "Closing output";
@@ -339,6 +369,9 @@ void Audio::playMono16Sound(const QByteArray& data)
     getInstance().PlayMono16Sound(data);
 }
 
+/**
+Play a 44100Hz mono 16bit PCM sound
+*/
 void Audio::PlayMono16Sound(const QByteArray& data)
 {
     QMutexLocker lock(&audioOutLock);
@@ -377,6 +410,11 @@ void Audio::PlayMono16Sound(const QByteArray& data)
     alDeleteBuffers(1, &buffer);
 }
 
+/**
+@brief May be called from any thread, will always queue a call to playGroupAudio.
+
+The first and last argument are ignored, but allow direct compatibility with toxcore.
+*/
 void Audio::playGroupAudioQueued(Tox*,int group, int peer, const int16_t* data,
                         unsigned samples, uint8_t channels, unsigned sample_rate, void* core)
 {
@@ -392,6 +430,9 @@ void Audio::playGroupAudio(int group, int peer, const int16_t* data,
     getInstance().PlayGroupAudio(group, peer, data, samples, channels, sample_rate);
 }
 
+/**
+Must be called from the audio thread, plays a group call's received audio
+*/
 void Audio::PlayGroupAudio(int group, int peer, const int16_t* data,
                            unsigned samples, uint8_t channels, unsigned sample_rate)
 {
@@ -465,6 +506,9 @@ bool Audio::isInputReady()
     return getInstance().IsInputReady();
 }
 
+/**
+Returns true if the input device is open and suscribed to
+*/
 bool Audio::IsInputReady()
 {
     QMutexLocker locker(&audioInLock);
@@ -476,6 +520,9 @@ bool Audio::isOutputClosed()
     return getInstance().IsOutputClosed();
 }
 
+/**
+Returns true if the output device is open
+*/
 bool Audio::IsOutputClosed()
 {
     QMutexLocker locker(&audioOutLock);
@@ -487,6 +534,9 @@ bool Audio::tryCaptureSamples(uint8_t* buf, int framesize)
     return getInstance().TryCaptureSamples(buf, framesize);
 }
 
+/**
+Does nothing and return false on failure
+*/
 bool Audio::TryCaptureSamples(uint8_t* buf, int framesize)
 {
     QMutexLocker lock(&audioInLock);

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -86,6 +86,8 @@ void Audio::startAudioThread()
 {
     if (!audioThread->isRunning())
         audioThread->start();
+    else
+        qWarning("Audio thread already started -> ignored.");
 
     moveToThread(audioThread);
 }

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -565,18 +565,6 @@ bool Audio::TryCaptureSamples(uint8_t* buf, int framesize)
     return true;
 }
 
-void Audio::pauseOutput()
-{
-    getInstance().PauseOutput();
-}
-
-void Audio::PauseOutput()
-{
-    qDebug() << "Pause";
-    if (!inputSubscriptions)
-        closeOutput();
-}
-
 #ifdef QTOX_FILTER_AUDIO
 #include "audiofilterer.h"
 

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -333,9 +333,6 @@ void Audio::playGroupAudio(int group, int peer, const int16_t* data,
 
     QMutexLocker lock(audioOutLock);
 
-    if (!alOutDev)
-        return;
-
     ToxGroupCall& call = Core::groupCalls[group];
 
     if (!call.active || call.muteVol)
@@ -362,9 +359,6 @@ void Audio::playAudioBuffer(ALuint alSource, const int16_t *data, int samples, u
     assert(channels == 1 || channels == 2);
 
     QMutexLocker lock(audioOutLock);
-
-    if (!alOutDev)
-        return;
 
     ALuint bufid;
     ALint processed = 0, queued = 16;

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -113,11 +113,11 @@ void Audio::setInputVolume(float volume)
 
 void Audio::suscribeInput()
 {
-    if (!alInDev)
+    /*if (!alInDev)
     {
         qWarning()<<"input device is closed";
         return;
-    }
+    }*/
 
     qDebug() << "suscribing input";
     QMutexLocker lock(audioInLock);
@@ -125,6 +125,7 @@ void Audio::suscribeInput()
     {
         timer->stop();
         openOutput(Settings::getInstance().getOutDev());
+        openInput(Settings::getInstance().getInDev());
 
 #if (!FIX_SND_PCM_PREPARE_BUG)
         if (alInDev)
@@ -144,7 +145,9 @@ void Audio::unsuscribeInput()
         return;
     }
 
-    qDebug() << "unsuscribing input";
+    assert(userCount > 0);
+
+    qDebug() << "unsuscribing input" << userCount;
     QMutexLocker lock(audioInLock);
     if (!--userCount)
     {
@@ -156,6 +159,7 @@ void Audio::unsuscribeInput()
             alcCaptureStop(alInDev);
         }
 #endif
+        closeInput();
     }
 }
 
@@ -186,7 +190,7 @@ void Audio::openInput(const QString& inDevDescr)
         core->resetCallSources(); // Force to regen each group call's sources
 
     // Restart the capture if necessary
-    if (userCount.load() != 0 && alInDev)
+    if (/*userCount.load() != 0 && */alInDev)
     {
         alcCaptureStart(alInDev);
     }

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -79,6 +79,9 @@ Audio::~Audio()
         audioThread->terminate();
 }
 
+/**
+Start the audio thread for capture and playback.
+*/
 void Audio::startAudioThread()
 {
     if (!audioThread->isRunning())
@@ -151,7 +154,9 @@ void Audio::suscribeInput()
 }
 
 /**
- Call when you need to capture sound from the open input device.
+@brief Subscribe to capture sound from the opened input device.
+
+If the input device is not open, it will be opened before capturing.
 */
 void Audio::SubscribeInput()
 {
@@ -181,7 +186,9 @@ void Audio::unsuscribeInput()
 }
 
 /**
-Call once you don't need to capture on the open input device anymore.
+@brief Unsubscribe from capturing from an opened input device.
+
+If the input device has no more subscriptions, it will be closed.
 */
 void Audio::UnsubscribeInput()
 {

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -147,8 +147,7 @@ void Audio::SetInputVolume(qreal volume)
 
 void Audio::suscribeInput()
 {
-    Audio& inst = Audio::getInstance();
-    inst.SubscribeInput();
+    getInstance().SubscribeInput();
 }
 
 /**
@@ -178,14 +177,13 @@ void Audio::SubscribeInput()
 
 void Audio::unsuscribeInput()
 {
-    Audio& inst = Audio::getInstance();
-    inst.UnSubscribeInput();
+    getInstance().UnsubscribeInput();
 }
 
 /**
 Call once you don't need to capture on the open input device anymore.
 */
-void Audio::UnSubscribeInput()
+void Audio::UnsubscribeInput()
 {
     qDebug() << "unsubscribing input" << inputSubscriptions;
     if (inputSubscriptions > 0)
@@ -400,8 +398,7 @@ void Audio::PlayMono16Sound(const QByteArray& data)
 
     ALint frequency;
     alGetBufferi(buffer, AL_FREQUENCY, &frequency);
-    float duration = (lengthInSamples / static_cast<float>(frequency)) * 1000;
-
+    qreal duration = (lengthInSamples / static_cast<qreal>(frequency)) * 1000;
     int remaining = timer->interval();
 
     if (duration > remaining)
@@ -526,7 +523,7 @@ Returns true if the output device is open
 bool Audio::IsOutputClosed()
 {
     QMutexLocker locker(&audioOutLock);
-    return (alOutDev);
+    return alOutDev;
 }
 
 bool Audio::tryCaptureSamples(uint8_t* buf, int framesize)
@@ -575,8 +572,6 @@ void Audio::pauseOutput()
 
 void Audio::PauseOutput()
 {
-    QMutexLocker lock(&audioOutLock);
-
     qDebug() << "Pause";
     if (!inputSubscriptions)
         closeOutput();

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -188,7 +188,7 @@ void Audio::openInput(const QString& inDevDescr)
         core->resetCallSources(); // Force to regen each group call's sources
 
     // Restart the capture if necessary
-    if (/*userCount.load() != 0 && */alInDev)
+    if (alInDev)
     {
         alcCaptureStart(alInDev);
     }

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -62,6 +62,7 @@ Audio& Audio::getInstance()
         audioOutLock = new QMutex(QMutex::Recursive);
         instance->moveToThread(audioThread);
         timer = new QTimer(instance);
+        timer->moveToThread(audioThread);
         timer->setSingleShot(true);
         instance->connect(timer, &QTimer::timeout, instance, &Audio::closeOutput);
     }
@@ -113,18 +114,15 @@ void Audio::setInputVolume(float volume)
 
 void Audio::suscribeInput()
 {
-    /*if (!alInDev)
-    {
-        qWarning()<<"input device is closed";
-        return;
-    }*/
 
-    qDebug() << "suscribing input";
     QMutexLocker lock(audioInLock);
+    QMutexLocker locker(audioOutLock);
+    assert(userCount >= 0);
+
+    qDebug() << "subscribing input";
+
     if (!userCount++)
     {
-        timer->stop();
-        openOutput(Settings::getInstance().getOutDev());
         openInput(Settings::getInstance().getInDev());
 
 #if (!FIX_SND_PCM_PREPARE_BUG)
@@ -135,20 +133,20 @@ void Audio::suscribeInput()
         }
 #endif
     }
+
+    QTimer::singleShot(1, []()
+    {
+        Audio::openOutput(Settings::getInstance().getOutDev());
+    });
 }
 
 void Audio::unsuscribeInput()
 {
-    if (!alInDev)
-    {
-        qWarning()<<"input device is closed";
-        return;
-    }
-
+    QMutexLocker lock(audioInLock);
+    QMutexLocker locker(audioOutLock);
     assert(userCount > 0);
 
-    qDebug() << "unsuscribing input" << userCount;
-    QMutexLocker lock(audioInLock);
+    qDebug() << "unsubscribing input" << userCount;
     if (!--userCount)
     {
         closeOutput();
@@ -238,7 +236,6 @@ bool Audio::openOutput(const QString& outDevDescr)
             alGenSources(1, &alMainSource);
         }
 
-
         qDebug() << "Opening audio output " + outDevDescr;
     }
 
@@ -271,8 +268,15 @@ void Audio::closeOutput()
 {
     qDebug() << "Closing output";
     QMutexLocker lock(audioOutLock);
+
+    if (userCount > 0)
+        return;
+
     if (alContext && alcMakeContextCurrent(nullptr) == ALC_TRUE)
+    {
         alcDestroyContext(alContext);
+        alContext = nullptr;
+    }
 
     if (alOutDev)
     {
@@ -441,9 +445,10 @@ bool Audio::tryCaptureSamples(uint8_t* buf, int framesize)
 
 void Audio::pauseOutput()
 {
-    QMutexLocker lock(audioInLock);
+    QMutexLocker lock(audioOutLock);
 
-    if (!userCount)
+    qDebug() << "Pause";
+    if (userCount == 0)
         closeOutput();
 }
 

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -116,7 +116,7 @@ private:
     QThread*            audioThread;
     QMutex              audioInLock;
     QMutex              audioOutLock;
-    std::atomic<int>    userCount;
+    std::atomic<int>    inputSubscriptions;
     ALCdevice*          alOutDev;
     ALCdevice*          alInDev;
     qreal               outputVolume;

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -23,6 +23,7 @@
 
 #include <QObject>
 #include <QHash>
+#include <QMutexLocker>
 #include <atomic>
 
 #if defined(__APPLE__) && defined(__MACH__)
@@ -48,29 +49,47 @@ class Audio : public QObject
 public:
     static Audio& getInstance(); ///< Returns the singleton's instance. Will construct on first call.
 
+public:
+    void startAudioThread();
+
     static float getOutputVolume(); ///< Returns the current output volume, between 0 and 1
+    qreal GetOutputVolume();
     static void setOutputVolume(float volume); ///< The volume must be between 0 and 1
+    void SetOutputVolume(qreal volume);
+
     static void setInputVolume(float volume); ///< The volume must be between 0 and 2
+    void SetInputVolume(qreal volume);
 
     static void suscribeInput(); ///< Call when you need to capture sound from the open input device.
+    void SubscribeInput();
     static void unsuscribeInput(); ///< Call once you don't need to capture on the open input device anymore.
+    void UnSubscribeInput();
 
     static void openInput(const QString& inDevDescr); ///< Open an input device, use before suscribing
+    void OpenInput(const QString& inDevDescr);
     static bool openOutput(const QString& outDevDescr); ///< Open an output device
-
-    static void closeInput(); ///< Close an input device, please don't use unless everyone's unsuscribed
+    bool OpenOutput(const QString& outDevDescr);
+    static void closeInput();
+    void CloseInput();
     static void closeOutput(); ///< Close an output device
+    void CloseOutput();
 
     static bool isInputReady(); ///< Returns true if the input device is open and suscribed to
+    bool IsInputReady();
     static bool isOutputClosed(); ///< Returns true if the output device is open
+    bool IsOutputClosed();
 
     static void playMono16Sound(const QByteArray& data); ///< Play a 44100Hz mono 16bit PCM sound
+    void PlayMono16Sound(const QByteArray& data);
     static bool tryCaptureSamples(uint8_t* buf, int framesize); ///< Does nothing and return false on failure
+    bool TryCaptureSamples(uint8_t* buf, int framesize);
 
     /// May be called from any thread, will always queue a call to playGroupAudio
     /// The first and last argument are ignored, but allow direct compatibility with toxcore
     static void playGroupAudioQueued(Tox*, int group, int peer, const int16_t* data,
                         unsigned samples, uint8_t channels, unsigned sample_rate, void*);
+    void PlayGroupAudio(int group, int peer, const int16_t* data,
+                        unsigned samples, uint8_t channels, unsigned sample_rate);
 
 #ifdef QTOX_FILTER_AUDIO
     static void getEchoesToFilter(AudioFilterer* filter, int framesize);
@@ -82,26 +101,31 @@ public slots:
     void playGroupAudio(int group, int peer, const int16_t* data,
                         unsigned samples, uint8_t channels, unsigned sample_rate);
     static void pauseOutput();
+    void PauseOutput();
 
 signals:
     void groupAudioPlayed(int group, int peer, unsigned short volume);
 
 private:
-    explicit Audio()=default;
+    Audio();
     ~Audio();
-    static void playAudioBuffer(ALuint alSource, const int16_t *data, int samples, unsigned channels, int sampleRate);
+
+    void playAudioBuffer(ALuint alSource, const int16_t *data, int samples, unsigned channels, int sampleRate);
 
 private:
     static Audio* instance;
-    static std::atomic<int> userCount;
-    static ALCdevice* alOutDev, *alInDev;
-    static QMutex* audioInLock, *audioOutLock;
-    static float outputVolume;
-    static float inputVolume;
-    static ALuint alMainSource;
-    static QThread* audioThread;
-    static ALCcontext* alContext;
-    static QTimer* timer;
+
+    QThread*            audioThread;
+    QMutex              audioInLock;
+    QMutex              audioOutLock;
+    std::atomic<int>    userCount;
+    ALCdevice*          alOutDev;
+    ALCdevice*          alInDev;
+    qreal               outputVolume;
+    qreal               inputVolume;
+    ALuint              alMainSource;
+    ALCcontext*         alContext;
+    QTimer*             timer;
 };
 
 #endif // AUDIO_H

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -47,45 +47,43 @@ class Audio : public QObject
     Q_OBJECT
 
 public:
-    static Audio& getInstance(); ///< Returns the singleton's instance. Will construct on first call.
+    static Audio& getInstance();
 
 public:
     void startAudioThread();
 
-    static float getOutputVolume(); ///< Returns the current output volume, between 0 and 1
+    static float getOutputVolume();
     qreal GetOutputVolume();
-    static void setOutputVolume(float volume); ///< The volume must be between 0 and 1
+    static void setOutputVolume(float volume);
     void SetOutputVolume(qreal volume);
 
-    static void setInputVolume(float volume); ///< The volume must be between 0 and 2
+    static void setInputVolume(float volume);
     void SetInputVolume(qreal volume);
 
-    static void suscribeInput(); ///< Call when you need to capture sound from the open input device.
+    static void suscribeInput();
     void SubscribeInput();
-    static void unsuscribeInput(); ///< Call once you don't need to capture on the open input device anymore.
+    static void unsuscribeInput();
     void UnSubscribeInput();
 
-    static void openInput(const QString& inDevDescr); ///< Open an input device, use before suscribing
+    static void openInput(const QString& inDevDescr);
     void OpenInput(const QString& inDevDescr);
-    static bool openOutput(const QString& outDevDescr); ///< Open an output device
+    static bool openOutput(const QString& outDevDescr);
     bool OpenOutput(const QString& outDevDescr);
     static void closeInput();
     void CloseInput();
-    static void closeOutput(); ///< Close an output device
+    static void closeOutput();
     void CloseOutput();
 
-    static bool isInputReady(); ///< Returns true if the input device is open and suscribed to
+    static bool isInputReady();
     bool IsInputReady();
-    static bool isOutputClosed(); ///< Returns true if the output device is open
+    static bool isOutputClosed();
     bool IsOutputClosed();
 
-    static void playMono16Sound(const QByteArray& data); ///< Play a 44100Hz mono 16bit PCM sound
+    static void playMono16Sound(const QByteArray& data);
     void PlayMono16Sound(const QByteArray& data);
-    static bool tryCaptureSamples(uint8_t* buf, int framesize); ///< Does nothing and return false on failure
+    static bool tryCaptureSamples(uint8_t* buf, int framesize);
     bool TryCaptureSamples(uint8_t* buf, int framesize);
 
-    /// May be called from any thread, will always queue a call to playGroupAudio
-    /// The first and last argument are ignored, but allow direct compatibility with toxcore
     static void playGroupAudioQueued(Tox*, int group, int peer, const int16_t* data,
                         unsigned samples, uint8_t channels, unsigned sample_rate, void*);
     void PlayGroupAudio(int group, int peer, const int16_t* data,
@@ -97,7 +95,6 @@ public:
 #endif
 
 public slots:
-    /// Must be called from the audio thread, plays a group call's received audio
     void playGroupAudio(int group, int peer, const int16_t* data,
                         unsigned samples, uint8_t channels, unsigned sample_rate);
     static void pauseOutput();
@@ -115,6 +112,7 @@ private:
 private:
     static Audio* instance;
 
+private:
     QThread*            audioThread;
     QMutex              audioInLock;
     QMutex              audioOutLock;

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -63,7 +63,7 @@ public:
     static void suscribeInput();
     void SubscribeInput();
     static void unsuscribeInput();
-    void UnSubscribeInput();
+    void UnsubscribeInput();
 
     static void openInput(const QString& inDevDescr);
     void OpenInput(const QString& inDevDescr);

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -97,8 +97,6 @@ public:
 public slots:
     void playGroupAudio(int group, int peer, const int16_t* data,
                         unsigned samples, uint8_t channels, unsigned sample_rate);
-    static void pauseOutput();
-    void PauseOutput();
 
 signals:
     void groupAudioPlayed(int group, int peer, unsigned short volume);

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -52,42 +52,24 @@ public:
 public:
     void startAudioThread();
 
-    static float getOutputVolume();
-    qreal GetOutputVolume();
-    static void setOutputVolume(float volume);
-    void SetOutputVolume(qreal volume);
+    qreal getOutputVolume();
+    void setOutputVolume(qreal volume);
 
-    static void setInputVolume(float volume);
-    void SetInputVolume(qreal volume);
+    void setInputVolume(qreal volume);
 
-    static void suscribeInput();
-    void SubscribeInput();
-    static void unsuscribeInput();
-    void UnsubscribeInput();
+    void subscribeInput();
+    void unsubscribeInput();
+    void openInput(const QString& inDevDescr);
+    bool openOutput(const QString& outDevDescr);
 
-    static void openInput(const QString& inDevDescr);
-    void OpenInput(const QString& inDevDescr);
-    static bool openOutput(const QString& outDevDescr);
-    bool OpenOutput(const QString& outDevDescr);
-    static void closeInput();
-    void CloseInput();
-    static void closeOutput();
-    void CloseOutput();
+    bool isInputReady();
+    bool isOutputClosed();
 
-    static bool isInputReady();
-    bool IsInputReady();
-    static bool isOutputClosed();
-    bool IsOutputClosed();
-
-    static void playMono16Sound(const QByteArray& data);
-    void PlayMono16Sound(const QByteArray& data);
-    static bool tryCaptureSamples(uint8_t* buf, int framesize);
-    bool TryCaptureSamples(uint8_t* buf, int framesize);
+    void playMono16Sound(const QByteArray& data);
+    bool tryCaptureSamples(uint8_t* buf, int framesize);
 
     static void playGroupAudioQueued(Tox*, int group, int peer, const int16_t* data,
                         unsigned samples, uint8_t channels, unsigned sample_rate, void*);
-    void PlayGroupAudio(int group, int peer, const int16_t* data,
-                        unsigned samples, uint8_t channels, unsigned sample_rate);
 
 #ifdef QTOX_FILTER_AUDIO
     static void getEchoesToFilter(AudioFilterer* filter, int framesize);
@@ -95,6 +77,8 @@ public:
 #endif
 
 public slots:
+    void closeInput();
+    void closeOutput();
     void playGroupAudio(int group, int peer, const int16_t* data,
                         unsigned samples, uint8_t channels, unsigned sample_rate);
 

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -56,7 +56,7 @@ public:
     static void unsuscribeInput(); ///< Call once you don't need to capture on the open input device anymore.
 
     static void openInput(const QString& inDevDescr); ///< Open an input device, use before suscribing
-    static void openOutput(const QString& outDevDescr); ///< Open an output device
+    static bool openOutput(const QString& outDevDescr); ///< Open an output device
 
     static void closeInput(); ///< Close an input device, please don't use unless everyone's unsuscribed
     static void closeOutput(); ///< Close an output device

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -50,6 +50,7 @@ public:
 
     static float getOutputVolume(); ///< Returns the current output volume, between 0 and 1
     static void setOutputVolume(float volume); ///< The volume must be between 0 and 1
+    static void setInputVolume(float volume); ///< The volume must be between 0 and 2
 
     static void suscribeInput(); ///< Call when you need to capture sound from the open input device.
     static void unsuscribeInput(); ///< Call once you don't need to capture on the open input device anymore.
@@ -95,6 +96,7 @@ private:
     static ALCdevice* alOutDev, *alInDev;
     static QMutex* audioInLock, *audioOutLock;
     static float outputVolume;
+    static float inputVolume;
     static ALuint alMainSource;
     static QThread* audioThread;
     static ALCcontext* alContext;

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -81,6 +81,7 @@ public slots:
     /// Must be called from the audio thread, plays a group call's received audio
     void playGroupAudio(int group, int peer, const int16_t* data,
                         unsigned samples, uint8_t channels, unsigned sample_rate);
+    static void pauseOutput();
 
 signals:
     void groupAudioPlayed(int group, int peer, unsigned short volume);
@@ -100,6 +101,7 @@ private:
     static ALuint alMainSource;
     static QThread* audioThread;
     static ALCcontext* alContext;
+    static QTimer* timer;
 };
 
 #endif // AUDIO_H

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -80,12 +80,6 @@ Core::Core(QThread *CoreThread, Profile& profile) :
         calls[i].sendAudioTimer = new QTimer();
         calls[i].sendAudioTimer->moveToThread(coreThread);
     }
-
-    // OpenAL init
-    //QString outDevDescr = Settings::getInstance().getOutDev();
-    //Audio::openOutput(outDevDescr);
-    //QString inDevDescr = Settings::getInstance().getInDev();
-    //Audio::openInput(inDevDescr);
 }
 
 void Core::deadifyTox()

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -125,8 +125,9 @@ Core::~Core()
     delete[] videobuf;
     videobuf=nullptr;
 
-    Audio::closeInput();
-    Audio::closeOutput();
+    Audio& audio = Audio::getInstance();
+    audio.closeInput();
+    audio.closeOutput();
 }
 
 Core* Core::getInstance()

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -84,8 +84,8 @@ Core::Core(QThread *CoreThread, Profile& profile) :
     // OpenAL init
     //QString outDevDescr = Settings::getInstance().getOutDev();
     //Audio::openOutput(outDevDescr);
-    QString inDevDescr = Settings::getInstance().getInDev();
-    Audio::openInput(inDevDescr);
+    //QString inDevDescr = Settings::getInstance().getInDev();
+    //Audio::openInput(inDevDescr);
 }
 
 void Core::deadifyTox()

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -82,8 +82,8 @@ Core::Core(QThread *CoreThread, Profile& profile) :
     }
 
     // OpenAL init
-    QString outDevDescr = Settings::getInstance().getOutDev();
-    Audio::openOutput(outDevDescr);
+    //QString outDevDescr = Settings::getInstance().getOutDev();
+    //Audio::openOutput(outDevDescr);
     QString inDevDescr = Settings::getInstance().getInDev();
     Audio::openInput(inDevDescr);
 }

--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -70,7 +70,7 @@ void Core::prepareCall(uint32_t friendId, int32_t callId, ToxAv* toxav, bool vid
         qWarning() << QString("Error starting call %1: toxav_prepare_transmission failed with %2").arg(callId).arg(r);
 
     // Audio
-    Audio::suscribeInput();
+    Audio::getInstance().subscribeInput();
 
     // Go
     calls[callId].active = true;
@@ -248,7 +248,7 @@ void Core::cleanupCall(int32_t callId)
         }
     }
 
-    Audio::unsuscribeInput();
+    Audio::getInstance().unsubscribeInput();
     toxav_kill_transmission(Core::getInstance()->toxav, callId);
 
     if (!anyActiveCalls())
@@ -278,7 +278,7 @@ void Core::sendCallAudio(int32_t callId, ToxAv* toxav)
     if (!calls[callId].active)
         return;
 
-    if (calls[callId].muteMic || !Audio::isInputReady())
+    if (calls[callId].muteMic || !Audio::getInstance().isInputReady())
     {
         calls[callId].sendAudioTimer->start();
         return;
@@ -288,7 +288,7 @@ void Core::sendCallAudio(int32_t callId, ToxAv* toxav)
     const int bufsize = framesize * 2 * av_DefaultSettings.audio_channels;
     uint8_t buf[bufsize];
 
-    if (Audio::tryCaptureSamples(buf, framesize))
+    if (Audio::getInstance().tryCaptureSamples(buf, framesize))
     {
 #ifdef QTOX_FILTER_AUDIO
         if (Settings::getInstance().getFilterAudio())
@@ -602,7 +602,7 @@ void Core::playAudioBuffer(ALuint alSource, const int16_t *data, int samples, un
 
     ALint state;
     alGetSourcei(alSource, AL_SOURCE_STATE, &state);
-    alSourcef(alSource, AL_GAIN, Audio::getOutputVolume());
+    alSourcef(alSource, AL_GAIN, Audio::getInstance().getOutputVolume());
     if (state != AL_PLAYING)
     {
         alSourcePlay(alSource);
@@ -628,7 +628,7 @@ void Core::joinGroupCall(int groupId)
     groupCalls[groupId].codecSettings.max_video_height = TOXAV_MAX_VIDEO_HEIGHT;
 
     // Audio
-    Audio::suscribeInput();
+    Audio::getInstance().subscribeInput();
 
     // Go
     Core* core = Core::getInstance();
@@ -651,7 +651,7 @@ void Core::leaveGroupCall(int groupId)
     for (ALuint source : groupCalls[groupId].alSources)
         alDeleteSources(1, &source);
     groupCalls[groupId].alSources.clear();
-    Audio::unsuscribeInput();
+    Audio::getInstance().unsubscribeInput();
     delete groupCalls[groupId].sendAudioTimer;
 }
 
@@ -660,7 +660,7 @@ void Core::sendGroupCallAudio(int groupId, ToxAv* toxav)
     if (!groupCalls[groupId].active)
         return;
 
-    if (groupCalls[groupId].muteMic || !Audio::isInputReady())
+    if (groupCalls[groupId].muteMic || !Audio::getInstance().isInputReady())
     {
         groupCalls[groupId].sendAudioTimer->start();
         return;
@@ -670,7 +670,7 @@ void Core::sendGroupCallAudio(int groupId, ToxAv* toxav)
     const int bufsize = framesize * 2 * av_DefaultSettings.audio_channels;
     uint8_t buf[bufsize];
 
-    if (Audio::tryCaptureSamples(buf, framesize))
+    if (Audio::getInstance().tryCaptureSamples(buf, framesize))
     {
         if (toxav_group_send_audio(toxav_get_tox(toxav), groupId, (int16_t*)buf,
                 framesize, av_DefaultSettings.audio_channels, av_DefaultSettings.audio_sample_rate) < 0)

--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -175,7 +175,6 @@ void Core::answerCall(int32_t callId)
 void Core::hangupCall(int32_t callId)
 {
     qDebug() << QString("hanging up call %1").arg(callId);
-    calls[callId].active = false;
     toxav_hangup(toxav, callId);
 }
 

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -226,6 +226,8 @@ void Settings::loadGlobal()
     s.beginGroup("Audio");
         inDev = s.value("inDev", "").toString();
         outDev = s.value("outDev", "").toString();
+        inVolume = s.value("inVolume", 100).toInt();
+        outVolume = s.value("outVolume", 100).toInt();
         filterAudio = s.value("filterAudio", false).toBool();
     s.endGroup();
 
@@ -426,6 +428,8 @@ void Settings::saveGlobal()
     s.beginGroup("Audio");
         s.setValue("inDev", inDev);
         s.setValue("outDev", outDev);
+        s.setValue("inVolume", inVolume);
+        s.setValue("outVolume", outVolume);
         s.setValue("filterAudio", filterAudio);
     s.endGroup();
 
@@ -1174,6 +1178,18 @@ void Settings::setInDev(const QString& deviceSpecifier)
     inDev = deviceSpecifier;
 }
 
+int Settings::getInVolume() const
+{
+    QMutexLocker locker{&bigLock};
+    return inVolume;
+}
+
+void Settings::setInVolume(int volume)
+{
+    QMutexLocker locker{&bigLock};
+    inVolume = volume;
+}
+
 QString Settings::getVideoDev() const
 {
     QMutexLocker locker{&bigLock};
@@ -1196,6 +1212,18 @@ void Settings::setOutDev(const QString& deviceSpecifier)
 {
     QMutexLocker locker{&bigLock};
     outDev = deviceSpecifier;
+}
+
+int Settings::getOutVolume() const
+{
+    QMutexLocker locker{&bigLock};
+    return outVolume;
+}
+
+void Settings::setOutVolume(int volume)
+{
+    QMutexLocker locker{&bigLock};
+    outVolume = volume;
 }
 
 bool Settings::getFilterAudio() const

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -154,6 +154,12 @@ public:
     QString getOutDev() const;
     void setOutDev(const QString& deviceSpecifier);
 
+    int getInVolume() const;
+    void setInVolume(int volume);
+
+    int getOutVolume() const;
+    void setOutVolume(int volume);
+
     bool getFilterAudio() const;
     void setFilterAudio(bool newValue);
 
@@ -374,6 +380,8 @@ private:
     // Audio
     QString inDev;
     QString outDev;
+    int inVolume;
+    int outVolume;
     bool filterAudio;
 
     // Video

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -62,8 +62,10 @@ AVForm::AVForm() :
 
     connect(bodyUI->filterAudio, &QCheckBox::toggled, this, &AVForm::onFilterAudioToggled);
     connect(bodyUI->rescanButton, &QPushButton::clicked, this, [=](){getAudioInDevices(); getAudioOutDevices();});
-    bodyUI->playbackSlider->setValue(100);
-    bodyUI->microphoneSlider->setValue(100);
+    connect(bodyUI->playbackSlider, &QSlider::sliderReleased, this, &AVForm::onPlaybackSliderReleased);
+    connect(bodyUI->microphoneSlider, &QSlider::sliderReleased, this, &AVForm::onMicrophoneSliderReleased);
+    bodyUI->playbackSlider->setValue(Settings::getInstance().getOutVolume());
+    bodyUI->microphoneSlider->setValue(Settings::getInstance().getInVolume());
 
     for (QComboBox* cb : findChildren<QComboBox*>())
     {
@@ -332,8 +334,18 @@ void AVForm::on_playbackSlider_valueChanged(int value)
 
 void AVForm::on_microphoneSlider_valueChanged(int value)
 {
-    Audio::setOutputVolume(value / 100.0);
+    Audio::setInputVolume(value / 100.0);
     bodyUI->microphoneMax->setText(QString::number(value));
+}
+
+void AVForm::onPlaybackSliderReleased()
+{
+    Settings::getInstance().setOutVolume(bodyUI->playbackSlider->value());
+}
+
+void AVForm::onMicrophoneSliderReleased()
+{
+    Settings::getInstance().setInVolume(bodyUI->microphoneSlider->value());
 }
 
 bool AVForm::eventFilter(QObject *o, QEvent *e)

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -316,7 +316,6 @@ void AVForm::onInDevChanged(const QString &deviceDescriptor)
     Settings::getInstance().setInDev(deviceDescriptor);
 
     Audio& audio = Audio::getInstance();
-    audio.openInput(deviceDescriptor);
     audio.unsubscribeInput();
     audio.subscribeInput();
 }
@@ -326,7 +325,6 @@ void AVForm::onOutDevChanged(const QString& deviceDescriptor)
     Settings::getInstance().setOutDev(deviceDescriptor);
 
     Audio& audio = Audio::getInstance();
-    audio.openOutput(deviceDescriptor);
     audio.unsubscribeInput();
     audio.subscribeInput();
 }

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -89,7 +89,7 @@ void AVForm::showEvent(QShowEvent*)
     getAudioInDevices();
     createVideoSurface();
     getVideoDevices();
-    Audio::suscribeInput();
+    Audio::getInstance().subscribeInput();
 }
 
 void AVForm::onVideoModesIndexChanged(int index)
@@ -220,7 +220,7 @@ void AVForm::hideEvent(QHideEvent *)
         killVideoSurface();
     }
     videoDeviceList.clear();
-    Audio::unsuscribeInput();
+    Audio::getInstance().unsubscribeInput();
 }
 
 void AVForm::getVideoDevices()
@@ -314,19 +314,21 @@ void AVForm::getAudioOutDevices()
 void AVForm::onInDevChanged(const QString &deviceDescriptor)
 {
     Settings::getInstance().setInDev(deviceDescriptor);
-    Audio::openInput(deviceDescriptor);
 
-    Audio::unsuscribeInput();
-    Audio::suscribeInput();
+    Audio& audio = Audio::getInstance();
+    audio.openInput(deviceDescriptor);
+    audio.unsubscribeInput();
+    audio.subscribeInput();
 }
 
 void AVForm::onOutDevChanged(const QString& deviceDescriptor)
 {
-    Settings::getInstance().setInDev(deviceDescriptor);
-    Audio::openOutput(deviceDescriptor);
+    Settings::getInstance().setOutDev(deviceDescriptor);
 
-    Audio::unsuscribeInput();
-    Audio::suscribeInput();
+    Audio& audio = Audio::getInstance();
+    audio.openOutput(deviceDescriptor);
+    audio.unsubscribeInput();
+    audio.subscribeInput();
 }
 
 void AVForm::onFilterAudioToggled(bool filterAudio)
@@ -336,13 +338,13 @@ void AVForm::onFilterAudioToggled(bool filterAudio)
 
 void AVForm::on_playbackSlider_valueChanged(int value)
 {
-    Audio::setOutputVolume(value / 100.0);
+    Audio::getInstance().setOutputVolume(value / 100.0);
     bodyUI->playbackMax->setText(QString::number(value));
 }
 
 void AVForm::on_microphoneSlider_valueChanged(int value)
 {
-    Audio::setInputVolume(value / 100.0);
+    Audio::getInstance().setInputVolume(value / 100.0);
     bodyUI->microphoneMax->setText(QString::number(value));
 }
 

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -89,6 +89,7 @@ void AVForm::showEvent(QShowEvent*)
     getAudioInDevices();
     createVideoSurface();
     getVideoDevices();
+    Audio::suscribeInput();
 }
 
 void AVForm::onVideoModesIndexChanged(int index)
@@ -219,6 +220,7 @@ void AVForm::hideEvent(QHideEvent *)
         killVideoSurface();
     }
     videoDeviceList.clear();
+    Audio::unsuscribeInput();
 }
 
 void AVForm::getVideoDevices()
@@ -313,12 +315,18 @@ void AVForm::onInDevChanged(const QString &deviceDescriptor)
 {
     Settings::getInstance().setInDev(deviceDescriptor);
     Audio::openInput(deviceDescriptor);
+
+    Audio::unsuscribeInput();
+    Audio::suscribeInput();
 }
 
 void AVForm::onOutDevChanged(const QString& deviceDescriptor)
 {
-    Settings::getInstance().setOutDev(deviceDescriptor);
+    Settings::getInstance().setInDev(deviceDescriptor);
     Audio::openOutput(deviceDescriptor);
+
+    Audio::unsuscribeInput();
+    Audio::suscribeInput();
 }
 
 void AVForm::onFilterAudioToggled(bool filterAudio)

--- a/src/widget/form/settings/avform.h
+++ b/src/widget/form/settings/avform.h
@@ -59,6 +59,8 @@ private slots:
     void onFilterAudioToggled(bool filterAudio);
     void on_playbackSlider_valueChanged(int value);
     void on_microphoneSlider_valueChanged(int value);
+    void onPlaybackSliderReleased();
+    void onMicrophoneSliderReleased();
 
     // camera
     void onVideoDevChanged(int index);

--- a/src/widget/form/settings/avsettings.ui
+++ b/src/widget/form/settings/avsettings.ui
@@ -48,7 +48,7 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="0">
+          <item row="7" column="0">
            <widget class="QCheckBox" name="filterAudio">
             <property name="toolTip">
              <string>Filter sound from your microphone, so that people hearing you would get better sound.</string>
@@ -74,15 +74,15 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="0">
+          <item row="5" column="0">
            <widget class="QLabel" name="microphoneLabel">
             <property name="text">
              <string>Microphone</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="3">
-           <widget class="QLabel" name="playbackMax">
+          <item row="5" column="3">
+           <widget class="QLabel" name="microphoneMax">
             <property name="text">
              <string>100</string>
             </property>
@@ -95,24 +95,10 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="3">
-           <widget class="QLabel" name="microphoneMax">
+          <item row="2" column="3">
+           <widget class="QLabel" name="playbackMax">
             <property name="text">
              <string>100</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="2">
-           <widget class="QSlider" name="microphoneSlider">
-            <property name="toolTip">
-             <string>Use slider to set volume of your microphone.
-WARNING: slider is not supposed to work yet.</string>
-            </property>
-            <property name="maximum">
-             <number>100</number>
-            </property>
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
             </property>
            </widget>
           </item>
@@ -123,10 +109,24 @@ WARNING: slider is not supposed to work yet.</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="1">
+          <item row="5" column="1">
            <widget class="QLabel" name="microphoneMin">
             <property name="text">
              <string>0</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="2">
+           <widget class="QSlider" name="microphoneSlider">
+            <property name="toolTip">
+             <string>Use slider to set volume of your microphone.
+WARNING: slider is not supposed to work yet.</string>
+            </property>
+            <property name="maximum">
+             <number>200</number>
+            </property>
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
             </property>
            </widget>
           </item>
@@ -146,6 +146,9 @@ WARNING: slider is not supposed to work yet.</string>
              <string>Playback device</string>
             </property>
            </widget>
+          </item>
+          <item row="6" column="2">
+           <widget class="MicFeedbackWidget" name="microphoneFeedback" native="true"/>
           </item>
          </layout>
         </widget>
@@ -232,6 +235,12 @@ which may lead to problems with video calls.</string>
    <class>VerticalOnlyScroller</class>
    <extends>QScrollArea</extends>
    <header>src/widget/form/settings/verticalonlyscroller.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>MicFeedbackWidget</class>
+   <extends>QWidget</extends>
+   <header>src/widget/tool/micfeedbackwidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/widget/form/settings/avsettings.ui
+++ b/src/widget/form/settings/avsettings.ui
@@ -119,11 +119,10 @@
           <item row="5" column="2">
            <widget class="QSlider" name="microphoneSlider">
             <property name="toolTip">
-             <string>Use slider to set volume of your microphone.
-WARNING: slider is not supposed to work yet.</string>
+             <string>Use slider to set volume of your microphone.</string>
             </property>
             <property name="maximum">
-             <number>200</number>
+             <number>400</number>
             </property>
             <property name="orientation">
              <enum>Qt::Horizontal</enum>

--- a/src/widget/tool/micfeedbackwidget.cpp
+++ b/src/widget/tool/micfeedbackwidget.cpp
@@ -1,0 +1,83 @@
+/*
+    Copyright © 2015 by The qTox Project
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "micfeedbackwidget.h"
+#include "src/audio/audio.h"
+#include <QPainter>
+#include <QLinearGradient>
+
+MicFeedbackWidget::MicFeedbackWidget(QWidget *parent) : QWidget(parent)
+{
+    setFixedHeight(20);
+    startTimer(60);
+    Audio::suscribeInput();
+    Audio::setOutputVolume(1.0f);
+}
+
+void MicFeedbackWidget::paintEvent(QPaintEvent*)
+{
+    QPainter painter(this);
+    painter.setPen(QPen(Qt::black));
+    painter.drawRect(QRect(0, 0, width() - 1, height() - 1));
+
+    int gradientWidth = round(width() * rms) - 4;
+    if (gradientWidth < 0)
+        gradientWidth = 0;
+
+    QRect gradientRect(2, 2, gradientWidth, height() - 4);
+
+    QLinearGradient gradient(0, 0, width(), 0);
+    gradient.setColorAt(0, Qt::red);
+    gradient.setColorAt(0.5, Qt::yellow);
+    gradient.setColorAt(1, Qt::green);
+    painter.fillRect(gradientRect, gradient);
+
+    float slice = width() / 5;
+    int padding = slice / 2;
+
+    for (int i = 0; i < 5; ++i)
+    {
+        float pos = slice * i + padding;
+        painter.drawLine(pos, 2, pos, height() - 4);
+    }
+}
+
+void MicFeedbackWidget::timerEvent(QTimerEvent*)
+{
+    const int framesize = (20 * 48000) / 1000;
+    const int bufsize = framesize * 2;
+    uint8_t buff[bufsize];
+    memset(buff, 0, bufsize);
+
+    if (Audio::tryCaptureSamples(buff, framesize))
+    {
+        double max = 0;
+        int16_t* buffReal = (int16_t*)(&buff[0]);
+
+        for (int i = 0; i < bufsize / 2; ++i)
+            max = std::max(max, fabs(buffReal[i] / 32767.0));
+
+        if (max > rms)
+            rms = max;
+        else
+            rms -= 0.05;
+
+        update();
+    }
+}

--- a/src/widget/tool/micfeedbackwidget.cpp
+++ b/src/widget/tool/micfeedbackwidget.cpp
@@ -43,9 +43,9 @@ void MicFeedbackWidget::paintEvent(QPaintEvent*)
     QRect gradientRect(2, 2, gradientWidth, height() - 4);
 
     QLinearGradient gradient(0, 0, width(), 0);
-    gradient.setColorAt(0, Qt::red);
+    gradient.setColorAt(0, Qt::green);
     gradient.setColorAt(0.5, Qt::yellow);
-    gradient.setColorAt(1, Qt::green);
+    gradient.setColorAt(1, Qt::red);
     painter.fillRect(gradientRect, gradient);
 
     float slice = width() / 5;

--- a/src/widget/tool/micfeedbackwidget.cpp
+++ b/src/widget/tool/micfeedbackwidget.cpp
@@ -22,7 +22,9 @@
 #include <QPainter>
 #include <QLinearGradient>
 
-MicFeedbackWidget::MicFeedbackWidget(QWidget *parent) : QWidget(parent)
+MicFeedbackWidget::MicFeedbackWidget(QWidget *parent)
+    : QWidget(parent)
+    , timerId(0)
 {
     setFixedHeight(20);
 }
@@ -83,11 +85,16 @@ void MicFeedbackWidget::timerEvent(QTimerEvent*)
 void MicFeedbackWidget::showEvent(QShowEvent*)
 {
     Audio::suscribeInput();
-    int timerId = startTimer(60);
+    timerId = startTimer(60);
 }
 
 void MicFeedbackWidget::hideEvent(QHideEvent*)
 {
     Audio::unsuscribeInput();
-    killTimer(timerId);
+
+    if (timerId != 0)
+    {
+        killTimer(timerId);
+        timerId = 0;
+    }
 }

--- a/src/widget/tool/micfeedbackwidget.cpp
+++ b/src/widget/tool/micfeedbackwidget.cpp
@@ -80,6 +80,10 @@ void MicFeedbackWidget::timerEvent(QTimerEvent*)
 
         update();
     }
+    else if (current > 0)
+    {
+        current -= 0.01;
+    }
 }
 
 void MicFeedbackWidget::showEvent(QShowEvent*)

--- a/src/widget/tool/micfeedbackwidget.cpp
+++ b/src/widget/tool/micfeedbackwidget.cpp
@@ -65,7 +65,7 @@ void MicFeedbackWidget::timerEvent(QTimerEvent*)
     uint8_t buff[bufsize];
     memset(buff, 0, bufsize);
 
-    if (Audio::tryCaptureSamples(buff, framesize))
+    if (Audio::getInstance().tryCaptureSamples(buff, framesize))
     {
         double max = 0;
         int16_t* buffReal = reinterpret_cast<int16_t*>(&buff[0]);
@@ -88,13 +88,13 @@ void MicFeedbackWidget::timerEvent(QTimerEvent*)
 
 void MicFeedbackWidget::showEvent(QShowEvent*)
 {
-    Audio::suscribeInput();
+    Audio::getInstance().subscribeInput();
     timerId = startTimer(60);
 }
 
 void MicFeedbackWidget::hideEvent(QHideEvent*)
 {
-    Audio::unsuscribeInput();
+    Audio::getInstance().unsubscribeInput();
 
     if (timerId != 0)
     {

--- a/src/widget/tool/micfeedbackwidget.h
+++ b/src/widget/tool/micfeedbackwidget.h
@@ -31,11 +31,12 @@ public:
 protected:
     void paintEvent(QPaintEvent* event) override;
     void timerEvent(QTimerEvent* event) override;
+    void showEvent(QShowEvent* event) override;
+    void hideEvent(QHideEvent* event) override;
 
 private:
-    double rms;
-    static const int previousNum = 4;
-    double previous[previousNum];
+    double current;
+    int timerId;
 };
 
 #endif // MICFEEDBACKWIDGET_H

--- a/src/widget/tool/micfeedbackwidget.h
+++ b/src/widget/tool/micfeedbackwidget.h
@@ -1,0 +1,41 @@
+/*
+    Copyright © 2015 by The qTox Project
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef MICFEEDBACKWIDGET_H
+#define MICFEEDBACKWIDGET_H
+
+#include <QWidget>
+
+class MicFeedbackWidget : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit MicFeedbackWidget(QWidget *parent = 0);
+
+protected:
+    void paintEvent(QPaintEvent* event) override;
+    void timerEvent(QTimerEvent* event) override;
+
+private:
+    double rms;
+    static const int previousNum = 4;
+    double previous[previousNum];
+};
+
+#endif // MICFEEDBACKWIDGET_H

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1249,7 +1249,7 @@ bool Widget::newMessageAlert(QWidget* currentWindow, bool isActive, bool notify)
                 sndFile.close();
             }
 
-            Audio::playMono16Sound(sndData);
+            Audio::getInstance().playMono16Sound(sndData);
         }
     }
 
@@ -1271,7 +1271,7 @@ void Widget::playRingtone()
         sndFile1.close();
     }
 
-    Audio::playMono16Sound(sndData1);
+    Audio::getInstance().playMono16Sound(sndData1);
 }
 
 void Widget::onFriendRequestReceived(const QString& userId, const QString& message)


### PR DESCRIPTION
**Copied description from #2094:**
- Audio output and input are opened and closed when needed.
- There is now a feedback widget that displays how loud you're speaking in the audio settings.
- Microphone volume slider is now fully functioning and max value is 400. You will never be speaking too low ever again!

This PR is WIP ~~because it relies on a small hack - audio output does not open when requested, so I use a timer at 1 ms to open output. Without it, audio fails to open output (incorrectly saying it succeeded) the second time you start a call (ringtones and such still worked).~~

Fixes:
- [x] #1862 #1416 #1880
- [x] #1880
- [x] #1995
- [ ] paused message sound notification is never removed unless cancelling an active call https://github.com/tux3/qTox/pull/2415#issuecomment-149213985

Similar:
- [ ] #1139
- [ ] #1250
- [x] #1750
- [ ] #1832 
