### PR TITLE
[WIP] fix volume control for audio sources

### DIFF
--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -307,7 +307,9 @@ qreal Audio::outputVolume()
 }
 
 /**
-The volume must be between 0 and 1
+Set the master output volume.
+
+@param[in] volume   the master volume (between 0 and 1)
 */
 void Audio::setOutputVolume(qreal volume)
 {

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -327,7 +327,7 @@ qreal Audio::outputVolume()
     }
 
     ALfloat volume;
-    alGetSourcef(d->alMainSource, AL_GAIN, &volume);
+    alGetListenerf(AL_GAIN, &volume);
 
     return volume;
 }

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -321,13 +321,12 @@ qreal Audio::outputVolume()
 {
     QMutexLocker locker(&d->audioLock);
 
-    if (!d->alMainSource) {
-        qWarning("Audio output source not initialized.");
-        return 0.0;
-    }
+    ALfloat volume = 0.0;
 
-    ALfloat volume;
-    alGetListenerf(AL_GAIN, &volume);
+    if (d->alOutDev) {
+        alGetListenerf(AL_GAIN, &volume);
+        CHECK_AL_ERROR;
+    }
 
     return volume;
 }

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -28,8 +28,8 @@
 
 #include "audio.h"
 #include "src/core/core.h"
-#include "src/persistence/settings.h"
 #include "src/core/coreav.h"
+#include "src/persistence/settings.h"
 
 #include <QDebug>
 #include <QFile>
@@ -54,6 +54,22 @@
 
 #ifdef QTOX_FILTER_AUDIO
 #include "audiofilterer.h"
