### PR TITLE
Disable tray icon is no is available to prevent looking for systray next time

### DIFF
--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -770,7 +770,7 @@ void Widget::onIconClick(QSystemTrayIcon::ActivationReason reason)
     }
     else if (reason == QSystemTrayIcon::Unknown)
     {
-        if (isHidden()) 
+        if (isHidden())
             forceShow();
     }
 }
@@ -1702,7 +1702,8 @@ void Widget::onTryCreateTrayIcon()
         disconnect(timer, &QTimer::timeout, this, &Widget::onTryCreateTrayIcon);
         if (!icon)
         {
-            qWarning() << "No system tray detected!";
+            Settings::getInstance().setShowSystemTray(false);
+            qWarning() << "No system tray detected, disabling system tray!";
             show();
         }
     }


### PR DESCRIPTION
There is a bug in KDE latest version that does not create system tray immediately, qtox tries to load to system tray, fails and crashes after several seconds. The same happens after restart. This fix prevent loading to tray again after is was not available before.
