### PR TITLE
fix: remove unnecessary qDebug call

### DIFF
--- a/src/chatlog/chatmessage.cpp
+++ b/src/chatlog/chatmessage.cpp
@@ -210,8 +210,6 @@ QString ChatMessage::detectMarkdown(const QString &str)
 
             QString htmledSnippet;
 
-            qDebug() << "snipCheck: " << snipCheck << " out: " << out << " snipLength: " << snippet.toHtmlEscaped().length() << " outLength: " << out.toHtmlEscaped().length();
-
             // Only parse if surrounded by spaces, newline(s) and/or beginning/end of line
             if ((snipCheck.startsWith(' ') || snipCheck.startsWith('>') || offset == 0) && ((snipCheck.endsWith(' ') || snipCheck.endsWith('<')) || offset + snippet.toHtmlEscaped().length() == out.toHtmlEscaped().length()))
             {


### PR DESCRIPTION
qTox logs shouldn't contain any info that might include even parts of
user messages/etc.
