### PR TITLE
Fixes #2484 - Error message when unable to save file

### DIFF
--- a/src/chatlog/content/filetransferwidget.cpp
+++ b/src/chatlog/content/filetransferwidget.cpp
@@ -22,6 +22,7 @@
 
 #include "src/nexus.h"
 #include "src/core/core.h"
+#include "src/widget/gui.h"
 #include "src/widget/style.h"
 #include "src/widget/widget.h"
 #include "src/persistence/settings.h"
@@ -138,8 +139,7 @@ void FileTransferWidget::acceptTransfer(const QString &filepath)
     //test if writable
     if (!Nexus::tryRemoveFile(filepath))
     {
-        QMessageBox::warning(this,
-                             tr("Location not writable", "Title of permissions popup"),
+        GUI::showWarning(    tr("Location not writable", "Title of permissions popup"),
                              tr("You do not have permission to write that location. Choose another, or cancel the save dialog.", "text of permissions popup"));
         return;
     }

--- a/src/chatlog/content/filetransferwidget.cpp
+++ b/src/chatlog/content/filetransferwidget.cpp
@@ -139,8 +139,8 @@ void FileTransferWidget::acceptTransfer(const QString &filepath)
     //test if writable
     if (!Nexus::tryRemoveFile(filepath))
     {
-        GUI::showWarning(    tr("Location not writable", "Title of permissions popup"),
-                             tr("You do not have permission to write that location. Choose another, or cancel the save dialog.", "text of permissions popup"));
+        GUI::showWarning(tr("Location not writable", "Title of permissions popup"),
+                         tr("You do not have permission to write that location. Choose another, or cancel the save dialog.", "text of permissions popup"));
         return;
     }
 


### PR DESCRIPTION
Show proper error message. qTox is not locked.
