### PR TITLE
Adds button to enable camera preview when user order it

### DIFF
--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -46,6 +46,7 @@ AVForm::AVForm() :
 {
     bodyUI = new Ui::AVSettings;
     bodyUI->setupUi(this);
+    bodyUI->camFrame->hide();
 
 #ifdef QTOX_FILTER_AUDIO
     bodyUI->filterAudio->setChecked(Settings::getInstance().getFilterAudio());
@@ -59,6 +60,7 @@ AVForm::AVForm() :
     connect(bodyUI->outDevCombobox, qcbxIndexChangedStr, this, &AVForm::onOutDevChanged);
     connect(bodyUI->videoDevCombobox, qcbxIndexChangedInt, this, &AVForm::onVideoDevChanged);
     connect(bodyUI->videoModescomboBox, qcbxIndexChangedInt, this, &AVForm::onVideoModesIndexChanged);
+    connect(bodyUI->enableCameraButton, &QPushButton::clicked, this, &AVForm::onEnableCameraClicked);
 
     connect(bodyUI->filterAudio, &QCheckBox::toggled, this, &AVForm::onFilterAudioToggled);
     connect(bodyUI->rescanButton, &QPushButton::clicked, this, [=](){getAudioInDevices(); getAudioOutDevices();});
@@ -85,10 +87,9 @@ AVForm::~AVForm()
 
 void AVForm::showEvent(QShowEvent*)
 {
+    getVideoDevices();
     getAudioOutDevices();
     getAudioInDevices();
-    createVideoSurface();
-    getVideoDevices();
     Audio::getInstance().subscribeInput();
 }
 
@@ -212,8 +213,19 @@ void AVForm::onVideoDevChanged(int index)
     createVideoSurface();
 }
 
+void AVForm::onEnableCameraClicked()
+{
+    bodyUI->enableCameraButton->hide();
+    bodyUI->camFrame->show();
+    createVideoSurface();
+}
+
 void AVForm::hideEvent(QHideEvent *)
 {
+    bodyUI->camFrame->hide();
+
+    bodyUI->enableCameraButton->show();
+
     if (camVideoSurface)
     {
         camVideoSurface->setSource(nullptr);

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -50,7 +50,7 @@ AVForm::AVForm() :
 #ifdef QTOX_FILTER_AUDIO
     bodyUI->filterAudio->setChecked(Settings::getInstance().getFilterAudio());
 #else
-    bodyUI->filterAudio->setDisabled(true);
+    bodyUI->filterAudio->hide();
 #endif
 
     auto qcbxIndexChangedStr = (void(QComboBox::*)(const QString&)) &QComboBox::currentIndexChanged;
@@ -371,7 +371,7 @@ void AVForm::createVideoSurface()
 {
     if (camVideoSurface)
         return;
-    camVideoSurface = new VideoSurface(QPixmap(), bodyUI->CamFrame);
+    camVideoSurface = new VideoSurface(QPixmap(), bodyUI->camFrame);
     camVideoSurface->setObjectName(QStringLiteral("CamVideoSurface"));
     camVideoSurface->setMinimumSize(QSize(160, 120));
     camVideoSurface->setSource(&camera);

--- a/src/widget/form/settings/avform.h
+++ b/src/widget/form/settings/avform.h
@@ -61,6 +61,7 @@ private slots:
     void on_microphoneSlider_valueChanged(int value);
     void onPlaybackSliderReleased();
     void onMicrophoneSliderReleased();
+    void onEnableCameraClicked();
 
     // camera
     void onVideoDevChanged(int index);

--- a/src/widget/form/settings/avsettings.ui
+++ b/src/widget/form/settings/avsettings.ui
@@ -212,7 +212,7 @@ which may lead to problems with video calls.</string>
              </sizepolicy>
             </property>
             <property name="text">
-             <string>Enable camera</string>
+             <string>Enable video preview</string>
             </property>
             <property name="icon">
              <iconset resource="../../../../res.qrc">

--- a/src/widget/form/settings/avsettings.ui
+++ b/src/widget/form/settings/avsettings.ui
@@ -30,8 +30,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>824</width>
-        <height>489</height>
+        <width>830</width>
+        <height>495</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -204,7 +204,7 @@ which may lead to problems with video calls.</string>
            </layout>
           </item>
           <item>
-           <widget class="QFrame" name="CamFrame">
+           <widget class="QFrame" name="camFrame">
             <property name="sizePolicy">
              <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
               <horstretch>1</horstretch>

--- a/src/widget/form/settings/avsettings.ui
+++ b/src/widget/form/settings/avsettings.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>842</width>
-    <height>507</height>
+    <height>601</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -31,7 +31,7 @@
         <x>0</x>
         <y>0</y>
         <width>830</width>
-        <height>495</height>
+        <height>589</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -204,6 +204,23 @@ which may lead to problems with video calls.</string>
            </layout>
           </item>
           <item>
+           <widget class="QPushButton" name="enableCameraButton">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+              <horstretch>1</horstretch>
+              <verstretch>150</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Enable camera</string>
+            </property>
+            <property name="icon">
+             <iconset resource="../../../../res.qrc">
+              <normaloff>:/img/settings/av.png</normaloff>:/img/settings/av.png</iconset>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QFrame" name="camFrame">
             <property name="sizePolicy">
              <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
@@ -243,6 +260,8 @@ which may lead to problems with video calls.</string>
    <container>1</container>
   </customwidget>
  </customwidgets>
- <resources/>
+ <resources>
+  <include location="../../../../res.qrc"/>
+ </resources>
  <connections/>
 </ui>


### PR DESCRIPTION
adds a button in av settings tab which blocks automatic start
of camera preview in the tab. The camera/desktop preview will be
loaded after user explicitly ordered it.

Hopefully this will help with debugging freezing qtox. at least we will
know if camera or audio is broken.

![snapshot2](https://cloud.githubusercontent.com/assets/2544251/10714936/f4ea9b40-7afb-11e5-9d0e-9e49abe6930c.png)

Won't close, but will help with #2438 debugging. 
