### PR TITLE
Almost full translation into Ukrainian

### DIFF
--- a/translations/uk.ts
+++ b/translations/uk.ts
@@ -1,105 +1,88 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0" language="uk_UA">
+<TS version="2.1" language="uk_UA">
 <context>
     <name>AVForm</name>
     <message>
-        <location filename="../src/widget/form/settings/avform.cpp" line="33"/>
         <source>Audio/Video</source>
         <translation>Аудіо/Відео</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/avform.cpp" line="83"/>
-        <source>Initializing Camera...</source>
-        <translation>Ініціалізація камери...</translation>
+        <source>%1x%2</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Default resolution</source>
+        <translation>Роздільна здатність за замовчуванням</translation>
+    </message>
+    <message>
+        <source> at %1 FPS</source>
+        <translation> з %1 FPS</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation>Відсутній</translation>
     </message>
 </context>
 <context>
     <name>AVSettings</name>
     <message>
-        <location filename="../src/widget/form/settings/avsettings.ui" line="61"/>
-        <source>Playback</source>
-        <translation>Відтворення</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/avsettings.ui" line="54"/>
-        <source>Microphone</source>
-        <translation>Мікрофон</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/avsettings.ui" line="41"/>
         <source>Audio Settings</source>
         <translation>Аудіо параметри</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/avsettings.ui" line="89"/>
+        <source>Volume</source>
+        <translation>Гучність</translation>
+    </message>
+    <message>
         <source>Use slider to set volume of your speakers.</source>
         <translation>Використовуйте повзунок для регулювання гучності пристрою відтворення.</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/avsettings.ui" line="75"/>
-        <source>Use slider to set volume of your microphone.
-WARNING: slider is not supposed to work yet.</source>
-        <translation type="unfinished"></translation>
+        <source>Gain</source>
+        <translation>Підсилення</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/avsettings.ui" line="112"/>
+        <source>Use slider to set volume of your microphone.</source>
+        <translation>Використовуйте повзунок для регулювання чутливості мікрофону.</translation>
+    </message>
+    <message>
+        <source>Rescan devices</source>
+        <translation>Пересканувати пристрої</translation>
+    </message>
+    <message>
         <source>Playback device</source>
         <translation>Пристрій відтворення</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/avsettings.ui" line="68"/>
+        <source>...</source>
+        <translation></translation>
+    </message>
+    <message>
         <source>Capture device</source>
         <translation>Пристрій захоплення</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/avsettings.ui" line="126"/>
-        <source>Rescan audio devices</source>
-        <translation>Пересканувати аудіо пристрої</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/avsettings.ui" line="105"/>
         <source>Filter audio</source>
         <translation>Фільтр звуку</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/avsettings.ui" line="47"/>
-        <location filename="../src/widget/form/settings/avsettings.ui" line="140"/>
-        <location filename="../src/widget/form/settings/avsettings.ui" line="279"/>
-        <location filename="../src/widget/form/settings/avsettings.ui" line="286"/>
-        <location filename="../src/widget/form/settings/avsettings.ui" line="293"/>
-        <location filename="../src/widget/form/settings/avsettings.ui" line="300"/>
-        <source>100</source>
-        <translation>100</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/avsettings.ui" line="102"/>
         <source>Filter sound from your microphone, so that people hearing you would get better sound.</source>
         <translation>Фільтрація звуку вашого мікрофону для того, щоб люди краще вас чули.</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/avsettings.ui" line="119"/>
-        <location filename="../src/widget/form/settings/avsettings.ui" line="133"/>
-        <location filename="../src/widget/form/settings/avsettings.ui" line="195"/>
-        <location filename="../src/widget/form/settings/avsettings.ui" line="209"/>
-        <location filename="../src/widget/form/settings/avsettings.ui" line="244"/>
-        <location filename="../src/widget/form/settings/avsettings.ui" line="258"/>
-        <source>0</source>
-        <translation>0</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/avsettings.ui" line="156"/>
         <source>Video Settings</source>
         <translation>Параметри відео</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/avsettings.ui" line="237"/>
+        <source>Video device</source>
+        <translation>Відео пристрій</translation>
+    </message>
+    <message>
         <source>Resolution</source>
         <translation>Роздільна здатність</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/avsettings.ui" line="184"/>
-        <location filename="../src/widget/form/settings/avsettings.ui" line="230"/>
         <source>Set resolution of your camera.
 The higher values, the better video quality your friends may get.
 Note though that with better video quality there is needed better internet connection.
@@ -111,90 +94,208 @@ which may lead to problems with video calls.</source>
 Іноді ваше інтернет з’єднання може бути недостатньо якісним для досить високої якості відео,
 що може спричинити проблеми під час відео зв’язку.</translation>
     </message>
+</context>
+<context>
+    <name>AboutForm</name>
     <message>
-        <location filename="../src/widget/form/settings/avsettings.ui" line="223"/>
-        <source>Hue</source>
-        <translation>Відтінок</translation>
+        <source>Qt version:</source>
+        <translation>Версія Qt:</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/avsettings.ui" line="272"/>
-        <source>Brightness</source>
-        <translation>Яскравість</translation>
+        <source>Restart qTox to install version %1</source>
+        <translation>Перезапустіть qTox для встановлення версіїі %1</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/avsettings.ui" line="265"/>
-        <source>Saturation</source>
-        <translation>Насиченість</translation>
+        <source>qTox is downloading update %1</source>
+        <comment>%1 is the version of the update</comment>
+        <translation>qTox завантажує оновлення %1</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/avsettings.ui" line="202"/>
-        <source>Contrast</source>
-        <translation>Контраст</translation>
+        <source>About</source>
+        <translation>Про програму</translation>
+    </message>
+</context>
+<context>
+    <name>AboutSettings</name>
+    <message>
+        <source>Version</source>
+        <translation>Версія</translation>
+    </message>
+    <message>
+        <source>toxcore version: $TOXCOREVERSION</source>
+        <translation>Версія toxcore: $TOXCOREVERSION</translation>
+    </message>
+    <message>
+        <source>Qt version:</source>
+        <translation>Версія Qt:</translation>
+    </message>
+    <message>
+        <source>Commit hash: &lt;a href=&quot;https://github.com/tux3/qTox/commit/$GIT_VERSION&quot;&gt;$GIT_VERSION&lt;/a&gt;</source>
+        <translation>Хеш коміту: &lt;a href=&quot;https://github.com/tux3/qTox/commit/$GIT_VERSION&quot;&gt;$GIT_VERSION&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <source>You are using qTox version $GIT_DESCRIBE.</source>
+        <translation>Ви використовуєте qTox версії $GIT_DESCRIBE.</translation>
+    </message>
+    <message>
+        <source>Downloading update: %p%</source>
+        <translation>Завантаження оновлень: %p%</translation>
+    </message>
+    <message>
+        <source>License</source>
+        <translation>Ліцензія</translation>
+    </message>
+    <message>
+        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Noto Sans&apos;; font-size:12pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Sans Serif&apos;; font-size:10pt; color:#000000;&quot;&gt;Copyright © 2014-2015 by The qTox Project&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Ubuntu&apos;; font-size:10pt;&quot;&gt;qTox is a Qt-based graphical interface for Tox.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Sans Serif&apos;; font-size:10pt;&quot;&gt;qTox is libre software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Sans Serif&apos;; font-size:10pt;&quot;&gt;qTox is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details. &lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Ubuntu&apos;; font-size:10pt;&quot;&gt;You should have received a copy of the GNU General Public License along with this program. If not, see &lt;/span&gt;&lt;a href=&quot;https://www.gnu.org/copyleft/gpl.html&quot;&gt;&lt;span style=&quot; font-family:&apos;Ubuntu&apos;; font-size:10pt; text-decoration: underline; color:#007af4;&quot;&gt;https://www.gnu.org/copyleft/gpl.html&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-family:&apos;Ubuntu&apos;; font-size:10pt;&quot;&gt;.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Authors</source>
+        <translation>Автори</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Original author: &lt;a href=&quot;https://github.com/tux3&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;tux3&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;p&gt;See a full list of &lt;a href=&quot;https://github.com/tux3/qTox/graphs/contributors&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;contributors&lt;/span&gt;&lt;/a&gt; at Github&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt; Оригінальний автор: &lt;a href=&quot;https://github.com/tux3&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;tux3&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;p&gt;Дивіться повний список &lt;a href=&quot;https://github.com/tux3/qTox/graphs/contributors&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;учасників&lt;/span&gt;&lt;/a&gt; на Github&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>Known Issues</source>
+        <translation>Відомі проблеми</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A list of all known issues may be found at our &lt;a href=&quot;https://github.com/tux3/qTox/issues&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;bug-tracker&lt;/span&gt;&lt;/a&gt; at Github. If you discover a bug or security vulnerability within qTox, please report it according to the guidelines in our &lt;a href=&quot;https://github.com/tux3/qTox/wiki/Writing-Useful-Bug-Reports&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Writing Useful Bug Reports&lt;/span&gt;&lt;/a&gt; wiki article.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Повний перелік відомих проблем можна переглянути на нашому &lt;a href=&quot;https://github.com/tux3/qTox/issues&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;баг-трекері&lt;/span&gt;&lt;/a&gt; на Github. Якщо Ви знайшли баг чи вразливість в безпеці qTox, будь ласка, повідомте про це відповідно до вказівок нашої wiki-статті: &lt;a href=&quot;https://github.com/tux3/qTox/wiki/Writing-Useful-Bug-Reports&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Writing Useful Bug Reports&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>AboutUser</name>
+    <message>
+        <source>Dialog</source>
+        <translation>Діалог</translation>
+    </message>
+    <message>
+        <source>username</source>
+        <translation>Ім&apos;я користувача</translation>
+    </message>
+    <message>
+        <source>status message</source>
+        <translation>Статус</translation>
+    </message>
+    <message>
+        <source>Public key:</source>
+        <translation>Відкритий ключ:</translation>
+    </message>
+    <message>
+        <source>Used aliases:</source>
+        <translation>Використовуємі псевдоніми:</translation>
+    </message>
+    <message>
+        <source>HISTORY OF ALIASES</source>
+        <translation>ІСТОРІЯ ПСЕВДОНІМІВ</translation>
+    </message>
+    <message>
+        <source>Default directory to save files:</source>
+        <translatorcomment>To reduce string length it is also possible: &quot;Каталог для збергіання файлів:&quot;, which means &quot;Directory to save files&quot; (withot default).</translatorcomment>
+        <translation>Каталог для зберігання файлів за замовчуванням:</translation>
+    </message>
+    <message>
+        <source>Auto accept for this contact is disabled</source>
+        <translatorcomment>To reduce string length it is also possible: 
+1) &quot;Автоприйом файлів для цього контакту вимкнено&quot;. Where &quot;Автоприйом&quot; means the same as &quot;Автоматичний прийом&quot; but is not a dictionary word.
+2) &quot;Автоматичний прийом файлів вимкнено&quot;. Which means &quot;auto accept files is disabled&quot;, without &quot;for this contact&quot;.</translatorcomment>
+        <translation>Автоматичний прийом файлів для цього контакту вимкнено</translation>
+    </message>
+    <message>
+        <source>Auto accept files</source>
+        <translation>Автоматично приймати файли</translation>
+    </message>
+    <message>
+        <source>Remove history (operation can not be undone!)</source>
+        <translation>Видалити історію (операцію відмінити неможливо!)</translation>
+    </message>
+    <message>
+        <source>Notes</source>
+        <translation>Нотатки</translation>
+    </message>
+    <message>
+        <source>You can save comment about this contact here.</source>
+        <translation>Ви можете залишити коментар про даний контакт тут.</translation>
+    </message>
+    <message>
+        <source>Choose an auto accept directory</source>
+        <comment>popup title</comment>
+        <translatorcomment>I changed &quot;Оберіть теку, для автоматичного отримання файлів&quot; to &quot;Оберіть каталог для автоматичного отримання файлів&quot;, because there is no need to put comma there and &quot;Каталог&quot; is more common word for &quot;Directory&quot; then &quot;тека (теку)&quot;</translatorcomment>
+        <translation>Оберіть каталог для автоматичного отримання файлів</translation>
+    </message>
+    <message>
+        <source>History removed</source>
+        <translation>Історію видалено</translation>
+    </message>
+    <message>
+        <source>Chat history with %1 removed!</source>
+        <translation>Історію переписки з %1 видалено!</translation>
     </message>
 </context>
 <context>
     <name>AddFriendForm</name>
     <message>
-        <location filename="../src/widget/form/addfriendform.cpp" line="35"/>
         <source>Add Friends</source>
         <translation>Додати друзів</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/addfriendform.cpp" line="38"/>
         <source>Tox ID</source>
         <comment>Tox ID of the person you&apos;re sending a friend request to</comment>
         <translation>Tox ID</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/addfriendform.cpp" line="39"/>
+        <source>qTox needs to use the Tox DNS, but can&apos;t do it through a proxy.
+    Ignore the proxy and connect to the Internet directly?</source>
+        <translation>qTox повинен використовувати Tox DNS, але це неможливо через проксі.
+    Ігнорувати проксі та під&apos;єднатись до Інтернету напряму?</translation>
+    </message>
+    <message>
+        <source>either 76 hexadecimal characters or name@example.com</source>
+        <comment>Tox ID format description</comment>
+        <translation>76 шістнадцяткових цифр або name@example.com</translation>
+    </message>
+    <message>
+        <source>Invalid Tox ID format</source>
+        <translation>Некоректний формат Tox ID</translation>
+    </message>
+    <message>
         <source>Message</source>
         <comment>The message you send in friend requests</comment>
         <translation>Повідомлення</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/addfriendform.cpp" line="40"/>
         <source>Send friend request</source>
         <translation>Надіслати запит на дружбу</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/addfriendform.cpp" line="81"/>
         <source>%1 here! Tox me maybe?</source>
         <comment>Default message in friend requests if the field is left blank. Write something appropriate!</comment>
-        <translation type="unfinished"></translation>
+        <translatorcomment>That means &quot;Hi, I&apos;m %1! Please, add me to you contact list.
+It&apos;s difficult to translate &quot;Tox me maybe&quot; because in Ukrainian noun can&apos;t mean a verb (like &quot;call&quot; for noun and verb in English)</translatorcomment>
+        <translation>Привіт, я %1! Додай мене в свій список контактів, будь ласка.
+</translation>
     </message>
     <message>
-        <source>Tox me maybe?</source>
-        <comment>Default message in friend requests if the field is left blank. Write something appropriate!</comment>
-        <translation>Може поспілкуємось?</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/addfriendform.cpp" line="90"/>
-        <source>Please fill in a valid Tox ID</source>
-        <comment>Tox ID of the friend you&apos;re sending a friend request to</comment>
-        <translation>Введіть коректний Tox ID</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/addfriendform.cpp" line="90"/>
-        <location filename="../src/widget/form/addfriendform.cpp" line="95"/>
-        <location filename="../src/widget/form/addfriendform.cpp" line="116"/>
         <source>Couldn&apos;t add friend</source>
         <translation>Не можемо додати друга</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/addfriendform.cpp" line="95"/>
         <source>You can&apos;t add yourself as a friend!</source>
         <comment>When trying to add your own Tox ID as friend</comment>
         <translation>Ви не можете додати самого себе до друзів!</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/addfriendform.cpp" line="106"/>
-        <source>qTox needs to use the Tox DNS, but can&apos;t do it through a proxy.
-Ignore the proxy and connect to the Internet directly?</source>
-        <translation>qTox потребує Tox DNS, але не може скористатися ним через проксі.
-Проігнорувати проксі та під&apos;єднатися напряму?</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/addfriendform.cpp" line="116"/>
         <source>This Tox ID does not exist</source>
         <comment>DNS error</comment>
         <translation>Даного Tox ID не існує</translation>
@@ -203,362 +304,190 @@ Ignore the proxy and connect to the Internet directly?</source>
 <context>
     <name>AdvancedForm</name>
     <message>
-        <location filename="../src/widget/form/settings/advancedform.cpp" line="23"/>
         <source>Advanced</source>
         <translation>Додатково</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/advancedform.cpp" line="33"/>
