### PR TITLE
Fix toxURI parsing.

### DIFF
--- a/src/net/toxuri.cpp
+++ b/src/net/toxuri.cpp
@@ -57,11 +57,7 @@ bool handleToxURI(const QString &toxURI)
     while (!core->isReady())
         qApp->processEvents();
 
-    QString toxaddr;
-    if (toxURI.startsWith("tox:"))
-        toxaddr = toxURI.mid(6);
-    else
-        toxaddr = toxURI.mid(4);
+    QString toxaddr = toxURI.mid(4);
 
     QString toxId = Toxme::lookup(toxaddr).toString();
     if (toxId.isEmpty())


### PR DESCRIPTION
It was always eating two characters more than needed.

A toxURI passed to handleToxURI always starts with "tox:", it's checked in the handleToxURI callers. So here we need to remove that prefix, that's long 4 characters and not 6.

The previous code was meant to handle tox:// and tox: cases, but the tox:// case is invalid and should not be handled (see #2118).

Fixes: d6a0910fc8098ecb37d7f7fdfcdd2592adaac0ad ("fix uri parsing and tox URI detection, closes #2118")
