### PR TITLE
add PREFIX variable

### DIFF
--- a/qtox.pro
+++ b/qtox.pro
@@ -178,15 +178,19 @@ win32 {
             LIBS += -llibjpeg -llibwebp -llibpng -llibtiff -llibjasper -lIlmImf
             LIBS += -lopus -lvpx -lsodium -lopenal
         } else {
-            target.path = /usr/bin
-            desktop.path = /usr/share/applications
+            isEmpty(PREFIX) {
+                PREFIX = /usr
+            }
+
+            BINDIR = $$PREFIX/bin
+            DATADIR = $$PREFIX/share
+            target.path = $$BINDIR
+            desktop.path = $$DATADIR/applications
             desktop.files += qTox.desktop
             INSTALLS += target desktop
 
             # If we're building a package, static link libtox[core,av] and libsodium, since they are not provided by any package
             contains(STATICPKG, YES) {
-                target.path = /usr/bin
-                INSTALLS += target
                 LIBS += -L$$PWD/libs/lib/ -lopus -lvpx -lopenal -Wl,-Bstatic -ltoxcore -ltoxav -ltoxencryptsave -ltoxdns -lsodium -lavformat -lavdevice -lavcodec -lavutil -lswscale -lz -Wl,-Bdynamic
                 LIBS += -Wl,-Bstatic -ljpeg -ltiff -lpng -ljasper -lIlmImf -lIlmThread -lIex -ldc1394 -lraw1394 -lHalf -lz -llzma -ljbig
                 LIBS += -Wl,-Bdynamic -lv4l1 -lv4l2 -lavformat -lavcodec -lavutil -lswscale -lusb-1.0


### PR DESCRIPTION
adding PREFIX variable and check if not set to use the default /usr directory. This allows you to set the location to install qtox with `qmake PREFIX=/usr/local`. Also removed redundant setting install path for STATICPKG.
