### PR TITLE
Add issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,29 @@
+Brief description:
+
+Operating System: Windows / OS X / Linux (include version and/or distro)  
+qTox version: (shown on `About` page in settings)  
+Hardware: 
+…
+
+Reproducible: Always / Almost Always / Sometimes / Rarely / Couldn't Reproduce
+
+
+**Steps to reproduce:**  
+1.  
+2.  
+3.  
+…
+
+
+**Observed Behavior:**  
+
+
+**Expected Behavior:**  
+
+
+**Additional info:**  
+(links, images, etc go here)
+
+----
+
+More information on how to write good bug reports in the wiki: https://github.com/tux3/qTox/wiki/Writing-Useful-Bug-Reports


### PR DESCRIPTION
Using GitHubs [new feature](https://github.com/blog/2111-issue-and-pull-request-templates).

The template is based on the one included in the wiki, but I [styled](https://github.com/tux3/qTox/wiki/Writing-Useful-Bug-Reports/8bc3443e15e85fb5f23196c0c9d4fa481a77b871) it a bit so that it looks good in Markdown.
