### PR TITLE
Add alext.h to audio.h

### DIFF
--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -33,6 +33,7 @@
 #else
  #include <AL/al.h>
  #include <AL/alc.h>
+ #include <AL/alext.h>
 #endif
 
 class QString;


### PR DESCRIPTION
ALC_ALL_DEVICES_SPECIFIER may be defined in different headers of
libopenal (alext.h < 1.14 and alc.h >= 1.14). Seems there is no
harm in always include both.

Related commit is: @1d9e89f
