### PR TITLE
Chatform improvements

### DIFF
--- a/qtox.pro
+++ b/qtox.pro
@@ -517,6 +517,7 @@ SOURCES += \
     src/widget/tool/indicatorscrollbar.cpp \
     src/video/genericnetcamview.cpp \
     src/widget/tool/labeledlineedit.cpp \
+    src/widget/tool/dynamicscrollbar.cpp \
     src/widget/tool/activatedialog.cpp \
     src/widget/tool/movablewidget.cpp \
     src/widget/tool/micfeedbackwidget.cpp \
@@ -575,6 +576,7 @@ HEADERS += \
     src/widget/tool/indicatorscrollbar.h \
     src/widget/tool/activatedialog.h \
     src/widget/tool/labeledlineedit.h \
+    src/widget/tool/dynamicscrollbar.h \
     src/widget/tool/micfeedbackwidget.h \
     src/widget/tool/removefrienddialog.h \
     src/widget/tool/movablewidget.h \

--- a/qtox.pro
+++ b/qtox.pro
@@ -513,6 +513,8 @@ SOURCES += \
     src/widget/categorywidget.cpp \
     src/widget/contentlayout.cpp \
     src/widget/contentdialog.cpp \
+    src/widget/tool/findwidget.cpp \
+    src/widget/tool/indicatorscrollbar.cpp \
     src/video/genericnetcamview.cpp \
     src/widget/tool/activatedialog.cpp \
     src/widget/tool/movablewidget.cpp \
@@ -568,6 +570,8 @@ HEADERS += \
     src/widget/categorywidget.h \
     src/widget/contentlayout.h \
     src/widget/contentdialog.h \
+    src/widget/tool/findwidget.h \
+    src/widget/tool/indicatorscrollbar.h \
     src/widget/tool/activatedialog.h \
     src/widget/tool/micfeedbackwidget.h \
     src/widget/tool/removefrienddialog.h \

--- a/qtox.pro
+++ b/qtox.pro
@@ -516,6 +516,7 @@ SOURCES += \
     src/widget/tool/findwidget.cpp \
     src/widget/tool/indicatorscrollbar.cpp \
     src/video/genericnetcamview.cpp \
+    src/widget/tool/labeledlineedit.cpp \
     src/widget/tool/activatedialog.cpp \
     src/widget/tool/movablewidget.cpp \
     src/widget/tool/micfeedbackwidget.cpp \
@@ -573,6 +574,7 @@ HEADERS += \
     src/widget/tool/findwidget.h \
     src/widget/tool/indicatorscrollbar.h \
     src/widget/tool/activatedialog.h \
+    src/widget/tool/labeledlineedit.h \
     src/widget/tool/micfeedbackwidget.h \
     src/widget/tool/removefrienddialog.h \
     src/widget/tool/movablewidget.h \

--- a/qtox.pro
+++ b/qtox.pro
@@ -500,6 +500,7 @@ SOURCES += \
     src/video/cameradevice.cpp \
     src/video/camerasource.cpp \
     src/video/corevideosource.cpp \
+    src/video/genericnetcamview.cpp \
     src/core/toxid.cpp \
     src/persistence/profile.cpp \
     src/widget/translator.cpp \
@@ -513,12 +514,11 @@ SOURCES += \
     src/widget/categorywidget.cpp \
     src/widget/contentlayout.cpp \
     src/widget/contentdialog.cpp \
+    src/widget/tool/activatedialog.cpp \
+    src/widget/tool/dynamicscrollbar.cpp \
     src/widget/tool/findwidget.cpp \
     src/widget/tool/indicatorscrollbar.cpp \
-    src/video/genericnetcamview.cpp \
     src/widget/tool/labeledlineedit.cpp \
-    src/widget/tool/dynamicscrollbar.cpp \
-    src/widget/tool/activatedialog.cpp \
     src/widget/tool/movablewidget.cpp \
     src/widget/tool/micfeedbackwidget.cpp \
     src/widget/tool/removefrienddialog.cpp \
@@ -572,11 +572,11 @@ HEADERS += \
     src/widget/categorywidget.h \
     src/widget/contentlayout.h \
     src/widget/contentdialog.h \
+    src/widget/tool/activatedialog.h \
+    src/widget/tool/dynamicscrollbar.h \
     src/widget/tool/findwidget.h \
     src/widget/tool/indicatorscrollbar.h \
-    src/widget/tool/activatedialog.h \
     src/widget/tool/labeledlineedit.h \
-    src/widget/tool/dynamicscrollbar.h \
     src/widget/tool/micfeedbackwidget.h \
     src/widget/tool/removefrienddialog.h \
     src/widget/tool/movablewidget.h \

--- a/src/chatlog/chatline.cpp
+++ b/src/chatlog/chatline.cpp
@@ -118,6 +118,40 @@ void ChatLine::selectionFocusChanged(bool focusIn)
         c->selectionFocusChanged(focusIn);
 }
 
+bool ChatLine::selectNext(const QString& text)
+{
+    bool done = false;
+
+    // First, check if a selection has been made. If it has, then move to next one.
+    for (ChatLineContent* c : content)
+    {
+        if (c->hasSelection())
+        {
+            done = true;
+
+            if (c->selectNext(text))
+                return true;
+            else
+                continue;
+        }
+    }
+
+    // If not, then find the next one starting from the beginning.
+    if (!done)
+    {
+        for (ChatLineContent* c : content)
+        {
+             if (c->selectNext(text))
+                return true;
+            else
+                continue;
+        }
+    }
+
+    // Text not found for selection.
+    return false;
+}
+
 int ChatLine::getColumnCount()
 {
     return content.size();

--- a/src/chatlog/chatline.cpp
+++ b/src/chatlog/chatline.cpp
@@ -118,38 +118,19 @@ void ChatLine::selectionFocusChanged(bool focusIn)
         c->selectionFocusChanged(focusIn);
 }
 
-bool ChatLine::selectNext(const QString& text)
+bool ChatLine::selectNext(const QString&)
 {
-    bool done = false;
-
-    // First, check if a selection has been made. If it has, then move to next one.
-    for (ChatLineContent* c : content)
-    {
-        if (c->hasSelection())
-        {
-            done = true;
-
-            if (c->selectNext(text))
-                return true;
-            else
-                continue;
-        }
-    }
-
-    // If not, then find the next one starting from the beginning.
-    if (!done)
-    {
-        for (ChatLineContent* c : content)
-        {
-             if (c->selectNext(text))
-                return true;
-            else
-                continue;
-        }
-    }
-
-    // Text not found for selection.
     return false;
+}
+
+bool ChatLine::selectPrevious(const QString&)
+{
+    return false;
+}
+
+int ChatLine::setHighlight(const QString&)
+{
+    return 0;
 }
 
 int ChatLine::getColumnCount()

--- a/src/chatlog/chatline.cpp
+++ b/src/chatlog/chatline.cpp
@@ -179,7 +179,7 @@ void ChatLine::replaceContent(int col, ChatLineContent *lineContent)
         content[col]->update();
     }
 }
-#include <QDebug>
+
 void ChatLine::layout(qreal w, QPointF scenePos)
 {
     width = w;
@@ -241,7 +241,6 @@ void ChatLine::layout(qreal w, QPointF scenePos)
 
         // set the width of the current column
         content[i]->setWidth(width);
-        qDebug() << "WIDHT: " << width << "content:" << content[i]->getText();
 
         // calculate horizontal alignment
         qreal xAlign = 0.0;

--- a/src/chatlog/chatline.cpp
+++ b/src/chatlog/chatline.cpp
@@ -118,17 +118,17 @@ void ChatLine::selectionFocusChanged(bool focusIn)
         c->selectionFocusChanged(focusIn);
 }
 
-bool ChatLine::selectNext(const QString&)
+bool ChatLine::selectNext(const QString&, Qt::CaseSensitivity)
 {
     return false;
 }
 
-bool ChatLine::selectPrevious(const QString&)
+bool ChatLine::selectPrevious(const QString&, Qt::CaseSensitivity)
 {
     return false;
 }
 
-int ChatLine::setHighlight(const QString&)
+int ChatLine::setHighlight(const QString&, Qt::CaseSensitivity)
 {
     return 0;
 }

--- a/src/chatlog/chatline.cpp
+++ b/src/chatlog/chatline.cpp
@@ -20,8 +20,8 @@
 #include "chatline.h"
 #include "chatlinecontent.h"
 
-#include <QDebug>
 #include <QGraphicsScene>
+#include "src/persistence/settings.h"
 
 ChatLine::ChatLine()
 {
@@ -175,10 +175,25 @@ void ChatLine::layout(qreal w, QPointF scenePos)
 
     for (int i = 0; i < static_cast<int>(format.size()); ++i)
     {
-        if (format[i].policy == ColumnFormat::FixedSize)
-            fixedWidth += format[i].size;
-        else
-            varWidth += format[i].size;
+        switch(format[i].policy)
+        {
+            case ColumnFormat::RightColumn:
+                format[i].size = Settings::getInstance().getColumnRightWidth();
+                fixedWidth += format[i].size;
+                break;
+            case ColumnFormat::LeftColumn:
+                format[i].size = Settings::getInstance().getColumnLeftWidth();
+                fixedWidth += format[i].size;
+                break;
+            case ColumnFormat::FixedSize:
+                fixedWidth += format[i].size;
+                break;
+            case ColumnFormat::VariableSize:
+                varWidth += format[i].size;
+                break;
+            default:
+                break;
+        }
     }
 
     if (varWidth == 0.0)
@@ -195,10 +210,20 @@ void ChatLine::layout(qreal w, QPointF scenePos)
     {
         // calculate the effective width of the current column
         qreal width;
-        if (format[i].policy == ColumnFormat::FixedSize)
-            width = format[i].size;
-        else
-            width = format[i].size / varWidth * leftover;
+
+        switch(format[i].policy)
+        {
+            case ColumnFormat::RightColumn:
+            case ColumnFormat::LeftColumn:
+            case ColumnFormat::FixedSize:
+                width = format[i].size;
+                break;
+            case ColumnFormat::VariableSize:
+                width = format[i].size / varWidth * leftover;
+                break;
+            default:
+                width = 0;
+        }
 
         // set the width of the current column
         content[i]->setWidth(width);

--- a/src/chatlog/chatline.cpp
+++ b/src/chatlog/chatline.cpp
@@ -179,7 +179,7 @@ void ChatLine::replaceContent(int col, ChatLineContent *lineContent)
         content[col]->update();
     }
 }
-
+#include <QDebug>
 void ChatLine::layout(qreal w, QPointF scenePos)
 {
     width = w;
@@ -220,7 +220,6 @@ void ChatLine::layout(qreal w, QPointF scenePos)
     qreal xOffset = 0.0;
     qreal xPos[content.size()];
 
-
     for (int i = 0; i < static_cast<int>(content.size()); ++i)
     {
         // calculate the effective width of the current column
@@ -242,6 +241,7 @@ void ChatLine::layout(qreal w, QPointF scenePos)
 
         // set the width of the current column
         content[i]->setWidth(width);
+        qDebug() << "WIDHT: " << width << "content:" << content[i]->getText();
 
         // calculate horizontal alignment
         qreal xAlign = 0.0;

--- a/src/chatlog/chatline.cpp
+++ b/src/chatlog/chatline.cpp
@@ -118,14 +118,14 @@ void ChatLine::selectionFocusChanged(bool focusIn)
         c->selectionFocusChanged(focusIn);
 }
 
-bool ChatLine::selectNext(const QString&, Qt::CaseSensitivity)
+int ChatLine::selectNext(const QString&, Qt::CaseSensitivity)
 {
-    return false;
+    return -1;
 }
 
-bool ChatLine::selectPrevious(const QString&, Qt::CaseSensitivity)
+int ChatLine::selectPrevious(const QString&, Qt::CaseSensitivity)
 {
-    return false;
+    return -1;
 }
 
 int ChatLine::setHighlight(const QString&, Qt::CaseSensitivity)

--- a/src/chatlog/chatline.cpp
+++ b/src/chatlog/chatline.cpp
@@ -19,9 +19,9 @@
 
 #include "chatline.h"
 #include "chatlinecontent.h"
+#include "src/persistence/settings.h"
 
 #include <QGraphicsScene>
-#include "src/persistence/settings.h"
 
 ChatLine::ChatLine()
 {

--- a/src/chatlog/chatline.h
+++ b/src/chatlog/chatline.h
@@ -35,6 +35,8 @@ struct ColumnFormat
     enum Policy {
         FixedSize,
         VariableSize,
+        RightColumn,
+        LeftColumn
     };
 
     enum Align {
@@ -44,6 +46,10 @@ struct ColumnFormat
     };
 
     ColumnFormat() {}
+    ColumnFormat(Policy p, Align halign = Left)
+        : policy(p),
+          hAlign(halign)
+    {}
     ColumnFormat(qreal s, Policy p, Align halign = Left)
         : size(s)
         , policy(p)

--- a/src/chatlog/chatline.h
+++ b/src/chatlog/chatline.h
@@ -81,8 +81,8 @@ public:
     void setVisible(bool visible);
     void selectionCleared();
     void selectionFocusChanged(bool focusIn);
-    virtual bool selectNext(const QString& text, Qt::CaseSensitivity sensitivity);
-    virtual bool selectPrevious(const QString& text, Qt::CaseSensitivity sensitivity);
+    virtual int selectNext(const QString& text, Qt::CaseSensitivity sensitivity);
+    virtual int selectPrevious(const QString& text, Qt::CaseSensitivity sensitivity);
     virtual int setHighlight(const QString& text, Qt::CaseSensitivity sensitivity);
 
     int getColumnCount();

--- a/src/chatlog/chatline.h
+++ b/src/chatlog/chatline.h
@@ -81,7 +81,9 @@ public:
     void setVisible(bool visible);
     void selectionCleared();
     void selectionFocusChanged(bool focusIn);
-    bool selectNext(const QString &text);
+    virtual bool selectNext(const QString& text);
+    virtual bool selectPrevious(const QString& text);
+    virtual int setHighlight(const QString& text);
 
     int getColumnCount();
     int getRow() const;

--- a/src/chatlog/chatline.h
+++ b/src/chatlog/chatline.h
@@ -81,9 +81,9 @@ public:
     void setVisible(bool visible);
     void selectionCleared();
     void selectionFocusChanged(bool focusIn);
-    virtual bool selectNext(const QString& text);
-    virtual bool selectPrevious(const QString& text);
-    virtual int setHighlight(const QString& text);
+    virtual bool selectNext(const QString& text, Qt::CaseSensitivity sensitivity);
+    virtual bool selectPrevious(const QString& text, Qt::CaseSensitivity sensitivity);
+    virtual int setHighlight(const QString& text, Qt::CaseSensitivity sensitivity);
 
     int getColumnCount();
     int getRow() const;

--- a/src/chatlog/chatline.h
+++ b/src/chatlog/chatline.h
@@ -81,6 +81,7 @@ public:
     void setVisible(bool visible);
     void selectionCleared();
     void selectionFocusChanged(bool focusIn);
+    bool selectNext(const QString &text);
 
     int getColumnCount();
     int getRow() const;

--- a/src/chatlog/chatline.h
+++ b/src/chatlog/chatline.h
@@ -47,8 +47,8 @@ struct ColumnFormat
 
     ColumnFormat() {}
     ColumnFormat(Policy p, Align halign = Left)
-        : policy(p),
-          hAlign(halign)
+        : policy(p)
+        , hAlign(halign)
     {}
     ColumnFormat(qreal s, Policy p, Align halign = Left)
         : size(s)

--- a/src/chatlog/chatlinecontent.cpp
+++ b/src/chatlog/chatlinecontent.cpp
@@ -81,24 +81,19 @@ bool ChatLineContent::hasSelection() const
     return false;
 }
 
-bool ChatLineContent::selectNext(const QString&)
+bool ChatLineContent::selectNext(const QString&, Qt::CaseSensitivity)
 {
     return false;
 }
 
-bool ChatLineContent::selectPrevious(const QString&)
+bool ChatLineContent::selectPrevious(const QString&, Qt::CaseSensitivity)
 {
     return false;
 }
 
-int ChatLineContent::setHighlight(const QString&)
+int ChatLineContent::setHighlight(const QString&, Qt::CaseSensitivity)
 {
     return 0;
-}
-
-QTextCursor ChatLineContent::setHighlight(const QString&, const QTextCursor&)
-{
-    return QTextCursor();
 }
 
 qreal ChatLineContent::getAscent() const

--- a/src/chatlog/chatlinecontent.cpp
+++ b/src/chatlog/chatlinecontent.cpp
@@ -18,6 +18,7 @@
 */
 
 #include "chatlinecontent.h"
+#include <QTextCursor>
 
 void ChatLineContent::setIndex(int r, int c)
 {
@@ -73,6 +74,16 @@ bool ChatLineContent::isOverSelection(QPointF) const
 QString ChatLineContent::getSelectedText() const
 {
     return QString();
+}
+
+int ChatLineContent::setHighlight(const QString&)
+{
+    return 0;
+}
+
+QTextCursor ChatLineContent::setHighlight(const QString&, const QTextCursor&)
+{
+    return QTextCursor();
 }
 
 qreal ChatLineContent::getAscent() const

--- a/src/chatlog/chatlinecontent.cpp
+++ b/src/chatlog/chatlinecontent.cpp
@@ -86,6 +86,11 @@ bool ChatLineContent::selectNext(const QString&)
     return false;
 }
 
+bool ChatLineContent::selectPrevious(const QString&)
+{
+    return false;
+}
+
 int ChatLineContent::setHighlight(const QString&)
 {
     return 0;

--- a/src/chatlog/chatlinecontent.cpp
+++ b/src/chatlog/chatlinecontent.cpp
@@ -76,6 +76,16 @@ QString ChatLineContent::getSelectedText() const
     return QString();
 }
 
+bool ChatLineContent::hasSelection() const
+{
+    return false;
+}
+
+bool ChatLineContent::selectNext(const QString&)
+{
+    return false;
+}
+
 int ChatLineContent::setHighlight(const QString&)
 {
     return 0;

--- a/src/chatlog/chatlinecontent.h
+++ b/src/chatlog/chatlinecontent.h
@@ -47,6 +47,7 @@ public:
     virtual QString getSelectedText() const;
     virtual bool hasSelection() const;
     virtual bool selectNext(const QString& search);
+    virtual bool selectPrevious(const QString& search);
     virtual int setHighlight(const QString& highlight);
     virtual QTextCursor setHighlight(const QString &highlight, const QTextCursor &previous);
 

--- a/src/chatlog/chatlinecontent.h
+++ b/src/chatlog/chatlinecontent.h
@@ -45,6 +45,8 @@ public:
     virtual void selectionFocusChanged(bool focusIn);
     virtual bool isOverSelection(QPointF scenePos) const;
     virtual QString getSelectedText() const;
+    virtual bool hasSelection() const;
+    virtual bool selectNext(const QString& search);
     virtual int setHighlight(const QString& highlight);
     virtual QTextCursor setHighlight(const QString &highlight, const QTextCursor &previous);
 

--- a/src/chatlog/chatlinecontent.h
+++ b/src/chatlog/chatlinecontent.h
@@ -45,6 +45,8 @@ public:
     virtual void selectionFocusChanged(bool focusIn);
     virtual bool isOverSelection(QPointF scenePos) const;
     virtual QString getSelectedText() const;
+    virtual int setHighlight(const QString& highlight);
+    virtual QTextCursor setHighlight(const QString &highlight, const QTextCursor &previous);
 
     virtual QString getText() const;
 

--- a/src/chatlog/chatlinecontent.h
+++ b/src/chatlog/chatlinecontent.h
@@ -46,10 +46,9 @@ public:
     virtual bool isOverSelection(QPointF scenePos) const;
     virtual QString getSelectedText() const;
     virtual bool hasSelection() const;
-    virtual bool selectNext(const QString& search);
-    virtual bool selectPrevious(const QString& search);
-    virtual int setHighlight(const QString& highlight);
-    virtual QTextCursor setHighlight(const QString &highlight, const QTextCursor &previous);
+    virtual bool selectNext(const QString& search, Qt::CaseSensitivity sensitivity);
+    virtual bool selectPrevious(const QString& search, Qt::CaseSensitivity sensitivity);
+    virtual int setHighlight(const QString& highlight, Qt::CaseSensitivity sensitivity);
 
     virtual QString getText() const;
 

--- a/src/chatlog/chatlinecontent.h
+++ b/src/chatlog/chatlinecontent.h
@@ -32,11 +32,14 @@ public:
         ChatLineContentType = QGraphicsItem::UserType + 1,
     };
 
+public:
     int getColumn() const;
     int getRow() const;
 
+    int type() const final override;
+
+public:
     virtual void setWidth(qreal width) = 0;
-    virtual int type() const final;
 
     virtual void selectionMouseMove(QPointF scenePos);
     virtual void selectionStarted(QPointF scenePos);
@@ -51,11 +54,7 @@ public:
     virtual int setHighlight(const QString& highlight, Qt::CaseSensitivity sensitivity);
 
     virtual QString getText() const;
-
     virtual qreal getAscent() const;
-
-    virtual QRectF boundingRect() const = 0;
-    virtual void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget) = 0;
 
     virtual void visibilityChanged(bool visible);
 

