### PR TITLE
Improve audio based on "newav_final_for_realsies"

### DIFF
--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -108,12 +108,13 @@ Start the audio thread for capture and playback.
 */
 void Audio::startAudioThread()
 {
+    moveToThread(audioThread);
+
     if (!audioThread->isRunning())
         audioThread->start();
     else
         qWarning("Audio thread already started -> ignored.");
 
-    moveToThread(audioThread);
 }
 
 /**

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -313,7 +313,7 @@ bool Audio::initOutput(const QString& outDevDescr)
         else
         {
             qWarning() << "Cannot create output audio context";
-            alcCloseDevice(alOutDev);
+            cleanupOutput();
             return false;
         }
     }

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -781,11 +781,13 @@ void Audio::deleteSource(quint32 sid)
 
 void Audio::startLoop()
 {
+    QMutexLocker locker(&d->audioLock);
     alSourcei(d->alMainSource, AL_LOOPING, AL_TRUE);
 }
 
 void Audio::stopLoop()
 {
+    QMutexLocker locker(&d->audioLock);
     alSourcei(d->alMainSource, AL_LOOPING, AL_FALSE);
     alSourceStop(d->alMainSource);
 }

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -527,12 +527,6 @@ bool Audio::isInputReady()
     return alInDev;
 }
 
-bool Audio::isInputSubscribed()
-{
-    // No lock, inputSubscriptions is atomic!
-    return inputSubscriptions;
-}
-
 /**
 Returns true if the output device is open
 */

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -564,19 +564,16 @@ bool Audio::tryCaptureSamples(int16_t* buf, int samples)
 
     alcCaptureSamples(Audio::alInDev, buf, samples);
 
-    if (inputVolume != 1)
+    for (size_t i = 0; i < samples * AUDIO_CHANNELS; ++i)
     {
-        for (size_t i = 0; i < samples * AUDIO_CHANNELS; ++i)
-        {
-            int sample = buf[i] * pow(inputVolume, 2);
+        int sample = buf[i] * pow(inputVolume, 2);
 
-            if (sample < std::numeric_limits<int16_t>::min())
-                sample = std::numeric_limits<int16_t>::min();
-            else if (sample > std::numeric_limits<int16_t>::max())
-                sample = std::numeric_limits<int16_t>::max();
+        if (sample < std::numeric_limits<int16_t>::min())
+            sample = std::numeric_limits<int16_t>::min();
+        else if (sample > std::numeric_limits<int16_t>::max())
+            sample = std::numeric_limits<int16_t>::max();
 
-            buf[i] = sample;
-        }
+        buf[i] = sample;
     }
 
     return true;

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -167,7 +167,7 @@ void Audio::unsubscribeInput()
     if (inputSubscriptions > 0)
         inputSubscriptions--;
 
-    if (!inputSubscriptions) {
+    if (!inputSubscriptions)
         cleanupInput();
 }
 

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -140,7 +140,9 @@ void Audio::subscribeInput()
     if (!inputSubscriptions++)
     {
         openInput(Settings::getInstance().getInDev());
-        openOutput(Settings::getInstance().getOutDev());
+        if (!alOutDev)
+            openOutput(Settings::getInstance().getOutDev());
+
 
 #if (!FIX_SND_PCM_PREPARE_BUG)
         if (alInDev)

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -59,6 +59,7 @@ Audio::Audio()
     , audioInLock(QMutex::Recursive)
     , audioOutLock(QMutex::Recursive)
     , inputSubscriptions(0)
+    , outputSubscriptions(0)
     , alOutDev(nullptr)
     , alInDev(nullptr)
     , outputVolume(1.0)
@@ -159,6 +160,29 @@ void Audio::unsubscribeInput()
 
     if (!inputSubscriptions)
         cleanupInput();
+}
+
+void Audio::subscribeOutput()
+{
+    QMutexLocker locker(&audioOutLock);
+
+    if (!alOutDev)
+        initOutput(Settings::getInstance().getOutDev());
+
+    outputSubscriptions++;
+    qDebug() << "Subscribed to audio output device [" << outputSubscriptions << " subscriptions ]";
+}
+
+void Audio::unsubscribeOutput()
+{
+    if (outputSubscriptions > 0)
+    {
+        outputSubscriptions--;
+        qDebug() << "Unsubscribed from audio output device [" << outputSubscriptions << " subscriptions]";
+    }
+
+    if (!outputSubscriptions)
+        cleanupOutput();
 }
 
 /**

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -73,6 +73,8 @@ Audio::Audio()
 
 Audio::~Audio()
 {
+    closeInput();
+    closeOutput();
     audioThread->exit();
     audioThread->wait();
     if (audioThread->isRunning())

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -137,21 +137,21 @@ If the input device is not open, it will be opened before capturing.
 void Audio::subscribeInput()
 {
     qDebug() << "subscribing input" << inputSubscriptions;
-    if (!inputSubscriptions++)
-    {
+
+    if (!alInDev) {
         openInput(Settings::getInstance().getInDev());
-        if (!alOutDev)
-            openOutput(Settings::getInstance().getOutDev());
-
-
 #if (!FIX_SND_PCM_PREPARE_BUG)
-        if (alInDev)
-        {
+        if (alInDev) {
             qDebug() << "starting capture";
             alcCaptureStart(alInDev);
         }
 #endif
     }
+
+    if (!alOutDev)
+        openOutput(Settings::getInstance().getOutDev());
+
+    inputSubscriptions++;
 }
 
 /**

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -455,11 +455,11 @@ void Audio::playMono16Sound(const QByteArray& data)
 /**
 Play a 44100Hz mono 16bit PCM sound from a file
 */