-        <source>FULL - very safe, slowest (recommended)</source>
-        <translation>ПОВНА - найбезпечніше, але повільніше (рекомендується)</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/advancedform.cpp" line="34"/>
-        <source>NORMAL - almost as safe as FULL, about 20% faster than FULL</source>
-        <translation>ЗВИЧАЙНА - менш безпечно, а ніж ПОВНА, але на 20% швидше</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/advancedform.cpp" line="35"/>
-        <source>OFF - disables all safety, when something goes wrong your history may be lost, fastest (not recommended)</source>
-        <translation>ВІДСУТНЯ - вимкнені всі перевірки, якщо щось піде не так Вашу історію буде втрачено, найшвидша робота (не рекомендується)</translation>
     </message>
 </context>
 <context>
     <name>AdvancedSettings</name>
     <message>
-        <location filename="../src/widget/form/settings/advancedsettings.ui" line="14"/>
-        <source>Form</source>
-        <translation>Form</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/advancedsettings.ui" line="35"/>
         <source>Save settings to the working directory instead of the usual conf dir</source>
         <extracomment>describes makeToxPortable checkbox</extracomment>
         <translation>Зберігати налаштування в робочій теці замість звичайної теки конфігурацій</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/advancedsettings.ui" line="38"/>
         <source>Make Tox portable</source>
         <translation>Портативний запуск Tox</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/advancedsettings.ui" line="45"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; color:#ff0000;&quot;&gt;IMPORTANT NOTE&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;Unless you &lt;/span&gt;&lt;span style=&quot; font-weight:600; color:#ff0000;&quot;&gt;really&lt;/span&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt; know what you are doing, please do &lt;/span&gt;&lt;span style=&quot; font-weight:600; color:#ff0000;&quot;&gt;not&lt;/span&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt; change anything here. Changes made here may lead to problems with qTox, and even to loss of your data, e.g. history.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
         <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; color:#ff0000;&quot;&gt;ВАЖЛИВЕ ЗАУВАЖЕННЯ&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;Доки ви &lt;/span&gt;&lt;span style=&quot; font-weight:600; color:#ff0000;&quot;&gt;дійсно&lt;/span&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt; не зрозумієте, що робите, будь ласка, &lt;/span&gt;&lt;span style=&quot; font-weight:600; color:#ff0000;&quot;&gt;не&lt;/span&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt; змінюйте жодні параметри тут. Внесені зміни можуть викликати проблеми із qTox, і призвести до втрати Ваших даних, наприклад історії.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/advancedsettings.ui" line="61"/>
         <source>Reset to default settings</source>
         <translation>Скинути на типові значення</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/advancedsettings.ui" line="68"/>
-        <source>Chat history</source>
-        <translation>Історія чату</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/advancedsettings.ui" line="107"/>
-        <source>License</source>
-        <translation>Ліцензія</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/advancedsettings.ui" line="122"/>
-        <source>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Ubuntu&apos;; font-size:10pt;&quot;&gt;qTox is a Qt-based graphical interface for Tox.&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Ubuntu&apos;; font-size:10pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Ubuntu&apos;; font-size:10pt;&quot;&gt;This program is libre software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Ubuntu&apos;; font-size:10pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Ubuntu&apos;; font-size:10pt;&quot;&gt;This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Ubuntu&apos;; font-size:10pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Ubuntu&apos;; font-size:10pt;&quot;&gt;You should have received a copy of the GNU General Public License     along with this program.  If not, see &lt;/span&gt;&lt;a href=&quot;https://www.gnu.org/copyleft/gpl.html&quot;&gt;&lt;span style=&quot; font-family:&apos;Ubuntu&apos;; font-size:10pt; text-decoration: underline; color:#007af4;&quot;&gt;https://www.gnu.org/copyleft/gpl.html&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-family:&apos;Ubuntu&apos;; font-size:10pt;&quot;&gt;.&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;Ubuntu&apos;; font-size:10pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Ubuntu&apos;; font-size:10pt;&quot;&gt;Author: &lt;/span&gt;&lt;a href=&quot;https://github.com/tux3&quot;&gt;&lt;span style=&quot; font-family:&apos;Ubuntu&apos;; font-size:10pt; text-decoration: underline; color:#007af4;&quot;&gt;tux3&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Ubuntu&apos;; font-size:10pt;&quot;&gt;Contributors: &lt;/span&gt;&lt;a href=&quot;https://github.com/tux3/qTox/graphs/contributors&quot;&gt;&lt;span style=&quot; font-family:&apos;Ubuntu&apos;; font-size:10pt; text-decoration: underline; color:#007af4;&quot;&gt;see all on GitHub.com&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;Ubuntu&apos;; font-size:10pt;&quot;&gt;Known issues: &lt;/span&gt;&lt;a href=&quot;https://github.com/tux3/qTox/issues&quot;&gt;&lt;span style=&quot; font-family:&apos;Ubuntu&apos;; font-size:10pt; text-decoration: underline; color:#007af4;&quot;&gt;see all on GitHub.com&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>History</source>
-        <translation type="obsolete">Історія</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/advancedsettings.ui" line="76"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;http://www.sqlite.org/pragma.html#pragma_synchronous&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Synchronous writing to DB&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;http://www.sqlite.org/pragma.html#pragma_synchronous&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Синхронізація запису в БД&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
 </context>
 <context>
     <name>Android</name>
     <message>
-        <location filename="../src/android.ui" line="14"/>
         <source>Form</source>
         <translation type="unfinished">Form</translation>
     </message>
     <message>
-        <location filename="../src/android.ui" line="252"/>
         <source>qTox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/android.ui" line="343"/>
         <source>Someone</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/android.ui" line="348"/>
         <source>Someone else</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/android.ui" line="353"/>
         <source>Groupbot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/android.ui" line="358"/>
         <source>That guy who I don&apos;t remember adding</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/android.ui" line="363"/>
         <source>NASA manager</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/android.ui" line="368"/>
         <source>Lorem</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/android.ui" line="373"/>
         <source>Ipsum</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/android.ui" line="378"/>
         <source>Dolor</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Your name</source>
-        <translation type="obsolete">Ваше ім&apos;я</translation>
-    </message>
-    <message>
-        <source>Your status</source>
-        <translation type="obsolete">Ваш статус</translation>
-    </message>
-    <message>
-        <source>Add friends</source>
-        <translation type="obsolete">Додати друзів</translation>
-    </message>
-    <message>
-        <source>Create a group chat</source>
-        <translation type="obsolete">Створити груповий чат</translation>
-    </message>
-    <message>
-        <source>View completed file transfers</source>
-        <translation type="obsolete">Переглянути завершені передачі файлів</translation>
-    </message>
-    <message>
-        <source>Change your settings</source>
-        <translation type="obsolete">Змінити параметри</translation>
-    </message>
-</context>
-<context>
-    <name>AndroidGUI</name>
-    <message>
-        <source>Online</source>
-        <comment>Button to set your status to &apos;Online&apos;</comment>
-        <translation type="obsolete">В мережі</translation>
-    </message>
-    <message>
-        <source>Away</source>
-        <comment>Button to set your status to &apos;Away&apos;</comment>
-        <translation type="obsolete">Відійшов</translation>
-    </message>
-    <message>
-        <source>Busy</source>
-        <comment>Button to set your status to &apos;Busy&apos;</comment>
-        <translation type="obsolete">Зайнятий</translation>
     </message>
 </context>
 <context>
     <name>ChatForm</name>
     <message>
-        <source>Load History...</source>
-        <translation type="obsolete">Завантажити історію…</translation>
-    </message>
-    <message>
         <source>Load chat history...</source>
         <translation>Завантажити історію чату...</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/chatform.cpp" line="150"/>
         <source>Send a file</source>
         <translation>Надіслати файл</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/chatform.cpp" line="159"/>
-        <location filename="../src/widget/form/chatform.cpp" line="750"/>
-        <source>File not read</source>
-        <translation>Файл не читається</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/chatform.cpp" line="159"/>
-        <location filename="../src/widget/form/chatform.cpp" line="750"/>
         <source>qTox wasn&apos;t able to open %1</source>
         <translation>qTox не може відкрити файл %1</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/chatform.cpp" line="164"/>
-        <location filename="../src/widget/form/chatform.cpp" line="756"/>
-        <source>Bad Idea</source>
-        <translation>Погана ідея</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/chatform.cpp" line="164"/>
-        <location filename="../src/widget/form/chatform.cpp" line="756"/>
         <source>You&apos;re trying to send a special (sequential) file, that&apos;s not going to work!</source>
         <translation>Ви намагаєтесь передати спеціальний (послідовний) файл, це не так працює!</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/chatform.cpp" line="252"/>
         <source>Accept video call</source>
         <translation>Прийняти відеодзвінок</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/chatform.cpp" line="265"/>
         <source>Accept audio call</source>
         <translation>Прийняти аудіо дзвінок</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/chatform.cpp" line="273"/>
         <source>%1 calling</source>
         <translation>Дзвінок від %1</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/chatform.cpp" line="302"/>
-        <location filename="../src/widget/form/chatform.cpp" line="420"/>
         <source>End video call</source>
         <translation>Завершити відеодзвінок</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/chatform.cpp" line="311"/>
-        <location filename="../src/widget/form/chatform.cpp" line="429"/>
         <source>End audio call</source>
         <translation>Завершити аудіодзвінок</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/chatform.cpp" line="322"/>
-        <location filename="../src/widget/form/chatform.cpp" line="676"/>
         <source>Mute microphone</source>
         <translation>Вимкнути мікрофон</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/chatform.cpp" line="325"/>
-        <location filename="../src/widget/form/chatform.cpp" line="696"/>
         <source>Mute call</source>
         <translatorcomment>(переклад може бути неточний)</translatorcomment>
         <translation>Призупинити дзвінок</translation>
     </message>
     <message>
-        <source>%1 is calling</source>
-        <translation type="obsolete">%1 дзвонить</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/chatform.cpp" line="350"/>
-        <source>%1 stopped calling</source>
-        <translation>%1 припинив виклик</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/chatform.cpp" line="385"/>
         <source>Cancel video call</source>
         <translation>Скинути відеодзвінок</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/chatform.cpp" line="393"/>
         <source>Cancel audio call</source>
         <translation>Скинути аудіодзвінок</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/chatform.cpp" line="401"/>
-        <source>Calling to %1</source>
-        <translation>Викликаємо %1</translation>
+        <source>Unable to open</source>
+        <translation>Неможливо відкрити</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/chatform.cpp" line="653"/>
+        <source>Bad idea</source>
+        <translation>Погана ідея</translation>
+    </message>
+    <message>
+        <source>Calling %1</source>
+        <translation>Дзінок до %1</translation>
+    </message>
+    <message>
         <source>Start audio call</source>
         <translation>Почати аудіодзвінок</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/chatform.cpp" line="656"/>
         <source>Start video call</source>
         <translation>Почати відеодзвінок</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/chatform.cpp" line="681"/>
         <source>Unmute microphone</source>
         <translation>Увімкнути мікрофон</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/chatform.cpp" line="701"/>
         <source>Unmute call</source>
         <translatorcomment>(переклад може бути неточний)</translatorcomment>
         <translation>Відновити дзвінок</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/chatform.cpp" line="713"/>
         <source>Failed to send file &quot;%1&quot;</source>
         <translation>Не вдалось відправити файл «%1»</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/chatform.cpp" line="884"/>
         <source>Failed to open temporary file</source>
         <comment>Temporary file for screenshot</comment>
         <translation>Помилка під час відкриття тимчасового файлу</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/chatform.cpp" line="885"/>
         <source>qTox wasn&apos;t able to save the screenshot</source>
         <translation>qTox не може зберегти снімок екрану</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/chatform.cpp" line="927"/>
         <source>Call with %1 ended. %2</source>
         <translation>Виклик із %1 завершено. %2</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/chatform.cpp" line="946"/>
         <source>Call duration: </source>
         <translation>Тривалість дзвінка: </translation>
-    </message>
-    <message>
-        <source>is typing...</source>
-        <translation type="obsolete">набирає...</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/chatform.cpp" line="499"/>
-        <source>Call rejected</source>
-        <translation>Дзвінок відхилено</translation>
     </message>
 </context>
 <context>
     <name>ChatLog</name>
     <message>
-        <location filename="../src/chatlog/chatlog.cpp" line="64"/>
         <source>Copy</source>
         <translation>Копіювати</translation>
     </message>
     <message>
-        <location filename="../src/chatlog/chatlog.cpp" line="79"/>
         <source>Select all</source>
         <translation>Виділити всі</translation>
     </message>
     <message>
-        <location filename="../src/chatlog/chatlog.cpp" line="494"/>
         <source>pending</source>
         <translation>очікування</translation>
     </message>
@@ -566,375 +495,250 @@ p, li { white-space: pre-wrap; }
 <context>
     <name>ChatTextEdit</name>
     <message>
-        <location filename="../src/widget/tool/chattextedit.cpp" line="21"/>
         <source>Type your message here...</source>
         <translation>Наберіть Ваше повідомлення тут…</translation>
     </message>
 </context>
 <context>
+    <name>CircleWidget</name>
+    <message>
+        <source>Rename circle</source>
+        <comment>Menu for renaming a circle</comment>
+        <translation>Перейменувати коло</translation>
+    </message>
+    <message>
+        <source>Remove circle</source>
+        <comment>Menu for removing a circle</comment>
+        <translation>Видалити коло</translation>
+    </message>
+    <message>
+        <source>Open all in new window</source>
+        <translation>Відкрити всі в новому вікні</translation>
+    </message>
+</context>
+<context>
     <name>Core</name>
     <message>
-        <location filename="../src/core/core.cpp" line="254"/>
         <source>Toxing on qTox</source>
         <translation>Вітання з qTox</translation>
     </message>
     <message>
-        <location filename="../src/core/core.cpp" line="255"/>
-        <source>qTox User</source>
-        <translation>Користувач qTox</translation>
-    </message>
-    <message>
-        <location filename="../src/core/core.cpp" line="594"/>
         <source>You need to write a message with your request</source>
         <translation>Напишіть повідомлення з вашим запитом</translation>
     </message>
     <message>
-        <location filename="../src/core/core.cpp" line="598"/>
         <source>Your message is too long!</source>
         <translation>Ваше повідомлення завелике!</translation>
     </message>
     <message>
-        <location filename="../src/core/core.cpp" line="602"/>
         <source>Friend is already added</source>
         <translation>Друга вже додано</translation>
     </message>
     <message>
-        <location filename="../src/core/core.cpp" line="620"/>
         <source>/me offers friendship.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/core.cpp" line="622"/>
         <source>/me offers friendship, &quot;%1&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/core.cpp" line="900"/>
-        <location filename="../src/core/core.cpp" line="998"/>
-        <source>Profile already in use</source>
-        <translation>Профіль вже використовується</translation>
-    </message>
-    <message>
-        <location filename="../src/core/core.cpp" line="901"/>
-        <location filename="../src/core/core.cpp" line="999"/>
-        <source>This profile is already used by another qTox instance
-Please select another profile</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/coreencryption.cpp" line="169"/>
-        <source>Encryption error</source>
-        <translation>Помилка шифрування</translation>
-    </message>
-    <message>
-        <location filename="../src/core/coreencryption.cpp" line="169"/>
-        <source>The .tox file is encrypted, but encryption was not checked, continuing regardless.</source>
-        <translation>Файл .tox зашифровано, але шифрування не перевірено, попри це продовжуємо.</translation>
-    </message>
-    <message>
-        <location filename="../src/core/coreencryption.cpp" line="173"/>
-        <source>Please enter the password for the %1 profile.</source>
-        <comment>used in load() when no pw is already set</comment>
-        <translation>Будь-ласка, введіть пароль для профілю %1.</translation>
-    </message>
-    <message>
-        <location filename="../src/core/coreencryption.cpp" line="174"/>
-        <location filename="../src/core/coreencryption.cpp" line="241"/>
         <source>The previous password is incorrect; please try again:</source>
         <comment>used on retries in load()</comment>
         <translatorcomment>можливо, не &quot;попередній&quot;, а &quot;перший&quot;</translatorcomment>
         <translation>Попередній пароль неправильний; спробуйте ще раз:</translation>
     </message>
     <message>
-        <location filename="../src/core/coreencryption.cpp" line="188"/>
-        <source>The profile password failed. Please try another?</source>
-        <comment>used only when pw set before load() doesn&apos;t work</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/core/coreencryption.cpp" line="233"/>
         <source>Encrypted chat history</source>
         <translation>Зашифрована історія</translation>
     </message>
     <message>
