### PR TITLE
 Add an event filter so you can't modify sliders by scrolling, closes #1932

### DIFF
--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -69,6 +69,9 @@ AVForm::AVForm() :
     bodyUI->playbackSlider->setValue(Settings::getInstance().getOutVolume());
     bodyUI->microphoneSlider->setValue(Settings::getInstance().getInVolume());
 
+    bodyUI->playbackSlider->installEventFilter(this);
+    bodyUI->microphoneSlider->installEventFilter(this);
+
     for (QComboBox* cb : findChildren<QComboBox*>())
     {
         cb->installEventFilter(this);
@@ -265,9 +268,9 @@ void AVForm::getAudioInDevices()
         {
             int len = strlen(pDeviceList);
 #ifdef Q_OS_WIN
-            QString inDev = QString::fromUtf8(pDeviceList,len);
+            QString inDev = QString::fromUtf8(pDeviceList, len);
 #else
-            QString inDev = QString::fromLocal8Bit(pDeviceList,len);
+            QString inDev = QString::fromLocal8Bit(pDeviceList, len);
 #endif
             bodyUI->inDevCombobox->addItem(inDev);
             if (settingsInDev == inDev)
@@ -300,9 +303,9 @@ void AVForm::getAudioOutDevices()
         {
             int len = strlen(pDeviceList);
 #ifdef Q_OS_WIN
-            QString outDev = QString::fromUtf8(pDeviceList,len);
+            QString outDev = QString::fromUtf8(pDeviceList, len);
 #else
-            QString outDev = QString::fromLocal8Bit(pDeviceList,len);
+            QString outDev = QString::fromLocal8Bit(pDeviceList, len);
 #endif
             bodyUI->outDevCombobox->addItem(outDev);
             if (settingsOutDev == outDev)
@@ -361,7 +364,7 @@ void AVForm::onMicrophoneValueChanged(int value)
 bool AVForm::eventFilter(QObject *o, QEvent *e)
 {
     if ((e->type() == QEvent::Wheel) &&
-         (qobject_cast<QComboBox*>(o) || qobject_cast<QAbstractSpinBox*>(o) ))
+         (qobject_cast<QComboBox*>(o) || qobject_cast<QAbstractSpinBox*>(o) || qobject_cast<QSlider*>(o)))
     {
         e->ignore();
         return true;

--- a/src/widget/form/settings/avform.h
+++ b/src/widget/form/settings/avform.h
@@ -73,8 +73,8 @@ protected:
 
 private:
     Ui::AVSettings *bodyUI;
-    VideoSurface* camVideoSurface;
-    CameraSource& camera;
+    VideoSurface *camVideoSurface;
+    CameraSource &camera;
     QVector<QPair<QString, QString>> videoDeviceList;
     QVector<VideoMode> videoModes;
 };


### PR DESCRIPTION
closes #1932
Now you can't modify a slider by scrolling on it.
But if you scroll on a slider it will propagate the event to the `AVForm` and it will make it scroll normally

I never worked with that type of stuff before, I would like that someone check if I've done it the right way