--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -210,11 +210,11 @@ void ChatLog::mouseMoveEvent(QMouseEvent* ev)
 
     int leftColumnWidth = Settings::getInstance().getColumnLeftWidth();
     int rightColumnWidth = Settings::getInstance().getColumnRightWidth();
-    //int endLocation = width() - rightColumnWidth - margins.left() - verticalScrollBar()->sizeHint().width() - 15 / 2;
+    int endLocation = width() - rightColumnWidth - margins.left() - verticalScrollBar()->sizeHint().width() - 15 / 2;
 
     bool splitterLeft = scenePos.x() > leftColumnWidth && scenePos.x() < leftColumnWidth + 15;
     // Uncomment this for movable time stamps.
-    bool splitterRight = false;//scenePos.x() > endLocation - 15 && scenePos.x() < endLocation;
+    bool splitterRight = scenePos.x() > endLocation - 15 && scenePos.x() < endLocation;
 
     if ((splitterLeft || splitterRight) && selectionMode == None)
     {

--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -1022,11 +1022,13 @@ void ChatLog::onWorkerTimeout()
 
 void ChatLog::onScrollBarChanged(int value)
 {
+
     if (verticalScrollBar()->maximum() == verticalScrollBar()->minimum())
         value = -margins.top();
+    else if (value < 0)
+        value = 0;
 
-    //int currentGlobalDateY = dateMessages[globalDateIndex].second->getContent(1)->y();
-
+    qDebug() << value;
 
     if (dateMessages.count() != 0)
     {
@@ -1060,6 +1062,7 @@ void ChatLog::onScrollBarChanged(int value)
                 int height = dateMessages[globalDateIndex - 1].second->sceneBoundingRect().height() + lineSpacing;
                 if (value > y - height)
                 {
+                    qDebug() << "NEW";
                     value = y - height;
                 }
                 break;

--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -109,8 +109,6 @@ ChatLog::ChatLog(QWidget* parent)
 #endif
     });
 
-    //setCursor(Qt::SplitHCursor);
-
     retranslateUi();
     Translator::registerHandler(std::bind(&ChatLog::retranslateUi, this), this);
 }
@@ -200,6 +198,8 @@ void ChatLog::mouseReleaseEvent(QMouseEvent* ev)
 
     viewport()->unsetCursor();
     selectionScrollDir = NoDirection;
+
+    mouseMoveEvent(ev); // To fix the cursor.
 }
 
 void ChatLog::mouseMoveEvent(QMouseEvent* ev)

--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -33,6 +33,7 @@ class QMouseEvent;
 class QTimer;
 class ChatLineContent;
 struct ToxFile;
+class NotificationEdgeWidget;
 
 class ChatLog : public QGraphicsView
 {
@@ -45,6 +46,7 @@ public:
     void insertChatlineAtBottom(ChatLine::Ptr l);
     void insertChatlineOnTop(ChatLine::Ptr l);
     void insertChatlineOnTop(const QList<ChatLine::Ptr>& newLines);
+    void showNotification(ChatLine::Ptr l);
     void clearSelection();
     void clear();
     void copySelectedText(bool toSelectionBuffer = false) const;
@@ -112,12 +114,15 @@ private slots:
     void onSelectionTimerTimeout();
     void onWorkerTimeout();
     void onScrollBarChanged(int value);
+    void focusNotifiedWidget();
+    void removeNotificationWidget();
 
 private:
     void retranslateUi();
 
 private:
     void updateLayout(int currentWidth, int previousWidth);
+    void recalculateNotificationEdge();
 
     enum SelectionMode {
         None          = 0x00,
@@ -175,6 +180,10 @@ private:
     QGraphicsRectItem* globalDateRect;
     QVector<QPair<QDate, ChatMessage::Ptr>> dateMessages;
     int globalDateIndex;
+
+    // notification
+    NotificationEdgeWidget* edgeWidget = nullptr;
+    ChatLine::Ptr edgeMessage;
 };
 
 #endif // CHATLOG_H

--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -41,6 +41,7 @@ public:
     explicit ChatLog(QWidget* parent = 0);
     virtual ~ChatLog();
 
+    void setVerticalScrollBar(QScrollBar* scrollbar);
     void insertChatlineAtBottom(ChatLine::Ptr l);
     void insertChatlineOnTop(ChatLine::Ptr l);
     void insertChatlineOnTop(const QList<ChatLine::Ptr>& newLines);
@@ -62,6 +63,7 @@ public:
 
     bool isEmpty() const;
     bool hasTextToBeCopied() const;
+    void addDateMessage(QDate date, ChatMessage::Ptr message);
 
     ChatLine::Ptr getTypingNotification() const;
     QVector<ChatLine::Ptr> getLines();
@@ -108,6 +110,7 @@ protected:
 private slots:
     void onSelectionTimerTimeout();
     void onWorkerTimeout();
+    void onScrollBarChanged(int value);
 
 private:
     void retranslateUi();
@@ -165,6 +168,12 @@ private:
 
     // find
     QHash<int, ChatLine::Ptr> foundText;
+
+    // global date
+    ChatMessage::Ptr globalDateMessage;
+    QGraphicsRectItem* globalDateRect;
+    QVector<QPair<QDate, ChatMessage::Ptr>> dateMessages;
+    int globalDateIndex;
 };
 
 #endif // CHATLOG_H

--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -169,7 +169,7 @@ private:
     ChatLine::Ptr workerAnchorLine;
 
     // layout
-    QMargins margins = QMargins(10,10,10,10);
+    QMargins margins = QMargins(0,10,0,10);
     qreal lineSpacing = 5.0f;
 
     // find

--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -68,6 +68,7 @@ public:
     ChatLine::Ptr getTypingNotification() const;
     QVector<ChatLine::Ptr> getLines();
     ChatLine::Ptr getLatestLine() const;
+    QDate getLatestDate() const;
     // repetition interval sender name (sec)
     const uint repNameAfter = 5*60;
 

--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -55,6 +55,10 @@ public:
     void forceRelayout();
 
     QString getSelectedText() const;
+    int findText(const QString &text, Qt::CaseSensitivity sensitivity, int &index);
+    int findNext(const QString& text, int to, int total, Qt::CaseSensitivity sensitivity);
+    int findPrevious(const QString& text, int to, int total, Qt::CaseSensitivity sensitivity);
+    const QHash<int, ChatLine::Ptr>& getFoundLines() const;
 
     bool isEmpty() const;
     bool hasTextToBeCopied() const;
@@ -158,6 +162,9 @@ private:
     // layout
     QMargins margins = QMargins(10,10,10,10);
     qreal lineSpacing = 5.0f;
+
+    // find
+    QHash<int, ChatLine::Ptr> foundText;
 };
 
 #endif // CHATLOG_H

--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -109,10 +109,16 @@ private:
     void retranslateUi();
 
 private:
+    void updateLayout(int currentWidth, int previousWidth);
+
     enum SelectionMode {
-        None,
-        Precise,
-        Multi,
+        None          = 0x00,
+        Precise       = 0x01,
+        Multi         = 0x02,
+        Selected      = Precise | Multi,
+        SplitterLeft  = 0x04,
+        SplitterRight = 0x08,
+        Splitter      = SplitterLeft | SplitterRight,
     };
 
     enum AutoScrollDirection {
@@ -142,6 +148,7 @@ private:
     QTimer* selectionTimer = nullptr;
     QTimer* workerTimer = nullptr;
     AutoScrollDirection selectionScrollDir = NoDirection;
+    int splitterVal;
 
     //worker vars
     int workerLastIndex = 0;

--- a/src/chatlog/chatmessage.cpp
+++ b/src/chatlog/chatmessage.cpp
@@ -333,5 +333,5 @@ QString ChatMessage::detectQuotes(const QString& str, MessageType type)
 
 QString ChatMessage::wrapDiv(const QString &str, const QString &div)
 {
-    return QString("<p class=%1>%2</p>").arg(div, QChar(0x200E) + str);
+    return QString("<p class=%1>%2</p>").arg(div, /*QChar(0x200E) + */str);
 }

--- a/src/chatlog/chatmessage.cpp
+++ b/src/chatlog/chatmessage.cpp
@@ -69,9 +69,9 @@ ChatMessage::Ptr ChatMessage::createChatMessage(const QString &sender, const QSt
     }
 
     // Note: Eliding cannot be enabled for RichText items. (QTBUG-17207)
-    msg->addColumn(new Text(senderText, isMe ? Style::getFont(Style::BigBold) : Style::getFont(Style::Big), true, sender, type == ACTION ? actionColor : Qt::black), ColumnFormat(NAME_COL_WIDTH, ColumnFormat::FixedSize, ColumnFormat::Right));
+    msg->addColumn(new Text(senderText, isMe ? Style::getFont(Style::BigBold) : Style::getFont(Style::Big), true, sender, type == ACTION ? actionColor : Qt::black), ColumnFormat(ColumnFormat::LeftColumn, ColumnFormat::Right));
     msg->addColumn(new Text(text, Style::getFont(Style::Big), false, ((type == ACTION) && isMe) ? QString("%1 %2").arg(sender, rawMessage) : rawMessage), ColumnFormat(1.0, ColumnFormat::VariableSize));
-    msg->addColumn(new Spinner(":/ui/chatArea/spinner.svg", QSize(16, 16), 360.0/1.6), ColumnFormat(TIME_COL_WIDTH, ColumnFormat::FixedSize, ColumnFormat::Right));
+    msg->addColumn(new Spinner(":/ui/chatArea/spinner.svg", QSize(16, 16), 360.0/1.6), ColumnFormat(ColumnFormat::RightColumn, ColumnFormat::Right));
 
     if (!date.isNull())
         msg->markAsSent(date);
@@ -92,9 +92,9 @@ ChatMessage::Ptr ChatMessage::createChatInfoMessage(const QString &rawMessage, S
     case TYPING: img = ":/ui/chatArea/typing.svg";   break;
     }
 
-    msg->addColumn(new Image(QSize(18, 18), img), ColumnFormat(NAME_COL_WIDTH, ColumnFormat::FixedSize, ColumnFormat::Right));
+    msg->addColumn(new Image(QSize(18, 18), img), ColumnFormat(ColumnFormat::LeftColumn, ColumnFormat::Right));
     msg->addColumn(new Text("<b>" + text + "</b>", Style::getFont(Style::Big), false, ""), ColumnFormat(1.0, ColumnFormat::VariableSize, ColumnFormat::Left));
-    msg->addColumn(new Timestamp(date, Settings::getInstance().getTimestampFormat(), Style::getFont(Style::Big)), ColumnFormat(TIME_COL_WIDTH, ColumnFormat::FixedSize, ColumnFormat::Right));
+    msg->addColumn(new Timestamp(date, Settings::getInstance().getTimestampFormat(), Style::getFont(Style::Big)), ColumnFormat(ColumnFormat::RightColumn, ColumnFormat::Right));
 
     return msg;
 }
@@ -103,9 +103,9 @@ ChatMessage::Ptr ChatMessage::createFileTransferMessage(const QString& sender, T
 {
     ChatMessage::Ptr msg = ChatMessage::Ptr(new ChatMessage);
 
-    msg->addColumn(new Text(sender, isMe ? Style::getFont(Style::BigBold) : Style::getFont(Style::Big), true), ColumnFormat(NAME_COL_WIDTH, ColumnFormat::FixedSize, ColumnFormat::Right));
+    msg->addColumn(new Text(sender, isMe ? Style::getFont(Style::BigBold) : Style::getFont(Style::Big), true), ColumnFormat(ColumnFormat::LeftColumn, ColumnFormat::Right));
     msg->addColumn(new ChatLineContentProxy(new FileTransferWidget(0, file), 320, 0.6f), ColumnFormat(1.0, ColumnFormat::VariableSize));
-    msg->addColumn(new Timestamp(date, Settings::getInstance().getTimestampFormat(), Style::getFont(Style::Big)), ColumnFormat(TIME_COL_WIDTH, ColumnFormat::FixedSize, ColumnFormat::Right));
+    msg->addColumn(new Timestamp(date, Settings::getInstance().getTimestampFormat(), Style::getFont(Style::Big)), ColumnFormat(ColumnFormat::RightColumn, ColumnFormat::Right));
 
     return msg;
 }
@@ -120,7 +120,7 @@ ChatMessage::Ptr ChatMessage::createTypingNotification()
     // user received typing notifications constantly since contact came online.
     // This causes "[user]..." to be displayed in place of user nick, as long
     // as user will keep typing. Issue #1280
-    msg->addColumn(new NotificationIcon(QSize(18, 18)), ColumnFormat(NAME_COL_WIDTH, ColumnFormat::FixedSize, ColumnFormat::Right));
+    msg->addColumn(new NotificationIcon(QSize(18, 18)), ColumnFormat(ColumnFormat::LeftColumn, ColumnFormat::Right));
     msg->addColumn(new Text("[user]...", Style::getFont(Style::Big), false, ""), ColumnFormat(1.0, ColumnFormat::VariableSize, ColumnFormat::Left));
 
     return msg;

--- a/src/chatlog/chatmessage.cpp
+++ b/src/chatlog/chatmessage.cpp
@@ -38,7 +38,7 @@ ChatMessage::ChatMessage()
 
 }
 