-        <location filename="../src/core/coreencryption.cpp" line="233"/>
         <source>No encrypted chat history file found, or it was corrupted.
 History will be disabled!</source>
         <translation>Не знайдено зашифрованої історії чату або вона була пошкоджена.
 Історія чату буде вимкнена!</translation>
     </message>
     <message>
-        <location filename="../src/core/coreencryption.cpp" line="240"/>
-        <source>Please enter the password for the chat history for the %1 profile.</source>
+        <source>Please enter the password for the chat history for the profile &quot;%1&quot;.</source>
         <comment>used in load() when no hist pw set</comment>
-        <translation>Будь-ласка, введіть пароль для історії чату з профілю %1.</translation>
+        <translation>Будь ласка, введіть пароль для історії переписки для профілю &quot;%1&quot;.</translation>
     </message>
     <message>
-        <location filename="../src/core/coreencryption.cpp" line="242"/>
         <source>
 Disabling chat history now will leave the encrypted history intact (but not usable); if you later remember the password, you may re-enable encryption from the Privacy tab with the correct password to use the history.</source>
         <comment>part of history password dialog</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/coreencryption.cpp" line="250"/>
         <source>The chat history password failed. Please try another?</source>
         <comment>used only when pw set before load() doesn&apos;t work</comment>
         <translation>Щось не так з паролем для історії чату. Спробуйте інший?</translation>
     </message>
     <message>
-        <location filename="../src/core/coreencryption.cpp" line="273"/>
         <source>Disable chat history</source>
         <translation>Вимкнути історію чату</translation>
-    </message>
-    <message>
-        <location filename="../src/core/coreencryption.cpp" line="325"/>
-        <source>Local file encryption is enabled, but there is no password! It will be disabled.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Tox datafile decryption password</source>
-        <translation type="obsolete">Розшифрування файлу даних Tox</translation>
-    </message>
-    <message>
-        <source>Password error</source>
-        <translation type="obsolete">Помилка паролю</translation>
-    </message>
-    <message>
-        <source>Failed to setup password.
-Empty password.</source>
-        <translation type="obsolete">Не вдалось встановити пароль.
-Пароль пустий.</translation>
-    </message>
-    <message>
-        <source>Try Again</source>
-        <translation type="obsolete">Спробуйте ще раз</translation>
-    </message>
-    <message>
-        <location filename="../src/core/coreencryption.cpp" line="200"/>
-        <source>Change profile</source>
-        <translation>Змінити профіль</translation>
-    </message>
-    <message>
-        <source>Reinit current profile</source>
-        <translation type="obsolete">Пере ініціалізувати поточний профіль</translation>
-    </message>
-    <message>
-        <source>Wrong password has been entered</source>
-        <translation type="obsolete">Введено хибний пароль</translation>
-    </message>
-    <message>
-        <source>History Log decryption password</source>
-        <translation type="obsolete">Розшифрування історії</translation>
-    </message>
-    <message>
-        <source>Your history is encrypted with different password.
-Do you want to try another password?</source>
-        <translation type="obsolete">Ваша історія зашифрована інакшим паролем.
-Бажаєте спробувати інший пароль?</translation>
-    </message>
-    <message>
-        <source>History</source>
-        <translation type="obsolete">Історія</translation>
-    </message>
-    <message>
-        <source>Due to incorret password history will be disabled.</source>
-        <translation type="obsolete">Введено некоректний пароль, звітування вимкнено.</translation>
-    </message>
-    <message>
-        <source>Encrypted log</source>
-        <translation type="obsolete">Зашифрований звіт</translation>
-    </message>
-    <message>
-        <location filename="../src/core/coreencryption.cpp" line="325"/>
-        <source>NO Password</source>
-        <translation>Відсутній пароль</translation>
-    </message>
-    <message>
-        <source>Will be saved without encryption!</source>
-        <translation type="obsolete">Буде збережено без шифрування!</translation>
-    </message>
-</context>
-<context>
-    <name>FileTransferInstance</name>
-    <message>
-        <source>Save a file</source>
-        <comment>Title of the file saving dialog</comment>
-        <translation type="obsolete">Зберегти файл</translation>
-    </message>
-    <message>
-        <source>Location not writable</source>
-        <comment>Title of permissions popup</comment>
-        <translation type="obsolete">Немає прав на запис</translation>
-    </message>
-    <message>
-        <source>You do not have permission to write that location. Choose another, or cancel the save dialog.</source>
-        <comment>text of permissions popup</comment>
-        <translation type="obsolete">Ви не маєте прав на запис за цим розташуванням. Оберіть інше місце призначення, або скасуйте передачу.</translation>
-    </message>
-    <message>
-        <source>ETA</source>
-        <translation type="obsolete">РЧЗ</translation>
     </message>
 </context>
 <context>
     <name>FileTransferWidget</name>
     <message>
-        <location filename="../src/chatlog/content/filetransferwidget.ui" line="14"/>
         <source>Form</source>
-        <translation type="unfinished">Form</translation>
+        <translation>Form</translation>
     </message>
     <message>
-        <location filename="../src/chatlog/content/filetransferwidget.ui" line="148"/>
         <source>10Mb</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">10МБ</translation>
     </message>
     <message>
-        <location filename="../src/chatlog/content/filetransferwidget.ui" line="164"/>
         <source>0kb/s</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">0кБ/с</translation>
     </message>
     <message>
-        <location filename="../src/chatlog/content/filetransferwidget.ui" line="180"/>
         <source>ETA:10:10</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/chatlog/content/filetransferwidget.ui" line="224"/>
         <source>Filename</source>
-        <translation type="unfinished"></translation>
+        <translation>Назва файлу</translation>
     </message>
     <message>
-        <location filename="../src/chatlog/content/filetransferwidget.ui" line="299"/>
         <source>[preview]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/chatlog/content/filetransferwidget.cpp" line="87"/>
         <source>Waiting to send...</source>
         <comment>file transfer widget</comment>
-        <translation type="unfinished"></translation>
+        <translation>Очікування передачі...</translation>
     </message>
     <message>
-        <location filename="../src/chatlog/content/filetransferwidget.cpp" line="91"/>
         <source>Accept to receive this file</source>
         <comment>file transfer widget</comment>
-        <translation type="unfinished"></translation>
+        <translation>Підтвердіть щоб прийняти файл</translation>
     </message>
     <message>
-        <location filename="../src/chatlog/content/filetransferwidget.cpp" line="134"/>
         <source>Location not writable</source>
         <comment>Title of permissions popup</comment>
-        <translation type="unfinished">Немає прав на запис</translation>
+        <translation>Немає прав на запис</translation>
     </message>
     <message>
-        <location filename="../src/chatlog/content/filetransferwidget.cpp" line="135"/>
         <source>You do not have permission to write that location. Choose another, or cancel the save dialog.</source>
         <comment>text of permissions popup</comment>
-        <translation type="unfinished">Ви не маєте прав на запис за цим розташуванням. Оберіть інше місце призначення, або скасуйте передачу.</translation>
+        <translation>Ви не маєте прав на запис за цим розташуванням. Оберіть інше місце призначення, або скасуйте передачу.</translation>
     </message>
     <message>
-        <location filename="../src/chatlog/content/filetransferwidget.cpp" line="303"/>
-        <source>paused</source>
-        <comment>file transfer widget</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/chatlog/content/filetransferwidget.cpp" line="323"/>
         <source>Resuming...</source>
         <comment>file transfer widget</comment>
-        <translation type="unfinished"></translation>
+        <translation>Продовження...</translation>
     </message>
     <message>
-        <location filename="../src/chatlog/content/filetransferwidget.cpp" line="349"/>
-        <source>Open file.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/chatlog/content/filetransferwidget.cpp" line="354"/>
-        <source>Open file directory.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/chatlog/content/filetransferwidget.cpp" line="406"/>
-        <location filename="../src/chatlog/content/filetransferwidget.cpp" line="418"/>
-        <location filename="../src/chatlog/content/filetransferwidget.cpp" line="431"/>
         <source>Cancel transfer</source>
-        <translation type="unfinished"></translation>
+        <translation>Скасувати передачу</translation>
     </message>
     <message>
-        <location filename="../src/chatlog/content/filetransferwidget.cpp" line="410"/>
-        <location filename="../src/chatlog/content/filetransferwidget.cpp" line="437"/>
         <source>Pause transfer</source>
-        <translation type="unfinished"></translation>
+        <translation>Призупинити передачу</translation>
     </message>
     <message>
-        <location filename="../src/chatlog/content/filetransferwidget.cpp" line="422"/>
+        <source>Paused</source>
+        <comment>file transfer widget</comment>
+        <translation>Призупинено</translation>
+    </message>
+    <message>
+        <source>Open file</source>
+        <translation>Відкрити файл</translation>
+    </message>
+    <message>
+        <source>Open file directory</source>
+        <translation>Відкрити каталог з файлом</translation>
+    </message>
+    <message>
         <source>Resume transfer</source>
-        <translation type="unfinished"></translation>
+        <translation>Продовжити передачу</translation>
     </message>
     <message>
-        <location filename="../src/chatlog/content/filetransferwidget.cpp" line="443"/>
         <source>Accept transfer</source>
-        <translation type="unfinished"></translation>
+        <translation>Підтвердити передачу</translation>
     </message>
     <message>
-        <location filename="../src/chatlog/content/filetransferwidget.cpp" line="470"/>
         <source>Save a file</source>
         <comment>Title of the file saving dialog</comment>
-        <translation type="unfinished">Зберегти файл</translation>
+        <translation>Зберегти файл</translation>
     </message>
 </context>
 <context>
     <name>FilesForm</name>
     <message>
-        <location filename="../src/widget/form/filesform.cpp" line="29"/>
-        <source>Transfered Files</source>
+        <source>Transferred Files</source>
         <comment>&quot;Headline&quot; of the window</comment>
         <translation>Передані файли</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/filesform.cpp" line="37"/>
         <source>Downloads</source>
         <translation>Завантажені</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/filesform.cpp" line="38"/>
         <source>Uploads</source>
         <translation>Вивантажені</translation>
     </message>
 </context>
 <context>
+    <name>FriendListWidget</name>
+    <message>
+        <source>Today</source>
+        <comment>Category for sorting friends by activity</comment>
+        <translation>Сьогодні</translation>
+    </message>
+    <message>
+        <source>Yesterday</source>
+        <comment>Category for sorting friends by activity</comment>
+        <translation>Вчора</translation>
+    </message>
+    <message>
+        <source>Last 7 days</source>
+        <comment>Category for sorting friends by activity</comment>
+        <translation>Останні 7 днів</translation>
+    </message>
+    <message>
+        <source>This month</source>
+        <comment>Category for sorting friends by activity</comment>
+        <translation>Цього місяця</translation>
+    </message>
+    <message>
+        <source>Older than 6 Months</source>
+        <comment>Category for sorting friends by activity</comment>
+        <translation>Раніше 6 місяців</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <comment>Category for sorting friends by activity</comment>
+        <translation>Невідомо</translation>
+    </message>
+</context>
+<context>
     <name>FriendRequestDialog</name>
     <message>
-        <location filename="../src/widget/tool/friendrequestdialog.cpp" line="31"/>
         <source>Friend request</source>
         <comment>Title of the window to aceept/deny a friend request</comment>
         <translation>Запит на дружбу</translation>
     </message>
     <message>
-        <location filename="../src/widget/tool/friendrequestdialog.cpp" line="33"/>
         <source>Someone wants to make friends with you</source>
         <translation>Дехто хоче долучитися до переліку ваших друзів</translation>
     </message>
     <message>
-        <location filename="../src/widget/tool/friendrequestdialog.cpp" line="34"/>
         <source>User ID:</source>
         <translation>ID користувача:</translation>
     </message>
     <message>
-        <location filename="../src/widget/tool/friendrequestdialog.cpp" line="38"/>
         <source>Friend request message:</source>
         <translation>Повідомлення запиту:</translation>
     </message>
     <message>
-        <location filename="../src/widget/tool/friendrequestdialog.cpp" line="45"/>
         <source>Accept</source>
         <comment>Accept a friend request</comment>
         <translation>Прийняти</translation>
     </message>
     <message>
-        <location filename="../src/widget/tool/friendrequestdialog.cpp" line="46"/>
         <source>Reject</source>
         <comment>Reject a friend request</comment>
         <translation>Відхилити</translation>
@@ -943,73 +747,74 @@ Do you want to try another password?</source>
 <context>
     <name>FriendWidget</name>
     <message>
-        <location filename="../src/widget/friendwidget.cpp" line="57"/>
         <source>Invite to group</source>
         <comment>Menu to invite a friend to a groupchat</comment>
         <translation>Запросити до групи</translation>
     </message>
     <message>
-        <location filename="../src/widget/friendwidget.cpp" line="58"/>
-        <source>Copy friend ID</source>
-        <comment>Menu to copy the Tox ID of that friend</comment>
-        <translation>Копіювати дружній ID</translation>
+        <source>Open chat in new window</source>
+        <translation>Відкрити чат в новому вікні</translation>
     </message>
     <message>
-        <location filename="../src/widget/friendwidget.cpp" line="70"/>
+        <source>Remove chat from this window</source>
+        <translation>Видалити чат з цього вікна</translation>
+    </message>
+    <message>
+        <source>Move to circle...</source>
+        <comment>Menu to move a friend into a different circle</comment>
+        <translation>Перемістити в коло...</translation>
+    </message>
+    <message>
+        <source>To new circle</source>
+        <translation>До нового кола</translation>
+    </message>
+    <message>
+        <source>Remove from circle &apos;%1&apos;</source>
+        <translation>Видалити з кола &apos;%1&apos;</translation>
+    </message>
+    <message>
+        <source>Move  to circle &quot;%1&quot;</source>
+        <translation>Перемістити в коло &quot;%1&quot;</translation>
+    </message>
+    <message>
         <source>Set alias...</source>
         <translation>Встановити псевдонім…</translation>
     </message>
     <message>
-        <location filename="../src/widget/friendwidget.cpp" line="73"/>
         <source>Auto accept files from this friend</source>
         <comment>context menu entry</comment>
         <translation>Автоматично приймати файли від даного друга</translation>
     </message>
     <message>
-        <location filename="../src/widget/friendwidget.cpp" line="172"/>
-        <source>New message</source>
-        <translation type="unfinished"></translation>
+        <source>Show details</source>
+        <translation>Показати деталі</translation>
     </message>
     <message>
-        <location filename="../src/widget/friendwidget.cpp" line="174"/>
+        <source>New message</source>
+        <translation>Нове повідомлення</translation>
+    </message>
+    <message>
         <source>Online</source>
         <translation>В мережі</translation>
     </message>
     <message>
-        <location filename="../src/widget/friendwidget.cpp" line="176"/>
         <source>Away</source>
         <translation>Відійшов</translation>
     </message>
     <message>
-        <location filename="../src/widget/friendwidget.cpp" line="178"/>
         <source>Busy</source>
         <translation>Зайнятий</translation>
     </message>
     <message>
-        <location filename="../src/widget/friendwidget.cpp" line="180"/>
         <source>Offline</source>
         <translation>Не в мережі</translation>
     </message>
     <message>
-        <location filename="../src/widget/friendwidget.cpp" line="261"/>
-        <source>User alias</source>
-        <translation>Псевдонім користувача</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/friendwidget.cpp" line="261"/>
-        <source>You can also set this by clicking the chat form name.
-Alias:</source>
-        <translation>Ви також можете встановити його натиснувши на назву форми в чаті.
-Псевдонім:</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/friendwidget.cpp" line="108"/>
         <source>Choose an auto accept directory</source>
         <comment>popup title</comment>
         <translation>Оберіть теку, для автоматичного отримання файлів</translation>
     </message>
     <message>
-        <location filename="../src/widget/friendwidget.cpp" line="78"/>
         <source>Remove friend</source>
         <comment>Menu to remove the friend from our friendlist</comment>
         <translation>Вилучити з друзів</translation>
@@ -1018,17 +823,14 @@ Alias:</source>
 <context>
     <name>GUI</name>
     <message>
-        <location filename="../src/widget/gui.cpp" line="281"/>
         <source>Enter your password</source>
         <translation>Введіть ваш пароль</translation>
     </message>
     <message>
-        <location filename="../src/widget/gui.cpp" line="283"/>
         <source>Decrypt</source>
         <translation>Розшифрувати</translation>
     </message>
     <message>
-        <location filename="../src/widget/gui.cpp" line="325"/>
         <source>You must enter a non-empty password:</source>
         <translation>Введіть непустий пароль:</translation>
     </message>
