### PR TITLE
Fix groupwidget not unregistered from Translator

### DIFF
--- a/src/widget/groupwidget.cpp
+++ b/src/widget/groupwidget.cpp
@@ -60,6 +60,11 @@ GroupWidget::GroupWidget(int GroupId, QString Name)
     Translator::registerHandler(std::bind(&GroupWidget::retranslateUi, this), this);
 }
 
+GroupWidget::~GroupWidget()
+{
+    Translator::unregister(this);
+}
+
 void GroupWidget::contextMenuEvent(QContextMenuEvent* event)
 {
     if (!active)

--- a/src/widget/groupwidget.h
+++ b/src/widget/groupwidget.h
@@ -27,6 +27,7 @@ class GroupWidget final : public GenericChatroomWidget
     Q_OBJECT
 public:
     GroupWidget(int GroupId, QString Name);
+    ~GroupWidget();
     virtual void setAsInactiveChatroom() final override;
     virtual void setAsActiveChatroom() final override;
     virtual void updateStatusLight() final override;


### PR DESCRIPTION
When #2304 was merged, GroupWidget wasn't unregistered from the Translator
