### PR TITLE
Added codeblock support with ` char.

### DIFF
--- a/src/chatlog/chatmessage.cpp
+++ b/src/chatlog/chatmessage.cpp
@@ -210,8 +210,10 @@ QString ChatMessage::detectMarkdown(const QString &str)
 
             QString htmledSnippet;
 
+            qDebug() << "snipCheck: " << snipCheck << " out: " << out << " snipLength: " << snippet.toHtmlEscaped().length() << " outLength: " << out.toHtmlEscaped().length();
+
             // Only parse if surrounded by spaces, newline(s) and/or beginning/end of line
-            if ((snipCheck.startsWith(' ') || snipCheck.startsWith('>') || offset == 0) && ((snipCheck.endsWith(' ') || snipCheck.endsWith('<')) || offset + snippet.toHtmlEscaped().length() == out.length()))
+            if ((snipCheck.startsWith(' ') || snipCheck.startsWith('>') || offset == 0) && ((snipCheck.endsWith(' ') || snipCheck.endsWith('<')) || offset + snippet.toHtmlEscaped().length() == out.toHtmlEscaped().length()))
             {
                 int mul = 0; // Determines how many characters to strip from markdown text
                 // Set mul depending on markdownPreference


### PR DESCRIPTION
Changes font to monospace with a gray color. Wanted to do a different background as well but requires QString be embedded in one of Qt's [rich text processing APIs](https://doc.qt.io/qt-5/richtext.html). 

Markdown inside codeblocks is not triggered.

Addresses #2999.
