### PR TITLE
Add static icons for tray menu logout and quit

### DIFF
--- a/img/others/logout-icon.svg
+++ b/img/others/logout-icon.svg
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="256"
+   height="256"
+   viewBox="0 0 256 256"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   sodipodi:docname="qtox-logout-icon.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.979899"
+     inkscape:cx="133.49606"
+     inkscape:cy="101.61612"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     units="px" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Ebene 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-193.78572,-394.00506)">
+    <path
+       style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#747474;stroke-width:13.775;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 226.93506,467.90949 0,-54.09557 c 0,-7.15835 5.76287,-12.92121 12.92121,-12.92121 l 160.59389,0 c 7.15835,0 12.92121,5.76286 12.92121,12.92121 l 0,216.38228 c 0,7.15835 -5.76286,12.92121 -12.92121,12.92121 l -160.59389,0 c -7.15834,0 -12.92121,-5.76286 -12.92121,-12.92121 l 0,-54.09557"
+       id="rect3336"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cssssssssc" />
+    <g
+       id="g5103"
+       transform="matrix(0.87568441,0,0,0.87568441,36.090589,64.79462)">
+      <path
+         inkscape:connector-curvature="0"
+         id="rect4803"
+         d="m 259.04041,488.17121 109.39969,0 0,66.07872 -109.39969,0 z"
+         style="fill:#bb2d2d;fill-opacity:1;fill-rule:nonzero;stroke:#bb2d2d;stroke-width:17.65876579;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="rect5099"
+         d="m 258.08773,573.0261 -51.81538,-51.81538 51.81538,-51.81538 z"
+         style="fill:#bb2d2d;fill-opacity:1;fill-rule:nonzero;stroke:#bb2d2d;stroke-width:17.65876579;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/res.qrc
+++ b/res.qrc
@@ -120,5 +120,6 @@
         <file>img/login_logo.svg</file>
         <file>ui/notificationEdge/notificationEdge.css</file>
         <file>ui/loginScreen/loginScreen.css</file>
+        <file>img/others/logout-icon.svg</file>
     </qresource>
 </RCC>

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -122,15 +122,15 @@ void Widget::init()
 
     icon_size = 15;
     statusOnline = new QAction(this);
-    statusOnline->setIcon(getStatusIcon(Status::Online, icon_size, icon_size));
+    statusOnline->setIcon(prepareIcon(getStatusIconPath(Status::Online), icon_size, icon_size));
     connect(statusOnline, &QAction::triggered, this, &Widget::setStatusOnline);
 
     statusAway = new QAction(this);
-    statusAway->setIcon(getStatusIcon(Status::Away, icon_size, icon_size));
+    statusAway->setIcon(prepareIcon(getStatusIconPath(Status::Away), icon_size, icon_size));
     connect(statusAway, &QAction::triggered, this, &Widget::setStatusAway);
 
     statusBusy = new QAction(this);
-    statusBusy->setIcon(getStatusIcon(Status::Busy, icon_size, icon_size));
+    statusBusy->setIcon(prepareIcon(getStatusIconPath(Status::Busy), icon_size, icon_size));
     connect(statusBusy, &QAction::triggered, this, &Widget::setStatusBusy);
 
     layout()->setContentsMargins(0, 0, 0, 0);
@@ -563,7 +563,7 @@ void Widget::onBadProxyCore()
 void Widget::onStatusSet(Status status)
 {
     ui->statusButton->setProperty("status", getStatusTitle(status));
-    ui->statusButton->setIcon(getStatusIcon(status, icon_size, icon_size));
+    ui->statusButton->setIcon(prepareIcon(getStatusIconPath(status), icon_size, icon_size));
     updateIcons();
 }
 
@@ -1657,12 +1657,12 @@ void Widget::onTryCreateTrayIcon()
             QStyle *style = qApp->style();
 
             actionLogout = new QAction(tr("&Logout"), this);
-            actionLogout->setIcon(style->standardIcon(QStyle::SP_DialogResetButton));
+            actionLogout->setIcon(prepareIcon("://img/others/logout-icon.svg", icon_size, icon_size));
             connect(actionLogout, &QAction::triggered, profileForm, &ProfileForm::onLogoutClicked);
 
             actionQuit = new QAction(tr("&Exit"), this);
             actionQuit->setMenuRole(QAction::QuitRole);
-            actionQuit->setIcon(style->standardIcon(QStyle::SP_DialogDiscardButton));
+            actionQuit->setIcon(prepareIcon("://ui/rejectCall/rejectCall.svg", icon_size, icon_size));
             connect(actionQuit, &QAction::triggered, qApp, &QApplication::quit);
 
             trayMenu->addAction(statusOnline);
@@ -1885,7 +1885,7 @@ QString Widget::getStatusIconPath(Status status)
     }
 }
 
-inline QIcon Widget::getStatusIcon(Status status, uint32_t w, uint32_t h)
+inline QIcon Widget::prepareIcon(QString path, uint32_t w, uint32_t h)
 {
 #ifdef Q_OS_LINUX
 
@@ -1900,17 +1900,17 @@ inline QIcon Widget::getStatusIcon(Status status, uint32_t w, uint32_t h)
     {
         if (w > 0 && h > 0)
         {
-            return getStatusIconPixmap(status, w, h);
+            return getStatusIconPixmap(path, w, h);
         }
     }
 #endif
-    return QIcon(getStatusIconPath(status));
+    return QIcon(path);
 }
 
-QPixmap Widget::getStatusIconPixmap(Status status, uint32_t w, uint32_t h)
+QPixmap Widget::getStatusIconPixmap(QString path, uint32_t w, uint32_t h)
 {
     QPixmap pix(w, h);
-    pix.load(getStatusIconPath(status));
+    pix.load(path);
     return pix;
 }
 

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -92,8 +92,8 @@ public:
 
     void reloadTheme();
     static QString getStatusIconPath(Status status);
-    static inline QIcon getStatusIcon(Status status, uint32_t w=0, uint32_t h=0);
-    static QPixmap getStatusIconPixmap(Status status, uint32_t w, uint32_t h);
+    static inline QIcon prepareIcon(QString path, uint32_t w=0, uint32_t h=0);
+    static QPixmap getStatusIconPixmap(QString path, uint32_t w, uint32_t h);
     static QString getStatusTitle(Status status);
     static Status getStatusFromString(QString status);
 


### PR DESCRIPTION
antis made us an icon for logout action and I reused cancel call icon
as quit action in tray menu

Refactored methods to change way how icons are loaded in widget.cpp
to make the methods more flexible

This should permanently fix #2491 
![twitchinstallarch6](https://cloud.githubusercontent.com/assets/2544251/11008603/7dbd6b42-84c9-11e5-8747-cdbba2054bad.png)
