### PR TITLE
feat: disable building with filter_audio by default

### DIFF
--- a/.travis/build-ubuntu_14_04.sh
+++ b/.travis/build-ubuntu_14_04.sh
@@ -90,12 +90,12 @@ $CC --version
 $CXX --version
 # first build qTox without support for optional dependencies
 echo '*** BUILDING "MINIMAL" VERSION ***'
-qmake qtox.pro QMAKE_CC="$CC" QMAKE_CXX="$CXX" DISABLE_FILTER_AUDIO=YES ENABLE_SYSTRAY_STATUSNOTIFIER_BACKEND=NO ENABLE_SYSTRAY_GTK_BACKEND=NO DISABLE_PLATFORM_EXT=YES
+qmake qtox.pro QMAKE_CC="$CC" QMAKE_CXX="$CXX" ENABLE_SYSTRAY_STATUSNOTIFIER_BACKEND=NO ENABLE_SYSTRAY_GTK_BACKEND=NO DISABLE_PLATFORM_EXT=YES
 # ↓ with $(nproc) fails, since travis gives 32 threads, and it leads to OOM
 make -j10
 # clean it up, and build normal version
 make clean
 echo '*** BUILDING "FULL" VERSION ***'
-qmake qtox.pro QMAKE_CC="$CC" QMAKE_CXX="$CXX" 
+qmake qtox.pro QMAKE_CC="$CC" QMAKE_CXX="$CXX" DISABLE_FILTER_AUDIO=NO
 # ↓ with $(nproc) fails, since travis gives 32 threads, and it leads to OOM
 make -j10

--- a/qtox.pro
+++ b/qtox.pro
@@ -68,7 +68,6 @@ android {
     LIBS += -L$$PWD/libs/lib -L$$ANDROID_TOOLCHAIN/lib
 
     DISABLE_PLATFORM_EXT=YES
-    DISABLE_FILTER_AUDIO=YES
 
     ANDROID_PACKAGE_SOURCE_DIR = $$PWD/android
     contains(ANDROID_TARGET_ARCH,armeabi) {
@@ -104,9 +103,7 @@ contains(DISABLE_PLATFORM_EXT, YES) {
     DEFINES += QTOX_PLATFORM_EXT
 }
 
-contains(DISABLE_FILTER_AUDIO, YES) {
-
-} else {
+contains(DISABLE_FILTER_AUDIO, NO) {
      DEFINES += QTOX_FILTER_AUDIO
 }
 


### PR DESCRIPTION
Given that currently `filter_audio` doesn't help qTox users to improve
quality of their conversations, there's little to no point in making
qTox build with it by default. This might change when (if?)
`filter_audio` support in qTox gets improved/fixed.

BREAKING CHANGE: Disabling of `filter_audio` was done by passing
`DISABLE_FILTER_AUDIO=YES` to `qmake`. With this change `filter_audio`
is disabled by default, and in order to enable it,
`DISABLE_FILTER_AUDIO=NO` has to be passed to `qmake`.