-bool ChatMessage::selectNext(const QString& text)
+bool ChatMessage::selectNext(const QString& text, Qt::CaseSensitivity sensitivity)
 {
     bool done = false;
 
@@ -49,7 +49,7 @@ bool ChatMessage::selectNext(const QString& text)
         {
             done = true;
 
-            if (getContent(i)->selectNext(text))
+            if (getContent(i)->selectNext(text, sensitivity))
                 return true;
             else
                 getContent(i)->selectionCleared();
@@ -64,7 +64,7 @@ bool ChatMessage::selectNext(const QString& text)
             if (i == 0 && isSenderHidden())
                 continue;
 
-            if (getContent(i)->selectNext(text))
+            if (getContent(i)->selectNext(text, sensitivity))
                 return true;
         }
     }
@@ -73,18 +73,18 @@ bool ChatMessage::selectNext(const QString& text)
     return false;
 }
 
-bool ChatMessage::selectPrevious(const QString& text)
+bool ChatMessage::selectPrevious(const QString& text, Qt::CaseSensitivity sensitivity)
 {
     bool done = false;
 
     // First, check if a selection has been made. If it has, then move to next one.
-    for (int i = 1; i > 0; --i)
+    for (int i = 1; i >= 0; --i)
     {
         if (getContent(i)->hasSelection() || done)
         {
             done = true;
 
-            if (getContent(i)->selectPrevious(text))
+            if (getContent(i)->selectPrevious(text, sensitivity))
                 return true;
             else
                 getContent(i)->selectionCleared();
@@ -94,12 +94,12 @@ bool ChatMessage::selectPrevious(const QString& text)
     // If not, then find the next one starting from the beginning.
     if (!done)
     {
-        for (int i = 1; i > 0; --i)
+        for (int i = 1; i >= 0; --i)
         {
             if (i == 0 && isSenderHidden())
                 continue;
 
-            if (getContent(i)->selectPrevious(text))
+            if (getContent(i)->selectPrevious(text, sensitivity))
                 return true;
         }
     }
@@ -108,14 +108,14 @@ bool ChatMessage::selectPrevious(const QString& text)
     return false;
 }
 
-int ChatMessage::setHighlight(const QString &text)
+int ChatMessage::setHighlight(const QString &text, Qt::CaseSensitivity sensitivity)
 {
     int total = 0;
 
     if (!isSenderHidden())
-        total += getContent(0)->setHighlight(text);
+        total += getContent(0)->setHighlight(text, sensitivity);
 
-    return total + getContent(1)->setHighlight(text);
+    return total + getContent(1)->setHighlight(text, sensitivity);
 }
 
 ChatMessage::Ptr ChatMessage::createChatMessage(const QString &sender, const QString &rawMessage, MessageType type, bool isMe, const QDateTime &date)

--- a/src/chatlog/chatmessage.cpp
+++ b/src/chatlog/chatmessage.cpp
@@ -173,7 +173,7 @@ ChatMessage::Ptr ChatMessage::createChatInfoMessage(const QString &rawMessage, S
     }
 
     msg->addColumn(new Image(QSize(18, 18), img), ColumnFormat(ColumnFormat::LeftColumn, ColumnFormat::Right));
-    msg->addColumn(new Text("<b>" + text + "</b>", Style::getFont(Style::Big), false, text), ColumnFormat(1.0, ColumnFormat::VariableSize, ColumnFormat::Left));
+    msg->addColumn(new Text("<b>" + text + "</b>", Style::getFont(Style::Big), false, ""), ColumnFormat(1.0, ColumnFormat::VariableSize, ColumnFormat::Left));
     msg->addColumn(new Timestamp(date, Settings::getInstance().getTimestampFormat(), Style::getFont(Style::Big)), ColumnFormat(ColumnFormat::RightColumn, ColumnFormat::Left));
 
     return msg;

--- a/src/chatlog/chatmessage.cpp
+++ b/src/chatlog/chatmessage.cpp
@@ -247,5 +247,5 @@ QString ChatMessage::detectQuotes(const QString& str, MessageType type)
 
 QString ChatMessage::wrapDiv(const QString &str, const QString &div)
 {
-    return QString("<div class=%1>%2</div>").arg(div, str);
+    return QString("<div class=%1>%2</div>").arg(div, QChar(0x200E) + QString(str).replace(" ", "&nbsp;"));
 }

--- a/src/chatlog/chatmessage.cpp
+++ b/src/chatlog/chatmessage.cpp
@@ -38,7 +38,7 @@ ChatMessage::ChatMessage()
 
 }
 
-bool ChatMessage::selectNext(const QString& text, Qt::CaseSensitivity sensitivity)
+int ChatMessage::selectNext(const QString& text, Qt::CaseSensitivity sensitivity)
 {
     bool done = false;
 
@@ -50,7 +50,7 @@ bool ChatMessage::selectNext(const QString& text, Qt::CaseSensitivity sensitivit
             done = true;
 
             if (getContent(i)->selectNext(text, sensitivity))
-                return true;
+                return i;
             else
                 getContent(i)->selectionCleared();
         }
@@ -65,15 +65,15 @@ bool ChatMessage::selectNext(const QString& text, Qt::CaseSensitivity sensitivit
                 continue;
 
             if (getContent(i)->selectNext(text, sensitivity))
-                return true;
+                return i;
         }
     }
 
     // Text not found for selection.
-    return false;
+    return -1;
 }
 
-bool ChatMessage::selectPrevious(const QString& text, Qt::CaseSensitivity sensitivity)
+int ChatMessage::selectPrevious(const QString& text, Qt::CaseSensitivity sensitivity)
 {
     bool done = false;
 
@@ -85,7 +85,7 @@ bool ChatMessage::selectPrevious(const QString& text, Qt::CaseSensitivity sensit
             done = true;
 
             if (getContent(i)->selectPrevious(text, sensitivity))
-                return true;
+                return i;
             else
                 getContent(i)->selectionCleared();
         }
@@ -100,12 +100,12 @@ bool ChatMessage::selectPrevious(const QString& text, Qt::CaseSensitivity sensit
                 continue;
 
             if (getContent(i)->selectPrevious(text, sensitivity))
-                return true;
+                return i;
         }
     }
 
     // Text not found for selection.
-    return false;
+    return -1;
 }
 
 int ChatMessage::setHighlight(const QString &text, Qt::CaseSensitivity sensitivity)
@@ -173,7 +173,7 @@ ChatMessage::Ptr ChatMessage::createChatInfoMessage(const QString &rawMessage, S
     }
 
     msg->addColumn(new Image(QSize(18, 18), img), ColumnFormat(ColumnFormat::LeftColumn, ColumnFormat::Right));
-    msg->addColumn(new Text("<b>" + text + "</b>", Style::getFont(Style::Big), false, ""), ColumnFormat(1.0, ColumnFormat::VariableSize, ColumnFormat::Left));
+    msg->addColumn(new Text("<b>" + text + "</b>", Style::getFont(Style::Big), false, text), ColumnFormat(1.0, ColumnFormat::VariableSize, ColumnFormat::Left));
     msg->addColumn(new Timestamp(date, Settings::getInstance().getTimestampFormat(), Style::getFont(Style::Big)), ColumnFormat(ColumnFormat::RightColumn, ColumnFormat::Left));
 
     return msg;

--- a/src/chatlog/chatmessage.cpp
+++ b/src/chatlog/chatmessage.cpp
@@ -38,6 +38,86 @@ ChatMessage::ChatMessage()
 
 }
 
+bool ChatMessage::selectNext(const QString& text)
+{
+    bool done = false;
+
+    // First, check if a selection has been made. If it has, then move to next one.
+    for (int i = 0; i < 2; ++i)
+    {
+        if (getContent(i)->hasSelection() || done)
+        {
+            done = true;
+
+            if (getContent(i)->selectNext(text))
+                return true;
+            else
+                getContent(i)->selectionCleared();
+        }
+    }
+
+    // If not, then find the next one starting from the beginning.
+    if (!done)
+    {
+        for (int i = 0; i < 2; ++i)
+        {
+            if (i == 0 && isSenderHidden())
+                continue;
+
+            if (getContent(i)->selectNext(text))
+                return true;
+        }
+    }
+
+    // Text not found for selection.
+    return false;
+}
+
+bool ChatMessage::selectPrevious(const QString& text)
+{
+    bool done = false;
+
+    // First, check if a selection has been made. If it has, then move to next one.
+    for (int i = 1; i > 0; --i)
+    {
+        if (getContent(i)->hasSelection() || done)
+        {
+            done = true;
+
+            if (getContent(i)->selectPrevious(text))
+                return true;
+            else
+                getContent(i)->selectionCleared();
+        }
+    }
+
+    // If not, then find the next one starting from the beginning.
+    if (!done)
+    {
+        for (int i = 1; i > 0; --i)
+        {
+            if (i == 0 && isSenderHidden())
+                continue;
+
+            if (getContent(i)->selectPrevious(text))
+                return true;
+        }
+    }
+
+    // Text not found for selection.
+    return false;
+}
+
+int ChatMessage::setHighlight(const QString &text)
+{
+    int total = 0;
+
+    if (!isSenderHidden())
+        total += getContent(0)->setHighlight(text);
+
+    return total + getContent(1)->setHighlight(text);
+}
+
 ChatMessage::Ptr ChatMessage::createChatMessage(const QString &sender, const QString &rawMessage, MessageType type, bool isMe, const QDateTime &date)
 {
     ChatMessage::Ptr msg = ChatMessage::Ptr(new ChatMessage);
@@ -71,7 +151,7 @@ ChatMessage::Ptr ChatMessage::createChatMessage(const QString &sender, const QSt
     // Note: Eliding cannot be enabled for RichText items. (QTBUG-17207)
     msg->addColumn(new Text(senderText, isMe ? Style::getFont(Style::BigBold) : Style::getFont(Style::Big), true, sender, type == ACTION ? actionColor : Qt::black), ColumnFormat(ColumnFormat::LeftColumn, ColumnFormat::Right));
     msg->addColumn(new Text(text, Style::getFont(Style::Big), false, ((type == ACTION) && isMe) ? QString("%1 %2").arg(sender, rawMessage) : rawMessage), ColumnFormat(1.0, ColumnFormat::VariableSize));
-    msg->addColumn(new Spinner(":/ui/chatArea/spinner.svg", QSize(16, 16), 360.0/1.6), ColumnFormat(ColumnFormat::RightColumn, ColumnFormat::Right));
+    msg->addColumn(new Spinner(":/ui/chatArea/spinner.svg", QSize(16, 16), 360.0/1.6), ColumnFormat(ColumnFormat::RightColumn, ColumnFormat::Left));
 
     if (!date.isNull())
         msg->markAsSent(date);
@@ -94,7 +174,7 @@ ChatMessage::Ptr ChatMessage::createChatInfoMessage(const QString &rawMessage, S
 
     msg->addColumn(new Image(QSize(18, 18), img), ColumnFormat(ColumnFormat::LeftColumn, ColumnFormat::Right));
     msg->addColumn(new Text("<b>" + text + "</b>", Style::getFont(Style::Big), false, ""), ColumnFormat(1.0, ColumnFormat::VariableSize, ColumnFormat::Left));
-    msg->addColumn(new Timestamp(date, Settings::getInstance().getTimestampFormat(), Style::getFont(Style::Big)), ColumnFormat(ColumnFormat::RightColumn, ColumnFormat::Right));
+    msg->addColumn(new Timestamp(date, Settings::getInstance().getTimestampFormat(), Style::getFont(Style::Big)), ColumnFormat(ColumnFormat::RightColumn, ColumnFormat::Left));
 
     return msg;
 }
@@ -105,7 +185,7 @@ ChatMessage::Ptr ChatMessage::createFileTransferMessage(const QString& sender, T
 
     msg->addColumn(new Text(sender, isMe ? Style::getFont(Style::BigBold) : Style::getFont(Style::Big), true), ColumnFormat(ColumnFormat::LeftColumn, ColumnFormat::Right));
     msg->addColumn(new ChatLineContentProxy(new FileTransferWidget(0, file), 320, 0.6f), ColumnFormat(1.0, ColumnFormat::VariableSize));
-    msg->addColumn(new Timestamp(date, Settings::getInstance().getTimestampFormat(), Style::getFont(Style::Big)), ColumnFormat(ColumnFormat::RightColumn, ColumnFormat::Right));
+    msg->addColumn(new Timestamp(date, Settings::getInstance().getTimestampFormat(), Style::getFont(Style::Big)), ColumnFormat(ColumnFormat::RightColumn, ColumnFormat::Left));
 
     return msg;
 }
@@ -153,19 +233,28 @@ QString ChatMessage::toString() const
 
 bool ChatMessage::isAction() const
 {
-    return action;
+    return flags & IsAction;
 }
 
 void ChatMessage::setAsAction()
 {
-    action = true;
+    flags |= IsAction;
+}
+
+bool ChatMessage::isSenderHidden() const
+{
+    return flags & SenderHidden;
 }
 
 void ChatMessage::hideSender()
 {
     ChatLineContent* c = getContent(0);
+
     if (c)
+    {
         c->hide();
+        flags |= SenderHidden;
+    }
 }
 
 void ChatMessage::hideDate()
@@ -247,5 +336,5 @@ QString ChatMessage::detectQuotes(const QString& str, MessageType type)
 
 QString ChatMessage::wrapDiv(const QString &str, const QString &div)
 {
-    return QString("<div class=%1>%2</div>").arg(div, QChar(0x200E) + QString(str).replace(" ", "&nbsp;"));
+    return QString("<div class=%1>%2</div>").arg(div, /*QChar(0x200E) + */QString(str).replace(" ", QChar(0xA0)));
 }

--- a/src/chatlog/chatmessage.cpp
+++ b/src/chatlog/chatmessage.cpp
@@ -333,5 +333,5 @@ QString ChatMessage::detectQuotes(const QString& str, MessageType type)
 
 QString ChatMessage::wrapDiv(const QString &str, const QString &div)
 {
-    return QString("<p class=%1>%2</p>").arg(div, /*QChar(0x200E) + */QString(str));
+    return QString("<p class=%1>%2</p>").arg(div, QChar(0x200E) + str);
 }

--- a/src/chatlog/chatmessage.cpp
+++ b/src/chatlog/chatmessage.cpp
@@ -30,9 +30,6 @@
 #include "src/persistence/smileypack.h"
 #include "src/widget/style.h"
 
-#define NAME_COL_WIDTH 90.0
-#define TIME_COL_WIDTH 90.0
-
 ChatMessage::ChatMessage()
 {
 
@@ -336,5 +333,5 @@ QString ChatMessage::detectQuotes(const QString& str, MessageType type)
 
 QString ChatMessage::wrapDiv(const QString &str, const QString &div)
 {
-    return QString("<div class=%1>%2</div>").arg(div, /*QChar(0x200E) + */QString(str).replace(" ", QChar(0xA0)));
+    return QString("<p class=%1>%2</p>").arg(div, /*QChar(0x200E) + */QString(str));
 }

--- a/src/chatlog/chatmessage.h
+++ b/src/chatlog/chatmessage.h
@@ -46,6 +46,9 @@ public:
     };
 
     ChatMessage();
+    virtual bool selectNext(const QString& text) override;
+    virtual bool selectPrevious(const QString& text) override;
+    virtual int setHighlight(const QString& text) override;
 
     static ChatMessage::Ptr createChatMessage(const QString& sender, const QString& rawMessage, MessageType type, bool isMe, const QDateTime& date = QDateTime());
     static ChatMessage::Ptr createChatInfoMessage(const QString& rawMessage, SystemMessageType type, const QDateTime& date);
@@ -57,6 +60,7 @@ public:
     QString toString() const;
     bool isAction() const;
     void setAsAction();
+    bool isSenderHidden() const;
     void hideSender();
     void hideDate();
 
@@ -66,7 +70,16 @@ protected:
     static QString wrapDiv(const QString& str, const QString& div);
 
 private:
-    bool action = false;
+
+    typedef uint8_t Flags;
+
+    enum Flag : Flags
+    {
+        IsAction     = 0x01,
+        SenderHidden = 0x02
+    };
+
+    Flags flags = 0;
 };
 
 #endif // CHATMESSAGE_H

--- a/src/chatlog/chatmessage.h
+++ b/src/chatlog/chatmessage.h
@@ -46,8 +46,8 @@ public:
     };
 
     ChatMessage();
-    virtual bool selectNext(const QString& text, Qt::CaseSensitivity sensitivity) override;
-    virtual bool selectPrevious(const QString&, Qt::CaseSensitivity sensitivity) override;
+    virtual int selectNext(const QString& text, Qt::CaseSensitivity sensitivity) override;
+    virtual int selectPrevious(const QString&, Qt::CaseSensitivity sensitivity) override;
     virtual int setHighlight(const QString& text, Qt::CaseSensitivity sensitivity) override;
 
     static ChatMessage::Ptr createChatMessage(const QString& sender, const QString& rawMessage, MessageType type, bool isMe, const QDateTime& date = QDateTime());

--- a/src/chatlog/chatmessage.h
+++ b/src/chatlog/chatmessage.h
@@ -51,7 +51,7 @@ public:
     virtual int setHighlight(const QString& text, Qt::CaseSensitivity sensitivity) override;
 
     static ChatMessage::Ptr createChatMessage(const QString& sender, const QString& rawMessage, MessageType type, bool isMe, const QDateTime& date = QDateTime());
