### PR TITLE
[WIP] Fix double sender name in action message

### DIFF
--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1081,7 +1081,7 @@ void Widget::onFriendMessageReceived(int friendId, const QString& message, bool 
     QDateTime timestamp = QDateTime::currentDateTime();
     f->getChatForm()->addMessage(f->getToxId(), message, isAction, timestamp, true);
 
-    HistoryKeeper::getInstance()->addChatEntry(f->getToxId().publicKey, isAction ? "/me " + f->getDisplayedName() + " " + message : message,
+    HistoryKeeper::getInstance()->addChatEntry(f->getToxId().publicKey, isAction ? "/me " + message : message,
                                                f->getToxId().publicKey, timestamp, true, f->getDisplayedName());
 
     newFriendMessageAlert(friendId);


### PR DESCRIPTION
I've fixed the first bug, the second is if you send an action message and the OfflinemsgEngine deliver it, then it is sent with the sender's name twice

Should fix #2336 when finished
- [ ] Ready
