### PR TITLE
open the first available audio in/out device as default, if specifier is empty

### DIFF
--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -422,27 +422,14 @@ bool AudioPrivate::initInput(QString inDevDescr)
     const uint16_t frameDuration = AUDIO_FRAME_DURATION;
     const uint32_t chnls = AUDIO_CHANNELS;
     const ALCsizei bufSize = (frameDuration * sampleRate * 4) / 1000 * chnls;
-    if (inDevDescr.isEmpty())
-    {
-        const ALchar *pDeviceList = alcGetString(NULL, ALC_CAPTURE_DEVICE_SPECIFIER);
+    if (inDevDescr.isEmpty()) {
+        const ALchar *pDeviceList = Audio::inDeviceNames();
         if (pDeviceList)
-        {
-            alInDev = alcCaptureOpenDevice(pDeviceList, sampleRate, stereoFlag, bufSize);
-            int len = strlen(pDeviceList);
-#ifdef Q_OS_WIN
-            inDevDescr = QString::fromUtf8(pDeviceList, len);
-#else
-            inDevDescr = QString::fromLocal8Bit(pDeviceList, len);
-#endif
-            Settings::getInstance().setInDev(inDevDescr);
-        }
-        else
-        {
-            alInDev = alcCaptureOpenDevice(nullptr, sampleRate, stereoFlag, bufSize);
-        }
+            inDevDescr = QString::fromUtf8(pDeviceList, strlen(pDeviceList));
     }
-    else
-        alInDev = alcCaptureOpenDevice(inDevDescr.toStdString().c_str(),
+
+    if (!inDevDescr.isEmpty())
+        alInDev = alcCaptureOpenDevice(inDevDescr.toUtf8().constData(),
                                        sampleRate, stereoFlag, bufSize);
 
     // Restart the capture if necessary
@@ -474,32 +461,15 @@ bool AudioPrivate::initOutput(QString outDevDescr)
 
     assert(!alOutDev);
 
-    if (outDevDescr.isEmpty())
-    {
-        // Attempt to default to the first available audio device.
-        const ALchar *pDeviceList;
-        if (alcIsExtensionPresent(NULL, "ALC_ENUMERATE_ALL_EXT") != AL_FALSE)
-            pDeviceList = alcGetString(NULL, ALC_ALL_DEVICES_SPECIFIER);
-        else
-            pDeviceList = alcGetString(NULL, ALC_DEVICE_SPECIFIER);
+    if (outDevDescr.isEmpty()) {
+        // default to the first available audio device.
+        const ALchar *pDeviceList = Audio::outDeviceNames();
         if (pDeviceList)
-        {
-            alOutDev = alcOpenDevice(pDeviceList);
-            int len = strlen(pDeviceList);
-#ifdef Q_OS_WIN
-            outDevDescr = QString::fromUtf8(pDeviceList, len);
-#else
-            outDevDescr = QString::fromLocal8Bit(pDeviceList, len);
-#endif
-            Settings::getInstance().setOutDev(outDevDescr);
-        }
-        else
-        {
-            alOutDev = alcOpenDevice(nullptr);
-        }
+            outDevDescr = QString::fromUtf8(pDeviceList, strlen(pDeviceList));
     }
-    else
-        alOutDev = alcOpenDevice(outDevDescr.toStdString().c_str());
+
+    if (!outDevDescr.isEmpty())
+        alOutDev = alcOpenDevice(outDevDescr.toUtf8().constData());
 
     if (alOutDev)
     {


### PR DESCRIPTION
fix #2711

@JacobHenner Sorry, I couldn't help and had to fix this :smile:.

If no device specifier is given, we fall back to the first available device, provided by the in/out lists. This specifier must not be saved in qTox settings to make it work every time! Also fixed some string conversion bugs and minor stuff. Could you please review?
