### PR TITLE
Fix #2433 (check blob to null)

### DIFF
--- a/src/persistence/historykeeper.cpp
+++ b/src/persistence/historykeeper.cpp
@@ -524,7 +524,7 @@ void HistoryKeeper::removeAvatar(const QString& ownerId)
 bool HistoryKeeper::hasAvatar(const QString& ownerId)
 {
     QSqlQuery sqlAnswer = db->exec(QString("SELECT avatar FROM aliases WHERE user_id= '%1'").arg(ownerId.left(64)));
-    if (sqlAnswer.first() && sqlAnswer.value(0).toByteArray()!=NULL)
+    if (sqlAnswer.first() && (sqlAnswer.value(0).toByteArray().length() > 0) )
     {
         return true;
     }


### PR DESCRIPTION
Fix #2433 
abaut "sqlAnswer.first()"
After the query is executed, the query is positioned on an invalid record and must be navigated to a valid record before data values can be retrieved (from help)