-    static ChatMessage::Ptr createChatInfoMessage(const QString& rawMessage, SystemMessageType type, const QDateTime& date);
+    static ChatMessage::Ptr createChatInfoMessage(const QString& rawMessage, SystemMessageType type, const QDateTime& date = QDateTime());
     static ChatMessage::Ptr createFileTransferMessage(const QString& sender, ToxFile file, bool isMe, const QDateTime& date);
     static ChatMessage::Ptr createTypingNotification();
     static ChatMessage::Ptr createBusyNotification();

--- a/src/chatlog/chatmessage.h
+++ b/src/chatlog/chatmessage.h
@@ -46,9 +46,9 @@ public:
     };
 
     ChatMessage();
-    virtual bool selectNext(const QString& text) override;
-    virtual bool selectPrevious(const QString& text) override;
-    virtual int setHighlight(const QString& text) override;
+    virtual bool selectNext(const QString& text, Qt::CaseSensitivity sensitivity) override;
+    virtual bool selectPrevious(const QString&, Qt::CaseSensitivity sensitivity) override;
+    virtual int setHighlight(const QString& text, Qt::CaseSensitivity sensitivity) override;
 
     static ChatMessage::Ptr createChatMessage(const QString& sender, const QString& rawMessage, MessageType type, bool isMe, const QDateTime& date = QDateTime());
     static ChatMessage::Ptr createChatInfoMessage(const QString& rawMessage, SystemMessageType type, const QDateTime& date);

--- a/src/chatlog/content/text.cpp
+++ b/src/chatlog/content/text.cpp
@@ -155,15 +155,32 @@ bool Text::selectNext(const QString& search)
 {
     int indexOf = selectionEnd;
 
-    if (search != selectedText)
-        indexOf = selectionAnchor;
-
     if (indexOf == -1)
         indexOf = 0;
 
-    if ((indexOf = getText().indexOf(search, indexOf)) != -1)
+    if ((indexOf = getText().indexOf(search, indexOf, Qt::CaseInsensitive)) != -1)
     {
-        qDebug() << "FOUND" << indexOf << getText() << text;
+        selectionAnchor = indexOf;
+        selectionEnd = indexOf + search.count();
+        selectedText = search;
+        update();
+        return true;
+    }
+
+    return false;
+}
+
+bool Text::selectPrevious(const QString& search)
+{
+    int indexOf = getText().length() - 1;
+
+    if (hasSelection())
+        indexOf = selectionAnchor;
+
+    qDebug() << getText().left(indexOf) << getText().left(indexOf).lastIndexOf(search, -1, Qt::CaseInsensitive);
+    if ((indexOf = (getText().left(indexOf + search.count() - 1).lastIndexOf(search, -1, Qt::CaseInsensitive)) ) != -1)
+    {
+        qDebug() << getText().mid(indexOf, search.count());
         selectionAnchor = indexOf;
         selectionEnd = indexOf + search.count();
         selectedText = search;
@@ -280,13 +297,15 @@ QString Text::getText() const
 int Text::setHighlight(const QString &highlight)
 {
     int foundCount = 0;
-    int index = 0;
+    int index = -highlight.count();
 
     if (!highlight.isEmpty())
     {
-        while ((index = getText().indexOf(highlight, index + highlight.count())) != -1)
+        while ((index = getText().indexOf(highlight, index + highlight.count(), Qt::CaseInsensitive)) != -1)
             ++foundCount;
     }
+
+    //qDebug() << getText() << foundCount;
 
     highlightText = highlight;
 

--- a/src/chatlog/content/text.cpp
+++ b/src/chatlog/content/text.cpp
@@ -161,6 +161,20 @@ void Text::paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWid
         QAbstractTextDocumentLayout::PaintContext ctx;
         QAbstractTextDocumentLayout::Selection sel;
 
+        if (!highlightText.isEmpty())
+        {
+            QTextCursor findCursor;
+
+            while (!(findCursor = doc->find(highlightText, findCursor)).isNull())
+            {
+                QAbstractTextDocumentLayout::Selection highlight;
+                highlight.cursor = findCursor;
+                highlight.format.setBackground(Qt::yellow);
+                highlight.format.setForeground(Qt::black);
+                ctx.selections.append(highlight);
+            }
+        }
+
         if (hasSelection())
         {
             sel.cursor = QTextCursor(doc);
@@ -223,7 +237,7 @@ void Text::hoverMoveEvent(QGraphicsSceneHoverEvent *event)
     if (!anchor.isEmpty())
         setCursor(QCursor(Qt::PointingHandCursor));
     else
-        setCursor(QCursor());
+        setCursor(QCursor(Qt::IBeamCursor));
 
     // tooltip
     setToolTip(extractImgTooltip(cursorFromPos(event->scenePos(), false)));
@@ -232,6 +246,39 @@ void Text::hoverMoveEvent(QGraphicsSceneHoverEvent *event)
 QString Text::getText() const
 {
     return rawText;
+}
+
+int Text::setHighlight(const QString &highlight)
+{
+    int foundCount = 0;
+    int index = 0;
+
+    if (!highlight.isEmpty())
+    {
+        while ((index = text.indexOf(highlight, index + highlight.count())) != -1)
+            ++foundCount;
+    }
+
+    highlightText = highlight;
+
+    if (!isVisible())
+        update();
+
+    return foundCount;
+}
+#include <QGraphicsScene>
+QTextCursor Text::setHighlight(const QString &highlight, const QTextCursor &from)
+{
+    highlightText = highlight;
+    update();
+
+    if (!doc)
+        return QTextCursor();
+
+    //this->scene()->invalidate(pos().x(), pos().y(), size()., size().height());
+
+
+    return doc->find(highlight, from);
 }
 
 void Text::regenerate()

--- a/src/chatlog/content/text.cpp
+++ b/src/chatlog/content/text.cpp
@@ -146,6 +146,34 @@ QString Text::getSelectedText() const
     return selectedText;
 }
 
+bool Text::hasSelection() const
+{
+    return selectionEnd != -1;
+}
+
+bool Text::selectNext(const QString& search)
+{
+    int indexOf = selectionEnd;
+
+    if (search != selectedText)
+        indexOf = selectionAnchor;
+
+    if (indexOf == -1)
+        indexOf = 0;
+
+    if ((indexOf = getText().indexOf(search, indexOf)) != -1)
+    {
+        qDebug() << "FOUND" << indexOf << getText() << text;
+        selectionAnchor = indexOf;
+        selectionEnd = indexOf + search.count();
+        selectedText = search;
+        update();
+        return true;
+    }
+
+    return false;
+}
+
 QRectF Text::boundingRect() const
 {
     return QRectF(QPointF(0, 0), size);
@@ -189,6 +217,7 @@ void Text::paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWid
         ctx.palette.setColor(QPalette::Text, color);
 
         // draw text
+        doc->setUseDesignMetrics(true);
         doc->documentLayout()->draw(painter, ctx);
     }
 
@@ -255,7 +284,7 @@ int Text::setHighlight(const QString &highlight)
 
     if (!highlight.isEmpty())
     {
-        while ((index = text.indexOf(highlight, index + highlight.count())) != -1)
+        while ((index = getText().indexOf(highlight, index + highlight.count())) != -1)
             ++foundCount;
     }
 
@@ -266,7 +295,7 @@ int Text::setHighlight(const QString &highlight)
 
     return foundCount;
 }
-#include <QGraphicsScene>
+
 QTextCursor Text::setHighlight(const QString &highlight, const QTextCursor &from)
 {
     highlightText = highlight;
@@ -274,9 +303,6 @@ QTextCursor Text::setHighlight(const QString &highlight, const QTextCursor &from
 
     if (!doc)
         return QTextCursor();
-
-    //this->scene()->invalidate(pos().x(), pos().y(), size()., size().height());
-
 
     return doc->find(highlight, from);
 }
@@ -356,11 +382,6 @@ int Text::getSelectionEnd() const
 int Text::getSelectionStart() const
 {
     return qMin(selectionAnchor, selectionEnd);
-}
-
-bool Text::hasSelection() const
-{
-    return selectionEnd >= 0;
 }
 
 QString Text::extractSanitizedText(int from, int to) const

--- a/src/chatlog/content/text.cpp
+++ b/src/chatlog/content/text.cpp
@@ -29,6 +29,7 @@
 #include <QGraphicsSceneMouseEvent>
 #include <QDesktopServices>
 #include <QTextFragment>
+#include <QRegularExpression>
 
 Text::Text(const QString& txt, QFont font, bool enableElide, const QString &rwText, const QColor c)
     : rawText(rwText)
@@ -306,7 +307,11 @@ int Text::setHighlight(const QString &highlight, Qt::CaseSensitivity sensitivity
             ++foundCount;
     }
 
-    highlightText = highlight;
+    if (foundCount)
+        highlightText = highlight;
+    else
+        highlightText.clear();
+
     this->sensitivity = sensitivity;
 
     if (!isVisible())

--- a/src/chatlog/content/text.h
+++ b/src/chatlog/content/text.h
@@ -45,6 +45,8 @@ public:
     virtual void selectionFocusChanged(bool focusIn) final;
     virtual bool isOverSelection(QPointF scenePos) const final;
     virtual QString getSelectedText() const final;
+    virtual int setHighlight(const QString& highlight) override final;
+    virtual QTextCursor setHighlight(const QString& highlight, const QTextCursor& from) override final;
 
     virtual QRectF boundingRect() const final;
     virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) final;
@@ -57,6 +59,7 @@ public:
     virtual void hoverMoveEvent(QGraphicsSceneHoverEvent* event) final override;
 
     virtual QString getText() const final;
+
 
 protected:
     // dynamic resource management
@@ -77,6 +80,7 @@ private:
     QString rawText;
     QString elidedText;
     QString selectedText;
+    QString highlightText;
     QSizeF size;
     bool keepInMemory = false;
     bool elide = false;

--- a/src/chatlog/content/text.h
+++ b/src/chatlog/content/text.h
@@ -62,7 +62,6 @@ public:
 
     virtual QString getText() const final;
 
-
 protected:
     // dynamic resource management
     void regenerate();

--- a/src/chatlog/content/text.h
+++ b/src/chatlog/content/text.h
@@ -45,6 +45,8 @@ public:
     virtual void selectionFocusChanged(bool focusIn) final;
     virtual bool isOverSelection(QPointF scenePos) const final;
     virtual QString getSelectedText() const final;
+    virtual bool hasSelection() const override final;
+    virtual bool selectNext(const QString& search) override final;
     virtual int setHighlight(const QString& highlight) override final;
     virtual QTextCursor setHighlight(const QString& highlight, const QTextCursor& from) override final;
 
@@ -70,7 +72,6 @@ protected:
     int cursorFromPos(QPointF scenePos, bool fuzzy = true) const;
     int getSelectionEnd() const;
     int getSelectionStart() const;
-    bool hasSelection() const;
     QString extractSanitizedText(int from, int to) const;
     QString extractImgTooltip(int pos) const;
 

--- a/src/chatlog/content/text.h
+++ b/src/chatlog/content/text.h
@@ -46,10 +46,9 @@ public:
     virtual bool isOverSelection(QPointF scenePos) const final;
     virtual QString getSelectedText() const final;
     virtual bool hasSelection() const override final;
-    virtual bool selectNext(const QString& search) override final;
-    virtual bool selectPrevious(const QString& search) override final;
-    virtual int setHighlight(const QString& highlight) override final;
-    virtual QTextCursor setHighlight(const QString& highlight, const QTextCursor& from) override final;
+    virtual bool selectNext(const QString& search, Qt::CaseSensitivity sensitivity) override final;
+    virtual bool selectPrevious(const QString& search, Qt::CaseSensitivity sensitivity) override final;
+    virtual int setHighlight(const QString& highlight, Qt::CaseSensitivity sensitivity) override final;
 
     virtual QRectF boundingRect() const final;
     virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) final;
@@ -94,7 +93,7 @@ private:
     qreal width = 0.0;
     QFont defFont;
     QColor color;
-
+    Qt::CaseSensitivity sensitivity;
 };
 
 #endif // TEXT_H

--- a/src/chatlog/content/text.h
+++ b/src/chatlog/content/text.h
@@ -47,6 +47,7 @@ public:
     virtual QString getSelectedText() const final;
     virtual bool hasSelection() const override final;
     virtual bool selectNext(const QString& search) override final;
+    virtual bool selectPrevious(const QString& search) override final;
     virtual int setHighlight(const QString& highlight) override final;
     virtual QTextCursor setHighlight(const QString& highlight, const QTextCursor& from) override final;
 

--- a/src/chatlog/content/text.h
+++ b/src/chatlog/content/text.h
@@ -36,31 +36,31 @@ public:
 
     void setText(const QString& txt);
 
-    virtual void setWidth(qreal width) final;
+    void setWidth(qreal width) final override;
 
-    virtual void selectionMouseMove(QPointF scenePos) final;
-    virtual void selectionStarted(QPointF scenePos) final;
-    virtual void selectionCleared() final;
-    virtual void selectionDoubleClick(QPointF scenePos) final;
-    virtual void selectionFocusChanged(bool focusIn) final;
-    virtual bool isOverSelection(QPointF scenePos) const final;
-    virtual QString getSelectedText() const final;
-    virtual bool hasSelection() const override final;
-    virtual bool selectNext(const QString& search, Qt::CaseSensitivity sensitivity) override final;
-    virtual bool selectPrevious(const QString& search, Qt::CaseSensitivity sensitivity) override final;
-    virtual int setHighlight(const QString& highlight, Qt::CaseSensitivity sensitivity) override final;
+    void selectionMouseMove(QPointF scenePos) final override;
+    void selectionStarted(QPointF scenePos) final override;
+    void selectionCleared() final override;
+    void selectionDoubleClick(QPointF scenePos) final override;
+    void selectionFocusChanged(bool focusIn) final override;
+    bool isOverSelection(QPointF scenePos) const final override;
+    QString getSelectedText() const final override;
+    bool hasSelection() const final override;
+    bool selectNext(const QString& search, Qt::CaseSensitivity sensitivity) final override;
+    bool selectPrevious(const QString& search, Qt::CaseSensitivity sensitivity) final override;
+    int setHighlight(const QString& highlight, Qt::CaseSensitivity sensitivity) final override;
 
-    virtual QRectF boundingRect() const final;
-    virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) final;
+    QRectF boundingRect() const final override;
+    void paint(QPainter *painter, const QStyleOptionGraphicsItem *option, QWidget *widget) final override;
 
-    virtual void visibilityChanged(bool keepInMemory) final;
+    void visibilityChanged(bool keepInMemory) final override;
 
-    virtual qreal getAscent() const final;
-    virtual void mousePressEvent(QGraphicsSceneMouseEvent *event) final override;
-    virtual void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) final override;
-    virtual void hoverMoveEvent(QGraphicsSceneHoverEvent* event) final override;
+    qreal getAscent() const final override;
+    void mousePressEvent(QGraphicsSceneMouseEvent *event) final override;
+    void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) final override;
+    void hoverMoveEvent(QGraphicsSceneHoverEvent* event) final override;
 
-    virtual QString getText() const final;
+    QString getText() const final override;
 
 protected:
     // dynamic resource management

--- a/src/chatlog/content/timestamp.cpp
+++ b/src/chatlog/content/timestamp.cpp
@@ -20,7 +20,7 @@
 #include "timestamp.h"
 #include <QCursor>
 Timestamp::Timestamp(const QDateTime &time, const QString &format, const QFont &font)