-void Audio::playMono16Sound(const char *path)
+void Audio::playMono16Sound(const QString& path)
 {
     QFile sndFile(path);
     sndFile.open(QIODevice::ReadOnly);
-    playMono16Sound(sndFile.readAll());
+    playMono16Sound(QByteArray(sndFile.readAll()));
 }
 
 /**

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -504,14 +504,13 @@ void Audio::cleanupOutput()
         alSourceStop(alMainSource);
         alDeleteSources(1, &alMainSource);
 
-        ALCdevice* device = alcGetContextsDevice(alContext);
         if (!alcMakeContextCurrent(nullptr))
             qWarning("Failed to clear current audio context.");
 
         alcDestroyContext(alContext);
         alContext = nullptr;
 
-        if (alcCloseDevice(device))
+        if (alcCloseDevice(alOutDev))
             alOutDev = nullptr;
         else
             qWarning("Failed to close output.");

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -106,6 +106,9 @@ private:
     Audio();
     ~Audio();
 
+    void cleanupInput();
+    void cleanupOutput();
+
 private:
     static Audio* instance;
 

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -22,7 +22,6 @@
 #define AUDIO_H
 
 #include <QObject>
-#include <QHash>
 #include <QMutexLocker>
 #include <atomic>
 #include <cmath>
@@ -36,11 +35,7 @@
  #include <AL/alext.h>
 #endif
 
-class QString;
-class QByteArray;
 class QTimer;
-class QThread;
-class QMutex;
 struct Tox;
 class AudioFilterer;
 

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -21,10 +21,10 @@
 #ifndef AUDIO_H
 #define AUDIO_H
 
-#include <QObject>
-#include <QMutexLocker>
 #include <atomic>
 #include <cmath>
+
+#include <QObject>
 #include <QWaitCondition>
 
 struct Tox;
@@ -44,7 +44,7 @@ class Audio : public QObject
     Q_OBJECT
 
 public:
-    typedef QList<const void*> PtrList;
+    typedef quint32 SID;
 
 public:
     static Audio& getInstance();
@@ -68,8 +68,8 @@ public:
 
     static const char* outDeviceNames();
     static const char* inDeviceNames();
-    void createSource(quint32* sid);
-    void deleteSource(quint32 sid);
+    void subscribeOutput(SID& sid);
+    void unsubscribeOutput(SID& sid);
 
     void startLoop();
     void stopLoop();
@@ -88,10 +88,8 @@ public:
 #endif
 
 public slots:
-    void subscribeInput(const void* inListener);
-    void subscribeOutput(const void* outListener);
-    void unsubscribeInput(const void* inListener);
-    void unsubscribeOutput(const void* outListener);
+    void subscribeInput();
+    void unsubscribeInput();
     void playGroupAudio(int group, int peer, const int16_t* data,
                         unsigned samples, uint8_t channels, unsigned sample_rate);
 

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -40,6 +40,7 @@ class Audio : public QObject
 {
     Q_OBJECT
 
+public:
     typedef QList<const void*> PtrList;
 
 public:
@@ -54,18 +55,8 @@ public:
     qreal inputVolume();
     void setInputVolume(qreal volume);
 
-    inline void reinitInput(const QString& inDevDesc)
-    {
-        QMutexLocker locker(&mAudioLock);
-        cleanupInput();
-        initInput(inDevDesc);
-    }
-    inline bool reinitOutput(const QString& outDevDesc)
-    {
-        QMutexLocker locker(&mAudioLock);
-        cleanupOutput();
-        return initOutput(outDevDesc);
-    }
+    void reinitInput(const QString& inDevDesc);
+    bool reinitOutput(const QString& outDevDesc);
 
     bool isInputReady();
     bool isOutputReady();
@@ -107,24 +98,11 @@ private:
     Audio();
     ~Audio();
 
-    void initInput(const QString& inDevDescr);
-    bool initOutput(const QString& outDevDescr);
-    void cleanupInput();
-    void cleanupOutput();
-
 private:
     static Audio* instance;
 
 private:
     AudioPrivate* d;
-
-private:
-    QThread*            audioThread;
-    QMutex              mAudioLock;
-    PtrList             inputSubscriptions;
-    PtrList             outputSubscriptions;
-    bool                mInputInitialized;
-    bool                mOutputInitialized;
 };
 
 #endif // AUDIO_H

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -82,9 +82,8 @@ public:
     static void playGroupAudioQueued(void *, int group, int peer, const int16_t* data,
                                      unsigned samples, uint8_t channels, unsigned sample_rate, void*);
 
-#ifdef QTOX_FILTER_AUDIO
-    static void getEchoesToFilter(AudioFilterer* filter, int framesize);
-    // is a null op #ifndef ALC_LOOPBACK_CAPTURE_SAMPLES
+#if defined(QTOX_FILTER_AUDIO) && defined(ALC_LOOPBACK_CAPTURE_SAMPLES)
+    void getEchoesToFilter(AudioFilterer* filter, int samples);
 #endif
 
 public slots:

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -116,6 +116,9 @@ private:
     static Audio* instance;
 
 private:
+    AudioPrivate* d;
+
+private:
     QThread*            audioThread;
     QMutex              mAudioLock;
     PtrList             inputSubscriptions;

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -60,13 +60,6 @@ public:
 
     void setInputVolume(qreal volume);
 
-    void subscribeInput();
-    void unsubscribeInput();
-    void subscribeOutput();
-    void unsubscribeOutput();
-    void openInput(const QString& inDevDescr);
-    bool openOutput(const QString& outDevDescr);
-
     inline void reinitInput(const QString& inDevDesc)
     {
         QMutexLocker locker(&audioInLock);
@@ -103,8 +96,10 @@ public:
 #endif
 
 public slots:
-    void closeInput();
-    void closeOutput();
+    void subscribeInput();
+    void subscribeOutput();
+    void unsubscribeInput();
+    void unsubscribeOutput();
     void playGroupAudio(int group, int peer, const int16_t* data,
                         unsigned samples, uint8_t channels, unsigned sample_rate);
 
@@ -114,6 +109,8 @@ signals:
 private:
     Audio();
     ~Audio();
+
+    void internalSubscribeOutput();
 
     void initInput(const QString& inDevDescr);
     bool initOutput(const QString& outDevDescr);

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -101,6 +101,8 @@ private:
     Audio();
     ~Audio();
 
+    void initInput(const QString& inDevDescr);
+    bool initOutput(const QString& outDevDescr);
     void cleanupInput();
     void cleanupOutput();
 

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -67,6 +67,19 @@ public:
     void openInput(const QString& inDevDescr);
     bool openOutput(const QString& outDevDescr);
 
+    inline void reinitInput(const QString& inDevDesc)
+    {
+        QMutexLocker locker(&audioInLock);
+        cleanupInput();
+        initInput(inDevDesc);
+    }
+    inline bool reinitOutput(const QString& outDevDesc)
+    {
+        QMutexLocker locker(&audioOutLock);
+        cleanupOutput();
+        return initOutput(outDevDesc);
+    }
+
     bool isInputReady();
     bool isInputSubscribed();
     bool isOutputReady();

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -81,7 +81,6 @@ public:
     }
 
     bool isInputReady();
-    bool isInputSubscribed();
     bool isOutputReady();
 
     static void createSource(ALuint* source);

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -28,6 +28,8 @@
 
 struct Tox;
 class AudioFilterer;
+class AudioMeter;
+class AudioMeterListener;
 class AudioPrivate;
 
 // Public default audio settings
@@ -48,6 +50,8 @@ public:
 
 public:
     void startAudioThread();
+
+    AudioMeterListener* createAudioMeterListener() const;
 
     qreal outputVolume();
     void setOutputVolume(qreal volume);
@@ -103,6 +107,27 @@ private:
 
 private:
     AudioPrivate* d;
+};
+
+class AudioMeterListener : public QObject
+{
+    Q_OBJECT
+public:
+    explicit AudioMeterListener(AudioMeter* measureThread);
+
+    void start();
+    void stop();
+
+signals:
+    void gainChanged(qreal newMaxGain);
+
+private slots:
+    void doListen();
+
+private:
+    bool            mActive;
+    AudioMeter*     mAudioMeter;
+    qreal           mMaxGain;
 };
 
 #endif // AUDIO_H

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -131,6 +131,8 @@ private:
     std::atomic<int>    outputSubscriptions;
     ALCdevice*          alOutDev;
     ALCdevice*          alInDev;
+    bool                mInputInitialized;
+    bool                mOutputInitialized;
     qreal               outputVolume;
     qreal               inputVolume;
     ALuint              alMainSource;

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -62,6 +62,8 @@ public:
 
     void subscribeInput();
     void unsubscribeInput();
+    void subscribeOutput();
+    void unsubscribeOutput();
     void openInput(const QString& inDevDescr);
     bool openOutput(const QString& outDevDescr);
 
@@ -114,6 +116,7 @@ private:
     QMutex              audioInLock;
     QMutex              audioOutLock;
     std::atomic<int>    inputSubscriptions;
+    std::atomic<int>    outputSubscriptions;
     ALCdevice*          alOutDev;
     ALCdevice*          alInDev;
     qreal               outputVolume;

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -35,7 +35,6 @@
  #include <AL/alext.h>
 #endif
 
-class QTimer;
 struct Tox;
 class AudioFilterer;
 
@@ -48,6 +47,8 @@ static constexpr uint32_t AUDIO_CHANNELS = 2; ///< Ideally, we'd auto-detect, bu
 class Audio : public QObject
 {
     Q_OBJECT
+
+    typedef QList<const void*> PtrList;
 
 public:
     static Audio& getInstance();
@@ -96,10 +97,10 @@ public:
 #endif
 
 public slots:
-    void subscribeInput();
-    void subscribeOutput();
-    void unsubscribeInput();
-    void unsubscribeOutput();
+    void subscribeInput(const void* inListener);
+    void subscribeOutput(const void* outListener);
+    void unsubscribeInput(const void* inListener);
+    void unsubscribeOutput(const void* outListener);
     void playGroupAudio(int group, int peer, const int16_t* data,
                         unsigned samples, uint8_t channels, unsigned sample_rate);
 
@@ -109,8 +110,6 @@ signals:
 private:
     Audio();
     ~Audio();
-
-    void internalSubscribeOutput();
 
     void initInput(const QString& inDevDescr);
     bool initOutput(const QString& outDevDescr);
@@ -122,9 +121,9 @@ private:
 
 private:
     QThread*            audioThread;
-    std::atomic<int>    inputSubscriptions;
-    std::atomic<int>    outputSubscriptions;
     QMutex              mAudioLock;
+    PtrList             inputSubscriptions;
+    PtrList             outputSubscriptions;
     ALCdevice*          alOutDev;
     ALCdevice*          alInDev;
     bool                mInputInitialized;
@@ -133,7 +132,6 @@ private:
     qreal               inputVolume;
     ALuint              alMainSource;
     ALCcontext*         alContext;
-    QTimer*             timer;
 };
 
 #endif // AUDIO_H

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -62,13 +62,13 @@ public:
 
     inline void reinitInput(const QString& inDevDesc)
     {
-        QMutexLocker locker(&audioInLock);
+        QMutexLocker locker(&mAudioLock);
         cleanupInput();
         initInput(inDevDesc);
     }
     inline bool reinitOutput(const QString& outDevDesc)
     {
-        QMutexLocker locker(&audioOutLock);
+        QMutexLocker locker(&mAudioLock);
         cleanupOutput();
         return initOutput(outDevDesc);
     }
@@ -122,10 +122,9 @@ private:
 
 private:
     QThread*            audioThread;
-    QMutex              audioInLock;
-    QMutex              audioOutLock;
     std::atomic<int>    inputSubscriptions;
     std::atomic<int>    outputSubscriptions;
+    QMutex              mAudioLock;
     ALCdevice*          alOutDev;
     ALCdevice*          alInDev;
     bool                mInputInitialized;

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -25,6 +25,7 @@
 #include <QMutexLocker>
 #include <atomic>
 #include <cmath>
+#include <QWaitCondition>
 
 struct Tox;
 class AudioFilterer;
@@ -117,6 +118,8 @@ public:
     void start();
     void stop();
 
+    void processed();
+
 signals:
     void gainChanged(qreal newMaxGain);
 
@@ -127,6 +130,7 @@ private:
     bool            mActive;
     AudioMeter*     mAudioMeter;
     qreal           mMaxGain;
+    QWaitCondition  mGainProcessed;
 };
 
 #endif // AUDIO_H

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -69,7 +69,7 @@ public:
     void startLoop();
     void stopLoop();
     void playMono16Sound(const QByteArray& data);
-    void playMono16Sound(const char* path);
+    void playMono16Sound(const QString& path);
     bool tryCaptureSamples(int16_t *buf, int samples);
 
     void playAudioBuffer(quint32 alSource, const int16_t *data, int samples,

--- a/src/audio/audiofilterer.cpp
+++ b/src/audio/audiofilterer.cpp
@@ -25,7 +25,7 @@ extern "C"{
 #include <filter_audio.h>
 }
 
-void AudioFilterer::startFilter(unsigned int fs)
+void AudioFilterer::startFilter(uint32_t fs)
 {
     closeFilter();
     filter = new_filter_audio(fs);
@@ -38,9 +38,9 @@ void AudioFilterer::closeFilter()
     filter = nullptr;
 }
 
-bool AudioFilterer::filterAudio(int16_t* data, int framesize)
+bool AudioFilterer::filterAudio(int16_t* data, unsigned int samples)
 {
-    return filter && 0 == filter_audio(filter, (int16_t*) data, framesize);
+    return filter && 0 == filter_audio(filter, data, samples);
 }
 
 /* Enable/disable filters. 1 to enable, 0 to disable. */

