### PR TITLE
Add SVG support to filetransfer preview

### DIFF
--- a/src/chatlog/content/filetransferwidget.cpp
+++ b/src/chatlog/content/filetransferwidget.cpp
@@ -496,7 +496,8 @@ void FileTransferWidget::handleButton(QPushButton *btn)
 
 void FileTransferWidget::showPreview(const QString &filename)
 {
-    static const QStringList previewExtensions = { "png", "jpeg", "jpg", "gif", "PNG", "JPEG", "JPG", "GIF" };
+    static const QStringList previewExtensions = { "png", "jpeg", "jpg", "gif", "svg",
+                                                   "PNG", "JPEG", "JPG", "GIF", "SVG" };
 
     if (previewExtensions.contains(QFileInfo(filename).suffix()))
     {


### PR DESCRIPTION
Only requires Qt SVG which is already a dependency of qTox.

Signed-off-by: Johannes Löthberg johannes@kyriasis.com
