### PR TITLE
Issue 3028 - Auto Homebrew version check

### DIFF
--- a/osx/qTox-Mac-Deployer-ULTIMATE.sh
+++ b/osx/qTox-Mac-Deployer-ULTIMATE.sh
@@ -97,16 +97,16 @@ function install() {
 	fi
 	fcho "Updating brew formulas ..."
 	if [[ $TRAVIS = true ]]; then
-		brew update > /dev/null
+		brew update -vv
 	else
 		brew update
 	fi
 	fcho "Getting home brew formulas ..."
 	sleep 3
 	if [[ $TRAVIS != true ]]; then #travis check
-		brew install -v wget libtool automake
+		brew install -vv wget libtool automake
 	fi
-	brew install -v git ffmpeg qrencode autoconf check qt5 libvpx opus sqlcipher libsodium
+	brew install -vv git ffmpeg qrencode autoconf check qt5 libvpx opus sqlcipher libsodium
 	
 	QT_VER=($(ls ${QT_DIR} | sed -n -e 's/^\([0-9]*\.([0-9]*\.([0-9]*\).*/\1/' -e '1p;$p'))
 	QT_DIR_VER="${QT_DIR}/${QT_VER[1]}"

--- a/osx/qTox-Mac-Deployer-ULTIMATE.sh
+++ b/osx/qTox-Mac-Deployer-ULTIMATE.sh
@@ -97,7 +97,7 @@ function install() {
 	fi
 	fcho "Updating brew formulas ..."
 	if [[ $TRAVIS = true ]]; then
-		brew update -v
+		brew update > /dev/null
 	else
 		brew update
 	fi

--- a/osx/qTox-Mac-Deployer-ULTIMATE.sh
+++ b/osx/qTox-Mac-Deployer-ULTIMATE.sh
@@ -97,16 +97,16 @@ function install() {
 	fi
 	fcho "Updating brew formulas ..."
 	if [[ $TRAVIS = true ]]; then
-		brew update -vv
+		brew update > /dev/null
 	else
 		brew update
 	fi
 	fcho "Getting home brew formulas ..."
 	sleep 3
 	if [[ $TRAVIS != true ]]; then #travis check
-		brew install -vv wget libtool automake
+		brew install wget libtool automake
 	fi
-	brew install -vv git ffmpeg qrencode autoconf check qt5 libvpx opus sqlcipher libsodium
+	brew install git ffmpeg qrencode autoconf check qt5 libvpx opus sqlcipher libsodium
 	
 	QT_VER=($(ls ${QT_DIR} | sed -n -e 's/^\([0-9]*\.([0-9]*\.([0-9]*\).*/\1/' -e '1p;$p'))
 	QT_DIR_VER="${QT_DIR}/${QT_VER[1]}"


### PR DESCRIPTION
Added check for QT5 and libsodium versions and use latest versions available from homebrew.

Also added `-bootstrap` option for users to independently bootstrap their qTox dir.

Fix for: tux3/qtox/issues/3028
