### PR TITLE
NSIS installer fixes

### DIFF
--- a/windows/qtox.nsi
+++ b/windows/qtox.nsi
@@ -9,7 +9,6 @@
 !define COPYRIGHT "The Tox Project"
 !define INSTALLER_NAME "setup-qtox.exe"
 !define MAIN_APP_EXE "bin\qtox.exe"
-!define INSTALL_TYPE "SetShellVarContext current"
 !define REG_ROOT "HKLM"
 !define REG_APP_PATH "Software\Microsoft\Windows\CurrentVersion\App Paths\qtox.exe"
 !define UNINSTALL_PATH "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}"
@@ -248,6 +247,7 @@ FunctionEnd
 #################
 #INSTALL
 #################
+SetShellVarContext all
 Section "Install"
 	# Install files
 	${SetOutPath} "$INSTDIR"
@@ -304,6 +304,7 @@ SectionEnd
 #UNINSTALL
 ################
 Section Uninstall
+  SetShellVarContext all
   ;If there's no uninstall log, we'll try anyway to clean what we can
   IfFileExists "$INSTDIR\${UninstLog}" +3
     Goto noLog

--- a/windows/qtox.nsi
+++ b/windows/qtox.nsi
@@ -225,10 +225,16 @@ FunctionEnd
 !define MUI_FINISHPAGE_SHOWREADME_TEXT "Create Desktop Shortcut"
 !define MUI_FINISHPAGE_SHOWREADME_FUNCTION finishpageaction
 
-!define MUI_FINISHPAGE_RUN "$INSTDIR\${MAIN_APP_EXE}"
+!define MUI_FINISHPAGE_RUN_FUNCTION Launch_qTox_without_Admin
+!define MUI_FINISHPAGE_RUN
 !define MUI_FINISHPAGE_LINK "Find qTox on GitHub"
 !define MUI_FINISHPAGE_LINK_LOCATION "https://github.com/tux3/qTox"
 !insertmacro MUI_PAGE_FINISH
+
+Function Launch_qTox_without_Admin
+   SetOutPath $INSTDIR
+   ShellExecAsUser::ShellExecAsUser "" "$INSTDIR\${MAIN_APP_EXE}" ""
+FunctionEnd
 
 !define MUI_UNABORTWARNING
 !define MUI_UNFINISHPAGE_NOAUTOCLOSE
@@ -247,21 +253,21 @@ Section "Install"
 	${SetOutPath} "$INSTDIR"
 	${WriteUninstaller} "uninstall.exe"
 	
-	${CreateDirectory} "bin"
+	${CreateDirectory} "$INSTDIR\bin"
 	${SetOutPath} "$INSTDIR\bin"
 	${File} "qtox\*.*"
 	
-	${CreateDirectory} "imageformats"
+	${CreateDirectory} "$INSTDIR\bin\imageformats"
 	${SetOutPath} "$INSTDIR\bin\imageformats"
 	File /nonfatal "qtox\imageformats\*.*"
 	${SetOutPath} "$INSTDIR\bin"
 	
-	${CreateDirectory} "platforms"
+	${CreateDirectory} "$INSTDIR\bin\platforms"
 	${SetOutPath} "$INSTDIR\bin\platforms"
 	File /nonfatal "qtox\platforms\*.*"
 	${SetOutPath} "$INSTDIR\bin"
 	
-	${CreateDirectory} "sqldrivers"
+	${CreateDirectory} "$INSTDIR\bin\sqldrivers"
 	${SetOutPath} "$INSTDIR\bin\sqldrivers"
 	File /nonfatal "qtox\sqldrivers\*.*"
 	${SetOutPath} "$INSTDIR\bin"

--- a/windows/qtox.nsi
+++ b/windows/qtox.nsi
@@ -247,8 +247,8 @@ FunctionEnd
 #################
 #INSTALL
 #################
-SetShellVarContext all
 Section "Install"
