### PR TITLE
Fix for #2522

### DIFF
--- a/src/persistence/offlinemsgengine.cpp
+++ b/src/persistence/offlinemsgengine.cpp
@@ -83,6 +83,7 @@ void OfflineMsgEngine::deliverOfflineMsgs()
 
     QMap<int64_t, MsgPtr> msgs = undeliveredMsgs;
     removeAllReciepts();
+    undeliveredMsgs.clear();
 
     for (auto iter = msgs.begin(); iter != msgs.end(); ++iter)
     {
@@ -110,5 +111,4 @@ void OfflineMsgEngine::removeAllReciepts()
     QMutexLocker ml(&mutex);
 
     receipts.clear();
-    undeliveredMsgs.clear();
 }

--- a/src/persistence/offlinemsgengine.cpp
+++ b/src/persistence/offlinemsgengine.cpp
@@ -82,7 +82,7 @@ void OfflineMsgEngine::deliverOfflineMsgs()
         return;
 
     QMap<int64_t, MsgPtr> msgs = undeliveredMsgs;
-    removeAllReciepts();
+    removeAllReceipts();
     undeliveredMsgs.clear();
 
     for (auto iter = msgs.begin(); iter != msgs.end(); ++iter)
@@ -106,7 +106,7 @@ void OfflineMsgEngine::deliverOfflineMsgs()
     }
 }
 
-void OfflineMsgEngine::removeAllReciepts()
+void OfflineMsgEngine::removeAllReceipts()
 {
     QMutexLocker ml(&mutex);
 

--- a/src/persistence/offlinemsgengine.h
+++ b/src/persistence/offlinemsgengine.h
@@ -43,7 +43,7 @@ public:
 
 public slots:
     void deliverOfflineMsgs();
-    void removeAllReciepts();
+    void removeAllReceipts();
 
 private:
     struct MsgPtr {

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -110,7 +110,7 @@ ChatForm::ChatForm(Friend* chatFriend)
     connect(msgEdit, &ChatTextEdit::enterPressed, this, &ChatForm::onSendTriggered);
     connect(msgEdit, &ChatTextEdit::textChanged, this, &ChatForm::onTextEditChanged);
     connect(core, &Core::fileSendFailed, this, &ChatForm::onFileSendFailed);
-    connect(this, &ChatForm::chatAreaCleared, getOfflineMsgEngine(), &OfflineMsgEngine::removeAllReciepts);
+    connect(this, &ChatForm::chatAreaCleared, getOfflineMsgEngine(), &OfflineMsgEngine::removeAllReceipts);
     connect(&typingTimer, &QTimer::timeout, this, [=]{
         Core::getInstance()->sendTyping(f->getFriendID(), false);
         isTyping = false;

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1848,7 +1848,7 @@ void Widget::clearAllReceipts()
 {
     QList<Friend*> frnds = FriendList::getAllFriends();
     for (Friend *f : frnds)
-        f->getChatForm()->getOfflineMsgEngine()->removeAllReciepts();
+        f->getChatForm()->getOfflineMsgEngine()->removeAllReceipts();
 }
 
 void Widget::reloadTheme()


### PR DESCRIPTION
qTox was emptying undelivered messages list along with sent messages when clearing the chat window.
Now undelivered messages are not removed and will be sent as soon as recipient gets online.
- changed Reciepts -> Receipts