--- a/src/audio/audiofilterer.h
+++ b/src/audio/audiofilterer.h
@@ -33,13 +33,13 @@ public:
     explicit AudioFilterer(const AudioFilterer&) = delete;
     ~AudioFilterer();
     AudioFilterer operator=(const AudioFilterer) = delete;
-    void startFilter(unsigned int fs);
+    void startFilter(uint32_t fs);
     void closeFilter();
 
     /* Enable/disable filters. 1 to enable, 0 to disable. */
     bool enableDisableFilters(int echo, int noise, int gain, int vad);
 
-    bool filterAudio(int16_t* data, int samples);
+    bool filterAudio(int16_t* data, unsigned int samples);
 
     /* Give the audio output from your software to this function so it knows what echo to cancel from the frame */
     bool passAudioOutput(const int16_t *data, int samples);

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -106,10 +106,6 @@ Core::~Core()
     }
 
     deadifyTox();
-
-    Audio& audio = Audio::getInstance();
-    audio.closeInput();
-    audio.closeOutput();
 }
 
 Core* Core::getInstance()

--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -263,9 +263,11 @@ bool CoreAV::sendCallAudio(uint32_t callId)
                 call.filterer = new AudioFilterer();
                 call.filterer->startFilter(AUDIO_SAMPLE_RATE);
             }