@@ -1036,30 +838,24 @@ Alias:</source>
 <context>
     <name>GeneralForm</name>
     <message>
-        <location filename="../src/widget/form/settings/generalform.cpp" line="40"/>
         <source>General</source>
         <translation>Основні</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalform.cpp" line="91"/>
-        <location filename="../src/widget/form/settings/generalform.cpp" line="96"/>
         <source>None</source>
         <translation>Відсутній</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalform.cpp" line="295"/>
         <source>Choose an auto accept directory</source>
         <comment>popup title</comment>
         <translation>Оберіть теку, для автоматичного отримання файлів</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalform.cpp" line="351"/>
         <source>Call active</source>
         <comment>popup title</comment>
         <translation>Дзвінок активний</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalform.cpp" line="352"/>
         <source>You can&apos;t disconnect while a call is active!</source>
         <comment>popup text</comment>
         <translation>Ви не можете від&apos;єднатись під час активного дзвінка!</translation>
@@ -1068,227 +864,159 @@ Alias:</source>
 <context>
     <name>GeneralSettings</name>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="56"/>
         <source>General Settings</source>
         <translation>Основні параметри</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="64"/>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="80"/>
         <source>The translation may not load until qTox restarts.</source>
         <translation>Переклад буде застосовано після перезавантаження qTox.</translation>
     </message>
     <message>
-        <source>Save settings to the working directory instead of the usual conf dir</source>
-        <extracomment>describes makeToxPortable checkbox</extracomment>
-        <translation type="obsolete">Зберігати налаштування в робочий теці</translation>
-    </message>
-    <message>
-        <source>Make Tox portable</source>
-        <translation type="obsolete">Портативний запуск</translation>
-    </message>
-    <message>
-        <source>System tray integration</source>
-        <translation type="obsolete">Інтеграція із системним лотком</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="129"/>
         <source>Show system tray icon</source>
         <translation>Показувати піктограму в системному лотку</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="153"/>
         <source>Enable light tray icon.</source>
         <comment>toolTip for light icon setting</comment>
         <translation>Увімкнути світлі піктограми.</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="119"/>
+        <source>Start qTox on operating system startup (current profile).</source>
+        <translation>Запускти qTox при завантаженні операційної системи (поточний профіль).</translation>
+    </message>
+    <message>
         <source>qTox will start minimized in tray.</source>
         <comment>toolTip for Start in tray setting</comment>
         <translation>qTox буде запускатися згорнутим в лоток.</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="122"/>
         <source>Start in tray</source>
         <translation>Запускати у системному лотку</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="142"/>
         <source>After pressing close (X) qTox will minimize to tray,
 instead of closing itself.</source>
         <comment>toolTip for close to tray setting</comment>
         <translation>При дії закриття (X) qTox буде згортатися до лотку, замість виходу з програми.</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="146"/>
         <source>Close to tray</source>
         <translation>Закривати до лотку</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="169"/>
         <source>After pressing minimize (_) qTox will minimize itself to tray,
 instead of system taskbar.</source>
         <comment>toolTip for minimize to tray setting</comment>
         <translation>При дії згортання (_) qTox буде згортатися до лотку, замість панелі задач.</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="173"/>
         <source>Minimize to tray</source>
         <translation>Мінімізувати до лотку</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="242"/>
-        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Start qTox on operating system startup (current profile).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;body&gt;&lt;p&gt;Запускати qTox при завантаженні системи (поточний профіль)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="245"/>
         <source>Autostart</source>
         <translation>Автозапуск</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="252"/>
         <source>Check for updates on startup</source>
         <translation>Перевіряти оновлення під час запуску</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="269"/>
-        <source>Autoaccept and save files:</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="282"/>
         <source>Set where files will be saved.</source>
         <translation>Вкажіть, куди саме зберігати файли.</translation>
     </message>
     <message>
-        <source>Save to:</source>
-        <translation>Зберігати в:</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="200"/>
         <source>Your status is changed to Away after set period of inactivity.</source>
         <translation>Ваш статус буде змінено на &apos;Відійшов&apos; після вказаного проміжку часу.</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="206"/>
         <source>Auto away after (0 to disable):</source>
         <translation>Автостатус &apos;Відійшов&apos; після (0, щоб вимкнути):</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="294"/>
+        <source>Default directory to save files:</source>
+        <translation>Каталог для зберігання файлів за замовчуванням:</translation>
+    </message>
+    <message>
         <source>Chat</source>
         <translation>Чат</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="356"/>
+        <source>Open qTox&apos;s window when you receive a new message and no window is open yet.</source>
+        <comment>tooltip for Show window setting</comment>
+        <translation>Відкривати вікно qTox при отриманні нового повідомлення, якщо вікно qTox ще не відкрите.</translation>
+    </message>
+    <message>
+        <source>Open window</source>
+        <translation>Відкрити вікно</translation>
+    </message>
+    <message>
         <source>Always notify about new messages in groupchats.</source>
         <comment>toolTip for Group chat always notify</comment>
         <translation>Завжди повідомляти про нові повідомлення у групових чатах.</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="359"/>
         <source>Group chats always notify</source>
         <translation>Постійні повідомлення з групових чатів</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="349"/>
         <source>Show contacts&apos; status changes</source>
         <translation>Показувати зміну статусів контактів</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="311"/>
         <source>Play a sound when you recieve message.</source>
         <comment>toolTip for Notify sound setting</comment>
-        <translation type="unfinished"></translation>
+        <translation>Відтворювати звук при отриманні повідомлення.</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="314"/>
         <source>Play sound</source>
         <translation>Відтворювати звук</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="376"/>
         <source>Messages you are trying to send to your friends when they are not online
 will be sent to them when they appear online to you.</source>
         <comment>toolTip for Faux offline messaging setting</comment>
-        <translation type="unfinished"></translation>
+        <translation>Повідомлення, які Ви намагаєтесь відправити друзям, які зараз не в мережі, будуть відправлені їм, коли вони з&apos;являться в мережі (одночасно з Вами).</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="366"/>
         <source>If checked, groupchats will be placed at the top of the friends list, otherwise, they&apos;ll be placed below online friends.</source>
         <comment>toolTip for groupchat positioning</comment>
         <translation>Групові чати будуть зверху в списку контактів.</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="369"/>
         <source>Place groupchats at top of friend list</source>
         <translation>Групові чати на початку</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="524"/>
         <source>Date format:</source>
         <translation>Формат дати:</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="682"/>
         <source>Proxy type:</source>
         <translation>Тип проксі:</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="689"/>
         <source>Address:</source>
         <extracomment>Text on proxy addr label</extracomment>
         <translation>Адреса проксі:</translation>
     </message>
     <message>
-        <source>Provided in minutes</source>
-        <translation type="obsolete">Встановлено в хвилинах</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="219"/>
         <source>Set to 0 to disable</source>
         <translation>Встановіть 0, аби вимкнути</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="225"/>
-        <source> minutes</source>
-        <translation> хвилин</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="400"/>
         <source>Theme</source>
         <translation>Графічна тема</translation>
     </message>
     <message>
-        <source>Translation</source>
-        <translation type="obsolete">Мова інтерфейсу</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="156"/>
         <source>Light icon</source>
         <translation>Світлі піктограми</translation>
     </message>
     <message>
-        <source>Check for updates on startup (unstable)</source>
-        <translation type="obsolete">Перевіряти оновлення під час запуску (нестабільна функція)</translation>
-    </message>
-    <message>
-        <source>Focus qTox when a message is received</source>
-        <translation type="obsolete">Перехоплювати фокус вікна при отриманні повідомлення</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="380"/>
         <source>Faux offline messaging</source>
         <translation>Фальшивий поза мережевий обмін повідомленнями</translation>
     </message>
     <message>
-        <source>Auto away after (0 to disable)</source>
-        <translation type="obsolete">Авто-статус «Відійшов» (0=вимкнено)</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="266"/>
         <source>You can set this on a per-friend basis by right clicking them.</source>
         <comment>autoaccept cb tooltip</comment>
         <translation>Ви також можете встановити це значення до кожного друга окремо викликавши правою кнопкою меню навпроти нього.</translation>
@@ -1298,177 +1026,105 @@ will be sent to them when they appear online to you.</source>
         <translation>Автоматично приймати файли</translation>
     </message>
     <message>
-        <source>Save files in</source>
-        <translation type="obsolete">Зберігати файли до</translation>
-    </message>
-    <message>
-        <source>PushButton</source>
-        <translation type="obsolete">Тисніть кнопку</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="406"/>
         <source>Use emoticons</source>
         <translation>Використовувати смайлики</translation>
     </message>
     <message>
-        <source>Smiley Pack</source>
-        <extracomment>Text on smiley pack label</extracomment>
-        <translation type="obsolete">Пакунок смайликів</translation>
-    </message>
-    <message>
-        <source>Style</source>
-        <translation type="obsolete">Стиль</translation>
-    </message>
-    <message>
-        <source>Theme color</source>
-        <translation type="obsolete">Колір графічної теми</translation>
-    </message>
-    <message>
-        <source>Emoticon size</source>
-        <translation type="obsolete">Розмір смайликів</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="457"/>
         <source> px</source>
         <translation> px</translation>
     </message>
     <message>
-        <source>Timestamp format</source>
-        <translation type="obsolete">Формати часового відбитку</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="624"/>
         <source>Connection Settings</source>
         <translation>Параметри підключення</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="648"/>
         <source>Enable IPv6 (recommended)</source>
         <extracomment>Text on a checkbox to enable IPv6</extracomment>
         <translation>Дозволити IPv6 (рекомендовано)</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="638"/>
         <source>Disabling this allows, e.g., toxing over Tor. It adds load to the Tox network however, so uncheck only when necessary.</source>
         <extracomment>force tcp checkbox tooltip</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Вимкнення цього дозволить, наприклад, використовувати qTox через Tor. Проте це збільшить навантаження на мережу Tox, то ж вимикайте лише в разі необхідності.</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="67"/>
         <source>Language:</source>
         <translation>Мова:</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="102"/>
-        <source>System tray</source>
-        <translation>Системний лоток</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="305"/>
         <source>On new message:</source>
         <translation>За нового повідомлення:</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="331"/>
-        <source>Show qTox&apos;s window when you receive new message.</source>
-        <comment>tooltip for Show window setting</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="334"/>
-        <source>Show window</source>
-        <translation>Показати вікно</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="321"/>
         <source>Focus qTox when you receive message.</source>
         <comment>toolTip for Focus window setting</comment>
-        <translation type="unfinished"></translation>
+        <translation>Фокусувати вікно qTox при отриманні повідомлення.</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="324"/>
         <source>Focus window</source>
         <translation>Фокусувати вікно</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="387"/>
         <source>Your contact list will be shown in compact mode.</source>
         <comment>toolTip for compact layout setting</comment>
-        <translation type="unfinished"></translation>
+        <translation>Ваш перелік контактів відображатиметься в компактному режимі.</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="390"/>
         <source>Compact contact list</source>
         <translation>Компактний список контактів</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="424"/>
+        <source>Multiple windows mode</source>
+        <translation>Багатовіконний режим</translation>
+    </message>
+    <message>
+        <source>Open each chat in an individual window</source>
+        <translation>Відкривати кожен чат в окремому вікні</translation>
+    </message>
+    <message>
         <source>Smiley Pack:</source>
         <extracomment>Text on smiley pack label</extracomment>
         <translation>Набір смайлів:</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="441"/>
         <source>Emoticon size:</source>
         <translation>Розмір смайлів:</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="473"/>
         <source>Style:</source>
         <translation>Стиль:</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="490"/>
         <source>Theme color:</source>
         <translation>Графічна тема:</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="507"/>
         <source>Timestamp format:</source>
         <translation>Формат часу:</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="641"/>
         <source>Enable UDP (recommended)</source>
         <extracomment>Text on checkbox to disable UDP</extracomment>
         <translation>Дозволити UDP (рекомендовано)</translation>
     </message>
     <message>
-        <source>Proxy type</source>
-        <translation type="obsolete">Тип проксі</translation>
+        <source>Port:</source>
+        <extracomment>Text on proxy port label</extracomment>
+        <translation>Порт:</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="713"/>
         <source>None</source>
         <translation>Відсутній</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="718"/>
         <source>SOCKS5</source>
         <translation>SOCKS5</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="723"/>
         <source>HTTP</source>
         <translation>HTTP</translation>
     </message>
     <message>
-        <source>Use proxy (SOCKS5)</source>
-        <translation type="obsolete">Використовувати проксі (SOCKS5)</translation>
-    </message>
-    <message>
-        <source>Address</source>
-        <extracomment>Text on proxy addr label</extracomment>
-        <translation type="obsolete">Адреса</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="699"/>
-        <source>Port</source>
-        <extracomment>Text on proxy port label</extracomment>
-        <translation>Порт</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/generalsettings.ui" line="748"/>
         <source>Reconnect</source>
         <comment>reconnect button</comment>
         <translation>Повторно під&apos;єднатись</translation>
@@ -1477,116 +1133,110 @@ will be sent to them when they appear online to you.</source>
 <context>
     <name>GenericChatForm</name>
     <message>
-        <location filename="../src/widget/form/genericchatform.cpp" line="72"/>
         <source>Send message</source>
         <translation>Відправити повідомлення</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/genericchatform.cpp" line="74"/>
         <source>Smileys</source>
         <translation>Смайлики</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/genericchatform.cpp" line="78"/>
         <source>Send file(s)</source>
         <translation>Відправити файл(и)</translation>
     </message>
     <message>
-        <source>Audio call: RED means you&apos;re on a call</source>
-        <translation>Аудіо дзвінок: Червоний - дзвінок активний</translation>
-    </message>
-    <message>
-        <source>Video call: RED means you&apos;re on a call</source>
-        <translation>Відео дзвінок: Червоний - дзвінок активний</translation>
-    </message>
-    <message>
-        <source>Toggle speakers volume: RED is OFF</source>
-        <translation>Перемкнути стан гучності відтворення: Червоний - вимкнено</translation>
-    </message>
-    <message>
-        <source>Toggle microphone: RED is OFF</source>
-        <translation>Перемкнути рівень підсилення мікрофону: Червоний - вимкнено</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/genericchatform.cpp" line="80"/>
         <source>Send a screenshot</source>
         <translation>Відправити знімок екрану</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/genericchatform.cpp" line="83"/>
-        <source>Start an audio call</source>
-        <translation>Почати аудіодзвінок</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/genericchatform.cpp" line="86"/>
-        <source>Start a video call</source>
-        <translation>Почати відеодзвінок</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/genericchatform.cpp" line="175"/>
-        <location filename="../src/widget/form/genericchatform.cpp" line="324"/>
         <source>Save chat log</source>
         <translation>Зберегти чат</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/genericchatform.cpp" line="176"/>
+        <source>Start audio call</source>
+        <translation>Почати аудіодзвінок</translation>
+    </message>
+    <message>
+        <source>Accept audio call</source>
+        <translation>Прийняти аудіо дзвінок</translation>
+    </message>
+    <message>
+        <source>End audio call</source>
+        <translation>Завершити аудіодзвінок</translation>
+    </message>
+    <message>
+        <source>Start video call</source>
+        <translation>Почати відеодзвінок</translation>
+    </message>
+    <message>
+        <source>Accept video call</source>
+        <translation>Прийняти відеодзвінок</translation>
+    </message>
+    <message>
+        <source>End video call</source>
+        <translation>Завершити відеодзвінок</translation>
+    </message>
+    <message>
         <source>Clear displayed messages</source>
         <translation>Очистити показані повідомлення</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/genericchatform.cpp" line="340"/>
         <source>Not sent</source>
         <translation>Не відправлено</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/genericchatform.cpp" line="378"/>
         <source>Cleared</source>
         <translation>Очищено</translation>
     </message>
 </context>
 <context>
+    <name>GenericNetCamView</name>
+    <message>
+        <source>Tox video</source>
+        <translation>Tox відео</translation>
+    </message>
+    <message>
+        <source>Show Messages</source>
+        <translation>Показати повідомлення</translation>
+    </message>
+    <message>
+        <source>Hide Messages</source>
+        <translation>Приховати повідомлення</translation>
+    </message>
+</context>
+<context>
     <name>GroupChatForm</name>
     <message>
