### PR TITLE
some cleanup for audio in "newav_final_for_realsies"

### DIFF
--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -170,8 +170,7 @@ void Audio::unsubscribeInput()
 
     if (inputSubscriptions > 0)
         inputSubscriptions--;
-    else if(inputSubscriptions < 0)
-        inputSubscriptions = 0;
+    assert(inputSubscriptions >= 0);
 
     if (!inputSubscriptions)
         _cleanupInput();

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -166,15 +166,15 @@ If the input device has no more subscriptions, it will be closed.
 void Audio::unsubscribeInput()
 {
     qDebug() << "unsubscribing input" << inputSubscriptions;
+    QMutexLocker locker(&audioInLock);
+
     if (inputSubscriptions > 0)
         inputSubscriptions--;
     else if(inputSubscriptions < 0)
         inputSubscriptions = 0;
 
-    if (!inputSubscriptions) {
-        closeOutput();
-        closeInput();
-    }
+    if (!inputSubscriptions)
+        _cleanupInput();
 }
 
 /**

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -521,19 +521,16 @@ bool Audio::tryCaptureSamples(int16_t* buf, int samples)
 
     alcCaptureSamples(Audio::alInDev, buf, samples);
 
-    if (inputVolume != 1)
+    for (size_t i = 0; i < samples * AUDIO_CHANNELS; ++i)
     {
-        for (size_t i = 0; i < samples * AUDIO_CHANNELS; ++i)
-        {
-            int sample = buf[i] * pow(inputVolume, 2);
+        int sample = buf[i] * pow(inputVolume, 2);
 
-            if (sample < std::numeric_limits<int16_t>::min())
-                sample = std::numeric_limits<int16_t>::min();
-            else if (sample > std::numeric_limits<int16_t>::max())
-                sample = std::numeric_limits<int16_t>::max();
+        if (sample < std::numeric_limits<int16_t>::min())
+            sample = std::numeric_limits<int16_t>::min();
+        else if (sample > std::numeric_limits<int16_t>::max())
+            sample = std::numeric_limits<int16_t>::max();
 
-            buf[i] = sample;
-        }
+        buf[i] = sample;
     }
 
     return true;

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -144,7 +144,9 @@ void Audio::subscribeInput()
     if (!inputSubscriptions++)
     {
         openInput(Settings::getInstance().getInDev());
-        openOutput(Settings::getInstance().getOutDev());
+        if (!alOutDev)
+            openOutput(Settings::getInstance().getOutDev());
+
 
 #if (!FIX_SND_PCM_PREPARE_BUG)
         if (alInDev)

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -22,7 +22,6 @@
 #define AUDIO_H
 
 #include <QObject>
-#include <QHash>
 #include <QMutexLocker>
 #include <atomic>
 #include <cmath>
@@ -35,11 +34,7 @@
  #include <AL/alc.h>
 #endif
 
-class QString;
-class QByteArray;
 class QTimer;
-class QThread;
-class QMutex;
 struct Tox;
 class AudioFilterer;
 

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -104,6 +104,9 @@ private:
     Audio();
     ~Audio();
 
+    void _cleanupInput();
+    void _cleanupOutput();
+
 private:
     static Audio* instance;
 


### PR DESCRIPTION
- ~~rename `Audio::subscribeInput()` -> `Audio::subscribe`~~
- Open audio output device only when not already open when subscribing to input.
  - It is questionable, that the output device should be opened at all in `subscribeInput`
