### PR TITLE
Move Qt generated files into subdirectory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ qtox
 build-*-Release
 build-*-Debug
 .DS_Store
+tmp

--- a/qtox.pro
+++ b/qtox.pro
@@ -320,6 +320,14 @@ contains(ENABLE_SYSTRAY_GTK_BACKEND, NO) {
 }
 }
 
+CONFIG(debug, debug|release):GENERATED_FILES_DIR=tmp/debug
+CONFIG(release, debug|release):GENERATED_FILES_DIR=tmp/release
+
+MOC_DIR=$${GENERATED_FILES_DIR}/moc
+OBJECTS_DIR=$${GENERATED_FILES_DIR}/obj
+RCC_DIR=$${GENERATED_FILES_DIR}/rcc
+UI_DIR=$${GENERATED_FILES_DIR}/ui
+
 !android {
     RESOURCES += res.qrc \
         smileys/smileys.qrc


### PR DESCRIPTION
When compiling qTox _not_ in "shadow build" mode (Qt Creator), root project dir gets filled with ui*.h, moc*.cpp and *.o files, which is annoying.

I have prepared patch to use qmake's MOC_DIR, UI_DIR and others to move these generated files into tmp subdirectory.

Addresses https://github.com/tux3/qTox/issues/2932
