### PR TITLE
fix sound sliders not saving when moved by keyboard

### DIFF
--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -63,14 +63,10 @@ AVForm::AVForm() :
 
     bodyUI->playbackSlider->setTracking(false);
     bodyUI->playbackSlider->installEventFilter(this);
-    connect(bodyUI->playbackSlider, &QSlider::sliderMoved,
-            this, &AVForm::onPlaybackSliderMoved);
     connect(bodyUI->playbackSlider, &QSlider::valueChanged,
             this, &AVForm::onPlaybackValueChanged);
     bodyUI->microphoneSlider->setTracking(false);
     bodyUI->microphoneSlider->installEventFilter(this);
-    connect(bodyUI->microphoneSlider, &QSlider::sliderMoved,
-            this, &AVForm::onMicrophoneSliderMoved);
     connect(bodyUI->microphoneSlider, &QSlider::valueChanged,
             this, &AVForm::onMicrophoneValueChanged);
 
@@ -402,8 +398,10 @@ void AVForm::onFilterAudioToggled(bool filterAudio)
     Settings::getInstance().setFilterAudio(filterAudio);
 }
 
-void AVForm::onPlaybackSliderMoved(int value)
+void AVForm::onPlaybackValueChanged(int value)
 {
+    Settings::getInstance().setOutVolume(value);
+
     Audio& audio = Audio::getInstance();
     if (audio.isOutputReady()) {
         const qreal percentage = value / 100.0;
@@ -414,20 +412,12 @@ void AVForm::onPlaybackSliderMoved(int value)
     }
 }
 
-void AVForm::onPlaybackValueChanged(int value)
-{
-    Settings::getInstance().setOutVolume(value);
-}
-
-void AVForm::onMicrophoneSliderMoved(int value)
-{
-    const qreal percentage = value / 100.0;
-    Audio::getInstance().setInputVolume(percentage);
-}
-
 void AVForm::onMicrophoneValueChanged(int value)
 {
     Settings::getInstance().setInVolume(value);
+
+    const qreal percentage = value / 100.0;
+    Audio::getInstance().setInputVolume(percentage);
 }
 
 void AVForm::createVideoSurface()

--- a/src/widget/form/settings/avform.h
+++ b/src/widget/form/settings/avform.h
@@ -57,9 +57,7 @@ private slots:
     void onInDevChanged(QString deviceDescriptor);
     void onOutDevChanged(QString deviceDescriptor);
     void onFilterAudioToggled(bool filterAudio);
-    void onPlaybackSliderMoved(int value);
     void onPlaybackValueChanged(int value);
-    void onMicrophoneSliderMoved(int value);
     void onMicrophoneValueChanged(int value);
 
     // camera


### PR DESCRIPTION
QSlider::sliderMoved is only emitted when using the mouse, not keyboard, so I consolidated everything into QSlider::valueChanged instead.

closes #2866
