### PR TITLE
Fix audio output subscriptions

### DIFF
--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -760,6 +760,8 @@ void Audio::unsubscribeOutput(SID& sid)
 {
     QMutexLocker locker(&d->audioLock);
 
+    d->outSources.removeAll(sid);
+
     if (sid) {
         if (alIsSource(sid)) {
             alDeleteSources(1, &sid);
@@ -771,8 +773,6 @@ void Audio::unsubscribeOutput(SID& sid)
 
         sid = 0;
     }
-
-    d->outSources.removeAll(sid);
 
     if (d->outSources.isEmpty())
         d->cleanupOutput();

--- a/src/core/toxcall.cpp
+++ b/src/core/toxcall.cpp
@@ -49,7 +49,6 @@ ToxCall::ToxCall(ToxCall&& other) noexcept
     // required -> ownership of audio input is moved to new instance
     Audio& audio = Audio::getInstance();
     audio.subscribeInput();
-    audio.subscribeOutput(alSource);
 
 #ifdef QTOX_FILTER_AUDIO
     filterer = other.filterer;


### PR DESCRIPTION
fix #2706

@agilob @tux3 @JacobHenner @TheNain38 @towlie (and all audio users on qTox…) Made a pretty silly little mistake in `Audio::unsubscribeOutput` (SID was invalidated **before** removing from the list) -> fixed! Please help  with **related** review and feedback. This should not leave any dangling audio output devices.

On Linux (probably OSX) we get a warning at the end of the logfile, when an audio device remains open reading `AL lib: ReleaseALC: 1 device not closed`. Not sure, but likely it is closed anyways.

Btw.: In Linux this is working with ALSA (using that by myself :)) and PulseAudio.
