### PR TITLE
Desktop Notifications Again

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -39,6 +39,7 @@ BASE_DIR=${SCRIPT_DIR}/${INSTALL_DIR}
 # directory names of cloned repositories
 TOX_CORE_DIR=libtoxcore-latest
 FILTER_AUDIO_DIR=libfilteraudio-latest
+SNORENOTIFY_DIR=libsnore-latest
 
 if [ -z "$BASE_DIR" ]; then
     echo "internal error detected!"
@@ -58,9 +59,16 @@ if [ -z "$FILTER_AUDIO_DIR" ]; then
     exit 1
 fi
 
+if [ -z "$SNORENOTIFY_DIR" ]; then
+    echo "internal error detected!"
+    echo "SNORENOTIFY_DIR should not be empty.  Aborting."
+    exit 1
+fi
+
 # default values for user given parameters
 INSTALL_TOX=true
 INSTALL_FILTER_AUDIO=true
+INSTALL_SNORENOTIFY=true
 SYSTEM_WIDE=true
 KEEP_BUILD_FILES=false
 
@@ -78,6 +86,12 @@ while [ $# -ge 1 ] ; do
         shift
     elif [ ${1} = "--without-filter-audio" ] ; then
         INSTALL_FILTER_AUDIO=false
+        shift
+    elif [ ${1} = "--with-snorenotify" ] ; then
+        INSTALL_SNORENOTIFY=true
+        shift
+    elif [ ${1} = "--without-snorenotify" ] ; then
+        INSTALL_SNORENOTIFY=false
         shift
     elif [ ${1} = "-l" -o ${1} = "--local" ] ; then
         SYSTEM_WIDE=false
@@ -102,6 +116,8 @@ while [ $# -ge 1 ] ; do
         echo "    --without-tox          : do not install/update libtoxcore"
         echo "    --with-filter-audio    : install/update libfilteraudio"
         echo "    --without-filter-audio : do not install/update libfilteraudio"
+        echo "    --with-snorenotify     : install/update Snorenotify"
+        echo "    --without-snorenotify  : do not install/update Snorenotify"
         echo "    -h|--help              : displays this help"
         echo "    -l|--local             : install packages into ${INSTALL_DIR}"
         echo "    -k|--keep              : keep build files after installation/update"
@@ -116,6 +132,7 @@ done
 ############ print debug output ############
 echo "with tox                    : ${INSTALL_TOX}"
 echo "with filter-audio           : ${INSTALL_FILTER_AUDIO}"
+echo "with Snorenotify            : ${INSTALL_SNORENOTIFY}"
 echo "install into ${INSTALL_DIR} : ${SYSTEM_WIDE}"
 echo "keep build files            : ${KEEP_BUILD_FILES}"
 
@@ -129,6 +146,7 @@ mkdir -p ${BASE_DIR}
 # if exists, otherwise cloning them may fail
 rm -rf ${BASE_DIR}/${TOX_CORE_DIR}
 rm -rf ${BASE_DIR}/${FILTER_AUDIO_DIR}
+rm -rf ${BASE_DIR}/${SNORENOTIFY_DIR}
 
 
 ############### install step ###############
@@ -184,10 +202,29 @@ if [[ $INSTALL_FILTER_AUDIO = "true" ]]; then
     popd
 fi
 
+#install Snorenotify
+if [[ $INSTALL_SNORENOTIFY = "true" ]]; then
+    git clone https://github.com/Snorenotify/Snorenotify.git ${BASE_DIR}/${SNORENOTIFY_DIR} --depth 1
+    pushd ${BASE_DIR}/${SNORENOTIFY_DIR}
+    
+    if [[ $SYSTEM_WIDE = "false" ]]; then
+    	PREFIX=${BASE_DIR} cmake -qt5 .
+        PREFIX=${BASE_DIR} make -j2
+        PREFIX=${BASE_DIR} make install
+    else
+    	cmake -qt5 .
+        make -j2
+        sudo make install
+        sudo ldconfig
+    fi
+    
+    popd
+fi
 
 ############### cleanup step ###############
 # remove cloned repositories
 if [[ $KEEP_BUILD_FILES = "false" ]]; then
     rm -rf ${BASE_DIR}/${TOX_CORE_DIR}
     rm -rf ${BASE_DIR}/${FILTER_AUDIO_DIR}
+    rm -rf ${BASE_DIR}/${SNORENOTIFY_DIR}
 fi

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -208,9 +208,9 @@ if [[ $INSTALL_SNORENOTIFY = "true" ]]; then
     pushd ${BASE_DIR}/${SNORENOTIFY_DIR}
     
     if [[ $SYSTEM_WIDE = "false" ]]; then
-    	PREFIX=${BASE_DIR} cmake -qt5 .
-        PREFIX=${BASE_DIR} make -j2
-        PREFIX=${BASE_DIR} make install
+        cmake -qt5 -DCMAKE_INSTALL_PREFIX="${BASE_DIR}" .
+        make -j2
+        make install
     else
     	cmake -qt5 .
         make -j2

--- a/qtox.pro
+++ b/qtox.pro
@@ -328,11 +328,11 @@ contains(ENABLE_NOTIFICATION_SNORE_BACKEND, YES) {
             INCLUDEPATH += "/usr/local/lib/i386-linux-gnu/libsnore-qt5/include"
         }
 
-        LIBS += -L/usr/local/lib64/ -lsnore-qt5
+        LIBS += -L/usr/local/lib64/ -lsnore-qt5 -lsnoresettings-qt5
     }
 
     win32 {
-        LIBS += -lsnore-qt5
+        LIBS += -lsnore-qt5 -lsnoresettings-qt5
     }
 
     SOURCES += src/widget/snorenotificationbackend.cpp

--- a/qtox.pro
+++ b/qtox.pro
@@ -312,6 +312,35 @@ contains(ENABLE_SYSTRAY_GTK_BACKEND, NO) {
 }
 }
 
