### PR TITLE
Fix #2774

### DIFF
--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -563,6 +563,8 @@ void Audio::playGroupAudio(int group, int peer, const int16_t* data,
 
     emit groupAudioPlayed(group, peer, volume / bufsize);
 
+    locker.unlock();
+
     playAudioBuffer(call.alSource, data, samples, channels, sample_rate);
 }
 


### PR DESCRIPTION
Fixup for issue #2522: Client freezes after attempt to start group audio

Mutex in Audio::playAudioBuffer(..) can't be locked because it is still locked in Audio::playGroupAudio(..) function.
