### PR TITLE
additions to `audio-next` branch

### DIFF
--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -55,6 +55,10 @@ Audio::Audio()
     , alMainBuffer(0)
     , outputInitialized(false)
 {
+    // initialize OpenAL error stack
+    alGetError();
+    alcGetError(nullptr);
+
     audioThread->setObjectName("qTox Audio");
     QObject::connect(audioThread, &QThread::finished, audioThread, &QThread::deleteLater);
 

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -297,10 +297,6 @@ bool Audio::initOutput(QString outDevDescr)
     }
 
     alGenSources(1, &alMainSource); checkAlError();
-    alSourcef(alMainSource, AL_GAIN, 1.f); checkAlError();
-    alSourcef(alMainSource, AL_PITCH, 1.f); checkAlError();
-    alSource3f(alMainSource, AL_VELOCITY, 0.f, 0.f, 0.f); checkAlError();
-    alSource3f(alMainSource, AL_POSITION, 0.f, 0.f, 0.f); checkAlError();
 
     // init master volume
     alListenerf(AL_GAIN, Settings::getInstance().getOutVolume() * 0.01f);
@@ -556,12 +552,6 @@ void Audio::subscribeOutput(ALuint& sid)
     alGenSources(1, &sid);
     assert(sid);
     outSources << sid;
-
-    // initialize source
-    alSourcef(sid, AL_GAIN, 1.f); checkAlError();
-    alSourcef(sid, AL_PITCH, 1.f); checkAlError();
-    alSource3f(sid, AL_VELOCITY, 0.f, 0.f, 0.f); checkAlError();
-    alSource3f(sid, AL_POSITION, 0.f, 0.f, 0.f); checkAlError();
 
     qDebug() << "Audio source" << sid << "created. Sources active:"
              << outSources.size();


### PR DESCRIPTION
(moved target-branch from #2842)

@tux3 Here's the two additions I mentioned in the comments on audio-next lately. Feel free to cherry-pick.