-            // is a null op #ifndef ALC_LOOPBACK_CAPTURE_SAMPLES
-            Audio::getEchoesToFilter(call.filterer, AUDIO_FRAME_SAMPLE_COUNT * AUDIO_CHANNELS);
 
+#ifdef ALC_LOOPBACK_CAPTURE_SAMPLES
+            // compatibility with older versions of OpenAL
+            Audio::getInstance().getEchoesToFilter(call.filterer, AUDIO_FRAME_SAMPLE_COUNT * AUDIO_CHANNELS);
+#endif
             call.filterer->filterAudio(buf, AUDIO_FRAME_SAMPLE_COUNT * AUDIO_CHANNELS);
         }
         else if (call.filterer)
@@ -413,10 +415,10 @@ bool CoreAV::sendGroupCallAudio(int groupId)
                 call.filterer = new AudioFilterer();
                 call.filterer->startFilter(AUDIO_SAMPLE_RATE);
             }
-            // is a null op #ifndef ALC_LOOPBACK_CAPTURE_SAMPLES
-            Audio::getEchoesToFilter(call.filterer, AUDIO_FRAME_SAMPLE_COUNT);
 
-            call.filterer->filterAudio(buf, AUDIO_FRAME_SAMPLE_COUNT * AUDIO_CHANNELS);
+#ifdef ALC_LOOPBACK_CAPTURE_SAMPLES
+            Audio::getInstance().getEchoesToFilter(call.filterer, AUDIO_FRAME_SAMPLE_COUNT);
+#endif
         }
         else if (call.filterer)
         {

--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -474,8 +474,8 @@ void CoreAV::resetCallSources()
     {
         if (call.alSource)
         {
-            Audio::deleteSource(&call.alSource);
-            Audio::createSource(&call.alSource);
+            Audio::getInstance().deleteSource(call.alSource);
+            Audio::getInstance().createSource(&call.alSource);
         }
     }
 
@@ -483,8 +483,8 @@ void CoreAV::resetCallSources()
     {
         if (call.alSource)
         {
-            Audio::deleteSource(&call.alSource);
-            Audio::createSource(&call.alSource);
+            Audio::getInstance().deleteSource(call.alSource);
+            Audio::getInstance().createSource(&call.alSource);
         }
     }
 }
