### PR TITLE
Remove ~duplicated code for tray backed selection

### DIFF
--- a/src/widget/systemtrayicon.cpp
+++ b/src/widget/systemtrayicon.cpp
@@ -88,16 +88,9 @@ SystemTrayIcon::SystemTrayIcon()
         g_signal_connect(gtkIcon, "button-release-event", G_CALLBACK(callbackButtonClick), this);
     }
     #endif
-    else if (desktop == "kde" && getenv("KDE_SESSION_VERSION") == QStringLiteral("5"))
-    {
-        qDebug() << "Using the Qt backend on KDE5";
-        qtIcon = new QSystemTrayIcon;
-        backendType = SystrayBackendType::Qt;
-        connect(qtIcon, &QSystemTrayIcon::activated, this, &SystemTrayIcon::activated);
-    }
     else
     {
-        qDebug() << "Using the Qt backend, because nothing else matches";
+        qDebug() << "Using the Qt backend";
         qtIcon = new QSystemTrayIcon;
         backendType = SystrayBackendType::Qt;
         connect(qtIcon, &QSystemTrayIcon::activated, this, &SystemTrayIcon::activated);


### PR DESCRIPTION
`else` clause already handles KDE5 case