-    : Text(time.toString(format), font, false, time.toString(format))
+    : Text(time.toString(format), font, true, time.toString(format))
 {
     this->time = time;
     setCursor(Qt::ForbiddenCursor);

--- a/src/friend.cpp
+++ b/src/friend.cpp
@@ -53,7 +53,7 @@ void Friend::loadHistory()
 {
     if (Nexus::getProfile()->isHistoryEnabled())
     {
-        chatForm->loadHistory(QDateTime::currentDateTime().addDays(-7), true);
+        chatForm->loadHistory(QDateTime(), true);
         widget->historyLoaded = true;
     }
 }

--- a/src/persistence/historykeeper.cpp
+++ b/src/persistence/historykeeper.cpp
@@ -133,6 +133,8 @@ HistoryKeeper::HistoryKeeper(GenericDdInterface *db_) :
     ans = oldDb->exec("PRAGMA table_info (\"history\")");
     ans.seek(5);
     if (!ans.value(1).toString().contains("alias"))
+    (void)time_from;
+    //qint64 time64_from = time_from.toMSecsSinceEpoch();
     {
         //add collum in table
         oldDb->exec("ALTER TABLE history ADD COLUMN alias TEXT");
@@ -143,6 +145,9 @@ HistoryKeeper::HistoryKeeper(GenericDdInterface *db_) :
 HistoryKeeper::~HistoryKeeper()
 {
     delete oldDb;
+
+    // Reverse list hack. TODO: Replace
+    for(int k = 0; k < (res.size()/2); k++) res.swap(k,res.size()-(1+k));
 }
 
 QList<HistoryKeeper::HistMessage> HistoryKeeper::exportMessages()

--- a/src/persistence/historykeeper.cpp
+++ b/src/persistence/historykeeper.cpp
@@ -133,32 +133,16 @@ HistoryKeeper::HistoryKeeper(GenericDdInterface *db_) :
     ans = oldDb->exec("PRAGMA table_info (\"history\")");
     ans.seek(5);
     if (!ans.value(1).toString().contains("alias"))
-    (void)time_from;
-    qint64 time64_from = time_from.toMSecsSinceEpoch();
     {
         //add collum in table
         oldDb->exec("ALTER TABLE history ADD COLUMN alias TEXT");
         qDebug() << "Struct DB updated: Added column alias in table history.";
-        QString query = QString("SELECT history.id, timestamp, user_id, message, status FROM history LEFT JOIN sent_status ON history.id = sent_status.id ");
-
-        if (time_from.isValid())
-        {
-            dbAnswer = db->exec(query + QString("INNER JOIN aliases ON history.sender = aliases.id AND timestamp BETWEEN %1 AND %2 AND chat_id = %3 ORDER BY timestamp DESC;")
-                                .arg(time64_from).arg(time64_to).arg(chat_id));
-        }
-        else
-        {
-            dbAnswer = db->exec(query + QString("INNER JOIN aliases ON history.sender = aliases.id AND timestamp < %1 AND chat_id = %2 ORDER BY timestamp DESC LIMIT 40;")
-                                .arg(time64_to).arg(chat_id));
-        }
     }
 }
 
 HistoryKeeper::~HistoryKeeper()
 {
     delete oldDb;
-    res.push_front(HistMessage(id, "", sender, message, time, isSent));
-
 }
 
 QList<HistoryKeeper::HistMessage> HistoryKeeper::exportMessages()

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -194,8 +194,8 @@ void Settings::loadGlobal()
     s.beginGroup("GUI");
         smileyPack = s.value("smileyPack", ":/smileys/TwitterEmojiSVG/emoticons.xml").toString();
         emojiFontPointSize = s.value("emojiFontPointSize", 16).toInt();
-        firstColumnHandlePos = s.value("firstColumnHandlePos", 50).toInt();
-        secondColumnHandlePosFromRight = s.value("secondColumnHandlePosFromRight", 50).toInt();
+        columnRightWidth = s.value("columnRightWidth", 90).toInt();
+        columnLeftWidth = s.value("columnLeftWidth", 90).toInt();
         timestampFormat = s.value("timestampFormat", "hh:mm:ss").toString();
         dateFormat = s.value("dateFormat", "dddd, MMMM d, yyyy").toString();
         minimizeOnClose = s.value("minimizeOnClose", false).toBool();
@@ -405,8 +405,8 @@ void Settings::saveGlobal()
     s.beginGroup("GUI");
         s.setValue("smileyPack", smileyPack);
         s.setValue("emojiFontPointSize", emojiFontPointSize);
-        s.setValue("firstColumnHandlePos", firstColumnHandlePos);
-        s.setValue("secondColumnHandlePosFromRight", secondColumnHandlePosFromRight);
+        s.setValue("firstColumnHandlePos", columnRightWidth);
+        s.setValue("secondColumnHandlePosFromRight", columnLeftWidth);
         s.setValue("timestampFormat", timestampFormat);
         s.setValue("dateFormat", dateFormat);
         s.setValue("minimizeOnClose", minimizeOnClose);
@@ -972,28 +972,28 @@ void Settings::setEmojiFontPointSize(int value)
     emit emojiFontChanged();
 }
 
-int Settings::getFirstColumnHandlePos() const
+int Settings::getColumnRightWidth() const
 {
     QMutexLocker locker{&bigLock};
-    return firstColumnHandlePos;
+    return columnRightWidth;
 }
 
-void Settings::setFirstColumnHandlePos(const int pos)
+void Settings::setColumnRightWidth(const int pos)
 {
     QMutexLocker locker{&bigLock};
-    firstColumnHandlePos = pos;
+    columnRightWidth = pos;
 }
 
-int Settings::getSecondColumnHandlePosFromRight() const
+int Settings::getColumnLeftWidth() const
 {
     QMutexLocker locker{&bigLock};
-    return secondColumnHandlePosFromRight;
+    return columnLeftWidth;
 }
 
-void Settings::setSecondColumnHandlePosFromRight(const int pos)
+void Settings::setColumnLeftWidth(const int pos)
 {
     QMutexLocker locker{&bigLock};
-    secondColumnHandlePosFromRight = pos;
+    columnLeftWidth = pos;
 }
 
 const QString& Settings::getTimestampFormat() const

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -405,8 +405,8 @@ void Settings::saveGlobal()
     s.beginGroup("GUI");
         s.setValue("smileyPack", smileyPack);
         s.setValue("emojiFontPointSize", emojiFontPointSize);
-        s.setValue("firstColumnHandlePos", columnRightWidth);
-        s.setValue("secondColumnHandlePosFromRight", columnLeftWidth);
+        s.setValue("columnRightWidth", columnRightWidth);
+        s.setValue("columnLeftWidth", columnLeftWidth);
         s.setValue("timestampFormat", timestampFormat);
         s.setValue("dateFormat", dateFormat);
         s.setValue("minimizeOnClose", minimizeOnClose);

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -317,6 +317,7 @@ void Settings::loadPersonnal(Profile* profile)
 
     ps.beginGroup("General");
         compactLayout = ps.value("compactLayout", true).toBool();
+        groupPeerListSide = ps.value("groupPeerListSide", false).toBool();
     ps.endGroup();
 
     ps.beginGroup("Circles");
@@ -492,6 +493,7 @@ void Settings::savePersonal(QString profileName, QString password)
 
     ps.beginGroup("General");
         ps.setValue("compactLayout", compactLayout);
+        ps.setValue("groupPeerListSide", groupPeerListSide);
     ps.endGroup();
 
     ps.beginGroup("Circles");
@@ -1388,6 +1390,19 @@ void Settings::setCompactLayout(bool value)
 {
     QMutexLocker locker{&bigLock};
     compactLayout = value;
+}
+
+bool Settings::getGroupPeerListSide() const
+{
+    QMutexLocker locker{&bigLock};
+    return groupPeerListSide;
+}
+
+void Settings::setGroupPeerListSide(bool value)
+{
+    QMutexLocker locker{&bigLock};
+    groupPeerListSide = value;
+    emit groupPeerListSideChanged();
 }
 
 bool Settings::getSeparateWindow() const

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -219,6 +219,7 @@ void Settings::loadGlobal()
         windowState = s.value("windowState", QByteArray()).toByteArray();
         splitterState = s.value("splitterState", QByteArray()).toByteArray();
         dialogGeometry = s.value("dialogGeometry", QByteArray()).toByteArray();
+        groupSplitterState = s.value("groupSplitterState", QByteArray()).toByteArray();
         dialogSplitterState = s.value("dialogSplitterState", QByteArray()).toByteArray();
         dialogSettingsGeometry = s.value("dialogSettingsGeometry", QByteArray()).toByteArray();
     s.endGroup();
@@ -424,6 +425,7 @@ void Settings::saveGlobal()
         s.setValue("windowState", windowState);
         s.setValue("splitterState", splitterState);
         s.setValue("dialogGeometry", dialogGeometry);
+        s.setValue("groupSplitterState", groupSplitterState);
         s.setValue("dialogSplitterState", dialogSplitterState);
         s.setValue("dialogSettingsGeometry", dialogSettingsGeometry);
     s.endGroup();
@@ -1080,6 +1082,18 @@ void Settings::setSplitterState(const QByteArray &value)
 {
     QMutexLocker locker{&bigLock};
     splitterState = value;
+}
+
+QByteArray Settings::getGroupSplitterState() const
+{
+    QMutexLocker locker{&bigLock};
+    return groupSplitterState;
+}
+
+void Settings::setGroupSplitterState(const QByteArray &value)
+{
+    QMutexLocker locker{&bigLock};
+    groupSplitterState = value;
 }
 
 QByteArray Settings::getDialogGeometry() const

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -191,11 +191,11 @@ public:
     void setGlobalAutoAcceptDir(const QString& dir);
 
     // ChatView
-    int getFirstColumnHandlePos() const;
-    void setFirstColumnHandlePos(const int pos);
+    int getColumnRightWidth() const;
+    void setColumnRightWidth(int width);
 
-    int getSecondColumnHandlePosFromRight() const;
-    void setSecondColumnHandlePosFromRight(const int pos);
+    int getColumnLeftWidth() const;
+    void setColumnLeftWidth(int pos);
 
     const QString& getTimestampFormat() const;
     void setTimestampFormat(const QString& format);
@@ -364,8 +364,8 @@ private:
     bool showSystemTray;
 
     // ChatView
-    int firstColumnHandlePos;
-    int secondColumnHandlePosFromRight;
+    int columnRightWidth;
+    int columnLeftWidth;
     QString timestampFormat;
     QString dateFormat;
     bool statusChangeNotificationEnabled;

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -60,6 +60,7 @@ signals:
     void dhtServerListChanged();
     void smileyPackChanged();
     void emojiFontChanged();
+    void groupPeerListSideChanged();
 
 public:
     // Getter/setters
@@ -252,6 +253,9 @@ public:
     bool getCompactLayout() const;
     void setCompactLayout(bool compact);
 
+    bool getGroupPeerListSide() const;
+    void setGroupPeerListSide(bool side);
+
     bool getSeparateWindow() const;
     void setSeparateWindow(bool value);
 
@@ -315,6 +319,7 @@ private:
     bool autoLogin;
     bool fauxOfflineMessaging;
     bool compactLayout;
+    bool groupPeerListSide;
     bool groupchatPosition;
     bool separateWindow;
     bool dontGroupWindows;

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -227,6 +227,9 @@ public:
     QByteArray getDialogGeometry() const;
     void setDialogGeometry(const QByteArray& value);
 
+    QByteArray getGroupSplitterState() const;
+    void setGroupSplitterState(const QByteArray &value);
+
     QByteArray getDialogSplitterState() const;
     void setDialogSplitterState(const QByteArray &value);
 
@@ -363,6 +366,7 @@ private:
     QByteArray windowState;
     QByteArray splitterState;
     QByteArray dialogGeometry;
+    QByteArray groupSplitterState;
     QByteArray dialogSplitterState;
     QByteArray dialogSettingsGeometry;
     QString style;

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -245,7 +245,7 @@ void ChatForm::onFileRecvRequest(ToxFile file)
     }
 
     ChatMessage::Ptr msg = ChatMessage::createFileTransferMessage(name, file, false, QDateTime::currentDateTime());
-    insertChatMessage(msg);
+    insertChatMessage(msg, true);
 
     ChatLineContentProxy* proxy = static_cast<ChatLineContentProxy*>(msg->getContent(1));
     assert(proxy->getWidgetType() == ChatLineContentProxy::FileTransferWidgetType);

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -712,7 +712,9 @@ void ChatForm::loadHistory(QDateTime since, bool processUndelivered)
         if (msgDate > lastDate)
         {
             lastDate = msgDate;
-            historyMessages.append(ChatMessage::createChatInfoMessage(msgDate.toString(Settings::getInstance().getDateFormat()), ChatMessage::INFO, QDateTime()));
+            ChatMessage::Ptr dateMessage = ChatMessage::createChatInfoMessage(msgDate.toString(Settings::getInstance().getDateFormat()), ChatMessage::INFO, QDateTime());
+            historyMessages.append(dateMessage);
+            chatWidget->addDateMessage(lastDate, dateMessage);
         }
 
         // Show each messages

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -131,7 +131,7 @@ ChatForm::ChatForm(Friend* chatFriend)
     connect(dynamicScroll, &DynamicScrollBar::dynamicRequest, [this]()
     {
         if (chatWidget->verticalScrollBar()->minimum() != chatWidget->verticalScrollBar()->maximum())
-            loadHistory(QDateTime(), false, true);
+            loadHistory(QDateTime(), false);
     });
 }
 
@@ -684,7 +684,7 @@ void ChatForm::onAvatarRemoved(uint32_t FriendId)
     avatar->setPixmap(QPixmap(":/img/contact_dark.svg"), Qt::transparent);
 }
 
-void ChatForm::loadHistory(QDateTime since, bool processUndelivered, bool next)
+void ChatForm::loadHistory(QDateTime since, bool processUndelivered)
 {
     QDateTime now = historyBaselineDate.addMSecs(-1);
 
@@ -702,11 +702,6 @@ void ChatForm::loadHistory(QDateTime since, bool processUndelivered, bool next)
             now = now.addMSecs(-1);
         }
     }
-
-    if (next)
-        now = getEarliestDate();
-
-    qDebug() << now;
 
     auto msgs = Nexus::getProfile()->getHistory()->getChatHistory(f->getToxId().publicKey, since, now);
 
@@ -771,8 +766,6 @@ void ChatForm::loadHistory(QDateTime since, bool processUndelivered, bool next)
     previousId = storedPrevId;
     int savedSliderPos = chatWidget->verticalScrollBar()->maximum() - chatWidget->verticalScrollBar()->value();
 
-    earliestMessage = since;
-
     QVectorIterator<QPair<QDate, ChatMessage::Ptr>> i(dateMessages);
     i.toBack();
     while (i.hasPrevious())
@@ -782,6 +775,11 @@ void ChatForm::loadHistory(QDateTime since, bool processUndelivered, bool next)
     }
 
     chatWidget->insertChatlineOnTop(historyMessages);
+
+    if (since.isNull())
+        earliestMessage = getEarliestDate();
+    else
+        earliestMessage = since;
 
     savedSliderPos = chatWidget->verticalScrollBar()->maximum() - savedSliderPos;
     chatWidget->verticalScrollBar()->setValue(savedSliderPos);

--- a/src/widget/form/chatform.h
+++ b/src/widget/form/chatform.h
@@ -43,7 +43,7 @@ public:
     ChatForm(Friend* chatFriend);
     ~ChatForm();
     void setStatusMessage(QString newMessage);
-    void loadHistory(QDateTime since, bool processUndelivered = false, bool next = false);
+    void loadHistory(QDateTime since, bool processUndelivered = false);
 
     void dischargeReceipt(int receipt);
     void setFriendTyping(bool isTyping);

--- a/src/widget/form/chatform.h
+++ b/src/widget/form/chatform.h
@@ -43,7 +43,7 @@ public:
     ChatForm(Friend* chatFriend);
     ~ChatForm();
     void setStatusMessage(QString newMessage);
-    void loadHistory(QDateTime since, bool processUndelivered = false);
+    void loadHistory(QDateTime since, bool processUndelivered = false, bool next = false);
 
     void dischargeReceipt(int receipt);
     void setFriendTyping(bool isTyping);

--- a/src/widget/form/chatform.h
+++ b/src/widget/form/chatform.h
@@ -49,7 +49,7 @@ public:
     void setFriendTyping(bool isTyping);
     OfflineMsgEngine* getOfflineMsgEngine();
 
-    virtual void show(ContentLayout* contentLayout) final override;
+    void show(ContentLayout* contentLayout) final override;
 
 signals:
     void sendFile(uint32_t friendId, QString, QString, long long);

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -471,17 +471,24 @@ void GenericChatForm::removeFindWidget()
         static_cast<IndicatorScrollBar*>(chatWidget->verticalScrollBar());
         indicatorScroll->clearIndicators();
 
-        //if (getChatLog()->getSelectedText())
+        foundText.clear();
+        foundText.squeeze();
+
+        QVector<ChatLine::Ptr> chatLines = getChatLog()->getLines();
+
+        for (ChatLine::Ptr chatLine : chatLines)
+        {
+            chatLine.get()->setHighlight(QString());
+
+            //if (chatLine.get()->getContent(0)->getSelectedText() == )
+        }
     }
 }
 
 void GenericChatForm::findText(const QString &text)
 {
-    findNext(text);
-}
+    foundText.clear();
 
-void GenericChatForm::findNext(const QString& text)
-{
     int i = 0;
     QVector<ChatLine::Ptr> chatLines = getChatLog()->getLines();
 
@@ -491,41 +498,113 @@ void GenericChatForm::findNext(const QString& text)
 
     int to = -1;
     ChatLine::Ptr toSelect;
+    ChatLine::Ptr first;
 
     for (ChatLine::Ptr chatLine : chatLines)
     {
-        if (chatLine.get()->getColumnCount() != 3)
-            continue;
-
         int last = i;
-        i += chatLine.get()->getContent(0)->setHighlight(text);
-        i += chatLine.get()->getContent(1)->setHighlight(text);
+        i += chatLine.get()->setHighlight(text);
 
         if (last != i)
         {
-            indicatorScroll->setTotal(chatWidget->sceneRect().height() - 40);
-            indicatorScroll->addIndicator(chatLine.get()->sceneBoundingRect().top());
+            if (!first)
+                first = chatLine;
+
+            for (int iter = last; iter != i; ++iter)
+                foundText.insert(iter, chatLine);
+
+            indicatorScroll->setTotal(chatWidget->sceneRect().height());
+            indicatorScroll->addIndicator(chatLine.get()->sceneBoundingRect().top() + 20);
             indicatorScroll->update();
 
-            if (chatLine.get()->sceneBoundingRect().top() >= getChatLog()->sceneRect().top() && to == -1)
+            bool above = chatLine.get()->sceneBoundingRect().top() >= getChatLog()->verticalScrollBar()->value();
+
+            if (to == -1 && above)
             {
-                to = i;
+                to = last;
                 toSelect = chatLine;
             }
         }
+
+        chatLine.get()->selectionCleared();
     }
 
-    emit findMatchesChanged(to, i);
+    // If we didn't find anything near the scroll area, then go to the first found.
+    if (to == -1 && i != 0)
+    {
+        to = 0;
+        toSelect = first;
+    }
+
+    emit findMatchesChanged(to + 1, i);
 
     if (to != -1)
+    {
         toSelect.get()->selectNext(text);
+        getChatLog()->ensureVisible(toSelect.get()->sceneBoundingRect());
+    }
 
     getChatLog()->update();
 }
 