@@ -645,9 +645,9 @@ void CoreAV::audioFrameCallback(ToxAV *, uint32_t friendNum, const int16_t *pcm,
         return;
 
     if (!call.alSource)
-        alGenSources(1, &call.alSource);
+        Audio::getInstance().createSource(&call.alSource);
 
-    Audio::playAudioBuffer(call.alSource, pcm, sampleCount, channels, samplingRate);
+    Audio::getInstance().playAudioBuffer(call.alSource, pcm, sampleCount, channels, samplingRate);
 }
 
 void CoreAV::videoFrameCallback(ToxAV *, uint32_t friendNum, uint16_t w, uint16_t h,

--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -416,7 +416,7 @@ bool CoreAV::sendGroupCallAudio(int groupId)
             // is a null op #ifndef ALC_LOOPBACK_CAPTURE_SAMPLES
             Audio::getEchoesToFilter(call.filterer, AUDIO_FRAME_SAMPLE_COUNT);
 
-            call.filterer->filterAudio(buf, AUDIO_FRAME_SAMPLE_COUNT);
+            call.filterer->filterAudio(buf, AUDIO_FRAME_SAMPLE_COUNT * AUDIO_CHANNELS);
         }
         else if (call.filterer)
         {

--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -470,24 +470,16 @@ bool CoreAV::isGroupAvEnabled(int groupId) const
     return tox_group_get_type(Core::getInstance()->tox, groupId) == TOX_GROUPCHAT_TYPE_AV;
 }
 
-void CoreAV::resetCallSources()
+void CoreAV::invalidateCallSources()
 {
     for (ToxGroupCall& call : groupCalls)
     {
-        if (call.alSource)
-        {
-            Audio::getInstance().deleteSource(call.alSource);
-            Audio::getInstance().createSource(&call.alSource);
-        }
+        call.alSource = 0;
     }
 
     for (ToxFriendCall& call : calls)
     {
-        if (call.alSource)
-        {
-            Audio::getInstance().deleteSource(call.alSource);
-            Audio::getInstance().createSource(&call.alSource);
-        }
+        call.alSource = 0;
     }
 }
 
@@ -646,10 +638,11 @@ void CoreAV::audioFrameCallback(ToxAV *, uint32_t friendNum, const int16_t *pcm,
     if (call.muteVol)
         return;
 
+    Audio& audio = Audio::getInstance();
     if (!call.alSource)
-        Audio::getInstance().createSource(&call.alSource);
+        audio.subscribeOutput(call.alSource);
 
-    Audio::getInstance().playAudioBuffer(call.alSource, pcm, sampleCount, channels, samplingRate);
+    audio.playAudioBuffer(call.alSource, pcm, sampleCount, channels, samplingRate);
 }
 
 void CoreAV::videoFrameCallback(ToxAV *, uint32_t friendNum, uint16_t w, uint16_t h,

--- a/src/core/coreav.h
+++ b/src/core/coreav.h
@@ -24,17 +24,8 @@
 #include <QObject>
 #include <memory>
 #include <atomic>
-#include <tox/toxav.h>
-
-#if defined(__APPLE__) && defined(__MACH__)
- #include <OpenAL/al.h>
- #include <OpenAL/alc.h>
-#else
- #include <AL/al.h>
- #include <AL/alc.h>
-#endif
-
 #include "src/core/toxcall.h"
+#include <tox/toxav.h>
 
 #ifdef QTOX_FILTER_AUDIO
 class AudioFilterer;

--- a/src/core/coreav.h
+++ b/src/core/coreav.h
@@ -57,7 +57,7 @@ public:
     bool sendGroupCallAudio(int groupNum);
 
     VideoSource* getVideoSourceFromCall(int callNumber); ///< Get a call's video source
-    void resetCallSources(); ///< Forces to regenerate each call's audio sources
+    void invalidateCallSources(); ///< Forces to regenerate each call's audio sources
     void sendNoVideo(); ///< Signal to all peers that we're not sending video anymore. The next frame sent cancels this.
 
     void joinGroupCall(int groupNum); ///< Starts a call in an existing AV groupchat. Call from the GUI thread.

--- a/src/core/toxcall.cpp
+++ b/src/core/toxcall.cpp
@@ -20,7 +20,9 @@ ToxCall::ToxCall(uint32_t CallId)
     sendAudioTimer->setInterval(5);
     sendAudioTimer->setSingleShot(true);
 
-    Audio::getInstance().subscribeInput();
+    Audio& audio = Audio::getInstance();
+    audio.subscribeInput();
+    audio.subscribeOutput();
 
 #ifdef QTOX_FILTER_AUDIO
     if (Settings::getInstance().getFilterAudio())
@@ -56,7 +58,9 @@ ToxCall::~ToxCall()
     {
         QObject::disconnect(sendAudioTimer, nullptr, nullptr, nullptr);
         sendAudioTimer->stop();
-        Audio::getInstance().unsubscribeInput();
+        Audio& audio = Audio::getInstance();
+        audio.unsubscribeInput();
+        audio.unsubscribeOutput();
     }
 
     if (alSource)

--- a/src/core/toxcall.cpp
+++ b/src/core/toxcall.cpp
@@ -21,8 +21,8 @@ ToxCall::ToxCall(uint32_t CallId)
     sendAudioTimer->setSingleShot(true);
 
     Audio& audio = Audio::getInstance();
-    audio.subscribeInput();
-    audio.subscribeOutput();
+    audio.subscribeInput(this);
+    audio.subscribeOutput(this);
 
 #ifdef QTOX_FILTER_AUDIO
     if (Settings::getInstance().getFilterAudio())
@@ -59,8 +59,8 @@ ToxCall::~ToxCall()
         QObject::disconnect(sendAudioTimer, nullptr, nullptr, nullptr);
         sendAudioTimer->stop();
         Audio& audio = Audio::getInstance();
-        audio.unsubscribeInput();
-        audio.unsubscribeOutput();
+        audio.unsubscribeInput(this);
+        audio.unsubscribeOutput(this);
     }
 
     if (alSource)