+	SetShellVarContext all
 	# Install files
 	${SetOutPath} "$INSTDIR"
 	${WriteUninstaller} "uninstall.exe"

--- a/windows/qtox64.nsi
+++ b/windows/qtox64.nsi
@@ -9,7 +9,6 @@
 !define COPYRIGHT "The Tox Project"
 !define INSTALLER_NAME "setup-qtox.exe"
 !define MAIN_APP_EXE "bin\qtox.exe"
-!define INSTALL_TYPE "SetShellVarContext current"
 !define REG_ROOT "HKLM"
 !define REG_APP_PATH "Software\Microsoft\Windows\CurrentVersion\App Paths\qtox.exe"
 !define UNINSTALL_PATH "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}"
@@ -249,6 +248,7 @@ FunctionEnd
 #INSTALL
 #################
 Section "Install"
+        SetShellVarContext all
 	# Install files
 	${SetOutPath} "$INSTDIR"
 	${WriteUninstaller} "uninstall.exe"
@@ -304,6 +304,7 @@ SectionEnd
 #UNINSTALL
 ################
 Section Uninstall
+  SetShellVarContext all
   ;If there's no uninstall log, we'll try anyway to clean what we can
   IfFileExists "$INSTDIR\${UninstLog}" +3
     Goto noLog

--- a/windows/qtox64.nsi
+++ b/windows/qtox64.nsi
@@ -225,10 +225,16 @@ FunctionEnd
 !define MUI_FINISHPAGE_SHOWREADME_TEXT "Create Desktop Shortcut"
 !define MUI_FINISHPAGE_SHOWREADME_FUNCTION finishpageaction
 
-!define MUI_FINISHPAGE_RUN "$INSTDIR\${MAIN_APP_EXE}"
+!define MUI_FINISHPAGE_RUN_FUNCTION Launch_qTox_without_Admin
+!define MUI_FINISHPAGE_RUN
 !define MUI_FINISHPAGE_LINK "Find qTox on GitHub"
 !define MUI_FINISHPAGE_LINK_LOCATION "https://github.com/tux3/qTox"
 !insertmacro MUI_PAGE_FINISH
+
+Function Launch_qTox_without_Admin
+   SetOutPath $INSTDIR
+   ShellExecAsUser::ShellExecAsUser "" "$INSTDIR\${MAIN_APP_EXE}" ""
+FunctionEnd
 
 !define MUI_UNABORTWARNING
 !define MUI_UNFINISHPAGE_NOAUTOCLOSE
@@ -247,21 +253,21 @@ Section "Install"
 	${SetOutPath} "$INSTDIR"
 	${WriteUninstaller} "uninstall.exe"
 	
-	${CreateDirectory} "bin"
+	${CreateDirectory} "$INSTDIR\bin"
 	${SetOutPath} "$INSTDIR\bin"
 	${File} "qtox\*.*"
 	
-	${CreateDirectory} "imageformats"
+	${CreateDirectory} "$INSTDIR\bin\imageformats"
 	${SetOutPath} "$INSTDIR\bin\imageformats"
 	File /nonfatal "qtox\imageformats\*.*"
 	${SetOutPath} "$INSTDIR\bin"
 	
-	${CreateDirectory} "platforms"
+	${CreateDirectory} "$INSTDIR\bin\platforms"
 	${SetOutPath} "$INSTDIR\bin\platforms"
 	File /nonfatal "qtox\platforms\*.*"
 	${SetOutPath} "$INSTDIR\bin"
 	
-	${CreateDirectory} "sqldrivers"
+	${CreateDirectory} "$INSTDIR\bin\sqldrivers"
 	${SetOutPath} "$INSTDIR\bin\sqldrivers"
 	File /nonfatal "qtox\sqldrivers\*.*"
 	${SetOutPath} "$INSTDIR\bin"


### PR DESCRIPTION
This fixes:
- qtox launched as admin from installer (But requires this NSIS plugin http://nsis.sourceforge.net/ShellExecAsUser_plug-in)
- The uninstaller now deletes the startmenu folders
