### PR TITLE
Disable echo cancelation

### DIFF
--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -499,8 +499,6 @@ void Audio::doCapture()
         getEchoesToFilter(filterer, AUDIO_FRAME_SAMPLE_COUNT * AUDIO_CHANNELS);
 #endif
         filterer.filterAudio(buf, AUDIO_FRAME_SAMPLE_COUNT * AUDIO_CHANNELS);
-        // disable echo cancelation, because we don't know the delay
-        filterer.enableDisableFilters(0, 1, 1, 1);
     }
 #endif
 

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -66,6 +66,8 @@ Audio::Audio()
 
 #ifdef QTOX_FILTER_AUDIO
     filterer.startFilter(AUDIO_SAMPLE_RATE);
+    // disable echo cancelation, because we don't know the delay
+    filterer.enableDisableFilters(0, 1, 1, 1);
 #endif
 
     connect(&captureTimer, &QTimer::timeout, this, &Audio::doCapture);
@@ -497,6 +499,8 @@ void Audio::doCapture()
         getEchoesToFilter(filterer, AUDIO_FRAME_SAMPLE_COUNT * AUDIO_CHANNELS);
 #endif
         filterer.filterAudio(buf, AUDIO_FRAME_SAMPLE_COUNT * AUDIO_CHANNELS);
+        // disable echo cancelation, because we don't know the delay
+        filterer.enableDisableFilters(0, 1, 1, 1);
     }
 #endif
 

--- a/src/audio/audiofilterer.h
+++ b/src/audio/audiofilterer.h
@@ -36,9 +36,16 @@ public:
     void startFilter(uint32_t fs);
     void closeFilter();
 
-    /* Enable/disable filters. 1 to enable, 0 to disable. */
+    /* Enable/disable filters. 1 to enable, 0 to disable.
+     * echo : enables/disables echo cancelation
+     * noise: enables/disables noise reduction
+     * gain : enables/disables automatic gain control
+     * vad  : enables/disables voice activity detection
+     * echo cancelation needs a precise value set by setEchoDelayMs, else it adds echo! */
     bool enableDisableFilters(int echo, int noise, int gain, int vad);
 
+    /* does the actual filtering
+     * returns True if voice was detected */
     bool filterAudio(int16_t* data, unsigned int samples);
 
     /* Give the audio output from your software to this function so it knows what echo to cancel from the frame */

--- a/src/audio/audiofilterer.h
+++ b/src/audio/audiofilterer.h
@@ -36,16 +36,22 @@ public:
     void startFilter(uint32_t fs);
     void closeFilter();
 
-    /* Enable/disable filters. 1 to enable, 0 to disable.
-     * echo : enables/disables echo cancelation
-     * noise: enables/disables noise reduction
-     * gain : enables/disables automatic gain control
-     * vad  : enables/disables voice activity detection
-     * echo cancelation needs a precise value set by setEchoDelayMs, else it adds echo! */
+    /**
+    Enable/disable filters. 1 to enable, 0 to disable.
+
+    @param[in] echo    enables/disables echo cancelation
+    @param[in] noise   enables/disables noise reduction
+    @param[in] gain    enables/disables automatic gain control
+    @param[in] vad     enables/disables voice activity detection
+
+    Echo cancelation needs a precise value for the input latency set by setEchoDelayMs(), else it adds echo!
+    */
     bool enableDisableFilters(int echo, int noise, int gain, int vad);
 
-    /* does the actual filtering
-     * returns True if voice was detected */
+    /**
+     * Does the actual filtering
+     * @return True if voice was detected
+    */
     bool filterAudio(int16_t* data, unsigned int samples);
 
     /* Give the audio output from your software to this function so it knows what echo to cancel from the frame */


### PR DESCRIPTION
It actually adds echo if the input latency is set incorrectly.
Should fix echo created by qTox, see also #2942
