### PR TITLE
Fix label text colour in login profile

### DIFF
--- a/src/loginscreen.ui
+++ b/src/loginscreen.ui
@@ -279,7 +279,7 @@
           </spacer>
          </item>
          <item>
-          <widget class="QLabel" name="label_3">
+          <widget class="QLabel" name="userNameLabel">
            <property name="text">
             <string>Username:</string>
            </property>

--- a/src/loginscreen.ui
+++ b/src/loginscreen.ui
@@ -42,7 +42,7 @@
     <bool>true</bool>
    </property>
    <property name="currentIndex">
-    <number>1</number>
+    <number>0</number>
    </property>
    <widget class="QWidget" name="newPage">
     <layout class="QHBoxLayout" name="horizontalLayout_5">

--- a/src/nexus.cpp
+++ b/src/nexus.cpp
@@ -25,7 +25,6 @@
 #include "persistence/settings.h"
 #include "video/camerasource.h"
 #include "widget/gui.h"
-#include "widget/style.h"
 #include "widget/loginscreen.h"
 #include <QThread>
 #include <QDebug>
@@ -98,7 +97,6 @@ void Nexus::start()
     qRegisterMetaType<std::shared_ptr<VideoFrame>>("std::shared_ptr<VideoFrame>");
 
     loginScreen = new LoginScreen();
-    loginScreen->setStyleSheet(Style::getStylesheet(":/ui/loginScreen/loginScreen.css"));
 
 #ifdef Q_OS_MAC
     globalMenuBar = new QMenuBar(0);

--- a/src/widget/loginscreen.cpp
+++ b/src/widget/loginscreen.cpp
@@ -26,6 +26,7 @@
 #include "src/persistence/settings.h"
 #include "src/widget/form/setpassworddialog.h"
 #include "src/widget/translator.h"
+#include "src/widget/style.h"
 #include <QMessageBox>
 #include <QDebug>
 
@@ -55,6 +56,8 @@ LoginScreen::LoginScreen(QWidget *parent) :
     connect(ui->autoLoginCB, &QCheckBox::stateChanged, this, &LoginScreen::onAutoLoginToggled);
 
     reset();
+    this->setStyleSheet(Style::getStylesheet(":/ui/loginScreen/loginScreen.css"));
+
     retranslateUi();
     Translator::registerHandler(std::bind(&LoginScreen::retranslateUi, this), this);
 }

--- a/ui/loginScreen/loginScreen.css
+++ b/ui/loginScreen/loginScreen.css
@@ -47,6 +47,6 @@ QStackedWidget QPushButton
   background: #0c530d;
 }
 
-QLabel, QCheckBox {
+QLabel, QCheckBox, QProgressBar {
   color: black;
 }

--- a/ui/loginScreen/loginScreen.css
+++ b/ui/loginScreen/loginScreen.css
@@ -46,3 +46,7 @@ QStackedWidget QPushButton
 #createAccountButton:hover {
   background: #0c530d;
 }
+
+QLabel {
+  color: black;
+}

--- a/ui/loginScreen/loginScreen.css
+++ b/ui/loginScreen/loginScreen.css
@@ -47,6 +47,6 @@ QStackedWidget QPushButton
   background: #0c530d;
 }
 
-QLabel {
+QLabel, QCheckBox {
   color: black;
 }

--- a/ui/loginScreen/loginScreen.css
+++ b/ui/loginScreen/loginScreen.css
@@ -50,3 +50,7 @@ QStackedWidget QPushButton
 QLabel, QCheckBox, QProgressBar {
   color: black;
 }
+
+QCheckBox::disabled {
+  color: gray;
+}


### PR DESCRIPTION
Before labels password and username were not visible for me
because colour (dark grey) for those label was inherited from OS
which has dark theme, and background of the label was light grey.