-void GenericChatForm::findPrevious()
+void GenericChatForm::findNext(const QString& text, int to, int total)
 {
+    bool clear = true;
+    int next = to;
+    auto newFound = foundText.find(next - 1);
+    auto lastFound = foundText.find(next - 2);
 
+    if (lastFound == foundText.end())
+        lastFound = foundText.find(total - 1);
+
+    if (newFound == foundText.end())
+    {
+        newFound = foundText.find(0);
+        next = 1;
+    }
+
+    if (newFound.value() == lastFound.value())
+        clear = false;
+
+    emit findMatchesChanged(next, total);
+
+    if (clear)
+        lastFound.value().get()->selectionCleared();
+
+    getChatLog()->ensureVisible(newFound.value().get()->sceneBoundingRect());
+    newFound.value().get()->selectNext(text);
+
+    getChatLog()->update();
+}
+
+void GenericChatForm::findPrevious(const QString& text, int to, int total)
+{
+    bool clear = true;
+    int next = to;
+    auto newFound = foundText.find(next - 1);
+    auto lastFound = foundText.find(next);
+
+    if (lastFound == foundText.end())
+        lastFound = foundText.find(0);
+
+    if (newFound == foundText.end())
+    {
+        newFound = foundText.find(total - 1);
+        next = total;
+    }
+
+    if (newFound.value() == lastFound.value())
+        clear = false;
+
+    emit findMatchesChanged(next, total);
+
+    if (clear)
+        lastFound.value().get()->selectionCleared();
+
+    getChatLog()->ensureVisible(newFound.value().get()->sceneBoundingRect());
+    newFound.value().get()->selectPrevious(text);
+
+    getChatLog()->update();
 }
 
 void GenericChatForm::addSystemInfoMessage(const QString &message, ChatMessage::SystemMessageType type, const QDateTime &datetime)

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -276,8 +276,6 @@ QDateTime GenericChatForm::getEarliestDate() const
             return timestamp->getTime();
     }
 
-    qDebug() << "NOP";
-
     return QDateTime::currentDateTime();
 }
 
@@ -478,15 +476,10 @@ void GenericChatForm::removeFindWidget(const QString& text)
         static_cast<IndicatorScrollBar*>(chatWidget->verticalScrollBar());
         indicatorScroll->clearIndicators();
 
-        //foundText.clear();
-        //foundText.squeeze();
-
         QVector<ChatLine::Ptr> chatLines = getChatLog()->getLines();
 
         for (ChatLine::Ptr chatLine : chatLines)
             chatLine.get()->setHighlight(QString(), Qt::CaseInsensitive);
-
-        qDebug() << getChatLog()->getSelectedText();
 
         if (getChatLog()->getSelectedText() == text)
             getChatLog()->clearSelection();

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -275,6 +275,24 @@ QDate GenericChatForm::getLatestDate() const
     return QDate();
 }
 
+QDateTime GenericChatForm::getEarliestDate() const
+{
+    QVector<ChatLine::Ptr> lines = chatWidget->getLines();
+    int index = 0;
+
+    while (index < lines.size() - 1)
+    {
+        Timestamp* timestamp = dynamic_cast<Timestamp*>(lines[index++]->getContent(2));
+
+        if (timestamp && timestamp->getTime().isValid())
+            return timestamp->getTime();
+    }
+
+    qDebug() << "NOP";
+
+    return QDateTime::currentDateTime();
+}
+
 void GenericChatForm::setName(const QString &newName)
 {
     nameLabel->setText(newName);

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -343,7 +343,7 @@ ChatMessage::Ptr GenericChatForm::addMessage(const ToxId& author, const QString 
         prevMsgDateTime = QDateTime::currentDateTime();
     }
 
-    insertChatMessage(msg);
+    insertChatMessage(msg, true);
 
     if (isSent)
         msg->markAsSent(datetime);
@@ -573,10 +573,13 @@ QString GenericChatForm::resolveToxId(const ToxId &id)
     return QString();
 }
 
-void GenericChatForm::insertChatMessage(ChatMessage::Ptr msg)
+void GenericChatForm::insertChatMessage(ChatMessage::Ptr msg, bool notify)
 {
     chatWidget->insertChatlineAtBottom(std::dynamic_pointer_cast<ChatLine>(msg));
     emit messageInserted();
+
+    if (notify)
+        chatWidget->showNotification(msg);
 }
 
 void GenericChatForm::hideEvent(QHideEvent* event)

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -32,6 +32,7 @@
 #include "src/widget/widget.h"
 #include "src/persistence/settings.h"
 #include "src/widget/tool/chattextedit.h"
+#include "src/widget/tool/findwidget.h"
 #include "src/widget/maskablepixmapwidget.h"
 #include "src/core/core.h"
 #include "src/grouplist.h"
@@ -43,6 +44,7 @@
 #include "src/widget/tool/flyoutoverlaywidget.h"
 #include "src/widget/translator.h"
 #include "src/widget/contentlayout.h"
+#include "src/widget/tool/indicatorscrollbar.h"
 #include "src/widget/tool/croppinglabel.h"
 #include <QPushButton>
 #include "src/video/genericnetcamview.h"
@@ -65,14 +67,15 @@ GenericChatForm::GenericChatForm(QWidget *parent)
     QHBoxLayout *mainFootLayout = new QHBoxLayout(),
                 *headLayout = new QHBoxLayout();
 
-    QVBoxLayout *mainLayout = new QVBoxLayout(),
-                *footButtonsSmall = new QVBoxLayout(),
+    mainLayout = new QVBoxLayout();
+    QVBoxLayout *footButtonsSmall = new QVBoxLayout(),
                 *micButtonsLayout = new QVBoxLayout();
                 headTextLayout = new QVBoxLayout();
 
     QGridLayout *buttonsLayout = new QGridLayout();
 
     chatWidget = new ChatLog(this);
+    chatWidget->setVerticalScrollBar(new IndicatorScrollBar(1));
     chatWidget->setBusyNotification(ChatMessage::createBusyNotification());
 
     connect(&Settings::getInstance(), &Settings::emojiFontChanged,
@@ -212,6 +215,9 @@ GenericChatForm::GenericChatForm(QWidget *parent)
     Translator::registerHandler(std::bind(&GenericChatForm::retranslateUi, this), this);
 
     netcam = nullptr;
+
+    QShortcut* shortcut = new QShortcut(QKeySequence::Find, this);
+    connect(shortcut, &QShortcut::activated, this, &GenericChatForm::toggleFindWidget);
 }
 
 GenericChatForm::~GenericChatForm()
@@ -295,7 +301,7 @@ bool GenericChatForm::event(QEvent* e)
     {
         QKeyEvent* ke = static_cast<QKeyEvent*>(e);
         if ((ke->modifiers() == Qt::NoModifier || ke->modifiers() == Qt::ShiftModifier)
-                && !ke->text().isEmpty())
+                && !ke->text().isEmpty() && !hasFindWidget())
             msgEdit->setFocus();
     }
     return QWidget::event(e);
@@ -335,6 +341,8 @@ ChatMessage::Ptr GenericChatForm::addMessage(const ToxId& author, const QString 
 
     if (isSent)
         msg->markAsSent(datetime);
+
+    static_cast<IndicatorScrollBar*>(chatWidget->verticalScrollBar())->setTotal(chatWidget->height());
 
     return msg;
 }
@@ -425,6 +433,99 @@ void GenericChatForm::onCopyLogClicked()
 void GenericChatForm::focusInput()
 {
     msgEdit->setFocus();
+}
+
+void GenericChatForm::toggleFindWidget()
+{
+    if (!hasFindWidget())
+        showFindWidget();
+    else
+        removeFindWidget();
+}
+
+void GenericChatForm::showFindWidget()
+{
+    if (!hasFindWidget())
+    {
+        FindWidget *findWidget = new FindWidget(this);
+
+        connect(findWidget, &FindWidget::findText, this, &GenericChatForm::findText);
+        connect(findWidget, &FindWidget::findNext, this, &GenericChatForm::findNext);
+        connect(findWidget, &FindWidget::findPrevious, this, &GenericChatForm::findPrevious);
+        connect(findWidget, &FindWidget::close, this, &GenericChatForm::removeFindWidget);
+
+        mainLayout->insertWidget(0, findWidget);
+    }
+}
+
+void GenericChatForm::removeFindWidget()
+{
+    if (hasFindWidget())
+    {
+        QWidget* findWidget = mainLayout->itemAt(0)->widget();
+        mainLayout->removeWidget(findWidget);
+        findWidget->deleteLater();
+
+        IndicatorScrollBar* indicatorScroll =
+        static_cast<IndicatorScrollBar*>(chatWidget->verticalScrollBar());
+        indicatorScroll->clearIndicators();
+    }
+}
+
+void GenericChatForm::findText(const QString &text)
+{
+    int i = 0;
+    QVector<ChatLine::Ptr> chatLines = getChatLog()->getLines();
+
+    IndicatorScrollBar* indicatorScroll =
+    static_cast<IndicatorScrollBar*>(chatWidget->verticalScrollBar());
+    indicatorScroll->clearIndicators();
+
+    for (ChatLine::Ptr chatLine : chatLines)
+    {
+        if (chatLine.get()->getColumnCount() != 3)
+            continue;
+
+        int last = i;
+        i += chatLine.get()->getContent(0)->setHighlight(text);
+        i += chatLine.get()->getContent(1)->setHighlight(text);
+
+        if (last != i)
+        {
+            indicatorScroll->setTotal(chatWidget->sceneRect().height() - 40);
+            indicatorScroll->addIndicator(chatLine.get()->getContent(0)->pos().y());
+            indicatorScroll->update();
+        }
+        /*qDebug() << chatLine.get()->getColumnCount();
+
+        QTextCursor cursor;
+
+        while (!(cursor = chatLine.get()->getContent(0)->setHighlight(text, cursor)).isNull())
+        {
+            ++i;
+        }
+
+        cursor = QTextCursor();
+
+        while (!(cursor = chatLine.get()->getContent(1)->setHighlight(text, cursor)).isNull())
+        {
+            ++i;
+        }*/
+    }
+
+    getChatLog()->repaint();
+
+    qDebug() << i << " AND " << chatLines.count();
+}
+
+void GenericChatForm::findNext()
+{
+
+}
+
+void GenericChatForm::findPrevious()
+{
+
 }
 
 void GenericChatForm::addSystemInfoMessage(const QString &message, ChatMessage::SystemMessageType type, const QDateTime &datetime)
@@ -528,6 +629,11 @@ bool GenericChatForm::eventFilter(QObject* object, QEvent* event)
     }
 
     return false;
+}
+
+bool GenericChatForm::hasFindWidget() const
+{
+    return mainLayout->itemAt(0)->widget() != chatWidget;
 }
 
 void GenericChatForm::onSplitterMoved(int, int)

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -260,19 +260,7 @@ ChatLog *GenericChatForm::getChatLog() const
 
 QDate GenericChatForm::getLatestDate() const
 {
-    ChatLine::Ptr chatLine = chatWidget->getLatestLine();
-
-    if (chatLine)
-    {
-        Timestamp* timestamp = dynamic_cast<Timestamp*>(chatLine->getContent(2));
-
-        if (timestamp)
-            return timestamp->getTime().date();
-        else
-            return QDate::currentDate();
-    }
-
-    return QDate();
+    return chatWidget->getLatestDate();
 }
 
 QDateTime GenericChatForm::getEarliestDate() const

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -477,15 +477,11 @@ void GenericChatForm::removeFindWidget()
         QVector<ChatLine::Ptr> chatLines = getChatLog()->getLines();
 
         for (ChatLine::Ptr chatLine : chatLines)
-        {
-            chatLine.get()->setHighlight(QString());
-
-            //if (chatLine.get()->getContent(0)->getSelectedText() == )
-        }
+            chatLine.get()->setHighlight(QString(), Qt::CaseInsensitive);
     }
 }
 
-void GenericChatForm::findText(const QString &text)
+void GenericChatForm::findText(const QString &text, Qt::CaseSensitivity sensitivity)
 {
     foundText.clear();
 
@@ -503,7 +499,7 @@ void GenericChatForm::findText(const QString &text)
     for (ChatLine::Ptr chatLine : chatLines)
     {
         int last = i;
-        i += chatLine.get()->setHighlight(text);
+        i += chatLine.get()->setHighlight(text, sensitivity);
 
         if (last != i)
         {
@@ -540,14 +536,14 @@ void GenericChatForm::findText(const QString &text)
 
     if (to != -1)
     {
-        toSelect.get()->selectNext(text);
+        toSelect.get()->selectNext(text, sensitivity);
         getChatLog()->ensureVisible(toSelect.get()->sceneBoundingRect());
     }
 
     getChatLog()->update();
 }
 
-void GenericChatForm::findNext(const QString& text, int to, int total)
+void GenericChatForm::findNext(const QString& text, int to, int total, Qt::CaseSensitivity sensitivity)
 {
     bool clear = true;
     int next = to;
@@ -572,12 +568,14 @@ void GenericChatForm::findNext(const QString& text, int to, int total)
         lastFound.value().get()->selectionCleared();
 
     getChatLog()->ensureVisible(newFound.value().get()->sceneBoundingRect());
-    newFound.value().get()->selectNext(text);
+
+    //if (total != 1)
+        newFound.value().get()->selectNext(text, sensitivity);
 
     getChatLog()->update();
 }
 
-void GenericChatForm::findPrevious(const QString& text, int to, int total)
+void GenericChatForm::findPrevious(const QString& text, int to, int total, Qt::CaseSensitivity sensitivity)
 {
     bool clear = true;
     int next = to;
@@ -602,7 +600,7 @@ void GenericChatForm::findPrevious(const QString& text, int to, int total)
         lastFound.value().get()->selectionCleared();
 
     getChatLog()->ensureVisible(newFound.value().get()->sceneBoundingRect());
-    newFound.value().get()->selectPrevious(text);
+    newFound.value().get()->selectPrevious(text, sensitivity);
 
     getChatLog()->update();
 }

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -622,7 +622,7 @@ bool GenericChatForm::eventFilter(QObject* object, QEvent* event)
 
 bool GenericChatForm::hasFindWidget() const
 {
-    return mainLayout->itemAt(0)->widget() != chatWidget;
+    return mainLayout->count() == 3;
 }
 
 void GenericChatForm::onSplitterMoved(int, int)

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -75,12 +75,13 @@ signals:
     void chatAreaCleared();
     void messageInserted();
     void findMatchesChanged(int index, int total);
+    void findIndexChanged(int index);
 
 public slots:
     void focusInput();
     void toggleFindWidget();
     void showFindWidget();
-    void removeFindWidget();
+    void removeFindWidget(const QString& text);
     void findText(const QString& text, Qt::CaseSensitivity sensitivity);
     void findNext(const QString& text, int to, int total, Qt::CaseSensitivity sensitivity);
     void findPrevious(const QString& text, int to, int total, Qt::CaseSensitivity sensitivity);
@@ -137,7 +138,6 @@ protected:
     bool audioInputFlag;
     bool audioOutputFlag;
     QSplitter* bodySplitter;
-    QHash<int, ChatLine::Ptr> foundText;
     GenericNetCamView* netcam;
 
 private:

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -110,7 +110,7 @@ protected:
     void hideNetcam();
     virtual GenericNetCamView* createNetcam() = 0;
     QString resolveToxId(const ToxId &id);
-    void insertChatMessage(ChatMessage::Ptr msg);
+    void insertChatMessage(ChatMessage::Ptr msg, bool notify = false);
     void adjustFileMenuPosition();
     virtual void hideEvent(QHideEvent* event) override;
     virtual void showEvent(QShowEvent *) override;

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -74,6 +74,7 @@ signals:
     void sendAction(uint32_t, QString);
     void chatAreaCleared();
     void messageInserted();
+    void findMatchesChanged(int index, int total);
 
 public slots:
     void focusInput();
@@ -81,7 +82,7 @@ public slots:
     void showFindWidget();
     void removeFindWidget();
     void findText(const QString& text);
-    void findNext();
+    void findNext(const QString& text);
     void findPrevious();
 
 protected slots:

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -82,8 +82,8 @@ public slots:
     void showFindWidget();
     void removeFindWidget();
     void findText(const QString& text);
-    void findNext(const QString& text);
-    void findPrevious();
+    void findNext(const QString& text, int to, int total);
+    void findPrevious(const QString& text, int to, int total);
 
 protected slots:
     void onChatContextMenuRequested(QPoint pos);
@@ -137,6 +137,7 @@ protected:
     bool audioInputFlag;
     bool audioOutputFlag;
     QSplitter* bodySplitter;
+    QHash<int, ChatLine::Ptr> foundText;
     GenericNetCamView* netcam;
 
 private:

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -77,6 +77,12 @@ signals:
 
 public slots:
     void focusInput();
+    void toggleFindWidget();
+    void showFindWidget();
+    void removeFindWidget();
+    void findText(const QString& text);
+    void findNext();
+    void findPrevious();
 
 protected slots:
     void onChatContextMenuRequested(QPoint pos);
@@ -93,6 +99,7 @@ protected slots:
     void onSplitterMoved(int pos, int index);
 
 private:
+    bool hasFindWidget() const;
     void retranslateUi();
 
 protected:
@@ -130,6 +137,9 @@ protected:
     bool audioOutputFlag;
     QSplitter* bodySplitter;
     GenericNetCamView* netcam;
+
+private:
+    QVBoxLayout* mainLayout;
 };
 
 #endif // GENERICCHATFORM_H

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -81,9 +81,9 @@ public slots:
     void toggleFindWidget();
     void showFindWidget();
     void removeFindWidget();
-    void findText(const QString& text);
-    void findNext(const QString& text, int to, int total);
-    void findPrevious(const QString& text, int to, int total);
+    void findText(const QString& text, Qt::CaseSensitivity sensitivity);
+    void findNext(const QString& text, int to, int total, Qt::CaseSensitivity sensitivity);
+    void findPrevious(const QString& text, int to, int total, Qt::CaseSensitivity sensitivity);
 
 protected slots:
     void onChatContextMenuRequested(QPoint pos);

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -68,6 +68,7 @@ public:
 
     ChatLog* getChatLog() const;
     QDate getLatestDate() const;
+    QDateTime getEarliestDate() const;
 
 signals:
     void sendMessage(uint32_t, QString);

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -56,7 +56,6 @@ public:
     ~GenericChatForm();
 
     void setName(const QString &newName);
-    virtual void show() final{}
     virtual void show(ContentLayout* contentLayout);
 
     ChatMessage::Ptr addMessage(const ToxId& author, const QString &message, bool isAction, const QDateTime &datetime, bool isSent);

--- a/src/widget/form/groupchatform.cpp
+++ b/src/widget/form/groupchatform.cpp
@@ -307,21 +307,24 @@ void GroupChatForm::resetLayout()
 
         delete namesListLayout;
 
+        QListView* listView = new QListView(this);
+        listView->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Expanding);
+        listView->setStyleSheet("QListView {background-color: white; border:none} QListView::item:selected {background-color:#6fc062;}");
+        listView->setEditTriggers(QAbstractItemView::NoEditTriggers);
+        listView->setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContents);
+        stringListModel = new QStringListModel(group->getPeerList());
+        listView->setModel(stringListModel);
+
         mainSplitter = new QSplitter(this);
         mainSplitter->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
         layout()->replaceWidget(chatWidget, mainSplitter);
         mainSplitter->setHandleWidth(6);
         mainSplitter->addWidget(chatWidget);
