### PR TITLE
Chat: set mouse cursor to I-Beam shape, when hovering over text

### DIFF
--- a/src/chatlog/content/text.cpp
+++ b/src/chatlog/content/text.cpp
@@ -220,10 +220,10 @@ void Text::hoverMoveEvent(QGraphicsSceneHoverEvent *event)
 
     QString anchor = doc->documentLayout()->anchorAt(event->pos());
 
-    if (!anchor.isEmpty())
-        setCursor(QCursor(Qt::PointingHandCursor));
+    if (anchor.isEmpty())
+        setCursor(Qt::IBeamCursor);
     else
-        setCursor(QCursor());
+        setCursor(Qt::PointingHandCursor);
 
     // tooltip
     setToolTip(extractImgTooltip(cursorFromPos(event->scenePos(), false)));

--- a/src/chatlog/content/text.h
+++ b/src/chatlog/content/text.h
@@ -54,7 +54,7 @@ public:
     virtual qreal getAscent() const final;
     virtual void mousePressEvent(QGraphicsSceneMouseEvent *event) final override;
     virtual void mouseReleaseEvent(QGraphicsSceneMouseEvent *event) final override;
-    virtual void hoverMoveEvent(QGraphicsSceneHoverEvent* event) final override;
+    void hoverMoveEvent(QGraphicsSceneHoverEvent* event) final override;
 
     virtual QString getText() const final;
 


### PR DESCRIPTION
As title says. :memo: Extracted from #2744 (and done right… :smile:).

@kehugter Please help testing this. Appears to be ok, but I guess we'll need to implement `void QWidget::leaveEvent(QEvent * event)` to unset the cursor correctly. ~~Or is that done by Qt's default implementation?… I'll check.~~ (**edit:** default implementation does nothing)
