### PR TITLE
fix audio device initialization

### DIFF
--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -396,9 +396,10 @@ bool AudioPrivate::initInput(QString inDevDescr)
 {
     qDebug() << "Opening audio input" << inDevDescr;
 
-    inputInitialized = false;
-    if (inDevDescr == "none")
-        return true;
+    if (inDevDescr == "none") {
+        qWarning("No audio input device selected.");
+        return false;
+    }
 
     assert(!alInDev);
 
@@ -441,9 +442,10 @@ bool AudioPrivate::initOutput(QString outDevDescr)
     qDebug() << "Opening audio output" << outDevDescr;
     outSources.clear();
 
-    outputInitialized = false;
-    if (outDevDescr == "none")
-        return true;
+    if (outDevDescr == "none") {
+        qWarning("No audio output device selected.");
+        return false;
+    }
 
     assert(!alOutDev);
 

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -160,8 +160,6 @@ public:
         , alContext(nullptr)
         , inputVolume(1.f)
         , outputVolume(1.f)
-        , inputInitialized(false)
-        , outputInitialized(false)
         , inSubscriptions(0)
     {
         audioThread->setObjectName("qTox Audio");
@@ -194,8 +192,6 @@ public:
     ALuint              alMainSource;
     qreal               inputVolume;
     qreal               outputVolume;
-    bool                inputInitialized;
-    bool                outputInitialized;
 
     quint32             inSubscriptions;
     ALSources           outSources;
@@ -428,7 +424,6 @@ bool AudioPrivate::initInput(QString inDevDescr)
         return false;
     }
 
-    inputInitialized = true;
     return true;
 }
 
@@ -478,7 +473,6 @@ bool AudioPrivate::initOutput(QString outDevDescr)
         if (core)
             core->getAv()->invalidateCallSources(); // Force to regen each group call's sources
 
-        outputInitialized = true;
         return true;
     }
 
@@ -573,7 +567,7 @@ void Audio::playAudioBuffer(quint32 alSource, const int16_t *data, int samples, 
     assert(channels == 1 || channels == 2);
     QMutexLocker locker(&d->audioLock);
 
-    if (!(d->alOutDev && d->outputInitialized))
+    if (!d->alOutDev)
         return;
 
     ALuint bufid;
@@ -616,8 +610,6 @@ Close active audio input device.
 */
 void AudioPrivate::cleanupInput()
 {
-    inputInitialized = false;
-
     if (alInDev)
     {
 #if (!FIX_SND_PCM_PREPARE_BUG)
@@ -640,8 +632,6 @@ Close active audio output device
 */
 void AudioPrivate::cleanupOutput()
 {
-    outputInitialized = false;
-
     if (alOutDev) {
         qDebug() << "Closing audio output";
         alSourcei(alMainSource, AL_LOOPING, AL_FALSE);
@@ -667,7 +657,7 @@ Returns true if the input device is open and suscribed to
 bool Audio::isInputReady()
 {
     QMutexLocker locker(&d->audioLock);
-    return d->alInDev && d->inputInitialized;
+    return d->alInDev;
 }
 
 /**
@@ -676,7 +666,7 @@ Returns true if the output device is open
 bool Audio::isOutputReady()
 {
     QMutexLocker locker(&d->audioLock);
-    return d->alOutDev && d->outputInitialized;
+    return d->alOutDev;
 }
 
 const char* Audio::outDeviceNames()
@@ -756,7 +746,7 @@ bool Audio::tryCaptureSamples(int16_t* buf, int samples)
 {
     QMutexLocker lock(&d->audioLock);
 
-    if (!(d->alInDev && d->inputInitialized))
+    if (!d->alInDev)
         return false;
 
     ALint curSamples = 0;

--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -640,11 +640,13 @@ void CoreAV::audioFrameCallback(ToxAV *, uint32_t friendNum, const int16_t *pcm,
         return;
 
     Audio& audio = Audio::getInstance();
-    if (!call.alSource)
-        audio.subscribeOutput(call.alSource);
+    if (audio.isOutputReady()) {
+        if (!call.alSource)
+            audio.subscribeOutput(call.alSource);
 
-    if (call.alSource)
-        audio.playAudioBuffer(call.alSource, pcm, sampleCount, channels, samplingRate);
+        if (call.alSource)
+            audio.playAudioBuffer(call.alSource, pcm, sampleCount, channels, samplingRate);
+    }
 }
 
 void CoreAV::videoFrameCallback(ToxAV *, uint32_t friendNum, uint16_t w, uint16_t h,

--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -253,7 +253,8 @@ bool CoreAV::sendCallAudio(uint32_t callId)
     }
 
     int16_t buf[AUDIO_FRAME_SAMPLE_COUNT * AUDIO_CHANNELS] = {0};
-    if (Audio::getInstance().tryCaptureSamples(buf, AUDIO_FRAME_SAMPLE_COUNT))
+    Audio& audio = Audio::getInstance();
+    if (audio.isInputReady() && audio.tryCaptureSamples(buf, AUDIO_FRAME_SAMPLE_COUNT))
     {
 #ifdef QTOX_FILTER_AUDIO
         if (Settings::getInstance().getFilterAudio())
@@ -266,7 +267,7 @@ bool CoreAV::sendCallAudio(uint32_t callId)
 
 #ifdef ALC_LOOPBACK_CAPTURE_SAMPLES
             // compatibility with older versions of OpenAL
-            Audio::getInstance().getEchoesToFilter(call.filterer, AUDIO_FRAME_SAMPLE_COUNT * AUDIO_CHANNELS);
+            audio.getEchoesToFilter(call.filterer, AUDIO_FRAME_SAMPLE_COUNT * AUDIO_CHANNELS);
 #endif
             call.filterer->filterAudio(buf, AUDIO_FRAME_SAMPLE_COUNT * AUDIO_CHANNELS);
         }
@@ -642,7 +643,8 @@ void CoreAV::audioFrameCallback(ToxAV *, uint32_t friendNum, const int16_t *pcm,
     if (!call.alSource)
         audio.subscribeOutput(call.alSource);
 
-    audio.playAudioBuffer(call.alSource, pcm, sampleCount, channels, samplingRate);
+    if (call.alSource)
+        audio.playAudioBuffer(call.alSource, pcm, sampleCount, channels, samplingRate);
 }
 
 void CoreAV::videoFrameCallback(ToxAV *, uint32_t friendNum, uint16_t w, uint16_t h,


### PR DESCRIPTION
If no audio device is selected (specifier == "none"), the initalization routines falsely reported, that initialization was successful.

Closes #2727

@ovalseven8 @zetok Please verify this works.