-        <location filename="../src/widget/form/groupchatform.cpp" line="56"/>
         <source>%1 users in chat</source>
         <comment>Number of users in chat</comment>
         <translation>Користувачів у чаті: %1</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/groupchatform.cpp" line="125"/>
-        <source>%1 users in chat</source>
-        <translation>Користувачів у чаті: %1</translation>
+        <source>1 user in chat</source>
+        <comment>Number of users in chat</comment>
+        <translation>1 користувач в чаті</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/groupchatform.cpp" line="167"/>
-        <location filename="../src/widget/form/groupchatform.cpp" line="274"/>
         <source>Start audio call</source>
         <translation>Почати аудіодзвінок</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/groupchatform.cpp" line="215"/>
-        <location filename="../src/widget/form/groupchatform.cpp" line="261"/>
         <source>Mute microphone</source>
         <translation>Вимкнути мікрофон</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/groupchatform.cpp" line="221"/>
         <source>Unmute microphone</source>
         <translation>Увімкнути мікрофон</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/groupchatform.cpp" line="236"/>
-        <location filename="../src/widget/form/groupchatform.cpp" line="264"/>
         <source>Mute call</source>
         <translation>Призупинити дзвінок</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/groupchatform.cpp" line="242"/>
         <source>Unmute call</source>
         <translation>Відновити дзвінок</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/groupchatform.cpp" line="258"/>
         <source>End audio call</source>
         <translation>Завершити аудіодзвінок</translation>
     </message>
@@ -1594,806 +1244,522 @@ will be sent to them when they appear online to you.</source>
 <context>
     <name>GroupWidget</name>
     <message>
-        <location filename="../src/widget/groupwidget.cpp" line="43"/>
-        <location filename="../src/widget/groupwidget.cpp" line="89"/>
+        <source>Open chat in new window</source>
+        <translation>Відкрити чат в новому вікні</translation>
+    </message>
+    <message>
+        <source>Remove chat from this window</source>
+        <translation>Видалити чат з цього вікна</translation>
+    </message>
+    <message>
+        <source>1 user in chat</source>
+        <translation>1 користувач в чаті</translation>
+    </message>
+    <message>
         <source>%1 users in chat</source>
         <translation>Користувачів у чаті: %1</translation>
     </message>
     <message>
-        <location filename="../src/widget/groupwidget.cpp" line="45"/>
-        <location filename="../src/widget/groupwidget.cpp" line="91"/>
-        <source>0 users in chat</source>
-        <translation>Немає користувачів</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/groupwidget.cpp" line="55"/>
         <source>Quit group</source>
         <comment>Menu to quit a groupchat</comment>
         <translation>Вийти з групи</translation>
     </message>
     <message>
-        <location filename="../src/widget/groupwidget.cpp" line="54"/>
         <source>Set title...</source>
         <translation>Встановити заголовок…</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/groupwidget.cpp" line="69"/>
-        <source>Group title</source>
-        <translation>Заголовок групи</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/groupwidget.cpp" line="69"/>
-        <source>You can also set this by clicking the chat form name.
-Title:</source>
-        <translation>Ви також можете встановити його натиснувши на назву форми в чаті.
-Заголовок:</translation>
-    </message>
-</context>
-<context>
-    <name>IdentityForm</name>
-    <message>
-        <source>Identity</source>
-        <translation>Ідентифікація</translation>
-    </message>
-    <message>
-        <source>Call active</source>
-        <comment>popup title</comment>
-        <translation>Дзвінок активний</translation>
-    </message>
-    <message>
-        <source>You can&apos;t switch profiles while a call is active!</source>
-        <comment>popup text</comment>
-        <translation>Ви не можете перемикати профіль під час активного дзвінка!</translation>
-    </message>
-    <message>
-        <source>Rename &quot;%1&quot;</source>
-        <comment>renaming a profile</comment>
-        <translation>Перейменувати «%1»</translation>
-    </message>
-    <message>
-        <source>Profile already exists</source>
-        <comment>rename confirm title</comment>
-        <translation>Профіль вже існує</translation>
-    </message>
-    <message>
-        <source>A profile named &quot;%1&quot; already exists. Do you want to erase it?</source>
-        <comment>rename confirm text</comment>
-        <translation>Профіль із назвою «%1» вже існує. Бажаєте стерти його?</translation>
-    </message>
-    <message>
-        <source>Export profile</source>
-        <comment>save dialog title</comment>
-        <translation>Експорт профілю</translation>
-    </message>
-    <message>
-        <source>Tox save file (*.tox)</source>
-        <comment>save dialog filter</comment>
-        <translation>Файл збереження Tox (*.tox)</translation>
-    </message>
-    <message>
-        <source>Failed to remove file</source>
-        <translation>Не вдалось вилучити файл</translation>
-    </message>
-    <message>
-        <source>The file you chose to overwrite could not be removed first.</source>
-        <translation>Неможливо вилучити файл, який ви обрали для перезапису.</translation>
-    </message>
-    <message>
-        <source>Failed to copy file</source>
-        <translation>На вдалось скопіювати файл</translation>
-    </message>
-    <message>
-        <source>The file you chose could not be written to.</source>
-        <translation>Неможливо записати в файл, який ви обрали.</translation>
-    </message>
-    <message>
-        <source>Profile currently loaded</source>
-        <comment>current profile deletion warning title</comment>
-        <translation>Поточний профіль завантажено</translation>
-    </message>
-    <message>
-        <source>This profile is currently in use. Please load a different profile before deleting this one.</source>
-        <comment>current profile deletion warning text</comment>
-        <translation>Даний профіль зараз використовується. Завантажте інший, парад вилученням поточного профілю.</translation>
-    </message>
-    <message>
-        <source>Deletion imminent!</source>
-        <comment>deletion confirmation title</comment>
-        <translation>Небезпечне вилучення!</translation>
-    </message>
-    <message>
-        <source>Are you sure you want to delete this profile?
-Associated friend information and chat logs will be deleted as well.</source>
-        <comment>deletion confirmation text</comment>
-        <translation type="obsolete">Дійсно вилучити даний профіль?
-Пов&apos;язана інформація про друзів та історія спілкування також буде вилучена.</translation>
-    </message>
-    <message>
-        <source>Import profile</source>
-        <comment>import dialog title</comment>
-        <translation>Імпортувати профіль</translation>
-    </message>
-    <message>
-        <source>Tox save file (*.tox)</source>
-        <comment>import dialog filter</comment>
-        <translation>Файл збереження Tox (*.tox)</translation>
-    </message>
-    <message>
-        <source>Ignoring non-Tox file</source>
-        <comment>popup title</comment>
-        <translation>Ігнорування не Tox файлу</translation>
-    </message>
-    <message>
-        <source>Warning: you&apos;ve chosen a file that is not a Tox save file; ignoring.</source>
-        <comment>popup text</comment>
-        <translation>Увага: вказаний вами файл не є файлом збереження Tox; ігнорую.</translation>
-    </message>
-    <message>
-        <source>Profile already exists</source>
-        <comment>import confirm title</comment>
-        <translation>Профіль вже існує</translation>
-    </message>
-    <message>
-        <source>A profile named &quot;%1&quot; already exists. Do you want to erase it?</source>
-        <comment>import confirm text</comment>
-        <translation>Профіль із назвою «%1» вже існує. Бажаєте стерти його?</translation>
     </message>
 </context>
 <context>
     <name>IdentitySettings</name>
     <message>
-        <location filename="../src/widget/form/profileform.ui" line="53"/>
         <source>Public Information</source>
         <translation>Публічна інформація</translation>
     </message>
     <message>
-        <source>Name</source>
-        <translation>Ім&apos;я</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>Статус</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/profileform.ui" line="92"/>
         <source>Tox ID</source>
         <translation>Tox ID</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/profileform.ui" line="98"/>
-        <location filename="../src/widget/form/profileform.ui" line="109"/>
         <source>This bunch of characters tells other Tox clients how to contact you.
 Share it with your friends to communicate.</source>
         <comment>Tox ID tooltip</comment>
-        <translation type="unfinished"></translation>
+        <translation>Цей набір символів дозволяє клієнтам Tox зв&apos;язатись з Вами. Для комунікації поділіться ним з своїм друзями.</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/profileform.ui" line="102"/>
         <source>Your Tox ID (click to copy)</source>
         <translation>Ваш Tox ID (клацніть аби скопіювати)</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/profileform.ui" line="120"/>
-        <source>QRCODE</source>
-        <translation>QR код</translation>
+        <source>Profile</source>
+        <translation>Профіль</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/profileform.ui" line="133"/>
+        <source>&lt;p&gt;&lt;a href=&quot;file:///Dir_Path&quot;&gt;&lt;span style=&quot; text-decoration: NONE; color:#000000;&quot;&gt;Current profile location:  Dir_Path&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;</source>
+        <translation>&lt;p&gt;&lt;a href=&quot;file:///Dir_Path&quot;&gt;&lt;span style=&quot; text-decoration: NONE; color:#000000;&quot;&gt;Поточне місцезнаходження файлів профілю:  Dir_Path&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <source>Rename profile.</source>
+        <comment>tooltip for renaming profile button</comment>
+        <translation>Перейменувати профіль.</translation>
+    </message>
+    <message>
+        <source>Delete profile.</source>
+        <comment>delete profile button tooltip</comment>
+        <translation>Видалити профіль.</translation>
+    </message>
+    <message>
+        <source>Go back to the login screen</source>
+        <comment>tooltip for logout button</comment>
+        <translation>Повернутись до екрану входу</translation>
+    </message>
+    <message>
+        <source>Logout</source>
+        <comment>import profile button</comment>
+        <translation>Вийти з облікового запису</translation>
+    </message>
+    <message>
+        <source>Remove password</source>
+        <translation>Видалити пароль</translation>
+    </message>
+    <message>
+        <source>Change password</source>
+        <translation>Змінити пароль</translation>
+    </message>
+    <message>
         <source>This QR code contains your Tox ID. You may share this with your friends as well.</source>
         <translation>Цей QR код містить ваш Tox ID. Ви можете ділитися ним зі своїми друзями.</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/profileform.ui" line="140"/>
         <source>Save image</source>
         <translation>Зберегти зображення</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/profileform.ui" line="147"/>
         <source>Copy image</source>
         <translation>Копіювати зображення</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/profileform.ui" line="163"/>
-        <source>Profiles</source>
-        <translation>Профілі</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/profileform.ui" line="171"/>
-        <source>Available profiles:</source>
-        <translation>Доступні профілі:</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/profileform.ui" line="184"/>
-        <source>Currently selected profile.</source>
-        <comment>toolTip for currently set profile</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/profileform.ui" line="195"/>
-        <source>Load selected profile and switch to it.</source>
-        <comment>tooltip for loading profile button</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/profileform.ui" line="198"/>
-        <source>Load</source>
-        <comment>load profile button</comment>
-        <translation>Завантажити</translation>
-    </message>
-    <message>
-        <source>Switching profiles is disabled during calls</source>
-        <comment>tooltip</comment>
-        <translation type="obsolete">Перемикання профілю заблоковано під час дзвінків</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/profileform.ui" line="208"/>
         <source>Rename</source>
         <comment>rename profile button</comment>
         <translation>Перейменувати</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/profileform.ui" line="205"/>
-        <source>Rename selected profile.</source>
-        <comment>tooltip for renaming profile button</comment>
-        <translation>Перейменування вибраного профілю.</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/profileform.ui" line="219"/>
         <source>Export</source>
         <comment>export profile button</comment>
         <translation>Експорт</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/profileform.ui" line="215"/>
         <source>Allows you to export your Tox profile to a file.
 Profile does not contain your history.</source>
         <comment>tooltip for profile exporting button</comment>
-        <translation type="unfinished"></translation>
+        <translation>Дозволяє Вами експортувати ваш профіль Tox в файл. Профіль не містить Вашу історію переписки.</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/profileform.ui" line="67"/>
         <source>Name:</source>
         <translation>Ім&apos;я:</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/profileform.ui" line="77"/>
         <source>Status:</source>
         <translation>Статус:</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/profileform.ui" line="226"/>
-        <source>Delete selected profile.</source>
-        <comment>delete profile button tooltip</comment>
-        <translation>Видалення вибраного профілю.</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/profileform.ui" line="229"/>
         <source>Delete</source>
         <comment>delete profile button</comment>
         <translation>Вилучити</translation>
-    </message>
-    <message>
-        <source>This is useful to remain safe on public computers</source>
-        <comment>delete profile button tooltip</comment>
-        <translation type="obsolete">Це стає в нагоді, при користуванні публічними комп&apos;ютерами</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/profileform.ui" line="243"/>
-        <source>Import a profile</source>
-        <comment>import profile button</comment>
-        <translation>Імпортувати профіль</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/profileform.ui" line="240"/>
-        <source>Import Tox profile from a .tox file.</source>
-        <comment>tooltip for importing profile button</comment>
-        <translation>Імпортувати профіль з .tox файлу.</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/profileform.ui" line="250"/>
-        <source>Create new Tox ID and switch to it.</source>
-        <comment>tooltip for creating new Tox ID button</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/profileform.ui" line="253"/>
-        <source>New Tox ID</source>
-        <comment>new profile button</comment>
-        <translation>Новий Tox ID</translation>
-    </message>
-</context>
-<context>
-    <name>InputPasswordDialog</name>
-    <message>
-        <source>Password Dialog</source>
-        <translation type="obsolete">Пароль</translation>
-    </message>
-    <message>
-        <source>Input password:</source>
-        <translation type="obsolete">Введіть пароль:</translation>
     </message>
 </context>
 <context>
     <name>LoadHistoryDialog</name>
     <message>
-        <location filename="../src/widget/form/loadhistorydialog.ui" line="14"/>
         <source>Load History Dialog</source>
         <translation>Історія</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/loadhistorydialog.ui" line="23"/>
         <source>Load history from:</source>
         <translation>Завантажити історію від:</translation>
     </message>
 </context>
 <context>
+    <name>LoginScreen</name>
+    <message>
+        <source>Username:</source>
+        <translation>Ім&apos;я користувача:</translation>
+    </message>
+    <message>
+        <source>Password:</source>
+        <translation>Пароль:</translation>
+    </message>
+    <message>
+        <source>Confirm:</source>
+        <translation>Підтвердження:</translation>
+    </message>
+    <message>
+        <source>Password strength: %p%</source>
+        <translation>Надійність пароля: %p%</translation>
+    </message>
+    <message>
+        <source>Create Profile</source>
+        <translation>Створити профіль</translation>
+    </message>
+    <message>
+        <source>If the profile does not have a password, qTox can skip the login screen</source>
+        <translation>Якщо пароль профілю не задано, qTox може пропускати екран входу</translation>
+    </message>
+    <message>
+        <source>Load automatically</source>
+        <translatorcomment>&quot;Завантажувати&quot; is exact translation of English &quot;Load&quot;, which is a synonym for &quot;Download&quot; in Ukrainian. 
+So I think in this case more appropriate is &quot;Входити автоматично&quot;, which means &quot;Log in automatically&quot;.</translatorcomment>
+        <translation>Завантажувати автоматично</translation>
+    </message>
+    <message>
+        <source>Load</source>
+        <translatorcomment>&quot;Завантажити&quot; is exact translation of English &quot;Load&quot;, which is a synonym for &quot;Download&quot; in Ukrainian. 
+So I think in this case more appropriate is &quot;Увійти&quot;, which means &quot;Log in&quot;.</translatorcomment>
+        <translation>Завантажити</translation>
+    </message>
+    <message>
+        <source>New Profile</source>
+        <translatorcomment>I think that more appropriate is &quot;Новий обліковий запис&quot;, but this string is too long.</translatorcomment>
+        <translation>Новий профіль</translation>
+    </message>
+    <message>
+        <source>Load Profile</source>
+        <translatorcomment>I think that more appropriate is &quot;Завантажити обліковий запис&quot;, but this string is too long.</translatorcomment>
+        <translation>Завантажити профіль</translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t create a new profile</source>
+        <translation>Неможливо створити новий профіль</translation>
+    </message>
+    <message>
+        <source>The username must not be empty.</source>
+        <translation>Ім&apos;я користувача не може бути пустим.</translation>
+    </message>
+    <message>
+        <source>The password must be at least 6 characters long.</source>
+        <translation>Пароль повинен містити щонайменше 6 символів.</translation>
+    </message>
+    <message>
+        <source>The passwords you&apos;ve entered are different.
+Please make sure to enter same password twice.</source>
+        <translation>Паролі, які Ви ввели, не співпадають.
+Переконайтесь, що ввели однаковий пароль двічі.</translation>
+    </message>
+    <message>
+        <source>A profile with this name already exists.</source>
+        <translation>Профіль з таким іменем уже існує.</translation>
+    </message>
+    <message>
+        <source>Unknown error: Couldn&apos;t create a new profile.
+If you encountered this error, please report it.</source>
+        <translation>Невідома помилка: Неможливо створити новий профіль. Якщо Ви зустріли цю помилку, будь ласка, повідомте про це.</translation>
+    </message>
+    <message>
+        <source>Password protected profile can&apos;t be loaded automatically.</source>
+        <translation>Профіль, захищений паролем, не може бути завантажений автоматично.</translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t load profile</source>
+        <translation>Неможливо завантажити профіль</translation>
+    </message>
+    <message>
+        <source>There is no selected profile.
+
+You may want to create one.</source>
+        <translation>Не обрано жодного профілю.
+
+Можливо, Ви б хотіли створити його.</translation>
+    </message>
+    <message>
+        <source>Couldn&apos;t load this profile</source>
+        <translation>Неможливо завантажити даний профіль</translation>
+    </message>
+    <message>
+        <source>This profile is already in use.</source>
+        <translation>Цей профіль вже використовується.</translation>
+    </message>
+    <message>
+        <source>Profile already in use. Close other clients.</source>
+        <translation>Профіль вже використовується. Закрийте інші клієнти.</translation>
+    </message>
+    <message>
+        <source>Wrong password.</source>
+        <translation>Неправильний пароль.</translation>
+    </message>
+</context>
+<context>
     <name>MainWindow</name>
     <message>
