### PR TITLE
Change logout icon to dialog type icon

### DIFF
--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1701,7 +1701,7 @@ void Widget::onTryCreateTrayIcon()
             QStyle *style = qApp->style();
 
             actionLogout = new QAction(tr("&Logout"), this);
-            actionLogout->setIcon(style->standardIcon(QStyle::SP_BrowserStop));
+            actionLogout->setIcon(style->standardIcon(QStyle::SP_DialogResetButton));
             connect(actionLogout, &QAction::triggered, profileForm, &ProfileForm::onLogoutClicked);
 
             actionQuit = new QAction(tr("&Exit"), this);


### PR DESCRIPTION
icon of type Browser doesnt scale on some environments
closes #2491 

On plasma this will look like this now:
![twitchinstallarch2](https://cloud.githubusercontent.com/assets/2544251/10891411/c5391c00-8195-11e5-9b56-be83dad0b105.png)