--- a/src/core/toxcall.cpp
+++ b/src/core/toxcall.cpp
@@ -54,6 +54,9 @@ ToxCall::ToxCall(ToxCall&& other) noexcept
 
 ToxCall::~ToxCall()
 {
+    if (alSource)
+        Audio::getInstance().deleteSource(alSource);
+
     if (sendAudioTimer)
     {
         QObject::disconnect(sendAudioTimer, nullptr, nullptr, nullptr);
@@ -62,9 +65,6 @@ ToxCall::~ToxCall()
         audio.unsubscribeInput(this);
         audio.unsubscribeOutput(this);
     }
-
-    if (alSource)
-        Audio::deleteSource(&alSource);
 
 #ifdef QTOX_FILTER_AUDIO
     if (filterer)

--- a/src/core/toxcall.h
+++ b/src/core/toxcall.h
@@ -2,15 +2,8 @@
 #define TOXCALL_H
 
 #include <cstdint>
+#include "src/audio/audio.h"
 #include "src/core/indexedlist.h"
-
-#if defined(__APPLE__) && defined(__MACH__)
- #include <OpenAL/al.h>
- #include <OpenAL/alc.h>
-#else
- #include <AL/al.h>
- #include <AL/alc.h>
-#endif
 
 #include <tox/toxav.h>
 
@@ -41,7 +34,7 @@ public:
     bool inactive; ///< True while we're not participating. (stopped group call, ringing but hasn't started yet, ...)
     bool muteMic;
     bool muteVol;
-    ALuint alSource;
+    quint32 alSource;
 
 #ifdef QTOX_FILTER_AUDIO
     AudioFilterer* filterer;

--- a/src/core/toxcall.h
+++ b/src/core/toxcall.h
@@ -2,7 +2,8 @@
 #define TOXCALL_H
 
 #include <cstdint>
-#include "src/audio/audio.h"
+#include <QtGlobal>
+
 #include "src/core/indexedlist.h"
 
 #include <tox/toxav.h>

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -294,7 +294,7 @@ void ChatForm::onAvInvite(uint32_t FriendId, bool video)
     Widget::getInstance()->newFriendMessageAlert(FriendId, false);
     Audio& audio = Audio::getInstance();
     audio.startLoop();
-    audio.playMono16Sound(":audio/ToxicIncomingCall.pcm");
+    audio.playMono16Sound(QStringLiteral(":/audio/ToxicIncomingCall.pcm"));
 }
 
 void ChatForm::onAvStart(uint32_t FriendId, bool video)

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -104,7 +104,9 @@ void AVForm::showEvent(QShowEvent*)
     getAudioInDevices();
     createVideoSurface();
     getVideoDevices();
-    Audio::getInstance().subscribeInput();
+    Audio& audio = Audio::getInstance();
+    audio.subscribeInput();
+    audio.subscribeOutput();
 }
 
 void AVForm::onVideoModesIndexChanged(int index)
@@ -241,7 +243,9 @@ void AVForm::hideEvent(QHideEvent *)
         killVideoSurface();
     }
     videoDeviceList.clear();
-    Audio::getInstance().unsubscribeInput();
+    Audio& audio = Audio::getInstance();
+    audio.unsubscribeInput();
+    audio.unsubscribeOutput();
 }
 
 void AVForm::getVideoDevices()

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -19,22 +19,14 @@
 
 #include "avform.h"
 #include "ui_avsettings.h"
-#include "src/persistence/settings.h"
 #include "src/audio/audio.h"
+#include "src/persistence/settings.h"
 #include "src/video/camerasource.h"
 #include "src/video/cameradevice.h"
 #include "src/video/videosurface.h"
 #include "src/widget/translator.h"
 #include "src/core/core.h"
 #include "src/core/coreav.h"
-
-#if defined(__APPLE__) && defined(__MACH__)
- #include <OpenAL/al.h>
- #include <OpenAL/alc.h>
-#else
- #include <AL/alc.h>
- #include <AL/al.h>
-#endif
 
 #include <QDebug>
 
@@ -274,7 +266,7 @@ void AVForm::getAudioInDevices()
     bodyUI->inDevCombobox->blockSignals(true);
     bodyUI->inDevCombobox->clear();
     bodyUI->inDevCombobox->addItem(tr("None"));
