### PR TITLE
Chatlog: Adjust whitespace behaviour/handling.

### DIFF
--- a/src/chatlog/chatmessage.cpp
+++ b/src/chatlog/chatmessage.cpp
@@ -247,5 +247,5 @@ QString ChatMessage::detectQuotes(const QString& str, MessageType type)
 
 QString ChatMessage::wrapDiv(const QString &str, const QString &div)
 {
-    return QString("<div class=%1>%2</div>").arg(div, str);
+    return QString("<p class=%1>%2</p>").arg(div, /*QChar(0x200E) + */QString(str));
 }

--- a/ui/chatArea/innerStyle.css
+++ b/ui/chatArea/innerStyle.css
@@ -1,14 +1,18 @@
-div.msg {
+p {
+  white-space: pre-wrap;
+}
+
+p.msg {
   color: @black;
   font: @big;
 }
 
-div.action {
+p.action {
   color: #1818FF;
   font: @big;
 }
 
-div.typing {
+p.typing {
   color: @mediumGreyLight;
   font: @big;
 }
@@ -17,7 +21,7 @@ span.quote {
   color: #279419;
 }
 
-div.alert {
+p.alert {
   margin-left: 0px;
   margin-right: 0px;
   color: @black;
@@ -25,7 +29,7 @@ div.alert {
   font: @big;
 }
 
-div.alert_name {
+p.alert_name {
   color: @black;
   background-color: @orange;
   font: @bigBold;


### PR DESCRIPTION
Essentially, this is just an undo of an undo: TheSpiritXIII@410277f4dc779d6801bc81b5b2b47b3d0fe2d6da

I've been building qTox with this for some weeks(?), using it daily on Linux, and tested somewhat on Windows.

The only issue thus far that I have discovered is:
- [ ] Tab-spacing acts odd in that, when copied in from outside qTox, they become twenty (20) characters wide (tested 2, 4, 8, and 16 characters wide tabulations).  I have no idea how simple that will be to fix.

Thoughts?