-        mainSplitter->setStretchFactor(0, 1);
-        mainSplitter->setCollapsible(0, false);
-        mainSplitter->setStyleSheet("QSplitter::handle:horizontal {border-right: 1px solid #c1c1c1;}");
-
-        QListView* listView = new QListView(this);
-        listView->setStyleSheet("QListView {background-color: white; border:none} QListView::item:selected {background-color:#6fc062;}");
-        listView->setEditTriggers(QAbstractItemView::NoEditTriggers);
-        stringListModel = new QStringListModel(group->getPeerList());
-        listView->setModel(stringListModel);
         mainSplitter->addWidget(listView);
+        mainSplitter->setStyleSheet("QSplitter::handle:horizontal {border-right: 1px solid #c1c1c1;}");
+        mainSplitter->setStretchFactor(0, 4);
+        mainSplitter->restoreState(Settings::getInstance().getGroupSplitterState());
+        connect(mainSplitter, &QSplitter::splitterMoved, this, &GroupChatForm::onSplitterMoved);
     }
 }
 
@@ -440,6 +443,11 @@ GenericNetCamView *GroupChatForm::createNetcam()
     }
 
     return view;
+}
+
+void GroupChatForm::onSplitterMoved()
+{
+    Settings::getInstance().setGroupSplitterState(mainSplitter->saveState());
 }
 
 void GroupChatForm::keyPressEvent(QKeyEvent* ev)

--- a/src/widget/form/groupchatform.cpp
+++ b/src/widget/form/groupchatform.cpp
@@ -226,6 +226,7 @@ void GroupChatForm::onUserListChanged()
     }
     else
     {
+        names.sort(Qt::CaseInsensitive);
         stringListModel->setStringList(names);
     }
 

--- a/src/widget/form/groupchatform.cpp
+++ b/src/widget/form/groupchatform.cpp
@@ -167,13 +167,12 @@ void GroupChatForm::onUserListChanged()
     int peersCount = group->getPeersCount();
     if (peersCount == 1)
         nusersLabel->setText(tr("1 user in chat", "Number of users in chat"));
+    else
+        nusersLabel->setText(tr("%1 users in chat", "Number of users in chat").arg(peersCount));
 
     retranslateUi(); // To update the text.
 
     QStringList names = group->getPeerList();
-    else
-        nusersLabel->setText(tr("%1 users in chat", "Number of users in chat").arg(peersCount));
-
     if (!Settings::getInstance().getGroupPeerListSide())
     {
         if (namesListLayout)
@@ -327,14 +326,6 @@ void GroupChatForm::resetLayout()
         mainSplitter->restoreState(Settings::getInstance().getGroupSplitterState());
         connect(mainSplitter, &QSplitter::splitterMoved, this, &GroupChatForm::onSplitterMoved);
     }
-}
-
-void GroupChatForm::show(Ui::MainWindow &ui)
-{
-    ui.mainContent->layout()->addWidget(this);
-    ui.mainHead->layout()->addWidget(headWidget);
-    headWidget->show();
-    QWidget::show();
 }
 
 void GroupChatForm::dragEnterEvent(QDragEnterEvent *ev)

--- a/src/widget/form/groupchatform.h
+++ b/src/widget/form/groupchatform.h
@@ -28,6 +28,9 @@ class Group;
 class TabCompleter;
 class FlowLayout;
 class QTimer;