+#endif
+
+#ifndef CHECK_AL_ERROR
+#define CHECK_AL_ERROR \
+    do { \
+    const ALenum al_err = alGetError(); \
+    if (al_err) { qWarning("OpenAL error: %d", al_err); } \
+    } while (0)
+#endif
+
+#ifndef CHECK_ALC_ERROR
+#define CHECK_ALC_ERROR(device) \
+    do { \
+    const ALCenum alc_err = alcGetError(device); \
+    if (alc_err) { qWarning("OpenAL error: %d", alc_err); } \
+    } while (0)
 #endif
 
 /**
@@ -156,13 +172,12 @@ public:
     AudioPrivate()
         : audioThread(new QThread)
         , alInDev(nullptr)
-        , alOutDev(nullptr)
-        , alContext(nullptr)
-        , inputVolume(1.f)
-        , outputVolume(1.f)
         , inputInitialized(false)
-        , outputInitialized(false)
         , inSubscriptions(0)
+        , alOutDev(nullptr)
+        , alOutContext(nullptr)
+        , alMainSource(0)
+        , outputInitialized(false)
     {
         audioThread->setObjectName("qTox Audio");
         QObject::connect(audioThread, &QThread::finished, audioThread, &QThread::deleteLater);
@@ -179,6 +194,8 @@ public:
         cleanupOutput();
     }
 
+    bool autoInitInput();
+    bool autoInitOutput();
     bool initInput(QString inDevDescr);
     bool initOutput(QString outDevDescr);
     void cleanupInput();
@@ -189,15 +206,15 @@ public:
     QMutex              audioLock;
 
     ALCdevice*          alInDev;
-    ALCdevice*          alOutDev;
-    ALCcontext*         alContext;
-    ALuint              alMainSource;
-    qreal               inputVolume;
-    qreal               outputVolume;
+    ALfloat             gain;
     bool                inputInitialized;
+    quint32             inSubscriptions;
+
+    ALCdevice*          alOutDev;
+    ALCcontext*         alOutContext;
+    ALuint              alMainSource;
     bool                outputInitialized;
 
-    quint32             inSubscriptions;
     ALSources           outSources;
 
     QPointer<AudioMeter>    audioMeter;
@@ -298,12 +315,21 @@ Audio::~Audio()
 }
 
 /**
-Returns the current output volume, between 0 and 1
+Returns the current output volume (between 0 and 1)
 */
 qreal Audio::outputVolume()
 {
     QMutexLocker locker(&d->audioLock);
-    return d->outputVolume;
+
+    if (!d->alMainSource) {
+        qWarning("Audio output source not initialized.");
+        return 0.0;
+    }
+
+    ALfloat volume;
+    alGetSourcef(d->alMainSource, AL_GAIN, &volume);
+
+    return volume;
 }
 
 /**
@@ -315,31 +341,34 @@ void Audio::setOutputVolume(qreal volume)
 {
     QMutexLocker locker(&d->audioLock);
 
-    d->outputVolume = volume;
-    alSourcef(d->alMainSource, AL_GAIN, volume);
-
-    for (const ToxGroupCall& call : CoreAV::groupCalls)
-    {
-        alSourcef(call.alSource, AL_GAIN, volume);
+    if (volume < 0.0) {
+        volume = 0.0;
+    } else if (volume > 1.0) {
+        volume = 1.0;
     }
 
-    for (const ToxFriendCall& call : CoreAV::calls)
-    {
-        alSourcef(call.alSource, AL_GAIN, volume);
-    }
+    alListenerf(AL_GAIN, volume);
+    CHECK_AL_ERROR;
 }
 
 qreal Audio::inputVolume()
 {
     QMutexLocker locker(&d->audioLock);
 
-    return d->inputVolume;
+    return d->gain;
 }
 
 void Audio::setInputVolume(qreal volume)
 {
     QMutexLocker locker(&d->audioLock);
-    d->inputVolume = volume;
+
+    if (volume < 0.0) {
+        volume = 0.0;
+    } else if (volume > 1.0) {
+        volume = 1.0;
+    }
+
+    d->gain = volume;
 }
 
 void Audio::reinitInput(const QString& inDevDesc)
@@ -365,11 +394,9 @@ void Audio::subscribeInput()
 {
     QMutexLocker locker(&d->audioLock);
 
-    if (!d->alInDev) {
-        if (!d->initInput(Settings::getInstance().getInDev())) {
-            qWarning("Failed to subscribe to audio input device.");
-            return;
-        }
+    if (!d->autoInitInput()) {
+        qWarning("Failed to subscribe to audio input device.");
+        return;
     }
 
     d->inSubscriptions++;
@@ -392,6 +419,26 @@ void Audio::unsubscribeInput()
 
     if (!d->inSubscriptions)
         d->cleanupInput();
+}
+
+/**
+Initialize audio input device, if not initialized.
+
+@return true, if device was initialized; false otherwise
+*/
+bool AudioPrivate::autoInitInput()
+{
+    return alInDev ? true : initInput(Settings::getInstance().getInDev());
+}
+
+/**
+Initialize audio output device, if not initialized.
+
+@return true, if device was initialized; false otherwise
+*/
+bool AudioPrivate::autoInitOutput()
+{
+    return alOutDev ? true : initOutput(Settings::getInstance().getOutDev());
 }
 
 bool AudioPrivate::initInput(QString inDevDescr)
@@ -421,13 +468,13 @@ bool AudioPrivate::initInput(QString inDevDescr)
                                        sampleRate, stereoFlag, bufSize);
 
     // Restart the capture if necessary