+# The snorenotify backend implements a notification system compatible with many systems
+!android {
+contains(ENABLE_NOTIFICATION_SNORE_BACKEND, YES) {
+    DEFINES += ENABLE_NOTIFICATION_SNORE_BACKEND
+
+    unix {
+        INCLUDEPATH += "/usr/local/include/snore/core"
+        equals(QT_ARCH, x86_64) {
+            INCLUDEPATH += "/usr/local/lib64/libsnore-qt5/include"
+            INCLUDEPATH += "/usr/local/lib/x86_64-linux-gnu/libsnore-qt5/include"
+        }
+        else {
+            INCLUDEPATH += "/usr/local/lib/libsnore-qt5/include"
+            INCLUDEPATH += "/usr/local/lib/i386-linux-gnu/libsnore-qt5/include"
+        }
+
+        LIBS += -L/usr/local/lib64/ -lsnore-qt5
+    }
+
+    win32 {
+        LIBS += -lsnore-qt5
+    }
+
+    SOURCES += src/widget/snorenotificationbackend.cpp
+
+    HEADERS += src/widget/snorenotificationbackend.h
+}
+}
+
 !android {
     RESOURCES += res.qrc \
         smileys/smileys.qrc
@@ -511,6 +540,7 @@ SOURCES += \
     src/widget/friendlistlayout.cpp \
     src/widget/genericchatitemlayout.cpp \
     src/widget/categorywidget.cpp \
+    src/widget/notificationbackend.cpp \
     src/widget/contentlayout.cpp \
     src/widget/contentdialog.cpp \
     src/video/genericnetcamview.cpp \
@@ -566,6 +596,7 @@ HEADERS += \
     src/widget/friendlistlayout.h \
     src/widget/genericchatitemlayout.h \
     src/widget/categorywidget.h \
+    src/widget/notificationbackend.h \
     src/widget/contentlayout.h \
     src/widget/contentdialog.h \
     src/widget/tool/activatedialog.h \

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -169,6 +169,15 @@ void Settings::loadGlobal()
         showInFront = s.value("showInFront", false).toBool();
         notifySound = s.value("notifySound", true).toBool();
         groupAlwaysNotify = s.value("groupAlwaysNotify", false).toBool();
+        desktopNotifications = s.value("desktopNotifications", 1).toUInt();
+        notifyOnNewMessage = s.value("notifyOnNewMessage", true).toBool();
+        notifyOnHighlight = s.value("notifyOnHighlight", true).toBool();
+        notifyOnFriendRequest = s.value("notifyOnFriendRequest", true).toBool();
+        notifyOnCallInvite = s.value("notifyOnCallInvite", true).toBool();
+        notifyOnGroupInvite = s.value("notifyOnGroupInvite", true).toBool();
+        notifyOnFileTransfer = s.value("notifyOnFileTransfer", true).toBool();
+        notifyOnFriendOnline = s.value("notifyOnFriendOnline", false).toBool();
+        notifyOnFriendOffline = s.value("notifyOnFriendOffline", false).toBool();
         fauxOfflineMessaging = s.value("fauxOfflineMessaging", true).toBool();
         autoSaveEnabled = s.value("autoSaveEnabled", false).toBool();
         globalAutoAcceptDir = s.value("globalAutoAcceptDir",
@@ -384,6 +393,15 @@ void Settings::saveGlobal()
         s.setValue("showInFront", showInFront);
         s.setValue("notifySound", notifySound);
         s.setValue("groupAlwaysNotify", groupAlwaysNotify);
+        s.setValue("desktopNotifications", desktopNotifications);
+        s.setValue("notifyOnNewMessage", notifyOnNewMessage);
+        s.setValue("notifyOnHighlight", notifyOnHighlight);
+        s.setValue("notifyOnFriendRequest", notifyOnFriendRequest);
+        s.setValue("notifyOnCallInvite", notifyOnCallInvite);
+        s.setValue("notifyOnGroupInvite", notifyOnGroupInvite);
+        s.setValue("notifyOnFileTransfer", notifyOnFileTransfer);
+        s.setValue("notifyOnFriendOnline", notifyOnFriendOnline);
+        s.setValue("notifyOnFriendOffline", notifyOnFriendOffline);
         s.setValue("fauxOfflineMessaging", fauxOfflineMessaging);
         s.setValue("separateWindow", separateWindow);
         s.setValue("dontGroupWindows", dontGroupWindows);
@@ -739,6 +757,114 @@ void Settings::setGroupAlwaysNotify(bool newValue)
 {
     QMutexLocker locker{&bigLock};
     groupAlwaysNotify = newValue;
+}
+
+uint8_t Settings::getDesktopNotifications() const
+{
+    QMutexLocker locker{&bigLock};
+    return desktopNotifications;
+}
+
+void Settings::setDesktopNotifications(uint8_t newValue)
+{
+    QMutexLocker locker{&bigLock};
+    desktopNotifications = newValue;
+}
+
+bool Settings::getNotifyOnNewMessage() const
+{
+    QMutexLocker locker{&bigLock};
+    return notifyOnNewMessage;
+}
+
+bool Settings::getNotifyOnFriendRequest() const
+{
+    QMutexLocker locker{&bigLock};
+    return notifyOnFriendRequest;
+}
+
+bool Settings::getNotifyOnHighlight() const
+{
+    QMutexLocker locker{&bigLock};
+    return notifyOnHighlight;
+}
+
+bool Settings::getNotifyOnCallInvite() const
+{
+    QMutexLocker locker{&bigLock};
+    return notifyOnCallInvite;
+}
+
+bool Settings::getNotifyOnGroupInvite() const
+{
+    QMutexLocker locker{&bigLock};
+    return notifyOnGroupInvite;
+}
+
+bool Settings::getNotifyOnFileTransfer() const
+{
+    QMutexLocker locker{&bigLock};
+    return notifyOnFileTransfer;
+}
+
+bool Settings::getNotifyOnFriendOnline() const
+{
+    QMutexLocker locker{&bigLock};
+    return notifyOnFriendOnline;
+}
+
+bool Settings::getNotifyOnFriendOffline() const
+{
+    QMutexLocker locker{&bigLock};
+    return notifyOnFriendOffline;
+}
+
+void Settings::setNotifyOnNewMessage(bool notify)
+{
+    QMutexLocker locker{&bigLock};
+    notifyOnNewMessage = notify;
+}
+
+void Settings::setNotifyOnFriendRequest(bool notify)
+{
+    QMutexLocker locker{&bigLock};
+    notifyOnFriendRequest = notify;
+}
+
+void Settings::setNotifyOnHighlight(bool notify)
+{
+    QMutexLocker locker{&bigLock};
+    notifyOnHighlight = notify;
+}
+
+void Settings::setNotifyOnCallInvite(bool notify)
+{
+    QMutexLocker locker{&bigLock};
+    notifyOnCallInvite = notify;
+}
+
+void Settings::setNotifyOnGroupInvite(bool notify)
+{
+    QMutexLocker locker{&bigLock};
+    notifyOnGroupInvite = notify;
+}
+
+void Settings::setNotifyOnFileTransfer(bool notify)
+{
+    QMutexLocker locker{&bigLock};
+    notifyOnFileTransfer = notify;
+}
+
+void Settings::setNotifyOnFriendOnline(bool notify)
+{
+    QMutexLocker locker{&bigLock};
+    notifyOnFriendOnline = notify;
+}
+
+void Settings::setNotifyOnFriendOffline(bool notify)
+{
+    QMutexLocker locker{&bigLock};
+    notifyOnFriendOffline = notify;
 }
 
 QString Settings::getTranslation() const

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -142,6 +142,26 @@ public:
     bool getGroupAlwaysNotify() const;
     void setGroupAlwaysNotify(bool newValue);
 
+    uint8_t getDesktopNotifications() const;
+    void setDesktopNotifications(uint8_t newValue);
+
+    bool getNotifyOnNewMessage() const;
+    bool getNotifyOnFriendRequest() const;
+    bool getNotifyOnHighlight() const;
+    bool getNotifyOnCallInvite() const;
+    bool getNotifyOnGroupInvite() const;
+    bool getNotifyOnFileTransfer() const;
+    bool getNotifyOnFriendOnline() const;
+    bool getNotifyOnFriendOffline() const;
+    void setNotifyOnNewMessage(bool notify);
+    void setNotifyOnFriendRequest(bool notify);
+    void setNotifyOnHighlight(bool notify);
+    void setNotifyOnCallInvite(bool notify);
+    void setNotifyOnGroupInvite(bool notify);
+    void setNotifyOnFileTransfer(bool notify);
+    void setNotifyOnFriendOnline(bool notify);
+    void setNotifyOnFriendOffline(bool notify);
+
     QString getInDev() const;
     void setInDev(const QString& deviceSpecifier);
 
@@ -331,6 +351,15 @@ private:
     bool showInFront;
     bool notifySound;
     bool groupAlwaysNotify;
+    uint8_t desktopNotifications;
+    bool notifyOnNewMessage;
+    bool notifyOnFriendRequest;
+    bool notifyOnHighlight;
+    bool notifyOnCallInvite;
+    bool notifyOnGroupInvite;
+    bool notifyOnFileTransfer;
+    bool notifyOnFriendOnline;
+    bool notifyOnFriendOffline;
 
     bool forceTCP;
 

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -295,6 +295,8 @@ void ChatForm::onAvInvite(uint32_t FriendId, bool video)
     Audio& audio = Audio::getInstance();
     audio.startLoop();
     audio.playMono16Sound(QStringLiteral(":/audio/ToxicIncomingCall.pcm"));
+
+    emit invitedCall(f->getFriendID());
 }
 
 void ChatForm::onAvStart(uint32_t FriendId, bool video)

--- a/src/widget/form/chatform.h
+++ b/src/widget/form/chatform.h
@@ -54,6 +54,7 @@ public:
 signals:
     void sendFile(uint32_t friendId, QString, QString, long long);
     void aliasChanged(const QString& alias);
+    void invitedCall(int friendId);
 
 public slots:
     void startFileSend(ToxFile file);

--- a/src/widget/form/settings/generalform.cpp
+++ b/src/widget/form/settings/generalform.cpp
@@ -38,6 +38,10 @@
 #include <QStandardPaths>
 #include <QDebug>
 
+#ifdef ENABLE_NOTIFICATION_SNORE_BACKEND
+#include "src/widget/snorenotificationbackend.h"
+#endif
+
 static QStringList locales = {"bg",
                               "cs",
                               "de",
@@ -127,12 +131,33 @@ GeneralForm::GeneralForm(SettingsWidget *myParent) :
     bodyUI->showInFront->setChecked(Settings::getInstance().getShowInFront());
     bodyUI->notifySound->setChecked(Settings::getInstance().getNotifySound());
     bodyUI->groupAlwaysNotify->setChecked(Settings::getInstance().getGroupAlwaysNotify());
+    bodyUI->notifyOnNewMessage->setChecked(Settings::getInstance().getNotifyOnNewMessage());
+    bodyUI->notifyOnHighlighted->setChecked(Settings::getInstance().getNotifyOnHighlight());
+    bodyUI->notifyOnFriendRequest->setChecked(Settings::getInstance().getNotifyOnFriendRequest());
+    bodyUI->notifyOnCallInvite->setChecked(Settings::getInstance().getNotifyOnCallInvite());
+    bodyUI->notifyOnGroupInvite->setChecked(Settings::getInstance().getNotifyOnGroupInvite());
+    bodyUI->notifyOnFileTransfer->setChecked(Settings::getInstance().getNotifyOnFileTransfer());
+    bodyUI->notifyOnFriendOnline->setChecked(Settings::getInstance().getNotifyOnFriendOnline());
+    bodyUI->notifyOnFriendOffline->setChecked(Settings::getInstance().getNotifyOnFriendOffline());
     bodyUI->cbFauxOfflineMessaging->setChecked(Settings::getInstance().getFauxOfflineMessaging());
     bodyUI->cbCompactLayout->setChecked(Settings::getInstance().getCompactLayout());
     bodyUI->cbSeparateWindow->setChecked(Settings::getInstance().getSeparateWindow());
     bodyUI->cbDontGroupWindows->setChecked(Settings::getInstance().getDontGroupWindows());
     bodyUI->cbDontGroupWindows->setEnabled(bodyUI->cbSeparateWindow->isChecked());
     bodyUI->cbGroupchatPosition->setChecked(Settings::getInstance().getGroupchatPosition());
+
+    bodyUI->desktopNotifications->addItem(tr("None", "Desktop notification"));
+    notificationFactories.push_back([]() -> NotificationBackend* { return nullptr; });
+#ifdef ENABLE_NOTIFICATION_SNORE_BACKEND
+    bodyUI->desktopNotifications->addItem(QStringLiteral("Snorenotify"));
+    notificationFactories.push_back([]() -> NotificationBackend* { return new SnoreNotificationBackend(); });
+#endif
+    int desktopNotificationIndex = Settings::getInstance().getDesktopNotifications();
+
+    if (desktopNotificationIndex >= bodyUI->desktopNotifications->count())
+        desktopNotificationIndex = 0;
+
+    bodyUI->desktopNotifications->setCurrentIndex(desktopNotificationIndex);
 
     for (auto entry : SmileyPack::listSmileyPacks())
         bodyUI->smileyPackBrowser->addItem(entry.first, entry.second);
@@ -207,6 +232,16 @@ GeneralForm::GeneralForm(SettingsWidget *myParent) :
     connect(bodyUI->groupAlwaysNotify, &QCheckBox::stateChanged, this, &GeneralForm::onSetGroupAlwaysNotify);
     connect(bodyUI->autoacceptFiles, &QCheckBox::stateChanged, this, &GeneralForm::onAutoAcceptFileChange);
     connect(bodyUI->autoSaveFilesDir, SIGNAL(clicked()), this, SLOT(onAutoSaveDirChange()));
+    // notifications
+    connect(bodyUI->desktopNotifications, SIGNAL(currentIndexChanged(int)), this, SLOT(onSetDesktopNotifications(int)));
+    connect(bodyUI->notifyOnNewMessage, &QCheckBox::stateChanged, this, &GeneralForm::onSetNotifyNewMessage);
+    connect(bodyUI->notifyOnHighlighted, &QCheckBox::stateChanged, this, &GeneralForm::onSetNotifyHighlighted);
+    connect(bodyUI->notifyOnCallInvite, &QCheckBox::stateChanged, this, &GeneralForm::onSetNotifyCallInvite);
+    connect(bodyUI->notifyOnGroupInvite, &QCheckBox::stateChanged, this, &GeneralForm::onSetNotifyGroupInvite);
+    connect(bodyUI->notifyOnFriendRequest, &QCheckBox::stateChanged, this, &GeneralForm::onSetNotifyFriendRequest);
+    connect(bodyUI->notifyOnFileTransfer, &QCheckBox::stateChanged, this, &GeneralForm::onSetNotifyFileTransfer);
+    connect(bodyUI->notifyOnFriendOnline, &QCheckBox::stateChanged, this, &GeneralForm::onSetNotifyFriendOnline);
+    connect(bodyUI->notifyOnFriendOffline, &QCheckBox::stateChanged, this, &GeneralForm::onSetNotifyFriendOffline);
     //theme
     connect(bodyUI->useEmoticons, &QCheckBox::stateChanged, this, &GeneralForm::onUseEmoticonsChange);
     connect(bodyUI->smileyPackBrowser, SIGNAL(currentIndexChanged(int)), this, SLOT(onSmileyBrowserIndexChanged(int)));
@@ -228,26 +263,7 @@ GeneralForm::GeneralForm(SettingsWidget *myParent) :
     connect(bodyUI->cbDontGroupWindows, &QCheckBox::stateChanged, this, &GeneralForm::onDontGroupWindowsChanged);
     connect(bodyUI->cbGroupchatPosition, &QCheckBox::stateChanged, this, &GeneralForm::onGroupchatPositionChanged);
 
-    // prevent stealing mouse wheel scroll
-    // scrolling event won't be transmitted to comboboxes or qspinboxes when scrolling
-    // you can scroll through general settings without accidentially chaning theme/skin/icons etc.
-    // @see GeneralForm::eventFilter(QObject *o, QEvent *e) at the bottom of this file for more
-    for (QComboBox *cb : findChildren<QComboBox*>())
-    {
-        cb->installEventFilter(this);
-        cb->setFocusPolicy(Qt::StrongFocus);
-    }
-
-    for (QSpinBox *sp : findChildren<QSpinBox*>())
-    {
-        sp->installEventFilter(this);
-        sp->setFocusPolicy(Qt::WheelFocus);
-    }
-
-    for (QCheckBox *cb : findChildren<QCheckBox*>()) // this one is to allow scrolling on checkboxes
-    {
-        cb->installEventFilter(this);
-    }
+    installObject(this);
 
 #ifndef QTOX_PLATFORM_EXT
     bodyUI->autoAwayLabel->setEnabled(false);   // these don't seem to change the appearance of the widgets,
@@ -261,6 +277,31 @@ GeneralForm::~GeneralForm()
 {
     Translator::unregister(this);
     delete bodyUI;
+}
+
+void GeneralForm::reloadNotificationBackend()
+{
+    onSetDesktopNotifications(bodyUI->desktopNotifications->currentIndex());
+}
+
+void GeneralForm::setNotificationWidget(QWidget* widget)
+{
+    QLayoutItem* item;
+
+    while ((item = bodyUI->notificationLayout->takeAt(0)))
+    {
+        delete item->widget();
+        delete item;
+    }
+
+    if (widget)
+    {
+        bodyUI->notificationLayout->addWidget(widget);
+        installObject(widget);
+    }
+
+    bodyUI->notificationSettingsGroup->setVisible(widget != nullptr);
+    bodyUI->notificationEnableGroup->setVisible(widget != nullptr);
 }
 
 void GeneralForm::onEnableIPv6Updated()
@@ -450,6 +491,36 @@ void GeneralForm::reloadSmiles()
     bodyUI->emoticonSize->setMaximum(SmileyPack::getInstance().getAsIcon(smiles[0]).actualSize(QSize(maxSize,maxSize)).width());
 }
 
+void GeneralForm::installObject(QObject* object)
+{
+    // prevent stealing mouse whell scroll
+    // scrolling event won't be transmitted to comboboxes or qspinboxes when scrolling
+    // you can scroll through general settings without accidentially chaning theme/skin/icons etc.
+    // @see GeneralForm::eventFilter(QObject *o, QEvent *e) at the bottom of this file for more
+    for (QComboBox* cb : object->findChildren<QComboBox*>())
+    {
+        cb->installEventFilter(this);
+        cb->setFocusPolicy(Qt::StrongFocus);
+    }
+
+    for (QSpinBox* sp : object->findChildren<QSpinBox*>())
+    {
+        sp->installEventFilter(this);
+        sp->setFocusPolicy(Qt::WheelFocus);
+    }
+
+    for (QTabBar* tb : object->findChildren<QTabBar*>())
+    {
+        tb->installEventFilter(this);
+        tb->setFocusPolicy(Qt::StrongFocus);
+    }
+
+    for (QCheckBox *cb : findChildren<QCheckBox*>()) // this one is to allow scrolling on checkboxes
+    {
+        cb->installEventFilter(this);
+    }
+}
+
 void GeneralForm::onCheckUpdateChanged()
 {
     Settings::getInstance().setCheckUpdates(bodyUI->checkUpdates->isChecked());
@@ -473,6 +544,59 @@ void GeneralForm::onSetNotifySound()
 void GeneralForm::onSetGroupAlwaysNotify()
 {
     Settings::getInstance().setGroupAlwaysNotify(bodyUI->groupAlwaysNotify->isChecked());
+}
+
+void GeneralForm::onSetDesktopNotifications(int index)
+{
+    Settings::getInstance().setDesktopNotifications(index);
+    bodyUI->notificationEnableGroup->setEnabled(index != 0);
+    NotificationBackend* notificationBackend = notificationFactories[index]();
+    emit parent->desktopNotificationsToggled(notificationBackend);
+
+    if (notificationBackend)
+        setNotificationWidget(notificationBackend->settingsWidget());
+    else
+        setNotificationWidget(nullptr);
+}
+
+void GeneralForm::onSetNotifyNewMessage()
+{
+    Settings::getInstance().setNotifyOnNewMessage(bodyUI->notifyOnNewMessage->isChecked());
+}
+
+void GeneralForm::onSetNotifyHighlighted()
+{
+    Settings::getInstance().setNotifyOnHighlight(bodyUI->notifyOnHighlighted->isChecked());
+}
+
+void GeneralForm::onSetNotifyFriendRequest()
+{
+    Settings::getInstance().setNotifyOnFriendRequest(bodyUI->notifyOnFriendRequest->isChecked());
+}
+
+void GeneralForm::onSetNotifyCallInvite()
+{
+    Settings::getInstance().setNotifyOnCallInvite(bodyUI->notifyOnCallInvite->isChecked());
+}
+
+void GeneralForm::onSetNotifyGroupInvite()
+{
+    Settings::getInstance().setNotifyOnGroupInvite(bodyUI->notifyOnGroupInvite->isChecked());
+}
+
+void GeneralForm::onSetNotifyFileTransfer()
+{
+    Settings::getInstance().setNotifyOnFileTransfer(bodyUI->notifyOnFileTransfer->isChecked());
+}
+
+void GeneralForm::onSetNotifyFriendOnline()
+{
+    Settings::getInstance().setNotifyOnFriendOnline(bodyUI->notifyOnFriendOnline->isChecked());
+}
+
+void GeneralForm::onSetNotifyFriendOffline()
+{
+    Settings::getInstance().setNotifyOnFriendOffline(bodyUI->notifyOnFriendOffline->isChecked());
 }
 
 void GeneralForm::onFauxOfflineMessaging()
@@ -515,7 +639,7 @@ void GeneralForm::onThemeColorChanged(int)
 bool GeneralForm::eventFilter(QObject *o, QEvent *e)
 {
     if ((e->type() == QEvent::Wheel) &&
-         (qobject_cast<QComboBox*>(o) || qobject_cast<QAbstractSpinBox*>(o) || qobject_cast<QCheckBox*>(o)))
+         (qobject_cast<QComboBox*>(o) || qobject_cast<QAbstractSpinBox*>(o) || qobject_cast<QTabBar*>(o) || qobject_cast<QCheckBox*>(o)))
     {
         e->ignore();
         return true;

--- a/src/widget/form/settings/generalform.h
+++ b/src/widget/form/settings/generalform.h
@@ -27,6 +27,9 @@ class GeneralSettings;
 }
 
 class SettingsWidget;
+class NotificationBackend;
+
+typedef NotificationBackend* (*NotificationFactory)();
 
 class GeneralForm : public GenericForm
 {
@@ -35,6 +38,7 @@ public:
     GeneralForm(SettingsWidget *parent);
     ~GeneralForm();
     virtual QString getFormName() final override {return tr("General");}
+    void reloadNotificationBackend();
 
 private slots:
     void onEnableIPv6Updated();
@@ -65,6 +69,15 @@ private slots:
     void onSetShowInFront();
     void onSetNotifySound();
     void onSetGroupAlwaysNotify();
+    void onSetDesktopNotifications(int index);
+    void onSetNotifyNewMessage();
+    void onSetNotifyHighlighted();
+    void onSetNotifyFriendRequest();
+    void onSetNotifyCallInvite();
+    void onSetNotifyGroupInvite();
+    void onSetNotifyFileTransfer();
+    void onSetNotifyFriendOnline();
+    void onSetNotifyFriendOffline();
     void onFauxOfflineMessaging();
     void onCompactLayout();
     void onSeparateWindowChanged();
@@ -76,9 +89,13 @@ private:
     void retranslateUi();
 
 private:
+    void setNotificationWidget(QWidget* widget);
+
     Ui::GeneralSettings *bodyUI;
     void reloadSmiles();
+    void installObject(QObject* object);
     SettingsWidget *parent;
+    QVector<NotificationFactory> notificationFactories;
 
 protected:
     bool eventFilter(QObject *o, QEvent *e) final override;

--- a/src/widget/form/settings/generalsettings.ui
+++ b/src/widget/form/settings/generalsettings.ui
@@ -29,12 +29,12 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>0</y>
-        <width>631</width>
-        <height>1141</height>
+        <y>-328</y>
+        <width>639</width>
+        <height>1826</height>
        </rect>
       </property>
-      <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,0,0,1">
+      <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,0,0,0,1">
        <property name="spacing">
         <number>32</number>
        </property>
@@ -431,6 +431,109 @@ will be sent to them when they appear online to you.</string>
              </layout>
             </item>
            </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="notificationGroup">
+         <property name="title">
+          <string>Notifications</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_5_1">
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_5_1">
+            <item>
+             <widget class="QLabel" name="desktopNotificationLabel">
+              <property name="text">
+               <string>Deskop notification backend:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="desktopNotifications">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="notificationEnableGroup">
+            <property name="title">
+             <string>Notify on...</string>
+            </property>
+            <layout class="QGridLayout" name="gridLayout">
+             <item row="1" column="1">
+              <widget class="QCheckBox" name="notifyOnGroupInvite">
+               <property name="text">
+                <string>Group invite</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="0">
+              <widget class="QCheckBox" name="notifyOnNewMessage">
+               <property name="text">
+                <string>New message</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="0">
+              <widget class="QCheckBox" name="notifyOnCallInvite">
+               <property name="text">
+                <string>Call invite</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QCheckBox" name="notifyOnHighlighted">
+               <property name="text">
+                <string>Highlighted</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="1">
+              <widget class="QCheckBox" name="notifyOnFileTransfer">
+               <property name="text">
+                <string>File transfer completed</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QCheckBox" name="notifyOnFriendRequest">
+               <property name="text">
+                <string>Friend request</string>
+               </property>
+              </widget>
+             </item>
+             <item row="4" column="0">
+              <widget class="QCheckBox" name="notifyOnFriendOnline">
+               <property name="text">
+                <string>Friend Online</string>
+               </property>
+              </widget>
+             </item>
+             <item row="4" column="1">
+              <widget class="QCheckBox" name="notifyOnFriendOffline">
+               <property name="text">
+                <string>Friend Offline</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="notificationSettingsGroup">
+            <property name="title">
+             <string>Backend Settings</string>
+            </property>
+            <layout class="QVBoxLayout" name="notificationLayout"/>
+           </widget>
           </item>
          </layout>
         </widget>

--- a/src/widget/form/settingswidget.cpp
+++ b/src/widget/form/settingswidget.cpp
@@ -57,7 +57,7 @@ SettingsWidget::SettingsWidget(QWidget* parent)
 
     bodyLayout->addWidget(settingsWidgets);
 
-    GeneralForm* gfrm = new GeneralForm(this);
+    gfrm = new GeneralForm(this);
     PrivacyForm* pfrm = new PrivacyForm;
     AVForm* avfrm = new AVForm;
     AdvancedForm *expfrm = new AdvancedForm;
@@ -86,6 +86,11 @@ void SettingsWidget::setBodyHeadStyle(QString style)
 void SettingsWidget::showAbout()
 {
     onTabChanged(settingsWidgets->count() - 1);
+}
+
+void SettingsWidget::reloadNotificationBackend()
+{
+    gfrm->reloadNotificationBackend();
 }
 
 bool SettingsWidget::isShown() const

--- a/src/widget/form/settingswidget.h
+++ b/src/widget/form/settingswidget.h
@@ -32,6 +32,7 @@ class PrivacyForm;
 class AVForm;
 class QLabel;
 class QTabWidget;
+class NotificationBackend;
 class ContentLayout;
 
 class SettingsWidget : public QWidget
@@ -44,6 +45,7 @@ public:
     bool isShown() const;
     void show(ContentLayout* contentLayout);
     void setBodyHeadStyle(QString style);
+    void reloadNotificationBackend();
 
     void showAbout();
 
@@ -52,6 +54,7 @@ signals:
     void compactToggled(bool compact);
     void separateWindowToggled(bool separateWindow);
     void groupchatPositionToggled(bool groupchatPosition);
+    void desktopNotificationsToggled(NotificationBackend* notificationBackend);
 
 private slots:
     void onTabChanged(int);
@@ -64,6 +67,7 @@ private:
     QTabWidget *settingsWidgets;
     QLabel *nameLabel, *imgLabel;
     std::array<GenericForm*, 5> cfgForms;
+    GeneralForm* gfrm;
     int currentIndex;
 };
 

--- a/src/widget/genericchatroomwidget.cpp
+++ b/src/widget/genericchatroomwidget.cpp
@@ -147,6 +147,11 @@ QString GenericChatroomWidget::getStatusMsg() const
     return statusMessageLabel->text();
 }
 
+QPixmap GenericChatroomWidget::getAvatar() const
+{
+    return avatar->getPixmap();
+}
+
 QString GenericChatroomWidget::getTitle() const
 {
     QString title = getName();

--- a/src/widget/genericchatroomwidget.h
+++ b/src/widget/genericchatroomwidget.h
@@ -54,6 +54,7 @@ public:
     void setName(const QString& name);
     void setStatusMsg(const QString& status);
     QString getStatusMsg() const;
+    QPixmap getAvatar() const;
     QString getTitle() const;
 
 	void reloadTheme();

--- a/src/widget/notificationbackend.cpp
+++ b/src/widget/notificationbackend.cpp
@@ -1,0 +1,24 @@
+/*
+    Copyright © 2015 by The qTox Project
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "notificationbackend.h"
+
+NotificationBackend::NotificationBackend(QObject* parent)
+    : QObject(parent)
+{}

--- a/src/widget/notificationbackend.h
+++ b/src/widget/notificationbackend.h
@@ -1,0 +1,51 @@
+/*
+    Copyright © 2015 by The qTox Project
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef NOTIFICATIONBACKEND_H
+#define NOTIFICATIONBACKEND_H
+
+#include <QObject>
+
+class GenericChatroomWidget;
+
+class NotificationBackend : public QObject
+{
+    Q_OBJECT
+public:
+    enum Type
+    {
+        NewMessage = 0x1,
+        Highlighted = 0x2,
+        FileTransferFinished = 0x4,
+        FriendRequest = 0x8,
+        AVCallInvite = 0x10,
+        GroupInvite = 0x20,
+        FriendOnline = 0x40,
+        FriendOffline = 0x80
+    };
+
+    NotificationBackend(QObject* parent = 0);
+    virtual void notify(Type type, GenericChatroomWidget* chat, const QString& title, const QString& message, const QPixmap &icon) = 0;
+    virtual QWidget* settingsWidget() = 0;
+
+signals:
+    void activated(GenericChatroomWidget* chat);
+};
+
+#endif // NOTIFICATIONBACKEND_H

--- a/src/widget/snorenotificationbackend.cpp
+++ b/src/widget/snorenotificationbackend.cpp
@@ -1,0 +1,137 @@
+/*
+    Copyright © 2015 by The qTox Project
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "snorenotificationbackend.h"
+#include "systemtrayicon.h"
+#include "widget.h"
+#include <QApplication>
+#include <QPushButton>
+#include <QBoxLayout>
+#include <QPointer>
+#include <QSystemTrayIcon>
+#include <libsnore/settingsdialog.h>
+
+SnoreNotificationBackend::SnoreNotificationBackend(QObject *parent)
+    : NotificationBackend(parent)
+{
+    Snore::Icon icon(QIcon("://img/icons/qtox.svg").pixmap(48, 48).toImage());
+    snoreApp = Snore::Application(QApplication::applicationName(), icon);
+    snoreApp.addAlert(Snore::Alert(typeToString(NewMessage), icon));
+    snoreApp.addAlert(Snore::Alert(typeToString(Highlighted), icon));
+    snoreApp.addAlert(Snore::Alert(typeToString(FileTransferFinished), icon));
+    snoreApp.addAlert(Snore::Alert(typeToString(FriendRequest), icon));
+    snoreApp.addAlert(Snore::Alert(typeToString(AVCallInvite), icon));
+
+    snoreApp.hints().setValue("windows-app-id", "ToxFoundation.qTox");
+    snoreApp.hints().setValue("desktop-entry", QApplication::applicationName());
+
+    SystemTrayIcon* qtoxTray = Widget::getInstance()->getSystemTrayIcon();
+
+    if (qtoxTray)
+    {
+        QSystemTrayIcon* trayIcon = qtoxTray->getSystemTrayIcon();
+
+        if (trayIcon)
+            snoreApp.hints().setValue("tray-icon", QVariant::fromValue(QPointer<QSystemTrayIcon>(trayIcon)));
+    }
+
+    if (Snore::SnoreCore::instance().pluginNames().isEmpty())
+        Snore::SnoreCore::instance().loadPlugins(Snore::SnorePlugin::BACKEND);
+
+    Snore::SnoreCore::instance().registerApplication(snoreApp);
+    Snore::SnoreCore::instance().setDefaultApplication(snoreApp);
+}
+
+SnoreNotificationBackend::~SnoreNotificationBackend()
+{
+    Snore::SnoreCore::instance().deregisterApplication(snoreApp);
+}
+
+void SnoreNotificationBackend::notify(Type type, GenericChatroomWidget *chat, const QString &title, const QString &message, const QPixmap &icon)
+{
+    Snore::Icon snoreIcon(icon.toImage());
+    Snore::Notification notification(snoreApp, snoreApp.alerts()[typeToString(type)], title, message, snoreIcon);
+    connect(&Snore::SnoreCore::instance(), &Snore::SnoreCore::actionInvoked, this, &SnoreNotificationBackend::notificationInvoked);
+    connect(&Snore::SnoreCore::instance(), &Snore::SnoreCore::notificationClosed, this, &SnoreNotificationBackend::notificationClose);
+
+    Snore::SnoreCore::instance().broadcastNotification(notification);
+
+    if (chat != nullptr)
+        chatList.insert(notification.id(), chat);
+}
+
+QWidget* SnoreNotificationBackend::settingsWidget()
+{
+    QWidget* settings = new QWidget();
+    QVBoxLayout* layout = new QVBoxLayout(settings);
+    Snore::SettingsDialog* dialog = new Snore::SettingsDialog(settings);
+    dialog->layout()->setMargin(0);
+    QPushButton* apply = new QPushButton(tr("Apply"), settings);
+
+    connect(apply, &QPushButton::clicked, [dialog]()
+    {
+        dialog->accept();
+    });
+
+    layout->addWidget(dialog);
+
+    QHBoxLayout* hlayout = new QHBoxLayout();
+    hlayout->addStretch(1);
+    hlayout->addWidget(apply);
+    layout->addLayout(hlayout);
+
+    return settings;
+}
+
+void SnoreNotificationBackend::setOptions(const QString& option)
+{
+    Snore::SnoreCore::instance().setPrimaryNotificationBackend(option);
+}
+
+void SnoreNotificationBackend::notificationInvoked(Snore::Notification notification)
+{
+    QHash<uint, GenericChatroomWidget*>::iterator chat = chatList.find(notification.id());
+
+    if (chat != chatList.end())
+        emit activated(chatList[notification.id()]);
+}
+
+void SnoreNotificationBackend::notificationClose(Snore::Notification notification)
+{
+    chatList.remove(notification.id());
+}
+
+QString SnoreNotificationBackend::typeToString(Type type)
+{
+    switch (type)
+    {
+        case NewMessage:
+            return QStringLiteral("New Message");
+        case Highlighted:
+            return QStringLiteral("Highlighted");
+        case FileTransferFinished:
+            return QStringLiteral("File Transfer Finished");
+        case FriendRequest:
+            return QStringLiteral("Friend Request");
+        case AVCallInvite:
+            return QStringLiteral("AV Call");
+        default:
+            return QString();
+    }
+}

--- a/src/widget/snorenotificationbackend.cpp
+++ b/src/widget/snorenotificationbackend.cpp
@@ -30,7 +30,7 @@
 SnoreNotificationBackend::SnoreNotificationBackend(QObject *parent)
     : NotificationBackend(parent)
 {
-    Snore::Icon icon(QIcon("://img/icons/qtox.svg").pixmap(48, 48).toImage());
+    Snore::Icon icon(QIcon("://img/icons/qtox.svg").pixmap(48, 48));
     snoreApp = Snore::Application(QApplication::applicationName(), icon);
     snoreApp.addAlert(Snore::Alert(typeToString(NewMessage), icon));
     snoreApp.addAlert(Snore::Alert(typeToString(Highlighted), icon));
@@ -65,7 +65,7 @@ SnoreNotificationBackend::~SnoreNotificationBackend()
 
 void SnoreNotificationBackend::notify(Type type, GenericChatroomWidget *chat, const QString &title, const QString &message, const QPixmap &icon)
 {
-    Snore::Icon snoreIcon(icon.toImage());
+    Snore::Icon snoreIcon(icon);
     Snore::Notification notification(snoreApp, snoreApp.alerts()[typeToString(type)], title, message, snoreIcon);
     connect(&Snore::SnoreCore::instance(), &Snore::SnoreCore::actionInvoked, this, &SnoreNotificationBackend::notificationInvoked);
     connect(&Snore::SnoreCore::instance(), &Snore::SnoreCore::notificationClosed, this, &SnoreNotificationBackend::notificationClose);

--- a/src/widget/snorenotificationbackend.cpp
+++ b/src/widget/snorenotificationbackend.cpp
@@ -25,7 +25,7 @@
 #include <QBoxLayout>
 #include <QPointer>
 #include <QSystemTrayIcon>
-#include <libsnore/settingsdialog.h>
+#include <libsnore/settings/settingsdialog.h>
 
 SnoreNotificationBackend::SnoreNotificationBackend(QObject *parent)
     : NotificationBackend(parent)
@@ -52,7 +52,7 @@ SnoreNotificationBackend::SnoreNotificationBackend(QObject *parent)
     }
 
     if (Snore::SnoreCore::instance().pluginNames().isEmpty())
-        Snore::SnoreCore::instance().loadPlugins(Snore::SnorePlugin::BACKEND);
+        Snore::SnoreCore::instance().loadPlugins(Snore::SnorePlugin::Backend);
 
     Snore::SnoreCore::instance().registerApplication(snoreApp);
     Snore::SnoreCore::instance().setDefaultApplication(snoreApp);

--- a/src/widget/snorenotificationbackend.h
+++ b/src/widget/snorenotificationbackend.h
@@ -1,0 +1,47 @@
+/*
+    Copyright © 2015 by The qTox Project
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef SNORENOTIFICATIONBACKEND_H
+#define SNORENOTIFICATIONBACKEND_H
+
+#include "notificationbackend.h"
+#include <libsnore/snore.h>
+
+class SnoreNotificationBackend : public NotificationBackend
+{
+    Q_OBJECT
+public:
+    SnoreNotificationBackend(QObject* parent = 0);
+    ~SnoreNotificationBackend();
+    virtual void notify(Type type, GenericChatroomWidget* chat, const QString& title, const QString& message, const QPixmap &icon) final override;
+    virtual QWidget* settingsWidget() final override;
+
+private slots:
+    void setOptions(const QString& option);
+    void notificationInvoked(Snore::Notification notification);
+    void notificationClose(Snore::Notification notification);
+
+private:
+    QString typeToString(Type type);
+
+    Snore::Application snoreApp;
+    QHash<uint, GenericChatroomWidget*> chatList;
+};
+
+#endif // SNORENOTIFICATIONBACKEND_H

--- a/src/widget/systemtrayicon.cpp
+++ b/src/widget/systemtrayicon.cpp
@@ -27,6 +27,7 @@
 #include "src/persistence/settings.h"
 
 SystemTrayIcon::SystemTrayIcon()
+    : qtIcon(nullptr)
 {
     QString desktop = getenv("XDG_CURRENT_DESKTOP");
     if (desktop.isEmpty())
@@ -393,4 +394,12 @@ void SystemTrayIcon::setIcon(QIcon &icon)
     {
         qtIcon->setIcon(icon);
     }
+}
+
+QSystemTrayIcon* SystemTrayIcon::getSystemTrayIcon() const
+{
+    if (backendType == SystrayBackendType::Qt)
+        return qtIcon;
+
+    return nullptr;
 }

--- a/src/widget/systemtrayicon.h
+++ b/src/widget/systemtrayicon.h
@@ -38,6 +38,7 @@ public:
     void hide();
     void setVisible(bool);
     void setIcon(QIcon &icon);
+    QSystemTrayIcon* getSystemTrayIcon() const;
 
 signals:
     void activated(QSystemTrayIcon::ActivationReason);

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -2091,7 +2091,13 @@ void Widget::onDesktopNotificationsToggled(NotificationBackend* notificationBack
     notification = notificationBackend;
 
     if (notification)
-        connect(notification, SIGNAL(activated(GenericChatroomWidget*)), this, SLOT(onChatroomWidgetClicked(GenericChatroomWidget*)));
+    {
+        connect(notification, &NotificationBackend::activated,
+                this, [this](GenericChatroomWidget* chatRoom)
+                        {
+                            this->onChatroomWidgetClicked(chatRoom, false);
+                        });
+    }
 }
 
 void Widget::notifyAvInvite(int friendId)

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1278,7 +1278,6 @@ void Widget::onFriendRequestReceived(const QString& userId, const QString& messa
 {
     if (notification && Settings::getInstance().getNotifyOnFriendRequest())
     {
-        Friend* f = FriendList::findFriend(userId);
         notification->notify(NotificationBackend::FriendRequest, nullptr, tr("Friend Request from %1 Recieved").arg(userId), message, QPixmap());
     }
 
@@ -2092,7 +2091,7 @@ void Widget::onDesktopNotificationsToggled(NotificationBackend* notificationBack
     notification = notificationBackend;
 
     if (notification)
-        connect(notification, &NotificationBackend::activated, this, &Widget::onChatroomWidgetClicked);
+        connect(notification, SIGNAL(activated(GenericChatroomWidget*)), this, SLOT(onChatroomWidgetClicked(GenericChatroomWidget*)));
 }
 
 void Widget::notifyAvInvite(int friendId)

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -25,6 +25,7 @@
 #include <QFileInfo>
 #include "src/core/corestructs.h"
 #include "genericchatitemwidget.h"
+#include "notificationbackend.h"
 
 #define PIXELS_TO_ACT 7
 
@@ -64,6 +65,7 @@ public:
     void setCentralWidget(QWidget *widget, const QString &widgetName);
     QString getUsername();
     Camera* getCamera();
+    SystemTrayIcon* getSystemTrayIcon() const;
     static Widget* getInstance();
     void showUpdateDownloadProgress(); ///< Switches to the About settings page
     void addFriendDialog(Friend* frnd, ContentDialog* dialog);
@@ -181,6 +183,9 @@ private slots:
     void onSplitterMoved(int pos, int index);
     void processOfflineMsgs();
     void friendListContextMenu(const QPoint &pos);
+    void onDesktopNotificationsToggled(NotificationBackend *notificationBackend);
+    void notifyAvInvite(int friendId);
+    void notifyFileTransferFinished(ToxFile file);
 
 private:
     int icon_size;
@@ -276,6 +281,8 @@ private:
     QAction* nextConversationAction;
     QAction* previousConversationAction;
 #endif
+
+    NotificationBackend* notification = nullptr;
 };
 
 bool toxActivateEventHandler(const QByteArray& data);


### PR DESCRIPTION
This is the same as PR #2082, but rebased to latest master branch with appropriate adaptations. Original commits by @TheSpiritXIII are squashed to ease reviewing, as there's a lot of intermediate work that got redone later. But a split into two commits
1. Adding notification framework and GUI settings
2. Adding snorenotify backend
can be considered. As well as adding simple backends not relying on snorenotify.

I wish to avoid the same bikeshed that plagued the original PR. Notification popups is a very useful, if not to say critical, functionality, that in my opinion should've been introduced much earlier. Let's focus on critical bugs and regressions. Feature requests like "a separate option for group notifications" and non-critical bugs like "notifications not always/for everything shown" can be addressed later, and should not obstruct merging this PR, as seeing the previous attempt I'm quite unenthusiastic about promoting it as it is.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tux3/qtox/2771)

<!-- Reviewable:end -->
