### PR TITLE
fix audio input/output initilization vars

### DIFF
--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -129,7 +129,6 @@ private:
     ALCcontext*         alOutContext;
     ALuint              alMainSource;
     ALuint              alMainBuffer;
-    bool                outputInitialized;
 
     QList<ALuint>       outSources;
 #ifdef QTOX_FILTER_AUDIO


### PR DESCRIPTION
@tux3 We forgot to transport the audio device initalization fixes. Those are available here. Btw. I rebased `audio-next` branch onto `master`, so we can continue work based on the latest version.