-    if (alInDev) {
-        qDebug() << "Opened audio input" << inDevDescr;
-        alcCaptureStart(alInDev);
-    } else {
-        qCritical() << "Failed to initialize audio input device:" << inDevDescr;
+    if (!alInDev) {
+        qWarning() << "Failed to initialize audio input device:" << inDevDescr;
         return false;
     }
+
+    qDebug() << "Opened audio input" << inDevDescr;
+    alcCaptureStart(alInDev);
 
     inputInitialized = true;
     return true;
@@ -445,7 +492,7 @@ bool AudioPrivate::initOutput(QString outDevDescr)
 
     outputInitialized = false;
     if (outDevDescr == "none")
-        return true;
+        return false;
 
     assert(!alOutDev);
 
@@ -459,31 +506,39 @@ bool AudioPrivate::initOutput(QString outDevDescr)
     if (!outDevDescr.isEmpty())
         alOutDev = alcOpenDevice(outDevDescr.toUtf8().constData());
 
-    if (alOutDev)
+    if (!alOutDev)
     {
-        alContext = alcCreateContext(alOutDev, nullptr);
-        if (alcMakeContextCurrent(alContext))
-        {
-            alGenSources(1, &alMainSource);
-            alSourcef(alMainSource, AL_GAIN, outputVolume);
-        }
-        else
-        {
-            qWarning() << "Cannot create output audio context";
-            cleanupOutput();
-            return false;
-        }
-
-        Core* core = Core::getInstance();
-        if (core)
-            core->getAv()->invalidateCallSources(); // Force to regen each group call's sources
-
-        outputInitialized = true;
-        return true;
+        qWarning() << "Cannot open output audio device" << outDevDescr;
+        return false;
     }
 
-    qWarning() << "Cannot open output audio device" << outDevDescr;
-    return false;
+    qDebug() << "Opened audio output" << outDevDescr;
+    alOutContext = alcCreateContext(alOutDev, nullptr);
+    CHECK_ALC_ERROR(alOutDev);
+
+    if (!alcMakeContextCurrent(alOutContext)) {
+        qWarning() << "Cannot create output audio context";
+        return false;
+    }
+
+    alGenSources(1, &alMainSource); CHECK_AL_ERROR;
+    alSourcef(alMainSource, AL_GAIN, 1.f); CHECK_AL_ERROR;
+    alSourcef(alMainSource, AL_PITCH, 1.f); CHECK_AL_ERROR;
+    alSource3f(alMainSource, AL_VELOCITY, 0.f, 0.f, 0.f); CHECK_AL_ERROR;
+    alSource3f(alMainSource, AL_POSITION, 0.f, 0.f, 0.f); CHECK_AL_ERROR;
+
+    // init master volume
+    alListenerf(AL_GAIN, Settings::getInstance().getOutVolume() * 0.01f);
+    CHECK_AL_ERROR;
+
+    Core* core = Core::getInstance();
+    if (core) {
+        // reset each call's audio source
+        core->getAv()->invalidateCallSources();
+    }
+
+    outputInitialized = true;
+    return true;
 }
 
 /**
@@ -493,10 +548,8 @@ void Audio::playMono16Sound(const QByteArray& data)
 {
     QMutexLocker locker(&d->audioLock);
 
-    if (!d->alOutDev)
-        d->initOutput(Settings::getInstance().getOutDev());
-
-    alSourcef(d->alMainSource, AL_GAIN, d->outputVolume);
+    if (!d->autoInitOutput())
+        return;
 
     AudioPlayer *player = new AudioPlayer(d->alMainSource, data);
     connect(player, &AudioPlayer::finished, [=]() {
@@ -552,12 +605,6 @@ void Audio::playGroupAudio(int group, int peer, const int16_t* data,
     if (call.inactive || call.muteVol)
         return;
 
-    if (!call.alSource)
-    {
-        alGenSources(1, &call.alSource);
-        alSourcef(call.alSource, AL_GAIN, d->outputVolume);
-    }
-
     qreal volume = 0.;
     int bufsize = samples * 2 * channels;
     for (int i = 0; i < bufsize; ++i)
@@ -604,7 +651,6 @@ void Audio::playAudioBuffer(quint32 alSource, const int16_t *data, int samples, 
 
     ALint state;
     alGetSourcei(alSource, AL_SOURCE_STATE, &state);
-    alSourcef(alSource, AL_GAIN, d->outputVolume);
     if (state != AL_PLAYING)
         alSourcePlay(alSource);
 }
@@ -643,17 +689,17 @@ void AudioPrivate::cleanupOutput()
     outputInitialized = false;
 
     if (alOutDev) {
-        qDebug() << "Closing audio output";
         alSourcei(alMainSource, AL_LOOPING, AL_FALSE);
         alSourceStop(alMainSource);
         alDeleteSources(1, &alMainSource);
 
         if (!alcMakeContextCurrent(nullptr))
-            qWarning("Failed to clear current audio context.");
+            qWarning("Failed to clear audio context.");
 
-        alcDestroyContext(alContext);
-        alContext = nullptr;
+        alcDestroyContext(alOutContext);
+        alOutContext = nullptr;
 
+        qDebug() << "Closing audio output";
         if (alcCloseDevice(alOutDev))
             alOutDev = nullptr;
         else
@@ -699,17 +745,26 @@ void Audio::subscribeOutput(SID& sid)
 {
     QMutexLocker locker(&d->audioLock);
 
-    if (!d->alOutDev) {
-        if (!d->initOutput(Settings::getInstance().getOutDev())) {
-            qWarning("Failed to subscribe to audio output device.");
-            return;
-        }
+    if (!d->autoInitOutput()) {
+        qWarning("Failed to subscribe to audio output device.");
+        return;
+    }
+
+    if (!alcMakeContextCurrent(d->alOutContext)) {
+        qWarning("Failed to activate output context.");
+        return;
     }
 
     alGenSources(1, &sid);
     assert(sid);
-    alSourcef(sid, AL_GAIN, d->outputVolume);
     d->outSources << sid;
+
+    // initialize source
+    alSourcef(sid, AL_GAIN, 1.f); CHECK_AL_ERROR;
+    alSourcef(sid, AL_PITCH, 1.f); CHECK_AL_ERROR;
+    alSource3f(sid, AL_VELOCITY, 0.f, 0.f, 0.f); CHECK_AL_ERROR;
+    alSource3f(sid, AL_POSITION, 0.f, 0.f, 0.f); CHECK_AL_ERROR;
+
     qDebug() << "Audio source" << sid << "created. Sources active:"
              << d->outSources.size();
 }
@@ -768,7 +823,7 @@ bool Audio::tryCaptureSamples(int16_t* buf, int samples)
 
     for (size_t i = 0; i < samples * AUDIO_CHANNELS; ++i)
     {
-        int sample = buf[i] * pow(d->inputVolume, 2);
+        int sample = buf[i];
 
         if (sample < std::numeric_limits<int16_t>::min())
             sample = std::numeric_limits<int16_t>::min();

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -708,7 +708,7 @@ void Audio::subscribeOutput(SID& sid)
 
     alGenSources(1, &sid);
     assert(sid);
-    alSourcef(sid, AL_GAIN, 1.f);
+    alSourcef(sid, AL_GAIN, d->outputVolume);
     d->outSources << sid;
     qDebug() << "Audio source" << sid << "created. Sources active:"
              << d->outSources.size();

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -282,7 +282,6 @@ void AVForm::getAudioInDevices()
     const char* pDeviceList = Audio::inDeviceNames();
     if (pDeviceList)
     {
-        //prevent currentIndexChanged to be fired while adding items
         while (*pDeviceList)
         {
             int len = strlen(pDeviceList);
@@ -292,8 +291,6 @@ void AVForm::getAudioInDevices()
                 inDevIndex = bodyUI->inDevCombobox->count()-1;
             pDeviceList += len+1;
         }
-        //addItem changes currentIndex -> reset
-        bodyUI->inDevCombobox->setCurrentIndex(-1);
     }
     bodyUI->inDevCombobox->blockSignals(false);
     bodyUI->inDevCombobox->setCurrentIndex(inDevIndex);
@@ -309,7 +306,6 @@ void AVForm::getAudioOutDevices()
     const char* pDeviceList = Audio::outDeviceNames();
     if (pDeviceList)
     {
-        //prevent currentIndexChanged to be fired while adding items
         while (*pDeviceList)
         {
             int len = strlen(pDeviceList);
@@ -321,8 +317,6 @@ void AVForm::getAudioOutDevices()
             }
             pDeviceList += len+1;
         }
-        //addItem changes currentIndex -> reset
-        bodyUI->outDevCombobox->setCurrentIndex(-1);
     }
     bodyUI->outDevCombobox->blockSignals(false);
     bodyUI->outDevCombobox->setCurrentIndex(outDevIndex);

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -44,6 +44,9 @@ AVForm::AVForm() :
     bodyUI = new Ui::AVSettings;
     bodyUI->setupUi(this);
 
+    bodyUI->btnPlayTestSound->setToolTip(
+                tr("Play a test sound while changing the output volume."));
+
 #ifdef QTOX_FILTER_AUDIO
     bodyUI->filterAudio->setChecked(Settings::getInstance().getFilterAudio());
 #else
@@ -361,6 +364,9 @@ void AVForm::onPlaybackSliderMoved(int value)
     if (audio.isOutputReady()) {
         const qreal percentage = value / 100.0;
         audio.setOutputVolume(percentage);
+
+        if (mPlayTestSound)
+            audio.playMono16Sound(QStringLiteral(":/audio/notification.pcm"));
     }
 }
 
@@ -418,4 +424,9 @@ bool AVForm::eventFilter(QObject *o, QEvent *e)
 void AVForm::retranslateUi()
 {
     bodyUI->retranslateUi(this);
+}
+
+void AVForm::on_btnPlayTestSound_clicked(bool checked)
+{
+    mPlayTestSound = checked;
 }

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -363,14 +363,12 @@ void AVForm::onPlaybackValueChanged(int value)
 {
     Audio::getInstance().setOutputVolume(value / 100.0);
     Settings::getInstance().setOutVolume(bodyUI->playbackSlider->value());
-    bodyUI->playbackMax->setText(QString::number(value));
 }
 
 void AVForm::onMicrophoneValueChanged(int value)
 {
     Audio::getInstance().setInputVolume(value / 100.0);
     Settings::getInstance().setInVolume(bodyUI->microphoneSlider->value());
-    bodyUI->microphoneMax->setText(QString::number(value));
 }
 
 void AVForm::createVideoSurface()
@@ -411,6 +409,4 @@ bool AVForm::eventFilter(QObject *o, QEvent *e)
 void AVForm::retranslateUi()
 {
     bodyUI->retranslateUi(this);
-    bodyUI->playbackMax->setText(QString::number(bodyUI->playbackSlider->value()));
-    bodyUI->microphoneMax->setText(QString::number(bodyUI->microphoneSlider->value()));
 }

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -286,11 +286,7 @@ void AVForm::getAudioInDevices()
         while (*pDeviceList)
         {
             int len = strlen(pDeviceList);
-#ifdef Q_OS_WIN
             QString inDev = QString::fromUtf8(pDeviceList, len);
-#else
-            QString inDev = QString::fromLocal8Bit(pDeviceList, len);
-#endif
             bodyUI->inDevCombobox->addItem(inDev);
             if (settingsInDev == inDev)
                 inDevIndex = bodyUI->inDevCombobox->count()-1;
@@ -317,11 +313,7 @@ void AVForm::getAudioOutDevices()
         while (*pDeviceList)
         {
             int len = strlen(pDeviceList);
-#ifdef Q_OS_WIN
             QString outDev = QString::fromUtf8(pDeviceList, len);
-#else
-            QString outDev = QString::fromLocal8Bit(pDeviceList, len);
-#endif
             bodyUI->outDevCombobox->addItem(outDev);
             if (settingsOutDev == outDev)
             {

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -339,6 +339,7 @@ void AVForm::onInDevChanged(QString deviceDescriptor)
     Settings::getInstance().setInDev(deviceDescriptor);
     Audio& audio = Audio::getInstance();
     audio.reinitInput(deviceDescriptor);
+    bodyUI->microphoneSlider->setEnabled(audio.isInputReady());
     bodyUI->microphoneSlider->setSliderPosition(audio.inputVolume() * 100.f);
 }
 
@@ -350,6 +351,7 @@ void AVForm::onOutDevChanged(QString deviceDescriptor)
     Settings::getInstance().setOutDev(deviceDescriptor);
     Audio& audio = Audio::getInstance();
     audio.reinitOutput(deviceDescriptor);
+    bodyUI->playbackSlider->setEnabled(audio.isOutputReady());
     bodyUI->playbackSlider->setSliderPosition(audio.outputVolume() * 100.f);
 }
 

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -64,10 +64,10 @@ AVForm::AVForm() :
         getAudioOutDevices();
         getVideoDevices();
     });
-    connect(bodyUI->playbackSlider, &QSlider::valueChanged, this, &AVForm::onPlaybackValueChanged);
-    connect(bodyUI->microphoneSlider, &QSlider::valueChanged, this, &AVForm::onMicrophoneValueChanged);
     bodyUI->playbackSlider->setValue(Settings::getInstance().getOutVolume());
     bodyUI->microphoneSlider->setValue(Settings::getInstance().getInVolume());
+    connect(bodyUI->playbackSlider, &QSlider::valueChanged, this, &AVForm::onPlaybackValueChanged);
+    connect(bodyUI->microphoneSlider, &QSlider::valueChanged, this, &AVForm::onMicrophoneValueChanged);
 
     bodyUI->playbackSlider->installEventFilter(this);
     bodyUI->microphoneSlider->installEventFilter(this);

--- a/src/widget/form/settings/avform.h
+++ b/src/widget/form/settings/avform.h
@@ -57,7 +57,9 @@ private slots:
     void onInDevChanged(QString deviceDescriptor);
     void onOutDevChanged(QString deviceDescriptor);
     void onFilterAudioToggled(bool filterAudio);
+    void onPlaybackSliderMoved(int value);
     void onPlaybackValueChanged(int value);
+    void onMicrophoneSliderMoved(int value);
     void onMicrophoneValueChanged(int value);
 
     // camera

--- a/src/widget/form/settings/avform.h
+++ b/src/widget/form/settings/avform.h
@@ -66,6 +66,8 @@ private slots:
     void onVideoDevChanged(int index);
     void onVideoModesIndexChanged(int index);
 
+    void on_btnPlayTestSound_clicked(bool checked);
+
 protected:
     void updateVideoModes(int curIndex);
 
@@ -78,6 +80,7 @@ private:
 private:
     Ui::AVSettings *bodyUI;
     bool subscribedToAudioIn;
+    bool mPlayTestSound;
     VideoSurface *camVideoSurface;
     CameraSource &camera;
     QVector<QPair<QString, QString>> videoDeviceList;

--- a/src/widget/form/settings/avsettings.ui
+++ b/src/widget/form/settings/avsettings.ui
@@ -41,20 +41,24 @@
           <string>Audio Settings</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_3">
-          <item row="6" column="0">
-           <widget class="QCheckBox" name="filterAudio">
-            <property name="toolTip">
-             <string>Filter sound from your microphone, so that people hearing you would get better sound.</string>
-            </property>
+          <item row="0" column="0">
+           <widget class="QLabel" name="outDevLabel">
             <property name="text">
-             <string>Filter audio</string>
+             <string>Playback device</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1" colspan="2">
+           <widget class="QComboBox" name="outDevCombobox"/>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="playbackLabel">
+            <property name="text">
+             <string>Volume</string>
             </property>
            </widget>
           </item>
           <item row="1" column="1">
-           <widget class="QComboBox" name="outDevCombobox"/>
-          </item>
-          <item row="2" column="1">
            <widget class="QSlider" name="playbackSlider">
             <property name="toolTip">
              <string>Use slider to set volume of your speakers.</string>
@@ -67,24 +71,38 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="0">
-           <widget class="QLabel" name="microphoneLabel">
+          <item row="1" column="2">
+           <widget class="QToolButton" name="btnPlayTestSound">
             <property name="text">
-             <string>Gain</string>
+             <string>...</string>
+            </property>
+            <property name="icon">
+             <iconset resource="../../../../res.qrc">
+              <normaloff>:/ui/volButton/volButton.png</normaloff>:/ui/volButton/volButton.png</iconset>
+            </property>
+            <property name="checkable">
+             <bool>true</bool>
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
+          <item row="2" column="0">
            <widget class="QLabel" name="inDevLabel">
             <property name="text">
              <string>Capture device</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
+          <item row="2" column="1" colspan="2">
            <widget class="QComboBox" name="inDevCombobox"/>
           </item>
-          <item row="5" column="2">
+          <item row="3" column="0">
+           <widget class="QLabel" name="microphoneLabel">
+            <property name="text">
+             <string>Gain</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1" colspan="2">
            <widget class="QSlider" name="microphoneSlider">
             <property name="toolTip">
              <string>Use slider to set volume of your microphone.</string>
@@ -97,17 +115,13 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="playbackLabel">
-            <property name="text">
-             <string>Volume</string>
+          <item row="5" column="0">
+           <widget class="QCheckBox" name="filterAudio">
+            <property name="toolTip">
+             <string>Filter sound from your microphone, so that people hearing you would get better sound.</string>
             </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="outDevLabel">
             <property name="text">
-             <string>Playback device</string>
+             <string>Filter audio</string>
             </property>
            </widget>
           </item>
@@ -206,6 +220,8 @@ which may lead to problems with video calls.</string>
    <container>1</container>
   </customwidget>
  </customwidgets>
- <resources/>
+ <resources>
+  <include location="../../../../res.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/src/widget/form/settings/avsettings.ui
+++ b/src/widget/form/settings/avsettings.ui
@@ -90,7 +90,7 @@
              <string>Use slider to set volume of your microphone.</string>
             </property>
             <property name="maximum">
-             <number>400</number>
+             <number>100</number>
             </property>
             <property name="orientation">
              <enum>Qt::Horizontal</enum>

--- a/src/widget/form/settings/avsettings.ui
+++ b/src/widget/form/settings/avsettings.ui
@@ -41,13 +41,6 @@
           <string>Audio Settings</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_3">
-          <item row="2" column="1">
-           <widget class="QLabel" name="playbackMin">
-            <property name="text">
-             <string>0</string>
-            </property>
-           </widget>
-          </item>
           <item row="6" column="0">
            <widget class="QCheckBox" name="filterAudio">
             <property name="toolTip">
@@ -58,10 +51,10 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="2">
+          <item row="1" column="1">
            <widget class="QComboBox" name="outDevCombobox"/>
           </item>
-          <item row="2" column="2">
+          <item row="2" column="1">
            <widget class="QSlider" name="playbackSlider">
             <property name="toolTip">
              <string>Use slider to set volume of your speakers.</string>
@@ -77,21 +70,7 @@
           <item row="5" column="0">
            <widget class="QLabel" name="microphoneLabel">
             <property name="text">
-             <string>Microphone</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="3">
-           <widget class="QLabel" name="microphoneMax">
-            <property name="text">
-             <string>100</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="3">
-           <widget class="QLabel" name="playbackMax">
-            <property name="text">
-             <string>100</string>
+             <string>Gain</string>
             </property>
            </widget>
           </item>
@@ -102,14 +81,7 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="1">
-           <widget class="QLabel" name="microphoneMin">
-            <property name="text">
-             <string>0</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="2">
+          <item row="3" column="1">
            <widget class="QComboBox" name="inDevCombobox"/>
           </item>
           <item row="5" column="2">
@@ -128,7 +100,7 @@
           <item row="2" column="0">
            <widget class="QLabel" name="playbackLabel">
             <property name="text">
-             <string>Playback</string>
+             <string>Volume</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
The next milestone forward to support reliable audio calls. Anyone interested in improving audio calls, please let me know and help review/test.
- [x] Clean up audio settings ui.
- [x] Determine current master volume from qTox settings in output device initialization.
- [x] ~~Bind gain/volume controls to system settings.~~ OpenAL cannot control system volume and it's not the right thing to do anyway.
- [x] Remove destructive input gain algorithm:
  - Calculation of input gain is plain wrong, leading to destroyed input values.
- [ ] Replace the gain algorithm with something more suitable.
- [x] Remove invalid self-creation of unregistered audio source in `playGroupAudio`.
- [x] Moved to #2785 -> ~~Return false when initializing device with specifier "none".~~
- [x] Fix initialization of A/V settings:
  - [x] Do not open the audio device in constructor (called, when qTox starts)
  - [x] Fix initialization of in/out volumes (audio device must be initalized and valid **before**)
- [x] Add "test output" button to A/V settings form. This is how it looks like:
  - ![play-test-sound](https://cloud.githubusercontent.com/assets/440517/12374862/8cb5a2d6-bcaa-11e5-9e29-0c957e7081a4.png)
- [x] Disable volume sliders, when no device is selected.

**KNOWN BUGS THAT WON'T BE FIXED HERE:**
- :beetle: :+1: The introduced "play test sound" button adds a nice penetration check for `AudioPlayer`, that reveals an unrelated bug, when playing the same sound ~100 times.