-        <location filename="../src/mainwindow.ui" line="862"/>
         <source>Your name</source>
         <translation>Ваше ім&apos;я</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.ui" line="944"/>
         <source>Your status</source>
         <translation>Ваш статус</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.ui" line="1131"/>
+        <source>...</source>
+        <translation></translation>
+    </message>
+    <message>
         <source>Add friends</source>
         <translation>Додати друзів</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.ui" line="1175"/>
         <source>Create a group chat</source>
         <translation>Створити груповий чат</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.ui" line="1216"/>
         <source>View completed file transfers</source>
         <translation>Переглянути завершені передачі файлів</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.ui" line="1254"/>
         <source>Change your settings</source>
         <translation>Змінити параметри</translation>
     </message>
     <message>
-        <location filename="../src/mainwindow.ui" line="1848"/>
         <source>Close</source>
         <translation>Закрити</translation>
     </message>
 </context>
 <context>
-    <name>NetCamView</name>
-    <message>
-        <location filename="../src/widget/netcamview.cpp" line="26"/>
-        <source>Tox video</source>
-        <translation>Tox Відео</translation>
-    </message>
-</context>
-<context>
     <name>Nexus</name>
     <message>
-        <location filename="../src/nexus.cpp" line="181"/>
         <source>Images (%1)</source>
         <comment>filetype filter</comment>
         <translation>Зображення (%1)</translation>
+    </message>
+    <message>
+        <source>View</source>
+        <comment>OS X Menu bar</comment>
+        <translation>Вигляд</translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <comment>OS X Menu bar</comment>
+        <translation>Вікно</translation>
+    </message>
+    <message>
+        <source>Minimize</source>
+        <comment>OS X Menu bar</comment>
+        <translation>Мінімізувати</translation>
+    </message>
+    <message>
+        <source>Bring All to Front</source>
+        <comment>OS X Menu bar</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exit Fullscreen</source>
+        <translation>Вимкнути повноекранний режим</translation>
+    </message>
+    <message>
+        <source>Enter Fullscreen</source>
+        <translation>Увімкнути повноекранний режим</translation>
+    </message>
+</context>
+<context>
+    <name>NotificationEdgeWidget</name>
+    <message numerus="yes">
+        <source>Unread message(s)</source>
+        <translation>
+            <numerusform>%n непрочитане повідомлення</numerusform>
+            <numerusform>%n непрочитаних повідомлень</numerusform>
+            <numerusform>%n непрочитаних повідомлень</numerusform>
+        </translation>
     </message>
 </context>
 <context>
     <name>PrivacyForm</name>
     <message>
-        <location filename="../src/widget/form/settings/privacyform.cpp" line="29"/>
         <source>Privacy</source>
         <translation>Приватність</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/privacyform.cpp" line="76"/>
-        <source>Please set your new chat history password.</source>
-        <translation>Встановіть новий пароль для історії чату.</translation>
+        <source>Confirmation</source>
+        <translation>Підтвердження</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/privacyform.cpp" line="78"/>
-        <source>It appears you have an unused encrypted chat history; if the password matches, it will be added to your current history.</source>
-        <translation>Здається, у вас вже є зашифрована історія чату; якщо пароль співпаде, вона буде додана до поточної історії.</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/privacyform.cpp" line="81"/>
-        <source>Use data file password</source>
-        <comment>pushbutton text</comment>
-        <translation>Введіть пароль файлу даних</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/privacyform.cpp" line="108"/>
-        <source>Successfully decrypted old chat history</source>
-        <comment>popup title</comment>
-        <translation>Стара історія чату успішно розшифрована</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/privacyform.cpp" line="108"/>
-        <source>You have succesfully decrypted the old chat history, and it has been added to your current history and re-encrypted.</source>
-        <comment>popup text</comment>
-        <translation>Стара історія була успішно розшифрована, додана до поточної історії та знову зашифрована.</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/privacyform.cpp" line="115"/>
-        <location filename="../src/widget/form/settings/privacyform.cpp" line="117"/>
-        <source>Old encrypted chat history</source>
-        <comment>popup title</comment>
-        <translation>Стара зашифрована історія</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/privacyform.cpp" line="115"/>
-        <source>There is currently an unused encrypted chat history, but the password you just entered doesn&apos;t match.
-
-If you don&apos;t care about the old history, you may delete it and use the password you just entered.
-Otherwise, hit Cancel to try again.</source>
-        <comment>This happens when enabling encryption after previously &quot;Disabling History&quot;</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/privacyform.cpp" line="115"/>
-        <location filename="../src/widget/form/settings/privacyform.cpp" line="117"/>
-        <location filename="../src/widget/form/settings/privacyform.cpp" line="150"/>
-        <location filename="../src/widget/form/settings/privacyform.cpp" line="170"/>
-        <source>Delete</source>
-        <translation>Вилучити</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/privacyform.cpp" line="115"/>
-        <location filename="../src/widget/form/settings/privacyform.cpp" line="117"/>
-        <location filename="../src/widget/form/settings/privacyform.cpp" line="151"/>
-        <location filename="../src/widget/form/settings/privacyform.cpp" line="171"/>
-        <location filename="../src/widget/form/settings/privacyform.cpp" line="251"/>
-        <source>Cancel</source>
-        <translation>Скасувати</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/privacyform.cpp" line="117"/>
-        <source>Are you absolutely sure you want to lose the unused encrypted chat history?</source>
-        <comment>secondary popup</comment>
-        <translation>Ви точно впевнені, що хочете втратити невикористовувану та зашифровану історію чату?</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/privacyform.cpp" line="146"/>
-        <location filename="../src/widget/form/settings/privacyform.cpp" line="167"/>
-        <source>Old encrypted chat history</source>
-        <comment>title</comment>
-        <translation>Стара зашифрована історія</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/privacyform.cpp" line="147"/>
-        <source>Would you like to decrypt your chat history?
-Otherwise it will be deleted.</source>
-        <translation>Ви хочете розшифрувати історію чату?
-Інакше вона буде видалена.</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/privacyform.cpp" line="149"/>
-        <location filename="../src/widget/form/settings/privacyform.cpp" line="251"/>
-        <source>Decrypt</source>
-        <translation>Розшифрувати</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/privacyform.cpp" line="168"/>
-        <source>Are you sure you want to lose your entire chat history?</source>
-        <translation>Ви впевнені, що хочете втратити всю історію чату?</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/privacyform.cpp" line="204"/>
-        <source>Please set your new data file password.</source>
-        <translation>Встановіть новий пароль для файлу даних.</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/privacyform.cpp" line="206"/>
-        <source>Use chat history password</source>
-        <comment>pushbutton text</comment>
-        <translation>Введіть пароль історії чату</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/privacyform.cpp" line="249"/>
-        <source>Decrypt your data file</source>
-        <comment>title</comment>
-        <translation>Розшифрувати файл даних</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/privacyform.cpp" line="250"/>
-        <source>Would you like to decrypt your data file?</source>
-        <translation>Ви хочете розшифрувати ваш файл даних?</translation>
-    </message>
-    <message>
-        <source>Encrypted log</source>
-        <translation type="obsolete">Зашифрований звіт</translation>
-    </message>
-    <message>
-        <source>You already have history log file encrypted with different password
-Do you want to delete old history file?</source>
-        <translation type="obsolete">Ви вже маєте зашифрований файл історії іншим паролем
-Бажаєте вилучити старий файл історії?</translation>
+        <source>Do you want to permanently delete all chat history?</source>
+        <translation></translation>
     </message>
 </context>
 <context>
     <name>PrivacySettings</name>
     <message>
-        <source>Typing Notification</source>
-        <translation type="obsolete">Увімкнути сповіщення про набір</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/privacysettings.ui" line="47"/>
         <source>Your friends will be able to see when you are typing.</source>
         <comment>tooltip for typing notifications setting</comment>
         <translation>Ваші друзі зможуть побачити, коли ви друкуєте.</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/privacysettings.ui" line="50"/>
-        <source>Send Typing Notifications</source>
-        <translation>Надсилати сповіщення про набір</translation>
+        <source>Send typing notifications</source>
+        <translation>Відправляти сповіщення набирання повідомлення</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/settings/privacysettings.ui" line="57"/>
+        <source>Keep chat history</source>
+        <translation>Зберігати історію переписки</translation>
+    </message>
+    <message>
+        <source>NoSpam is part of your Tox ID.
+If you are being spammed with friend requests, you should change your NoSpam.
+People will be unable to add you with your old ID, but you will keep your current friends.</source>
+        <comment>toolTip for nospam</comment>
+        <translation>NoSpam - це частина Вашого Tox ID.
+Якщо Ви отримуєте багато небажаних запитів дружби, то Вам потрібно змінити NoSpam.
+Люди не зможуть додавати Вас за вашим старим ID, але ваші поточні друзі збережуться.</translation>
+    </message>
+    <message>
+        <source>NoSpam</source>
+        <translation>NoSpam</translation>
+    </message>
+    <message>
+        <source>NoSpam is a part of your ID that can be changed at will.
+If you are getting spammed with friend requests, change the NoSpam.</source>
+        <translation>NoSpam - це частина Вашого ID, що може бути змінена за бажанням.
+Якщо Вас спамлять запитами дружби, змініть NoSpam.</translation>
+    </message>
+    <message>
+        <source>Generate random NoSpam</source>
+        <translation>Згенерувати випадковий NoSpam</translation>
+    </message>
+    <message>
         <source>Chat history keeping is still in development.
 Save format changes are possible, which may result in data loss.</source>
         <comment>toolTip for Keep History setting</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/privacysettings.ui" line="61"/>
-        <source>Keep chat history (mostly stable)</source>
-        <translation>Зберігати історію чату</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/privacysettings.ui" line="71"/>
-        <source>Local file encryption</source>
-        <translation>Шифрування локальних файлів</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/privacysettings.ui" line="77"/>
-        <source>All Tox communications over the internet are encrypted, and this cannot be disabled. However, you may optionally password protect your local Tox files.</source>
-        <translation>Всі комунікації через Tox в інтернеті зашифровані і це неможливо змінити. Ви також можете зашифрувати локальні Tox файли.</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/privacysettings.ui" line="92"/>
-        <source>Encrypt Tox data file</source>
-        <translation>Шифрувати файл даних Tox</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/privacysettings.ui" line="99"/>
-        <location filename="../src/widget/form/settings/privacysettings.ui" line="123"/>
-        <source>Change password</source>
-        <translation>Змінити пароль</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/privacysettings.ui" line="113"/>
-        <source>Encrypt chat history</source>
-        <translation>Шифрувати історію чату</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/privacysettings.ui" line="135"/>
-        <source>Nospam is part of your Tox ID.
-It is there to help you change your Tox ID when you feel like you are getting too much spam friend requests.
-When you change nospam, your current contacts still can communicate with you,
-but new contacts need to know your new Tox ID to be able to add you.</source>
-        <comment>toolTip for nospam</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Keep History (unstable)</source>
-        <translation type="obsolete">Лишати історію (нестабільна функція)</translation>
-    </message>
-    <message>
-        <source>Encryption</source>
-        <translation type="obsolete">Шифрування</translation>
-    </message>
-    <message>
-        <source>Encrypt Tox datafile</source>
-        <translation type="obsolete">Шифрувати файл даних Tox</translation>
-    </message>
-    <message>
-        <source>Encrypt History</source>
-        <translation type="obsolete">Шифрувати історію</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/privacysettings.ui" line="141"/>
-        <source>Nospam</source>
-        <translation>Nospam</translation>
-    </message>
-    <message>
-        <source>HHHHHHHH</source>
-        <translation type="obsolete">HHHHHHHH</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/settings/privacysettings.ui" line="156"/>
-        <source>Generate random nospam</source>
-        <translation>Генерувати випадковий «nospam»</translation>
+        <translation>Зберігання історії переписки поки що в розробці.
+Можлива зміна формату зберігання, що може призвести до втрати даних.</translation>
     </message>
 </context>
 <context>
     <name>ProfileForm</name>
     <message>
-        <location filename="../src/widget/form/profileform.cpp" line="206"/>
         <source>Choose a profile picture</source>
         <translation>Оберіть зображення для профілю</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/profileform.cpp" line="216"/>
-        <location filename="../src/widget/form/profileform.cpp" line="223"/>
-        <location filename="../src/widget/form/profileform.cpp" line="245"/>
         <source>Error</source>
         <translation>Помилка</translation>
     </message>
     <message>
-        <source>Unable to open this file</source>
-        <translation type="obsolete">Неможливо відкрити цей файл</translation>
-    </message>
-    <message>
-        <source>Unable to read this image</source>
-        <translation type="obsolete">Неможливо прочитати це зображення</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/profileform.cpp" line="216"/>
         <source>Unable to open this file.</source>
         <translation>Неможливо відкрити цей файл.</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/profileform.cpp" line="223"/>
         <source>Unable to read this image.</source>
         <translation>Неможливо прочитати це зображення.</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/profileform.cpp" line="246"/>
         <source>The supplied image is too large.
 Please use another image.</source>
         <translation>Зображення завелике.
 Виберіть інше, будь ласка.</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/profileform.cpp" line="258"/>
-        <source>Call active</source>
-        <comment>popup title</comment>
-        <translation>Дзвінок активний</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/profileform.cpp" line="259"/>
-        <source>You can&apos;t switch profiles while a call is active!</source>
-        <comment>popup text</comment>
-        <translation>Ви не можете перемикати профіль під час активного дзвінка!</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/profileform.cpp" line="269"/>
         <source>Rename &quot;%1&quot;</source>
         <comment>renaming a profile</comment>
         <translation>Перейменувати «%1»</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/profileform.cpp" line="277"/>
+        <source>Current profile: </source>
+        <translation>Поточний профіль:</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation>Видалити</translation>
+    </message>
+    <message>
         <source>Profile already exists</source>
-        <comment>rename confirm title</comment>
+        <comment>rename failure title</comment>
         <translation>Профіль вже існує</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/profileform.cpp" line="278"/>
-        <source>A profile named &quot;%1&quot; already exists. Do you want to erase it?</source>
+        <source>A profile named &quot;%1&quot; already exists.</source>
         <comment>rename confirm text</comment>
-        <translation>Профіль &quot;%1&quot; вже існує. Ви хочете його стерти?</translation>
+        <translation>Профіль з іменем користувача &quot;%1&quot; вже існує.</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/profileform.cpp" line="282"/>
-        <source>Profile already exists</source>
+        <source>Failed to rename</source>
         <comment>rename failed title</comment>