-    const ALchar *pDeviceList = alcGetString(NULL, ALC_CAPTURE_DEVICE_SPECIFIER);
+    const char* pDeviceList = Audio::inDeviceNames();
     if (pDeviceList)
     {
         //prevent currentIndexChanged to be fired while adding items
@@ -305,11 +297,7 @@ void AVForm::getAudioOutDevices()
     bodyUI->outDevCombobox->blockSignals(true);
     bodyUI->outDevCombobox->clear();
     bodyUI->outDevCombobox->addItem(tr("None"));
-    const ALchar *pDeviceList;
-    if (alcIsExtensionPresent(NULL, "ALC_ENUMERATE_ALL_EXT") != AL_FALSE)
-        pDeviceList = alcGetString(NULL, ALC_ALL_DEVICES_SPECIFIER);
-    else
-        pDeviceList = alcGetString(NULL, ALC_DEVICE_SPECIFIER);
+    const char* pDeviceList = Audio::outDeviceNames();
     if (pDeviceList)
     {
         //prevent currentIndexChanged to be fired while adding items

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -335,21 +335,18 @@ void AVForm::onInDevChanged(QString deviceDescriptor)
 {
     if (!bodyUI->inDevCombobox->currentIndex())
         deviceDescriptor = "none";
-    Settings::getInstance().setInDev(deviceDescriptor);
 
-    Audio& audio = Audio::getInstance();
-    if (audio.isInputSubscribed())
-        audio.openInput(deviceDescriptor);
+    Settings::getInstance().setInDev(deviceDescriptor);
+    Audio::getInstance().reinitInput(deviceDescriptor);
 }
 
 void AVForm::onOutDevChanged(QString deviceDescriptor)
 {
     if (!bodyUI->outDevCombobox->currentIndex())
         deviceDescriptor = "none";
-    Settings::getInstance().setOutDev(deviceDescriptor);
 
-    Audio& audio = Audio::getInstance();
-    audio.openOutput(deviceDescriptor);
+    Settings::getInstance().setOutDev(deviceDescriptor);
+    Audio::getInstance().reinitOutput(deviceDescriptor);
 }
 
 void AVForm::onFilterAudioToggled(bool filterAudio)

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -105,8 +105,8 @@ void AVForm::showEvent(QShowEvent*)
     createVideoSurface();
     getVideoDevices();
     Audio& audio = Audio::getInstance();
-    audio.subscribeInput();
-    audio.subscribeOutput();
+    audio.subscribeInput(this);
+    audio.subscribeOutput(this);
 }
 
 void AVForm::onVideoModesIndexChanged(int index)
@@ -244,8 +244,8 @@ void AVForm::hideEvent(QHideEvent *)
     }
     videoDeviceList.clear();
     Audio& audio = Audio::getInstance();
-    audio.unsubscribeInput();
-    audio.unsubscribeOutput();
+    audio.unsubscribeInput(this);
+    audio.unsubscribeOutput(this);
 }
 
 void AVForm::getVideoDevices()

--- a/src/widget/form/settings/avform.h
+++ b/src/widget/form/settings/avform.h
@@ -39,7 +39,7 @@ class AVForm : public GenericForm
 public:
     AVForm();
     ~AVForm();
-    virtual QString getFormName() final override {return tr("Audio/Video");}
+    QString getFormName() final override {return tr("Audio/Video");}
 
 private:
     void getAudioInDevices();
@@ -64,15 +64,18 @@ private slots:
     void onVideoDevChanged(int index);
     void onVideoModesIndexChanged(int index);
 
-    virtual void hideEvent(QHideEvent*) final override;
-    virtual void showEvent(QShowEvent*) final override;
-
 protected:
-    virtual bool eventFilter(QObject *o, QEvent *e) final override;
     void updateVideoModes(int curIndex);
 
 private:
+    bool eventFilter(QObject *o, QEvent *e) final override;
+
+    void hideEvent(QHideEvent* event) final override;
+    void showEvent(QShowEvent*event) final override;
+
+private:
     Ui::AVSettings *bodyUI;
+    bool subscribedToAudioIn;
     VideoSurface *camVideoSurface;
     CameraSource &camera;
     QVector<QPair<QString, QString>> videoDeviceList;

