### PR TITLE
fix: increase faux offline message timeout

### DIFF
--- a/src/persistence/offlinemsgengine.cpp
+++ b/src/persistence/offlinemsgengine.cpp
@@ -26,7 +26,7 @@
 #include <QMutexLocker>
 #include <QTimer>
 
-const int OfflineMsgEngine::offlineTimeout = 2000;
+const int OfflineMsgEngine::offlineTimeout = 20000;
 QMutex OfflineMsgEngine::globalMutex;
 
 OfflineMsgEngine::OfflineMsgEngine(Friend *frnd) :

--- a/src/persistence/offlinemsgengine.h
+++ b/src/persistence/offlinemsgengine.h
@@ -57,6 +57,10 @@ private:
     QHash<int, int64_t> receipts;
     QMap<int64_t, MsgPtr> undeliveredMsgs;
 
+    // timeout after which faux offline messages get to be re-sent
+    // originally was 2s, but since that was causing lots of duplicated
+    // messages on receiving end, make qTox be more lazy about re-sending
+    // should be 20s
     static const int offlineTimeout;
 };
 


### PR DESCRIPTION
Should make problem with duplicated messages less common.
Related to #2726.

I don't even know whether that's it.