-        <translation>Профіль вже існує</translation>
+        <translation>Помилка перейменування</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/profileform.cpp" line="283"/>
-        <source>A profile named &quot;%1&quot; already exists and is in use.</source>
-        <translation>Профіль &quot;%1&quot; вже існує та використовується.</translation>
+        <source>Couldn&apos;t rename the profile to &quot;%1&quot;</source>
+        <translation>Неможливо перейменувати профіль в &quot;%1&quot;</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/profileform.cpp" line="305"/>
         <source>Export profile</source>
         <comment>save dialog title</comment>
         <translation>Експорт профілю</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/profileform.cpp" line="307"/>
         <source>Tox save file (*.tox)</source>
         <comment>save dialog filter</comment>
         <translation>Файл Tox (*.tox)</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/profileform.cpp" line="312"/>
-        <location filename="../src/widget/form/profileform.cpp" line="420"/>
         <source>Location not writable</source>
         <comment>Title of permissions popup</comment>
-        <translation type="unfinished">Немає прав на запис</translation>
+        <translation>Немає прав на запис</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/profileform.cpp" line="312"/>
-        <location filename="../src/widget/form/profileform.cpp" line="420"/>
         <source>You do not have permission to write that location. Choose another, or cancel the save dialog.</source>
         <comment>text of permissions popup</comment>
-        <translation type="unfinished">Ви не маєте прав на запис за цим розташуванням. Оберіть інше місце призначення, або скасуйте передачу.</translation>
+        <translation>Ви не маєте прав на запис за цим розташуванням. Оберіть інше місце призначення, або скасуйте передачу.</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/profileform.cpp" line="316"/>
-        <location filename="../src/widget/form/profileform.cpp" line="424"/>
         <source>Failed to copy file</source>
         <translation>На вдалось скопіювати файл</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/profileform.cpp" line="316"/>
-        <location filename="../src/widget/form/profileform.cpp" line="424"/>
         <source>The file you chose could not be written to.</source>
         <translation>Неможливо записати в файл, який ви обрали.</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/profileform.cpp" line="324"/>
-        <source>Profile currently loaded</source>
-        <comment>current profile deletion warning title</comment>
-        <translation type="unfinished">Цей профіль зараз використовується</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/profileform.cpp" line="324"/>
-        <source>This profile is currently in use. Please load a different profile before deleting this one.</source>
-        <comment>current profile deletion warning text</comment>
-        <translation>Даний профіль зараз використовується. Завантажте інший, перед вилученням поточного профілю.</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/profileform.cpp" line="328"/>
-        <source>Deletion imminent!</source>
+        <source>Really delete profile?</source>
         <comment>deletion confirmation title</comment>
-        <translation>Небезпечне вилучення!</translation>
+        <translation>Ви впевнені?</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/profileform.cpp" line="329"/>
+        <source>Nothing to remove</source>
+        <translation>Немає що видаляти</translation>
+    </message>
+    <message>
+        <source>Your profile does not have a password!</source>
+        <translation>Ваш обліковий запис не захищений паролем!</translation>
+    </message>
+    <message>
+        <source>Really delete password?</source>
+        <comment>deletion confirmation title</comment>
+        <translation>Ви впевнені?</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete your password?</source>
+        <comment>deletion confirmation text</comment>
+        <translation>Ви дійсно бажаєте видалити Ваш пароль?</translation>
+    </message>
+    <message>
+        <source>Please enter a new password.</source>
+        <translation>Введіть новий пароль, будь ласка.</translation>
+    </message>
+    <message>
+        <source>User Profile</source>
+        <translation>Профіль користувача</translation>
+    </message>
+    <message>
+        <source>This bunch of characters tells other Tox clients how to contact you.
+Share it with your friends to communicate.</source>
+        <translation>Цей набір символів дозволяє клієнтам Tox зв&apos;язатись з Вами. Для комунікації поділіться ним з своїм друзями.</translation>
+    </message>
+    <message>
         <source>Are you sure you want to delete this profile?</source>
         <comment>deletion confirmation text</comment>
         <translation>Ви впевнені, що хочете видалити цей профіль?</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/profileform.cpp" line="348"/>
-        <source>Import profile</source>
-        <comment>import dialog title</comment>
-        <translation>Імпортувати профіль</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/profileform.cpp" line="350"/>
-        <source>Tox save file (*.tox)</source>
-        <comment>import dialog filter</comment>
-        <translation>Файл Tox (*.tox)</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/profileform.cpp" line="359"/>
-        <source>Ignoring non-Tox file</source>
-        <comment>popup title</comment>
-        <translation type="unfinished">Ігнорування не Tox файлу</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/profileform.cpp" line="360"/>
-        <source>Warning: you&apos;ve chosen a file that is not a Tox save file; ignoring.</source>
-        <comment>popup text</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/profileform.cpp" line="366"/>
-        <source>Profile already exists</source>
-        <comment>import confirm title</comment>
-        <translation>Профіль вже існує</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/profileform.cpp" line="367"/>
-        <source>A profile named &quot;%1&quot; already exists. Do you want to erase it?</source>
-        <comment>import confirm text</comment>
-        <translation>Профіль із назвою &quot;%1&quot; вже існує. Бажаєте стерти його?</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/profileform.cpp" line="413"/>
         <source>Save</source>
         <comment>save qr image</comment>
         <translation>Збереження</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/profileform.cpp" line="415"/>
         <source>Save QrCode (*.png)</source>
         <comment>save dialog filter</comment>
         <translation>Зберегти Qr код (*.png)</translation>
@@ -2402,284 +1768,307 @@ Please use another image.</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox me maybe?</source>
-        <comment>Default message in Tox URI friend requests. Write something appropriate!</comment>
-        <translation>Може поспілкуємось?</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/toxsave.cpp" line="53"/>
         <source>Ignoring non-Tox file</source>
         <comment>popup title</comment>
         <translation>Ігнорування не Tox файлу</translation>
     </message>
     <message>
-        <location filename="../src/widget/toxsave.cpp" line="54"/>
         <source>Warning: you&apos;ve chosen a file that is not a Tox save file; ignoring.</source>
         <comment>popup text</comment>
         <translation>Увага: Вказаний Вами файл не є файлом збереження Tox; він буде проігнорований.</translation>
     </message>
     <message>
-        <location filename="../src/widget/toxsave.cpp" line="60"/>
         <source>Profile already exists</source>
         <comment>import confirm title</comment>
         <translation>Профіль вже існує</translation>
     </message>
     <message>
-        <location filename="../src/widget/toxsave.cpp" line="61"/>
         <source>A profile named &quot;%1&quot; already exists. Do you want to erase it?</source>
         <comment>import confirm text</comment>
         <translation>Профіль із назвою «%1» вже існує. Бажаєте перезаписати його?</translation>
     </message>
     <message>
-        <location filename="../src/widget/toxsave.cpp" line="67"/>
         <source>Profile imported</source>
         <translation>Профіль імпортовано</translation>
     </message>
     <message>
-        <location filename="../src/widget/toxsave.cpp" line="67"/>
         <source>%1.tox was successfully imported</source>
         <translation>%1.tox успішно імпортовано</translation>
     </message>
     <message>
-        <location filename="../src/autoupdate.cpp" line="496"/>
+        <source>Version %1, %2</source>
+        <translation>Версія %1, %2</translation>
+    </message>
+    <message>
         <source>Update</source>
         <comment>The title of a message box</comment>
         <translation>Оновити</translation>
     </message>
     <message>
-        <location filename="../src/autoupdate.cpp" line="497"/>
         <source>An update is available, do you want to download it now?
 It will be installed when qTox restarts.</source>
         <translation>Доступне оновлення, бажаєте завантажити його зараз?
 Оновлення буде встановлено після перезапуску qTox.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="107"/>
         <source>Tox URI to parse</source>
         <translation>Tox URI для розбору</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="108"/>
         <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished"></translation>
+        <translation>Запускає новий екземпляр і завантажує вказаний профіль.</translation>
     </message>
     <message>
-        <location filename="../src/main.cpp" line="108"/>
         <source>profile</source>
         <translation>профіль</translation>
     </message>
     <message>
-        <location filename="../src/misc/style.cpp" line="69"/>
         <source>Default</source>
         <translation>Типовий</translation>
     </message>
     <message>
-        <location filename="../src/misc/style.cpp" line="69"/>
         <source>Blue</source>
         <translation>Синій</translation>
     </message>
     <message>
-        <location filename="../src/misc/style.cpp" line="69"/>
         <source>Olive</source>
         <translation>Оливковий</translation>
     </message>
     <message>
-        <location filename="../src/misc/style.cpp" line="69"/>
         <source>Red</source>
         <translation>Червоний</translation>
     </message>
     <message>
-        <location filename="../src/misc/style.cpp" line="69"/>
         <source>Violet</source>
         <translation>Фіолетовий</translation>
     </message>
     <message>
-        <location filename="../src/widget/callconfirmwidget.cpp" line="28"/>
         <source>Incoming call...</source>
         <translation>Вхідний дзвінок...</translation>
     </message>
     <message>
-        <location filename="../src/chatlog/chatmessage.cpp" line="129"/>
         <source>Resizing</source>
         <translation>Змінити розмір</translation>
     </message>
     <message>
-        <location filename="../src/widget/toxuri.cpp" line="68"/>
         <source>%1 here! Tox me maybe?</source>
         <comment>Default message in Tox URI friend requests. Write something appropriate!</comment>
-        <translation type="unfinished"></translation>
+        <translatorcomment>That means &quot;Hi, I&apos;m %1! Please, add me to you contact list.
+It&apos;s difficult to translate &quot;Tox me maybe&quot; because in Ukrainian noun can&apos;t mean a verb (like &quot;call&quot; for noun and verb in English)</translatorcomment>
+        <translation>Привіт, я %1! Додай мене в свій список контактів, будь ласка.
+</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/chatform.cpp" line="82"/>
-        <source>Load chat history...</source>
-        <translation>Завантажити історію чату...</translation>
+        <source>Incorrect response</source>
+        <translation>Некоректна відповідь</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/profileform.cpp" line="70"/>
-        <source>User Profile</source>
-        <translation>Профіль користувача</translation>
+        <source>No password in response</source>
+        <translation>У відповіді відсутній пароль</translation>
+    </message>
+    <message>
+        <source>Server doesn&apos;t support Toxme</source>
+        <translation>Сервер не підтримує Toxme</translation>
+    </message>
+    <message>
+        <source>You must send POST requests to /api</source>
+        <translation>Ви повинні відправити POST-запит до /api</translation>
+    </message>
+    <message>
+        <source>Please try again using a HTTPS connection</source>
+        <translation>Спробуйте ще раз, використовуючи HTTPS-з&apos;єднання, будь ласка</translation>
+    </message>
+    <message>
+        <source>I was unable to read your encrypted payload</source>
+        <translation>Я не міг прочитати Ваш зашифрований трафік</translation>
+    </message>
+    <message>
+        <source>You&apos;re making too many requests. Wait an hour and try again</source>
+        <translation>Ви відправляєте забагато запитів. Зачекайте годинку та спробуйте ще раз</translation>
+    </message>
+    <message>
+        <source>This name is already in use</source>
+        <translation>Це ім&apos;я вже використовується</translation>
+    </message>
+    <message>
+        <source>This Tox ID is already registered under another name</source>
+        <translation>Цей Tox ID вже зареєстровано під іншим іменем</translation>
+    </message>
+    <message>
+        <source>Please don&apos;t use a space in your name</source>
+        <translation>Будь ласка, не використвуйте пробіли в Вашому імені</translation>
+    </message>
+    <message>
+        <source>Password incorrect</source>
+        <translation>Невірний пароль</translation>
+    </message>
+    <message>
+        <source>You can&apos;t use this name</source>
+        <translation>Ви не можете використати це ім&apos;я</translation>
+    </message>
+    <message>
+        <source>Name not found</source>
+        <translation>Ім&apos;я не знайдено</translation>
+    </message>
+    <message>
+        <source>Tox ID not sent</source>
+        <translation>Tox ID не надіслано</translation>
+    </message>
+    <message>
+        <source>Lookup failed because the server replied with invalid data</source>
+        <translation>Пошук завершився невдало, тому що сервер надіслав некоректні дані</translation>
+    </message>
+    <message>
+        <source>That user does not exist</source>
+        <translation>Такого користувача не існує</translation>
+    </message>
+    <message>
+        <source>Internal lookup error. Please file a bug</source>
+        <translation>Внутрішня помилка пошуку. Будь ласка, повідомте про помилку</translation>
+    </message>
+    <message>
+        <source>Unknown error (%1)</source>
+        <translation>Невідома помилка (%1)</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation>Помилка</translation>
+    </message>
+    <message>
+        <source>qTox couldn&apos;t open your chat logs, they will be disabled.</source>
+        <translation>qTox не може відкрити ваші чат логи, їх буде вимкнено.</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <comment>No camera device set</comment>
+        <translation>Відсутній</translation>
+    </message>
+    <message>
+        <source>Desktop</source>
+        <comment>Desktop as a camera input for screen sharing</comment>
+        <translatorcomment>I think in this case more appropriate is &quot;Екран&quot; which means &quot;Screen&quot;</translatorcomment>
+        <translation>Робочий стіл</translation>
+    </message>
+</context>
+<context>
+    <name>RemoveFriendDialog</name>
+    <message>
+        <source>Remove friend</source>
+        <translation>Вилучити з друзів</translation>
+    </message>
+    <message>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Are you sure you want to remove &lt;span style=&quot; font-weight:600;&quot;&gt;&amp;lt;name&amp;gt;&lt;/span&gt; from your contacts list?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ви дійсно хочете видалити &lt;span style=&quot; font-weight:600;&quot;&gt;&amp;lt;name&amp;gt;&lt;/span&gt; з вашого списку контактів?&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <source>Also remove chat history</source>
+        <translation>Також видалити історію переписки</translation>
+    </message>
+    <message>
+        <source>Remove</source>
+        <translation>Видалити</translation>
     </message>
 </context>
 <context>
     <name>ScreenshotGrabber</name>
     <message>
-        <location filename="../src/widget/tool/screenshotgrabber.cpp" line="127"/>
-        <source>Click and drag to select a region. Press &lt;b&gt;Escape&lt;/b&gt; to cancel.</source>
+        <source>Click and drag to select a region. Press &lt;b&gt;Space&lt;/b&gt; to hide/show qTox window, or &lt;b&gt;Escape&lt;/b&gt; to cancel.</source>
         <comment>Help text shown when no region has been selected yet</comment>
-        <translation>Натисніть і потяніть для вибору регіону. Натисніть &lt;b&gt;Escape&lt;/b&gt; для скасування.</translation>
+        <translation>Клікніть та перетягніть вказівник миші, щоб обрати область. Натисніть &lt;b&gt;Space&lt;/b&gt; щоб відобразити/приховати вікно qTox, або &lt;b&gt;Escape&lt;/b&gt; для скасування.</translation>
     </message>
     <message>
-        <location filename="../src/widget/tool/screenshotgrabber.cpp" line="134"/>
-        <source>Press &lt;b&gt;Enter&lt;/b&gt; to send a screenshot of the selected region or select a new region. Press &lt;b&gt;Escape&lt;/b&gt; to cancel.</source>
+        <source>Press &lt;b&gt;Enter&lt;/b&gt; to send a screenshot of the selection, &lt;b&gt;Space&lt;/b&gt; to hide/show qTox window, or &lt;b&gt;Escape&lt;/b&gt; to cancel.</source>
         <comment>Help text shown when a region has been selected</comment>
-        <translation>Натисність &lt;b&gt;Enter&lt;/b&gt; для того, щоб відіслати знімок вибраного регіону екрана. Натисніть &lt;b&gt;Escape&lt;/b&gt; для скасування.</translation>
+        <translation>Натисніть &lt;b&gt;Enter&lt;/b&gt; щоб надіслати знімок вибраної області, &lt;b&gt;Space&lt;/b&gt; щоб відобразити/приховати вікно qTox, або &lt;b&gt;Escape&lt;/b&gt; для скасування.</translation>
     </message>
 </context>
 <context>
     <name>SetPasswordDialog</name>
     <message>
-        <source>Type Password</source>
-        <translation type="obsolete">Наберіть пароль</translation>
-    </message>
-    <message>
-        <source>Repeat Password</source>
-        <translation type="obsolete">Повторіть пароль</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/form/setpassworddialog.ui" line="14"/>
         <source>Set your password</source>
         <translation>Встановіть свій пароль</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/setpassworddialog.ui" line="31"/>