--- a/src/widget/tool/micfeedbackwidget.cpp
+++ b/src/widget/tool/micfeedbackwidget.cpp
@@ -85,18 +85,11 @@ void MicFeedbackWidget::timerEvent(QTimerEvent*)
 
 void MicFeedbackWidget::showEvent(QShowEvent*)
 {
-    Audio& audio = Audio::getInstance();
-    audio.subscribeInput();
-    audio.subscribeOutput();
     timerId = startTimer(60);
 }
 
 void MicFeedbackWidget::hideEvent(QHideEvent*)
 {
-    Audio& audio = Audio::getInstance();
-    audio.unsubscribeInput();
-    audio.unsubscribeOutput();
-
     if (timerId != 0)
     {
         killTimer(timerId);

--- a/src/widget/tool/micfeedbackwidget.cpp
+++ b/src/widget/tool/micfeedbackwidget.cpp
@@ -31,30 +31,31 @@ MicFeedbackWidget::MicFeedbackWidget(QWidget *parent)
 
 void MicFeedbackWidget::paintEvent(QPaintEvent*)
 {
+    const int w = width();
+    const int h = height();
     QPainter painter(this);
-    painter.setPen(QPen(Qt::black));
-    painter.drawRect(QRect(0, 0, width() - 1, height() - 1));
+    painter.setPen(QPen(Qt::gray));
+    painter.drawRoundedRect(QRect(0, 0, w - 1, h - 1), 3., 3.);
 
-    int gradientWidth = round(width() * current) - 4;
+    int gradientWidth = qMax(0, qRound(w * current) - 4);
 
-    if (gradientWidth < 0)
-        gradientWidth = 0;
+    QRect gradientRect(2, 2, gradientWidth, h - 4);
 
-    QRect gradientRect(2, 2, gradientWidth, height() - 4);
-
-    QLinearGradient gradient(0, 0, width(), 0);
-    gradient.setColorAt(0, Qt::green);
+    QPainterPath path;
+    QLinearGradient gradient(0, 0, w, 0);
+    gradient.setColorAt(0.0, Qt::green);
     gradient.setColorAt(0.5, Qt::yellow);
-    gradient.setColorAt(1, Qt::red);
-    painter.fillRect(gradientRect, gradient);
+    gradient.setColorAt(1.0, Qt::red);
+    path.addRoundedRect(gradientRect, 2.0, 2.0);
+    painter.fillPath(path, gradient);
 
-    float slice = width() / 5;
+    float slice = w / 5.f;
     int padding = slice / 2;
 
     for (int i = 0; i < 5; ++i)
     {
         float pos = slice * i + padding;
-        painter.drawLine(pos, 2, pos, height() - 4);
+        painter.drawLine(pos, 2, pos, h - 4);
     }
 }
 

--- a/src/widget/tool/micfeedbackwidget.cpp
+++ b/src/widget/tool/micfeedbackwidget.cpp
@@ -85,13 +85,17 @@ void MicFeedbackWidget::timerEvent(QTimerEvent*)
 
 void MicFeedbackWidget::showEvent(QShowEvent*)
 {
-    Audio::getInstance().subscribeInput();
+    Audio& audio = Audio::getInstance();
+    audio.subscribeInput();
+    audio.subscribeOutput();
     timerId = startTimer(60);
 }
 
 void MicFeedbackWidget::hideEvent(QHideEvent*)
 {
-    Audio::getInstance().unsubscribeInput();
+    Audio& audio = Audio::getInstance();
+    audio.unsubscribeInput();
+    audio.unsubscribeOutput();
 
     if (timerId != 0)
     {

--- a/src/widget/tool/micfeedbackwidget.cpp
+++ b/src/widget/tool/micfeedbackwidget.cpp
@@ -61,7 +61,8 @@ void MicFeedbackWidget::paintEvent(QPaintEvent*)
 void MicFeedbackWidget::showEvent(QShowEvent*)
 {
     mMeterListener = Audio::getInstance().createAudioMeterListener();
-    connect(mMeterListener, &AudioMeterListener::gainChanged, this, &MicFeedbackWidget::onGainMetered);
+    connect(mMeterListener, &AudioMeterListener::gainChanged,
+            this, &MicFeedbackWidget::onGainMetered);
     mMeterListener->start();
 }
 
@@ -73,6 +74,6 @@ void MicFeedbackWidget::hideEvent(QHideEvent*)
 void MicFeedbackWidget::onGainMetered(qreal value)
 {
     current = value;
-    //qDebug("Gain metered at %.3f", current);
     update();
+    mMeterListener->processed();
 }

--- a/src/widget/tool/micfeedbackwidget.h
+++ b/src/widget/tool/micfeedbackwidget.h
@@ -22,6 +22,8 @@
 
 #include <QWidget>
 
+class AudioMeterListener;
+
 class MicFeedbackWidget : public QWidget
 {
     Q_OBJECT
@@ -30,13 +32,15 @@ public:
 
 protected:
     void paintEvent(QPaintEvent* event) override;
-    void timerEvent(QTimerEvent* event) override;
     void showEvent(QShowEvent* event) override;
     void hideEvent(QHideEvent* event) override;
 
+private slots:
+    void onGainMetered(qreal value);
+
 private:
-    double current;
-    int timerId;
+    qreal current;
+    AudioMeterListener* mMeterListener;
 };
 
 #endif // MICFEEDBACKWIDGET_H

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1243,7 +1243,7 @@ bool Widget::newMessageAlert(QWidget* currentWindow, bool isActive, bool sound, 
         }
 
         if (Settings::getInstance().getNotifySound() && sound)
-            Audio::getInstance().playMono16Sound(":/audio/notification.pcm");
+            Audio::getInstance().playMono16Sound(QStringLiteral(":/audio/notification.pcm"));
     }
 
     return true;


### PR DESCRIPTION
Revival of #2463
- [x] Open audio in-/output device only, if not already open, when subscribing to in-/output.
- [x] use internal methods to cleanup & close audio devices
- [x] Change audio device during active call.
- [x] Fix: un-/subscribe to audio in/out
- [x] Fix: open/close audio device
  - [x] Fix #2435: Close audio device after playing a "notification" sound.
  - [x] Fix: Audio devices remain open after finished call.
- [x] Fix: AV-Settings interfers with active audio call
  - Close AV-Settings window accidently calls `unsubscribeInput` twice and closes audio devices when hiding the widget
- [x] Fix #2504: Remove regular breaks in filtered audio.
- [x] Improve situation with clipping noise when (re-)opening audio in/out device
  - Still appears when re-opening qTox (not the audio device itself), but highly improved now -> it's a 99% solution… :)
- [x] Implement non-blocking audio player for playback of "notification" alerts and sound buffers/files with a known length. (Yay, no audio timers anymore! :smile:)
- [x] Privatize audio handling and move completely to private implementation -> make it stable and reliable.
  - [x] Move every dependency of OpenAL related stuff to `Audio`.
- [x] Our `Audio` class should be aware of how many OpenAL sources are in use -> "sync" `ToxCall::source` with a private `ALuint*` array (**caution: big topic!**)…
