### PR TITLE
Updated libsodium tag info,   added/updated  dependency info for  sqlcipher

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -370,7 +370,10 @@ make -j$(nproc)
 sudo make install
 ```
 
-### Sqlcipher compiling (Fedora)
+### sqlcipher
+
+If you are not using Fedora, skip this section, and go directly to installing [**toxcore**](#toxcore-dependencies).
+
 ```bash
 git clone https://github.com/sqlcipher/sqlcipher
 cd sqlcipher

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -32,7 +32,7 @@
     - [Ubuntu <15.04](#ubuntu14-toxcore)
     - [Ubuntu >=15.04](#ubuntu-toxcore)
   - [filter_audio](#filter_audio)
-  - [sqlcipher (Fedora)](#sqlcipher)
+  - [sqlcipher](#sqlcipher)
   - [toxcore compiling](#toxcore-compiling)
   - [Compile qTox](#compile-qtox)
 - [OS X](#osx)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -332,7 +332,7 @@ You will need to install manually `libsodium`:
 ```
 git clone git://github.com/jedisct1/libsodium.git
 cd libsodium
-git checkout tags/1.0.3
+git checkout tags/1.0.7
 ./autogen.sh
 ./configure && make check
 sudo checkinstall --install --pkgname libsodium --pkgversion 1.0.0 --nodoc
@@ -368,7 +368,16 @@ cd filter_audio
 make -j$(nproc)
 sudo make install
 ```
-
+### Sqlcipher compiling, For Fedora users and possibly others.
+```bash
+git clone https://github.com/sqlcipher/sqlcipher
+cd sqlcipher
+autoreconf -if
+./configure
+make -j$(nproc)
+sudo make install
+cd ..
+````
 
 ### toxcore compiling
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -32,6 +32,7 @@
     - [Ubuntu <15.04](#ubuntu14-toxcore)
     - [Ubuntu >=15.04](#ubuntu-toxcore)
   - [filter_audio](#filter_audio)
+  - [sqlcipher (Fedora)](#sqlcipher)
   - [toxcore compiling](#toxcore-compiling)
   - [Compile qTox](#compile-qtox)
 - [OS X](#osx)
@@ -368,7 +369,8 @@ cd filter_audio
 make -j$(nproc)
 sudo make install
 ```
-### Sqlcipher compiling, For Fedora users and possibly others.
+
+### Sqlcipher compiling (Fedora)
 ```bash
 git clone https://github.com/sqlcipher/sqlcipher
 cd sqlcipher


### PR DESCRIPTION
- updated libsodium tag to current tag of 1.0.7
- added sqlcipher  compile  for Fedora users and  any others where sqlcipher is  not a  distro available package ( linux distros)
