### PR TITLE
Login window: hide `Load automatically` if profile is encrypted

### DIFF
--- a/src/widget/loginscreen.cpp
+++ b/src/widget/loginscreen.cpp
@@ -172,11 +172,18 @@ void LoginScreen::onLoginUsernameSelected(const QString &name)
     {
         ui->loginPasswordLabel->show();
         ui->loginPassword->show();
+        // there is no way to do autologin if profile is encrypted, and
+        // visible option confuses users into thinking that it is possible,
+        // thus disable it (and hope that users won't think that it's a bug)
+        ui->autoLoginCB->setEnabled(false);
+        ui->autoLoginCB->setToolTip(tr("Password protected profile can't be loaded automatically."));
     }
     else
     {
         ui->loginPasswordLabel->hide();
         ui->loginPassword->hide();
+        ui->autoLoginCB->setEnabled(true);
+        ui->autoLoginCB->setToolTip("");
     }
 }
 


### PR DESCRIPTION
E.g. see #2817 

Before:
![before](https://cloud.githubusercontent.com/assets/3148759/12390062/e54bc878-bdd4-11e5-99ff-94c5e2937961.png)
now:
![now - no button](https://cloud.githubusercontent.com/assets/3148759/12390017/8d80a028-bdd4-11e5-905b-18eddc655a11.png)
