### PR TITLE
[WIP] Fix Quit/Close actions

### DIFF
--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -243,11 +243,13 @@ void Widget::init()
     connect(ui->friendList, &QWidget::customContextMenuRequested, this, &Widget::friendListContextMenu);
 
     // keyboard shortcuts
-    new QShortcut(Qt::CTRL + Qt::Key_Q, this, SLOT(close()));
     new QShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_Tab, this, SLOT(previousContact()));
     new QShortcut(Qt::CTRL + Qt::Key_Tab, this, SLOT(nextContact()));
     new QShortcut(Qt::CTRL + Qt::Key_PageUp, this, SLOT(previousContact()));
     new QShortcut(Qt::CTRL + Qt::Key_PageDown, this, SLOT(nextContact()));
+
+    if (!isMainWindow())
+        new QShortcut(Qt::CTRL + Qt::Key_W, this, SLOT(close()));
 
 #ifdef Q_OS_MAC
     QMenuBar* globalMenu = Nexus::getInstance().globalMenuBar;

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -70,6 +70,12 @@ public:
     bool newFriendMessageAlert(int friendId, bool sound=true);
     bool newGroupMessageAlert(int groupId, bool notify);
     bool getIsWindowMinimized();
+
+    inline bool isMainWindow() const
+    {
+        return isWindow() && objectName() == QStringLiteral("MainWindow");
+    }
+
     void updateIcons();
     void clearContactsList();
 


### PR DESCRIPTION
- [ ] Close qTox sub-windows with CTRL+W instead of CTRL+Q
- [ ] Quit qTox through central (and plattform-independent) CTRL+Q action.