-        <source>Repeat password</source>
-        <translation>Повторіть пароль</translation>
+        <source>Confirm:</source>
+        <translation>Підтвердження:</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/setpassworddialog.ui" line="41"/>
-        <source>Type password</source>
-        <translation>Введіть пароль</translation>
+        <source>Password:</source>
+        <translation>Пароль:</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/setpassworddialog.ui" line="65"/>
-        <source>Password strength</source>
-        <translation>Якість паролю</translation>
+        <source>Password strength: %p%</source>
+        <translation>Надійність пароля: %p%</translation>
     </message>
     <message>
-        <location filename="../src/widget/form/setpassworddialog.cpp" line="31"/>
-        <location filename="../src/widget/form/setpassworddialog.cpp" line="59"/>
-        <source>The passwords don&apos;t match.</source>
-        <translation>Введені паролі не співпадають.</translation>
+        <source>The password is too short</source>
+        <translation>Пароль занадто короткий</translation>
+    </message>
+    <message>
+        <source>The password doesn&apos;t match.</source>
+        <translation>Паролі не співпадають.</translation>
     </message>
 </context>
 <context>
     <name>Settings</name>
     <message>
-        <location filename="../src/misc/settings.cpp" line="154"/>
-        <source>Choose a profile</source>
-        <translation>Оберіть профіль</translation>
-    </message>
-    <message>
-        <location filename="../src/misc/settings.cpp" line="155"/>
-        <source>Please choose which identity to use</source>
-        <translation>Оберіть користувача для використання</translation>
+        <source>Circle #%1</source>
+        <translation>Коло №%1</translation>
     </message>
 </context>
 <context>
     <name>ToxDNS</name>
     <message>
-        <location filename="../src/toxdns.cpp" line="63"/>
         <source>The connection timed out</source>
         <comment>The DNS gives the Tox ID associated to toxme.se addresses</comment>
         <translation>Час очікування з&apos;єднання вийшов</translation>
     </message>
     <message>
-        <location filename="../src/toxdns.cpp" line="71"/>
         <source>This address does not exist</source>
         <comment>The DNS gives the Tox ID associated to toxme.se addresses</comment>
         <translation>Даної адреси не існує</translation>
     </message>
     <message>
-        <location filename="../src/toxdns.cpp" line="78"/>
         <source>Error while looking up DNS</source>
         <comment>The DNS gives the Tox ID associated to toxme.se addresses</comment>
         <translation>Помилка під час перегляду DNS</translation>
     </message>
     <message>
-        <location filename="../src/toxdns.cpp" line="87"/>
         <source>No text record found</source>
         <comment>Error with the DNS</comment>
         <translation>Не виявлено текстового запису</translation>
     </message>
     <message>
-        <location filename="../src/toxdns.cpp" line="96"/>
         <source>Unexpected number of values in text record</source>
         <comment>Error with the DNS</comment>
         <translation>Неочікуване число значень в текстових записах</translation>
-    </message>
-    <message>
-        <location filename="../src/toxdns.cpp" line="125"/>
-        <source>The version of Tox DNS used by this server is not supported</source>
-        <comment>Error with the DNS</comment>
-        <translation>Версія Tox DNS даного серверу не підтримується</translation>
-    </message>
-    <message>
-        <location filename="../src/toxdns.cpp" line="137"/>
-        <source>The DNS lookup does not contain any Tox ID</source>
-        <comment>Error with the DNS</comment>
-        <translation>Відповідь DNS не містить жодного Tox ID</translation>
-    </message>
-    <message>
-        <location filename="../src/toxdns.cpp" line="146"/>
-        <location filename="../src/toxdns.cpp" line="155"/>
-        <source>The DNS lookup does not contain a valid Tox ID</source>
-        <comment>Error with the DNS</comment>
-        <translation>Відповідь DNS не містить жодного коректного Tox ID</translation>
-    </message>
-    <message>
-        <location filename="../src/toxdns.cpp" line="242"/>
-        <location filename="../src/toxdns.cpp" line="294"/>
-        <source>It appears that qTox has to use the old tox1 protocol to access DNS record of your friend&apos;s Tox ID.
-Unfortunately tox1 is not secure, and you are at risk of someone hijacking what is sent between you and ToxDNS service.
-Should tox1 be used anyway?
-If unsure, press “No”, so that request to ToxDNS service will not be made using unsecure protocol.</source>
-        <translation>Схоже на те, що qTox має використати старий протокол tox1 для доступу до DNS запису про ID вашого Tox друга.
-На жаль, tox1 не є надійним і хтось може викрасти переслані між вами і ToxDNS сервісом дані.
-Ви все ж хочете використовувати tox1?
-Якщо ви не певні - відповідайте &quot;Ні&quot; - так при запиті до ToxDNS не буде використовуватись ненадійний протокол.</translation>
     </message>
 </context>
 <context>
     <name>ToxURIDialog</name>
     <message>
-        <location filename="../src/widget/toxuri.cpp" line="79"/>
         <source>Add a friend</source>
         <comment>Title of the window to add a friend through Tox URI</comment>
         <translation>Додати друга</translation>
     </message>
     <message>
-        <location filename="../src/widget/toxuri.cpp" line="81"/>
         <source>Do you want to add %1 as a friend?</source>
         <translation>Бажаєте додати %1 як друга?</translation>
     </message>
     <message>
-        <location filename="../src/widget/toxuri.cpp" line="82"/>
         <source>User ID:</source>
         <translation>ID користувача:</translation>
     </message>
     <message>
-        <location filename="../src/widget/toxuri.cpp" line="86"/>
         <source>Friend request message:</source>
         <translation>Повідомлення запиту:</translation>
     </message>
     <message>
-        <location filename="../src/widget/toxuri.cpp" line="91"/>
         <source>Send</source>
         <comment>Send a friend request</comment>
         <translation>Надіслати</translation>
     </message>
     <message>
-        <location filename="../src/widget/toxuri.cpp" line="92"/>
         <source>Cancel</source>
         <comment>Don&apos;t send a friend request</comment>
         <translation>Скасувати</translation>
@@ -2688,212 +2077,202 @@ If unsure, press “No”, so that request to ToxDNS service will not be made us
 <context>
     <name>Widget</name>
     <message>
-        <location filename="../src/widget/widget.cpp" line="135"/>
         <source>Online</source>
         <translation>В мережі</translation>
     </message>
     <message>
-        <source>Away</source>
-        <translation type="obsolete">Відійшов</translation>
-    </message>
-    <message>
-        <source>Busy</source>
-        <translation type="obsolete">Зайнятий</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/widget.cpp" line="1170"/>
-        <source>&amp;Quit</source>
-        <translation>&amp;Вийти</translation>
-    </message>
-    <message>
-        <source>Change status to:</source>
-        <translation type="obsolete">Змінити статус на:</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/widget.cpp" line="107"/>
         <source>Online</source>
         <comment>Button to set your status to &apos;Online&apos;</comment>
         <translation>В мережі</translation>
     </message>
     <message>
-        <location filename="../src/widget/widget.cpp" line="110"/>
         <source>Away</source>
         <comment>Button to set your status to &apos;Away&apos;</comment>
         <translation>Відійшов</translation>
     </message>
     <message>
-        <location filename="../src/widget/widget.cpp" line="113"/>
         <source>Busy</source>
         <comment>Button to set your status to &apos;Busy&apos;</comment>
         <translation>Зайнятий</translation>
     </message>
     <message>
-        <source>Choose a profile</source>
-        <translation type="obsolete">Оберіть профіль</translation>
-    </message>
-    <message>
-        <source>Please choose which identity to use</source>
-        <translation type="obsolete">Оберіть ідентифікатор для використання</translation>
-    </message>
-    <message>
-        <source>Choose a profile picture</source>
-        <translation>Оберіть зображення для профілю</translation>
-    </message>
-    <message>
-        <source>Error</source>
-        <translation>Помилка</translation>
-    </message>
-    <message>
-        <source>Unable to open this file</source>
-        <translation>Неможливо відкрити цей файл</translation>
-    </message>
-    <message>
-        <source>Unable to read this image</source>
-        <translation>Неможливо прочитати це зображення</translation>
-    </message>
-    <message>
-        <source>This image is too big</source>
-        <translation>Зображення завелике</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/widget.cpp" line="409"/>
-        <source>Toxcore failed to start, the application will terminate after you close this message.</source>
-        <translation>Помилка запуску ядра tox, програма буде завершена після закриття цього повідомлення.</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/widget.cpp" line="419"/>
         <source>toxcore failed to start with your proxy settings. qTox cannot run; please modify your settings and restart.</source>
         <comment>popup text</comment>
         <translation>Помилка запуску ядра tox із поточними параметрами проксі. qTox не працює; змініть параметри і перезапустіть.</translation>
     </message>
     <message>
-        <location filename="../src/widget/widget.cpp" line="217"/>
-        <location filename="../src/widget/widget.cpp" line="451"/>
         <source>Add friend</source>
         <translation>Додати друга</translation>
     </message>
     <message>
-        <location filename="../src/widget/widget.cpp" line="134"/>
+        <source>Add new circle...</source>
+        <translation>Додати нове коло...</translation>
+    </message>
+    <message>
+        <source>By Name</source>
+        <translation>За іменем</translation>
+    </message>
+    <message>
+        <source>By Activity</source>
+        <translation>За активністю</translation>
+    </message>
+    <message>
         <source>All</source>
         <translation>Всі контакти</translation>
     </message>
     <message>
-        <location filename="../src/widget/widget.cpp" line="136"/>
         <source>Offline</source>
         <translation>Не в мережі</translation>
     </message>
     <message>
-        <location filename="../src/widget/widget.cpp" line="137"/>
         <source>Friends</source>
         <translation>Друзі</translation>
     </message>
     <message>
-        <location filename="../src/widget/widget.cpp" line="138"/>
         <source>Groups</source>
         <translation>Групи</translation>
     </message>
     <message>
-        <location filename="../src/widget/widget.cpp" line="140"/>
         <source>Search Contacts</source>
         <translation>Пошук контактів</translation>
     </message>
     <message>
-        <location filename="../src/widget/widget.cpp" line="465"/>
+        <source>Logout</source>
+        <comment>Tray action menu to logout user</comment>
+        <translation>Вихід з облікового запису</translation>
+    </message>
+    <message>
+        <source>Exit</source>
+        <comment>Tray action menu to exit tox</comment>
+        <translation>Вихід</translation>
+    </message>
+    <message>
+        <source>Filter...</source>
+        <translation>Фільтр...</translation>
+    </message>
+    <message>
+        <source>File</source>
+        <translation>Файл</translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation>Редагувати</translation>
+    </message>
+    <message>
+        <source>Contacts</source>
+        <translation>Контакти</translation>
+    </message>
+    <message>
+        <source>Change Status</source>
+        <translation>Змінити статус</translation>
+    </message>
+    <message>
+        <source>Edit Profile</source>
+        <translation>Редагувати профіль</translation>
+    </message>
+    <message>
+        <source>Log out</source>
+        <translation>Вихід з облікового запису</translation>
+    </message>
+    <message>
+        <source>Add Contact...</source>
+        <translation>Додати контакт...</translation>
+    </message>
+    <message>
+        <source>Next Conversation</source>
+        <translation>Наступна бесіда</translation>
+    </message>
+    <message>
+        <source>Previous Conversation</source>
+        <translation>Попередня бесіда</translation>
+    </message>
+    <message>
         <source>File transfers</source>
         <translation>Передачі файлів</translation>
     </message>
     <message>
-        <location filename="../src/widget/widget.cpp" line="476"/>
         <source>Executable file</source>
         <comment>popup title</comment>
         <translation>Виконуваний файл</translation>
     </message>
     <message>
-        <location filename="../src/widget/widget.cpp" line="476"/>
         <source>You have asked qTox to open an executable file. Executable files can potentially damage your computer. Are you sure want to open this file?</source>
         <comment>popup text</comment>
         <translation>Ви намагаєтеся відкрити виконуваний файл. Виконувані файли можуть нанести шкоди вашому комп’ютеру. Ви все ще хочете відкрити цей файл?</translation>
     </message>
     <message>
-        <location filename="../src/widget/widget.cpp" line="544"/>
         <source>Settings</source>
         <translation>Параметри</translation>
     </message>
     <message>
-        <location filename="../src/widget/widget.cpp" line="553"/>
         <source>Profile</source>
         <translation>Профіль</translation>
     </message>
     <message>
-        <location filename="../src/widget/widget.cpp" line="661"/>
         <source>Couldn&apos;t request friendship</source>
         <translation>Не вдалось надіслати запит на дружбу</translation>
     </message>
     <message>
-        <location filename="../src/widget/widget.cpp" line="703"/>
+        <source>Status</source>
+        <translation>Статус</translation>
+    </message>
+    <message>
+        <source>toxcore failed to start, the application will terminate after you close this message.</source>
+        <translation>Неможливо запустити toxcore, додаток завершить роботу, коли Ви закриєте це повідомлення.</translation>
+    </message>
+    <message>
+        <source>Your name</source>
+        <translation>Ваше ім&apos;я</translation>
+    </message>
+    <message>
+        <source>Your status</source>
+        <translation>Ваш статус</translation>
+    </message>
+    <message>
         <source>away</source>
         <comment>contact status</comment>
         <translation>Відійшов</translation>
     </message>
     <message>
-        <location filename="../src/widget/widget.cpp" line="705"/>
         <source>busy</source>
         <comment>contact status</comment>
         <translation>Зайнятий</translation>
     </message>
     <message>
-        <location filename="../src/widget/widget.cpp" line="707"/>
         <source>offline</source>
         <comment>contact status</comment>
         <translation>Поза мережею</translation>
     </message>
     <message>
-        <location filename="../src/widget/widget.cpp" line="711"/>
         <source>online</source>
         <comment>contact status</comment>
         <translation>В мережі</translation>
     </message>
     <message>
-        <location filename="../src/widget/widget.cpp" line="714"/>
         <source>%1 is now %2</source>
         <comment>e.g. &quot;Dubslow is now online&quot;</comment>
         <translation>%1 тепер вже відомий як %2</translation>
     </message>
     <message>
-        <location filename="../src/widget/widget.cpp" line="869"/>
-        <source>Remove history</source>
-        <translation>Видалити історію</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/widget.cpp" line="870"/>
-        <source>Do you want to remove history as well?</source>
-        <translation>Ви хочете видалити історію також?</translation>
-    </message>
-    <message>
-        <location filename="../src/widget/widget.cpp" line="926"/>
         <source>Group invite</source>
         <comment>popup title</comment>
         <translation>Групове запрошення</translation>
     </message>
     <message>
-        <location filename="../src/widget/widget.cpp" line="926"/>
         <source>%1 has invited you to a groupchat. Would you like to join?</source>
         <comment>popup text</comment>
         <translation>%1 запросив вас до групового чату. Приєднаєтеся?</translation>
     </message>
     <message>
-        <location filename="../src/widget/widget.cpp" line="988"/>
         <source>&lt;Unknown&gt;</source>
         <comment>Placeholder when we don&apos;t know someone&apos;s name in a group chat</comment>
         <translation>&lt;Невідомо&gt;</translation>
     </message>
     <message>
-        <location filename="../src/widget/widget.cpp" line="1016"/>
         <source>%1 has set the title to %2</source>
         <translation>%1 встановив тему %2</translation>
     </message>
     <message>
-        <location filename="../src/widget/widget.cpp" line="1250"/>
         <source>Message failed to send</source>
         <translation>Не вдалось відправити повідомлення</translation>
     </message>


### PR DESCRIPTION
I translated almost everything into Ukrainian using Qt Linguist and [this guide](https://github.com/tux3/qTox/wiki/Translating). 

There are few things worth pointing out:
- **"Profile"** in Ukrainian is **"Профіль"**, but it has few more senses. I think more appropriate translation for "Profile" in this case is **"Обліковий запис"** (which exactly means **"Account"** in English). But I leaved **"Профіль"** everywhere because somebody already starts to translate this way and because the strings are shorter (it is matter for buttons like "Create profile" and so on). I can change it to **"Обліковий запис"** if needed.
- **"Load"** in Ukrainian is **"Завантажити"**, but it also means **"Download"**. So in case of "Log in" more appropriate would be **"Увійти"** (which is exactly **"Log in"**). But I also put **"Завантажити"** everywhere for the same reason - somebody has already started to translate it as **"Завантажити"**.

P.S. I am new to opensource contributing, so if I did something wrong please tell me:
