### PR TITLE
generic pixel format selection

### DIFF
--- a/src/platform/camera/v4l2.cpp
+++ b/src/platform/camera/v4l2.cpp
@@ -177,7 +177,7 @@ QString v4l2::getPixelFormatString(uint32_t pixel_format)
     {
         return QString("h264");
     }
-    if (pixel_format == V4L2_PIX_FMT_MJPEG)
+    else if (pixel_format == V4L2_PIX_FMT_MJPEG)
     {
         return QString("mjpeg");
     }

--- a/src/platform/camera/v4l2.cpp
+++ b/src/platform/camera/v4l2.cpp
@@ -113,6 +113,7 @@ QVector<VideoMode> v4l2::getDeviceModes(QString devName)
 
         while(!ioctl(fd, VIDIOC_ENUM_FRAMESIZES, &vfse)) {
             VideoMode mode;
+            mode.pixel_format = vfse.pixel_format;
             switch (vfse.type) {
             case V4L2_FRMSIZE_TYPE_DISCRETE:
                 mode.width = vfse.discrete.width;
@@ -169,3 +170,23 @@ QVector<QPair<QString, QString>> v4l2::getDeviceList()
     }
     return devices;
 }
+
+QString v4l2::getPixelFormatString(uint32_t pixel_format)
+{
+    if (pixel_format == V4L2_PIX_FMT_H264)
+    {
+        return QString("h264");
+    }
+    if (pixel_format == V4L2_PIX_FMT_MJPEG)
+    {
+        return QString("mjpeg");
+    }
+    else if (pixel_format == V4L2_PIX_FMT_YUYV)
+    {
+        return QString("yuyv422");
+    }
+    else {
+        return QString("unknown");
+    }
+}
+

--- a/src/platform/camera/v4l2.h
+++ b/src/platform/camera/v4l2.h
@@ -33,6 +33,7 @@ namespace v4l2
     QVector<VideoMode> getDeviceModes(QString devName);
     QVector<QPair<QString, QString>> getDeviceList();
     QString getPixelFormatString(uint32_t pixel_format);
+    bool betterPixelFormat(uint32_t a, uint32_t b);
 }
 
 #endif // V4L2_H

--- a/src/platform/camera/v4l2.h
+++ b/src/platform/camera/v4l2.h
@@ -32,6 +32,7 @@ namespace v4l2
 {
     QVector<VideoMode> getDeviceModes(QString devName);
     QVector<QPair<QString, QString>> getDeviceList();
+    QString getPixelFormatString(uint32_t pixel_format);
 }
 
 #endif // V4L2_H

--- a/src/video/cameradevice.cpp
+++ b/src/video/cameradevice.cpp
@@ -372,6 +372,15 @@ QString CameraDevice::getPixelFormatString(uint32_t pixel_format)
 #endif
 }
 
+bool CameraDevice::betterPixelFormat(uint32_t a, uint32_t b)
+{
+#ifdef Q_OS_LINUX
+	return v4l2::betterPixelFormat(a, b);
+#else
+	return false;
+#endif
+}
+
 bool CameraDevice::getDefaultInputFormat()
 {
     QMutexLocker locker(&iformatLock);

--- a/src/video/cameradevice.cpp
+++ b/src/video/cameradevice.cpp
@@ -166,7 +166,7 @@ CameraDevice* CameraDevice::open(QString devName, VideoMode mode)
         const char *pixel_format = v4l2::getPixelFormatString(mode.pixel_format).toStdString().c_str();
         if (strncmp(pixel_format, "unknown", 7) != 0)
         {
-		    av_dict_set(&options, "pixel_format", pixel_format, 0);
+            av_dict_set(&options, "pixel_format", pixel_format, 0);
         }
     }
 #endif

--- a/src/video/cameradevice.h
+++ b/src/video/cameradevice.h
@@ -59,6 +59,8 @@ public:
 
     /// Get the list of video modes for a device
     static QVector<VideoMode> getVideoModes(QString devName);
+    /// Get the name of the pixel format of a video mode
+    static QString getPixelFormatString(uint32_t pixel_format);
 
     /// Returns the short name of the default defice
     /// This is either the device in the settings

--- a/src/video/cameradevice.h
+++ b/src/video/cameradevice.h
@@ -61,6 +61,8 @@ public:
     static QVector<VideoMode> getVideoModes(QString devName);
     /// Get the name of the pixel format of a video mode
     static QString getPixelFormatString(uint32_t pixel_format);
+    /// Returns true if we prefer format a to b, false otherwise (such as if there's no preference)
+    static bool betterPixelFormat(uint32_t a, uint32_t b);
 
     /// Returns the short name of the default defice
     /// This is either the device in the settings

--- a/src/video/camerasource.cpp
+++ b/src/video/camerasource.cpp
@@ -35,7 +35,7 @@ extern "C" {
 CameraSource* CameraSource::instance{nullptr};
 
 CameraSource::CameraSource()
-    : deviceName{"none"}, device{nullptr}, mode(VideoMode{0,0,0}),
+    : deviceName{"none"}, device{nullptr}, mode(VideoMode{0,0,0,0}),
       cctx{nullptr}, cctxOrig{nullptr}, videoStreamIndex{-1},
       _isOpen{false}, streamBlocker{false}, subscriptions{0}
 {
@@ -67,7 +67,7 @@ void CameraSource::open()
 
 void CameraSource::open(const QString deviceName)
 {
-    open(deviceName, VideoMode{0,0,0});
+    open(deviceName, VideoMode{0,0,0,0});
 }
 
 void CameraSource::open(const QString DeviceName, VideoMode Mode)

--- a/src/video/videoframe.cpp
+++ b/src/video/videoframe.cpp
@@ -17,6 +17,8 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <iostream>
+
 #include <QMutexLocker>
 #include <QDebug>
 #include <vpx/vpx_image.h>
@@ -48,12 +50,13 @@ VideoFrame::VideoFrame(AVFrame* frame, int w, int h, int fmt, std::function<void
     else
         frame->color_range = AVCOL_RANGE_UNSPECIFIED;
 
-    if (pixFmt == AV_PIX_FMT_YUV420P)
+    if (pixFmt == AV_PIX_FMT_YUV420P) {
         frameYUV420 = frame;
-    else if (pixFmt == AV_PIX_FMT_RGB24)
+    } else if (pixFmt == AV_PIX_FMT_RGB24) {
         frameRGB24 = frame;
-    else
+    } else {
         frameOther = frame;
+    }
 }
 
 VideoFrame::VideoFrame(AVFrame* frame, std::function<void()> freelistCallback)
@@ -126,6 +129,7 @@ bool VideoFrame::convertToRGB24(QSize size)
         qWarning() << "None of the frames are valid! Did someone release us?";
         return false;
     }
+    //std::cout << "converting to RGB24" << std::endl;
 
     if (size.isEmpty())
     {
@@ -198,6 +202,7 @@ bool VideoFrame::convertToYUV420()
         qCritical() << "None of the frames are valid! Did someone release us?";
         return false;
     }
+    //std::cout << "converting to YUV420" << std::endl;
 
     frameYUV420=av_frame_alloc();
     if (!frameYUV420)

--- a/src/video/videomode.h
+++ b/src/video/videomode.h
@@ -26,6 +26,7 @@ struct VideoMode
 {
     unsigned short width, height; ///< Displayed video resolution (NOT frame resolution)
     float FPS; ///< Max frames per second supported by the device at this resolution
+    uint32_t pixel_format;
 
     /// All zeros means a default/unspecified mode
     operator bool() const
@@ -37,7 +38,8 @@ struct VideoMode
     {
         return width == other.width
                 && height == other.height
-                && FPS == other.FPS;
+                && FPS == other.FPS
+                && pixel_format == other.pixel_format;
     }
 };
 

--- a/src/video/videomode.h
+++ b/src/video/videomode.h
@@ -41,6 +41,11 @@ struct VideoMode
                 && FPS == other.FPS
                 && pixel_format == other.pixel_format;
     }
+
+    uint32_t norm(const VideoMode& other) const
+    {
+        return std::abs(this->width-other.width) + std::abs(this->height-other.height);
+    }
 };
 
 #endif // VIDEOMODE_H

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -30,6 +30,7 @@
 
 #include <QDebug>
 #include <QShowEvent>
+#include <map>
 
 #ifndef ALC_ALL_DEVICES_SPECIFIER
 #define ALC_ALL_DEVICES_SPECIFIER ALC_DEVICE_SPECIFIER
@@ -172,23 +173,65 @@ void AVForm::updateVideoModes(int curIndex)
                     a.FPS>b.FPS;});
     bool previouslyBlocked = bodyUI->videoModescomboBox->blockSignals(true);
     bodyUI->videoModescomboBox->clear();
+    
+    // Identify the best resolutions available for the supposed XXXXp resolutions. 
+    std::map<int, VideoMode> idealModes;
+    idealModes[240] = {460,240,0,0}; idealModes[360] = {640,360,0,0}; 
+    idealModes[480] = {854,480,0,0}; idealModes[720] = {1280,720,0,0}; 
+    idealModes[1080] = {1920,1080,0,0};
+    std::map<int, int> bestModeInds;
+    for (int i=0; i<videoModes.size(); ++i)
+    {
+        VideoMode mode = videoModes[i];
+        printf("width: %d, height: %d, FPS: %f, pixel format: %s\n", mode.width, mode.height, mode.FPS, CameraDevice::getPixelFormatString(mode.pixel_format).toStdString().c_str());
+        for(auto iter = idealModes.begin(); iter != idealModes.end(); ++iter)
+        {
+            int res = iter->first;
+            VideoMode idealMode = iter->second;
+            // don't take approximately correct resolutions unless they really
+            // are close
+            if (mode.norm(idealMode) > 300) continue;
+            if (bestModeInds.find(res) == bestModeInds.end())
+            {
+                bestModeInds[res] = i;
+                continue;
+            }
+            int ind = bestModeInds[res];
+            if (mode.norm(idealMode) < videoModes[ind].norm(idealMode))
+            {
+                bestModeInds[res] = i;
+            }
+            else if (mode.norm(idealMode) == videoModes[ind].norm(idealMode))
+            {
+                // prefer higher FPS and "better" pixel formats
+                if (mode.FPS > videoModes[ind].FPS) {
+                    bestModeInds[res] = i;
+                }
+                else if (mode.FPS == videoModes[ind].FPS &&
+                        CameraDevice::betterPixelFormat(mode.pixel_format, videoModes[ind].pixel_format)) 
+                {
+                    bestModeInds[res] = i;
+                }
+            }
+        }
+    }
+    printf("=====\n");
     int prefResIndex = -1;
     QSize prefRes = Settings::getInstance().getCamVideoRes();
     unsigned short prefFPS = Settings::getInstance().getCamVideoFPS();
-    for (int i=0; i<videoModes.size(); ++i)
+    // Iterate backwards to show higest resolution first.
+    for(auto iter = bestModeInds.rbegin(); iter != bestModeInds.rend(); ++iter)
     {
+        int i = iter->second;
         VideoMode mode = videoModes[i];
         if (mode.width==prefRes.width() && mode.height==prefRes.height() && mode.FPS == prefFPS && prefResIndex==-1)
             prefResIndex = i;
         QString str;
+        printf("width: %d, height: %d, FPS: %f, pixel format: %s\n", mode.width, mode.height, mode.FPS, CameraDevice::getPixelFormatString(mode.pixel_format).toStdString().c_str());
         if (mode.height && mode.width)
-            str += tr("%1x%2").arg(mode.width).arg(mode.height);
+            str += tr("%1p").arg(iter->first);
         else
             str += tr("Default resolution");
-        if (mode.FPS)
-            str += tr(" at %1 FPS").arg(mode.FPS);
-        if (mode.pixel_format)
-            str += tr(" using %1").arg(CameraDevice::getPixelFormatString(mode.pixel_format));
         bodyUI->videoModescomboBox->addItem(str);
     }
     if (videoModes.isEmpty())

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -187,6 +187,8 @@ void AVForm::updateVideoModes(int curIndex)
             str += tr("Default resolution");
         if (mode.FPS)
             str += tr(" at %1 FPS").arg(mode.FPS);
+        if (mode.pixel_format)
+            str += tr(" using %1").arg(CameraDevice::getPixelFormatString(mode.pixel_format));
         bodyUI->videoModescomboBox->addItem(str);
     }
     if (videoModes.isEmpty())


### PR DESCRIPTION
Now in the a/v drop down menu, it will show which pixel format it's using for taking data off the webcam. When you select either from the drop-down menu, it will use the correct one. So far, mjpeg, yuyv (raw), and h264 have been added, but only the first two have been tested since my webcam doesn't do h264 input. I googled around and I can't find any other formats listed, these three seem by far the most common. The interface is extensible so in the future, this can be done for more formats. And, I designed it so that it could easily be done for Windows/Mac in the future if necessary/beneficial. Finally, if the format is undetected, it will default to the same format it did before any of these changes were made, so the regression discussed in #2852 should be fixed.

Let me know if you have any questions or want any other changes to be made. As far as I can tell, the "short names" that the AVDictionary wants for the pixel formats are more or less arbitrary. Unfortunately there doesn't seem to be a good programmatic way of getting them. So I basically just made a lookup function in `v4l2.h/c`, which is where they belong, because they are v4l2/linux specific.