+class QSplitter;
+class QStringListModel;
+class QSortFilterProxyModel;
 
 class GroupChatForm : public GenericChatForm
 {
@@ -38,6 +41,9 @@ public:
 
     void onUserListChanged();
     void peerAudioPlaying(int peer);
+    void resetLayout();
+
+    virtual void show(Ui::MainWindow &ui);
 
 signals:
     void groupTitleChanged(int groupnum, const QString& name);
@@ -63,8 +69,10 @@ private:
     Group* group;
     QList<QLabel*> peerLabels; // maps peernumbers to the QLabels in namesListLayout
     QMap<int, QTimer*> peerAudioTimers; // timeout = peer stopped sending audio
-    FlowLayout* namesListLayout;
+    FlowLayout* namesListLayout = nullptr;
     QLabel *nusersLabel;
+    QSplitter* mainSplitter = nullptr;
+    QStringListModel* stringListModel = nullptr;
     TabCompleter* tabber;
     bool inCall;
     QString correctNames(QString& name);

--- a/src/widget/form/groupchatform.h
+++ b/src/widget/form/groupchatform.h
@@ -53,6 +53,7 @@ private slots:
     void onMicMuteToggle();
     void onVolMuteToggle();
     void onCallClicked();
+    void onSplitterMoved();
 
 protected:
     virtual GenericNetCamView* createNetcam() final override;

--- a/src/widget/form/groupchatform.h
+++ b/src/widget/form/groupchatform.h
@@ -43,8 +43,6 @@ public:
     void peerAudioPlaying(int peer);
     void resetLayout();
 
-    virtual void show(Ui::MainWindow &ui);
-
 signals:
     void groupTitleChanged(int groupnum, const QString& name);
 

--- a/src/widget/form/settings/generalform.cpp
+++ b/src/widget/form/settings/generalform.cpp
@@ -129,6 +129,7 @@ GeneralForm::GeneralForm(SettingsWidget *myParent) :
     bodyUI->groupAlwaysNotify->setChecked(Settings::getInstance().getGroupAlwaysNotify());
     bodyUI->cbFauxOfflineMessaging->setChecked(Settings::getInstance().getFauxOfflineMessaging());
     bodyUI->cbCompactLayout->setChecked(Settings::getInstance().getCompactLayout());
+    bodyUI->cbGroupPeerListSide->setChecked(Settings::getInstance().getGroupPeerListSide());
     bodyUI->cbSeparateWindow->setChecked(Settings::getInstance().getSeparateWindow());
     bodyUI->cbDontGroupWindows->setChecked(Settings::getInstance().getDontGroupWindows());
     bodyUI->cbDontGroupWindows->setEnabled(bodyUI->cbSeparateWindow->isChecked());
@@ -224,6 +225,7 @@ GeneralForm::GeneralForm(SettingsWidget *myParent) :
     connect(bodyUI->reconnectButton, &QPushButton::clicked, this, &GeneralForm::onReconnectClicked);
     connect(bodyUI->cbFauxOfflineMessaging, &QCheckBox::stateChanged, this, &GeneralForm::onFauxOfflineMessaging);
     connect(bodyUI->cbCompactLayout, &QCheckBox::stateChanged, this, &GeneralForm::onCompactLayout);
+    connect(bodyUI->cbGroupPeerListSide, &QCheckBox::stateChanged, this, &GeneralForm::onGroupPeerListSide);
     connect(bodyUI->cbSeparateWindow, &QCheckBox::stateChanged, this, &GeneralForm::onSeparateWindowChanged);
     connect(bodyUI->cbDontGroupWindows, &QCheckBox::stateChanged, this, &GeneralForm::onDontGroupWindowsChanged);
     connect(bodyUI->cbGroupchatPosition, &QCheckBox::stateChanged, this, &GeneralForm::onGroupchatPositionChanged);
@@ -484,6 +486,12 @@ void GeneralForm::onCompactLayout()
 {
     Settings::getInstance().setCompactLayout(bodyUI->cbCompactLayout->isChecked());
     emit parent->compactToggled(bodyUI->cbCompactLayout->isChecked());
+}
+
+void GeneralForm::onGroupPeerListSide()
+{
+    Settings::getInstance().setGroupPeerListSide(bodyUI->cbGroupPeerListSide->isChecked());
+    emit parent->groupPeerListToggled(bodyUI->cbGroupPeerListSide->isChecked());
 }
 
 void GeneralForm::onSeparateWindowChanged()

--- a/src/widget/form/settings/generalform.h
+++ b/src/widget/form/settings/generalform.h
@@ -67,6 +67,7 @@ private slots:
     void onSetGroupAlwaysNotify();
     void onFauxOfflineMessaging();
     void onCompactLayout();
+    void onGroupPeerListSide();
     void onSeparateWindowChanged();
     void onDontGroupWindowsChanged();
     void onGroupchatPositionChanged();

--- a/src/widget/form/settings/generalsettings.ui
+++ b/src/widget/form/settings/generalsettings.ui
@@ -399,6 +399,13 @@ will be sent to them when they appear online to you.</string>
            </widget>
           </item>
           <item>
+           <widget class="QCheckBox" name="cbGroupPeerListSide">
+            <property name="text">
+             <string>Show group peer list on the side.</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <layout class="QVBoxLayout" name="verticalLayout_11">
             <item>
              <widget class="QCheckBox" name="cbSeparateWindow">

--- a/src/widget/form/settingswidget.h
+++ b/src/widget/form/settingswidget.h
@@ -50,6 +50,7 @@ public:
 signals:
     void setShowSystemTray(bool newValue);
     void compactToggled(bool compact);
+    void groupPeerListToggled(bool side);
     void separateWindowToggled(bool separateWindow);
     void groupchatPositionToggled(bool groupchatPosition);
 

--- a/src/widget/tool/dynamicscrollbar.cpp
+++ b/src/widget/tool/dynamicscrollbar.cpp
@@ -1,0 +1,66 @@
+/*
+    Copyright © 2015 by The qTox Project
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "dynamicscrollbar.h"
+
+#include <QDebug>
+
+DynamicScrollBar::DynamicScrollBar(QWidget *parent)
+    : QScrollBar(parent)
+{
+    init();
+}
+
+DynamicScrollBar::DynamicScrollBar(Qt::Orientation orientation, QWidget *parent)
+    : QScrollBar(orientation, parent)
+{
+    init();
+}
+
+void DynamicScrollBar::onSliderMoved(int position)
+{
+    if (position == minimum() && lastValue != position)
+    {
+        if (!isSliderDown())
+            emit dynamicRequest();
+        else
+            ready = true;
+    }
+    else
+    {
+        ready = false;
+    }
+
+    lastValue = position;
+}
+
+void DynamicScrollBar::onSliderReleased()
+{
+    if (ready)
+    {
+        emit dynamicRequest();
+        ready = false;
+    }
+}
+
+void DynamicScrollBar::init()
+{
+    connect(this, &QScrollBar::valueChanged, this, &DynamicScrollBar::onSliderMoved);
+    connect(this, &QScrollBar::sliderReleased, this, &DynamicScrollBar::onSliderReleased);
+}

--- a/src/widget/tool/dynamicscrollbar.cpp
+++ b/src/widget/tool/dynamicscrollbar.cpp
@@ -19,8 +19,6 @@
 
 #include "dynamicscrollbar.h"
 
-#include <QDebug>
-
 DynamicScrollBar::DynamicScrollBar(QWidget *parent)
     : QScrollBar(parent)
 {

--- a/src/widget/tool/dynamicscrollbar.h
+++ b/src/widget/tool/dynamicscrollbar.h
@@ -17,25 +17,30 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef INDICATORSCROLLBAR_H
-#define INDICATORSCROLLBAR_H
+#ifndef DYNAMICSCROLLBAR_H
+#define DYNAMICSCROLLBAR_H
 
-#include "dynamicscrollbar.h"
+#include <QScrollBar>
 
-class IndicatorScrollBar : public DynamicScrollBar
+class DynamicScrollBar : public QScrollBar
 {
+    Q_OBJECT
 public:
-    IndicatorScrollBar(int total, QWidget *parent = 0);
-    void setTotal(int total);
-    void addIndicator(int pos);
-    void clearIndicators();
+    DynamicScrollBar(QWidget *parent = 0);
+    DynamicScrollBar(Qt::Orientation orientation, QWidget *parent = 0);
 
-protected:
-    virtual void paintEvent(QPaintEvent *event) final override;
+signals:
+    void dynamicRequest();
+
+private slots:
+    void onSliderMoved(int position);
+    void onSliderReleased();
 
 private:
-    QVector<int> indicators;
-    int total;
+    void init();
+
+    bool ready;
+    int lastValue;
 };
 
-#endif // INDICATORSCROLLBAR_H
+#endif // DYNAMICSCROLLBAR_H

--- a/src/widget/tool/findwidget.cpp
+++ b/src/widget/tool/findwidget.cpp
@@ -1,0 +1,72 @@
+/*
+    Copyright © 2015 by The qTox Project
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "findwidget.h"
+#include <QBoxLayout>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QCheckBox>
+#include <QLabel>
+
+FindWidget::FindWidget(QWidget *parent) : QWidget(parent)
+{
+    QHBoxLayout* findLayout = new QHBoxLayout(this);
+
+    matchesLabel = new QLabel();
+    findLayout->addWidget(matchesLabel, 1);
+    setMatches(0);
+
+    QLineEdit* lineEdit = new QLineEdit(this);
+    lineEdit->setFocus();
+    findLayout->addWidget(lineEdit, 1);
+
+    QPushButton* previousButton = new QPushButton();
+    previousButton->setToolTip(tr("Find the previous occurence of the phrase"));
+    previousButton->setIcon(QIcon("://ui/chatArea/scrollBarUpArrow.svg"));
+    findLayout->addWidget(previousButton);
+
+    QPushButton* nextButton = new QPushButton();
+    nextButton ->setToolTip(tr("Find the next occurence of the phrase"));
+    nextButton ->setIcon(QIcon("://ui/chatArea/scrollBarDownArrow.svg"));
+    findLayout->addWidget(nextButton);
+
+    QCheckBox* matchCheck = new QCheckBox(tr("Match Case"));
+    findLayout->addWidget(matchCheck);
+
+    QPushButton* closeButton = new QPushButton(this);
+    closeButton->setIcon(QIcon("://ui/fileTransferInstance/no.svg"));
+    closeButton->setToolTip(tr("Close the find bar"));
+    findLayout->addWidget(closeButton);
+
+    connect(lineEdit, &QLineEdit::textChanged, this, &FindWidget::findText);
+    connect(nextButton, &QPushButton::pressed, this, &FindWidget::findNext);
+    connect(previousButton, &QPushButton::pressed, this, &FindWidget::findPrevious);
+    connect(closeButton, &QPushButton::pressed, this, &FindWidget::close);
+}
+
+void FindWidget::setMatches(int matches)
+{
+    if (matches <= 0)
+        matchesLabel->setText(QString());
+    else if (matches > 100)
+        matchesLabel->setText(tr("More than 100 matches"));
+    else
+        matchesLabel->setText(tr("%1 of %2 matches").arg(matches));
+}
+

--- a/src/widget/tool/findwidget.cpp
+++ b/src/widget/tool/findwidget.cpp
@@ -30,7 +30,7 @@ FindWidget::FindWidget(QWidget *parent) : QWidget(parent)
 
     matchesLabel = new QLabel();
     findLayout->addWidget(matchesLabel, 1);
-    setMatches(0);
+    setMatches(0, 0);
 
     QLineEdit* lineEdit = new QLineEdit(this);
     lineEdit->setFocus();
@@ -55,18 +55,23 @@ FindWidget::FindWidget(QWidget *parent) : QWidget(parent)
     findLayout->addWidget(closeButton);
 
     connect(lineEdit, &QLineEdit::textChanged, this, &FindWidget::findText);
-    connect(nextButton, &QPushButton::pressed, this, &FindWidget::findNext);
-    connect(previousButton, &QPushButton::pressed, this, &FindWidget::findPrevious);
+    connect(nextButton, &QPushButton::pressed, [this, lineEdit]()
+    {
+        emit findNext(lineEdit->text());
+    });
+    connect(previousButton, &QPushButton::pressed, [this, lineEdit]()
+    {
+        emit findPrevious(lineEdit->text());
+    });
     connect(closeButton, &QPushButton::pressed, this, &FindWidget::close);
 }
 
-void FindWidget::setMatches(int matches)
+void FindWidget::setMatches(int index, int matches)
 {
     if (matches <= 0)
         matchesLabel->setText(QString());
     else if (matches > 100)
         matchesLabel->setText(tr("More than 100 matches"));
     else
-        matchesLabel->setText(tr("%1 of %2 matches").arg(matches));
+        matchesLabel->setText(tr("%1 of %2 matches").arg(index).arg(matches));
 }
-

--- a/src/widget/tool/findwidget.cpp
+++ b/src/widget/tool/findwidget.cpp
@@ -53,14 +53,19 @@ FindWidget::FindWidget(QWidget *parent) : QWidget(parent)
     connect(lineEdit, &QLineEdit::textChanged, this, &FindWidget::onFindText);
     connect(nextButton, &QPushButton::pressed, this, &FindWidget::onFindNextPressed);
     connect(previousButton, &QPushButton::pressed, this, &FindWidget::onFindPreviousPressed);
-    connect(closeButton, &QPushButton::pressed, this, &FindWidget::close);
+    connect(closeButton, &QPushButton::pressed, this, &FindWidget::onClosePressed);
     connect(caseCheck, &QCheckBox::clicked, this, &FindWidget::onFindText);
 }
 
 void FindWidget::setMatches(int index, int matches)
 {
-    this->index = index;
     total = matches;
+    setIndex(index);
+}
+
+void FindWidget::setIndex(int newIndex)
+{
+    index = newIndex;
 
     if (lineEdit->text().isEmpty())
     {
@@ -69,9 +74,9 @@ void FindWidget::setMatches(int index, int matches)
     }
     else
     {
-        lineEdit->setLabelText(tr("%1 of %2").arg(index).arg(matches));
+        lineEdit->setLabelText(tr("%1 of %2").arg(index).arg(total));
 
-        if (matches == 0)
+        if (total == 0)
             lineEdit->setStyleSheet("QLineEdit > QLabel {background-color: #ff6666;}");
         else
             lineEdit->setStyleSheet(QString());
@@ -93,4 +98,9 @@ void FindWidget::onFindPreviousPressed()
 void FindWidget::onFindText()
 {
     emit findText(lineEdit->text(), caseCheck->isChecked() ? Qt::CaseSensitive : Qt::CaseInsensitive);
+}
+
+void FindWidget::onClosePressed()
+{
+    emit close(lineEdit->text());
 }

--- a/src/widget/tool/findwidget.cpp
+++ b/src/widget/tool/findwidget.cpp
@@ -57,17 +57,22 @@ FindWidget::FindWidget(QWidget *parent) : QWidget(parent)
     connect(lineEdit, &QLineEdit::textChanged, this, &FindWidget::findText);
     connect(nextButton, &QPushButton::pressed, [this, lineEdit]()
     {
-        emit findNext(lineEdit->text());
+        if (total != 0)
+            emit findNext(lineEdit->text(), index + 1, total);
     });
     connect(previousButton, &QPushButton::pressed, [this, lineEdit]()
     {
-        emit findPrevious(lineEdit->text());
+        if (total != 0)
+            emit findPrevious(lineEdit->text(), index - 1, total);
     });
     connect(closeButton, &QPushButton::pressed, this, &FindWidget::close);
 }
 
 void FindWidget::setMatches(int index, int matches)
 {
+    this->index = index;
+    total = matches;
+
     if (matches <= 0)
         matchesLabel->setText(QString());
     else if (matches > 100)

--- a/src/widget/tool/findwidget.h
+++ b/src/widget/tool/findwidget.h
@@ -32,13 +32,13 @@ public:
 
 signals:
     void findText(const QString& text);
-    void findNext();
-    void findPrevious();
+    void findNext(const QString& text);
+    void findPrevious(const QString& text);
     void setCase(bool match);
     void close();
 
 public slots:
-    void setMatches(int matches);
+    void setMatches(int index, int matches);
 
 private:
     QLabel* matchesLabel;

--- a/src/widget/tool/findwidget.h
+++ b/src/widget/tool/findwidget.h
@@ -32,8 +32,8 @@ public:
 
 signals:
     void findText(const QString& text);
-    void findNext(const QString& text);
-    void findPrevious(const QString& text);
+    void findNext(const QString& text, int index, int total);
+    void findPrevious(const QString& text, int index, int total);
     void setCase(bool match);
     void close();
 
@@ -42,6 +42,8 @@ public slots:
 
 private:
     QLabel* matchesLabel;
+    int index;
+    int total;
 };
 
 #endif // FINDWIDGET_H

--- a/src/widget/tool/findwidget.h
+++ b/src/widget/tool/findwidget.h
@@ -36,15 +36,17 @@ signals:
     void findNext(const QString& text, int index, int total, Qt::CaseSensitivity);
     void findPrevious(const QString& text, int index, int total, Qt::CaseSensitivity);
     void setCase(bool match);
-    void close();
+    void close(const QString& text);
 
 public slots:
     void setMatches(int index, int matches);
+    void setIndex(int index);
 
 private slots:
     void onFindNextPressed();
     void onFindPreviousPressed();
     void onFindText();
+    void onClosePressed();
 
 private:
     QCheckBox* caseCheck;

--- a/src/widget/tool/findwidget.h
+++ b/src/widget/tool/findwidget.h
@@ -17,16 +17,31 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "timestamp.h"
-#include <QCursor>
-Timestamp::Timestamp(const QDateTime &time, const QString &format, const QFont &font)
-    : Text(time.toString(format), font, false, time.toString(format))
-{
-    this->time = time;
-    setCursor(Qt::ForbiddenCursor);
-}
+#ifndef FINDWIDGET_H
+#define FINDWIDGET_H
 
-QDateTime Timestamp::getTime()
+#include <QWidget>
+
+class QLabel;
+
+class FindWidget : public QWidget
 {
-    return time;
-}
+    Q_OBJECT
+public:
+    explicit FindWidget(QWidget *parent = 0);
+
+signals:
+    void findText(const QString& text);
+    void findNext();
+    void findPrevious();
+    void setCase(bool match);
+    void close();
+
+public slots:
+    void setMatches(int matches);
+
+private:
+    QLabel* matchesLabel;
+};
+
+#endif // FINDWIDGET_H

--- a/src/widget/tool/indicatorscrollbar.cpp
+++ b/src/widget/tool/indicatorscrollbar.cpp
@@ -19,13 +19,12 @@
 
 #include "indicatorscrollbar.h"
 #include <QPainter>
-#include <QDebug>
+#include <QStyleOptionSlider>
+
 IndicatorScrollBar::IndicatorScrollBar(int total, QWidget *parent)
     : QScrollBar(parent)
 {
     setTotal(total);
-    //addIndicator(10);
-    //addIndicator(100);
 }
 
 void IndicatorScrollBar::setTotal(int total)
@@ -42,6 +41,7 @@ void IndicatorScrollBar::addIndicator(int pos)
 void IndicatorScrollBar::clearIndicators()
 {
     indicators.clear();
+    indicators.squeeze();
     update();
 }
 
@@ -49,16 +49,17 @@ void IndicatorScrollBar::paintEvent(QPaintEvent *event)
 {
     QScrollBar::paintEvent(event);
 
-    QPainter painter(this);
-
-    int range = height();
-
-    for (int pos : indicators)
+    if (!indicators.isEmpty())
     {
-        int loc = (static_cast<float>(pos) / total) * range;
+        QPainter painter(this);
         painter.setBrush(Qt::yellow);
         painter.setPen(Qt::darkYellow);
-        painter.drawLine(0, loc, width() - 1, loc);
+
+        for (int pos : indicators)
+        {
+            int loc = (static_cast<float>(pos) / total) * height();
+            painter.drawRect(0, loc - 1, width() - 1, 2);
+        }
     }
 }
 

--- a/src/widget/tool/indicatorscrollbar.cpp
+++ b/src/widget/tool/indicatorscrollbar.cpp
@@ -1,0 +1,64 @@
+/*
+    Copyright © 2015 by The qTox Project
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "indicatorscrollbar.h"
+#include <QPainter>
+#include <QDebug>
+IndicatorScrollBar::IndicatorScrollBar(int total, QWidget *parent)
+    : QScrollBar(parent)
+{
+    setTotal(total);
+    //addIndicator(10);
+    //addIndicator(100);
+}
+
+void IndicatorScrollBar::setTotal(int total)
+{
+    this->total = total;
+}
+
+void IndicatorScrollBar::addIndicator(int pos)
+{
+    indicators.push_back(pos);
+    update();
+}
+
+void IndicatorScrollBar::clearIndicators()
+{
+    indicators.clear();
+    update();
+}
+
+void IndicatorScrollBar::paintEvent(QPaintEvent *event)
+{
+    QScrollBar::paintEvent(event);
+
+    QPainter painter(this);
+
+    int range = height();
+
+    for (int pos : indicators)
+    {
+        int loc = (static_cast<float>(pos) / total) * range;
+        painter.setBrush(Qt::yellow);
+        painter.setPen(Qt::darkYellow);
+        painter.drawLine(0, loc, width() - 1, loc);
+    }
+}
+

--- a/src/widget/tool/indicatorscrollbar.cpp
+++ b/src/widget/tool/indicatorscrollbar.cpp
@@ -22,7 +22,7 @@
 #include <QStyleOptionSlider>
 
 IndicatorScrollBar::IndicatorScrollBar(int total, QWidget *parent)
-    : QScrollBar(parent)
+    : DynamicScrollBar(parent)
 {
     setTotal(total);
 }

--- a/src/widget/tool/indicatorscrollbar.h
+++ b/src/widget/tool/indicatorscrollbar.h
@@ -17,16 +17,25 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "timestamp.h"
-#include <QCursor>
-Timestamp::Timestamp(const QDateTime &time, const QString &format, const QFont &font)
-    : Text(time.toString(format), font, false, time.toString(format))
-{
-    this->time = time;
-    setCursor(Qt::ForbiddenCursor);
-}
+#ifndef INDICATORSCROLLBAR_H
+#define INDICATORSCROLLBAR_H
 
-QDateTime Timestamp::getTime()
+#include <QScrollBar>
+
+class IndicatorScrollBar : public QScrollBar
 {
-    return time;
-}
+public:
+    IndicatorScrollBar(int total, QWidget *parent = 0);
+    void setTotal(int total);
+    void addIndicator(int pos);
+    void clearIndicators();
+
+protected:
+    virtual void paintEvent(QPaintEvent *event) final override;
+
+private:
+    QVector<int> indicators;
+    int total;
+};
+
+#endif // INDICATORSCROLLBAR_H

--- a/src/widget/tool/labeledlineedit.cpp
+++ b/src/widget/tool/labeledlineedit.cpp
@@ -1,0 +1,62 @@
+/*
+    Copyright © 2015 by The qTox Project
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "labeledlineedit.h"
+#include <QLineEdit>
+#include <QLabel>
+#include <QStyle>
+
+LabeledLineEdit::LabeledLineEdit(QWidget* parent)
+    : QLineEdit(parent)
+{
+    label = new QLabel(this);
+    label->setAlignment(Qt::AlignCenter);
+    label->show();
+
+    const int labelMargin = 4;
+    label->setContentsMargins(labelMargin, 0, labelMargin, 0);
+}
+
+void LabeledLineEdit::setLabelText(const QString& text)
+{
+    label->setText(text);
+    setLabelGeometry();
+}
+
+void LabeledLineEdit::resizeEvent(QResizeEvent* event)
+{
+    setLabelGeometry();
+    QWidget::resizeEvent(event);
+}
+
+void LabeledLineEdit::moveEvent(QMoveEvent *event)
+{
+    setLabelGeometry();
+    QWidget::moveEvent(event);
+}
+
+void LabeledLineEdit::setLabelGeometry()
+{
+    int frameWidth = style()->pixelMetric(QStyle::PM_DefaultFrameWidth) + 1;
+
+    int labelWidth = label->sizeHint().width() + frameWidth;
+    label->resize(labelWidth, height() - frameWidth * 2);
+    label->move(width() - labelWidth - frameWidth, frameWidth);
+    setTextMargins(0, 0, labelWidth, 0);
+}

--- a/src/widget/tool/labeledlineedit.h
+++ b/src/widget/tool/labeledlineedit.h
@@ -17,40 +17,27 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef FINDWIDGET_H
-#define FINDWIDGET_H
+#ifndef LABELEDLINEEDIT_H
+#define LABELEDLINEEDIT_H
 
-#include <QWidget>
+#include <QLineEdit>
 
-class QCheckBox;
-class LabeledLineEdit;
+class QLabel;
 
-class FindWidget : public QWidget
+class LabeledLineEdit : public QLineEdit
 {
-    Q_OBJECT
 public:
-    explicit FindWidget(QWidget *parent = 0);
+    LabeledLineEdit(QWidget* parent = 0);
+    void setLabelText(const QString& text);
 
-signals:
-    void findText(const QString& text, Qt::CaseSensitivity);
-    void findNext(const QString& text, int index, int total, Qt::CaseSensitivity);
-    void findPrevious(const QString& text, int index, int total, Qt::CaseSensitivity);
-    void setCase(bool match);
-    void close();
-
-public slots:
-    void setMatches(int index, int matches);
-
-private slots:
-    void onFindNextPressed();
-    void onFindPreviousPressed();
-    void onFindText();
+protected:
+    void resizeEvent(QResizeEvent* event) final override;
+    void moveEvent(QMoveEvent* event) final override;
 
 private:
-    QCheckBox* caseCheck;
-    LabeledLineEdit* lineEdit;
-    int index;
-    int total;
+    void setLabelGeometry();
+
+    QLabel* label;
 };
 
-#endif // FINDWIDGET_H
+#endif // LABELEDLINEEDIT_H

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -872,7 +872,7 @@ void Widget::setStatusMessage(const QString &statusMessage)
 void Widget::reloadHistory()
 {
     for (auto f : FriendList::getAllFriends())
-        f->getChatForm()->loadHistory(QDateTime::currentDateTime().addDays(-7), true);
+        f->getChatForm()->loadHistory(QDateTime(f->getChatForm()->getLatestDate()), true);
 }
 
 void Widget::addFriend(int friendId, const QString &userId)

--- a/ui/chatArea/innerStyle.css
+++ b/ui/chatArea/innerStyle.css
@@ -1,14 +1,18 @@
-div.msg {
+p {
+  white-space: pre-wrap;
+}
+
+p.msg {
   color: @black;
   font: @big;
 }
 
-div.action {
+p.action {
   color: #1818FF;
   font: @big;
 }
 
-div.typing {
+p.typing {
   color: @mediumGreyLight;
   font: @big;
 }
@@ -17,7 +21,7 @@ span.quote {
   color: #279419;
 }
 
-div.alert {
+p.alert {
   margin-left: 0px;
   margin-right: 0px;
   color: @black;
@@ -25,7 +29,7 @@ div.alert {
   font: @big;
 }
 
-div.alert_name {
+p.alert_name {
   color: @black;
   background-color: @orange;
   font: @bigBold;


### PR DESCRIPTION
# :exclamation: For reference only! Don't merge this!

**Copied description from original PR #2013 by @TheSpiritXIII** 

I've made a bunch of changes. Listen up!

Changes I’ve made:
- You can now adjust the left and right columns of the chat form by dragging them. This will surely help when text size is able to be changed. Helps with #1288 #1974 
- **moved to #2752:** ~~Hovering over text on the chat form gives the I-beam cursor.~~
- **moved to #2751:** ~~You can now search and find text in the chat form using Ctrl+F.~~
- Whitespace bug is now fixed.
- Option to show group peer list on the side instead of on top. #677
- Chats always load with some history no matter how far back it was (previously, it would load history up to 7 days back). History is loaded by amount instead of days so it never loads too much or too little.
- History is loaded dynamically when scrolling up.
- The date of the messages you’re seeing are always shown on top. You don’t have to scroll down or up to see which day you’re looking at.
- Whenever the day changes, you will see a new message about it on the chat form when you receive your next message (previously, you would have to restart, which sounded like a bug).
- Fix missing psuedo Arabic characters. #1887 
- Notification when a new message has been made while you scrolled up. #1905 
