### PR TITLE
Fixed incorrect desktop video resolution when using HiDPI scaling

### DIFF
--- a/src/video/cameradevice.cpp
+++ b/src/video/cameradevice.cpp
@@ -20,6 +20,7 @@
 #include <QDebug>
 #include <QApplication>
 #include <QDesktopWidget>
+#include <QScreen>
 extern "C" {
 #include <libavformat/avformat.h>
 #include <libavdevice/avdevice.h>
@@ -132,11 +133,14 @@ CameraDevice* CameraDevice::open(QString devName, VideoMode mode)
         }
         else
         {
-            screen = QApplication::desktop()->screenGeometry().size();
+            QScreen* defaultScreen = QApplication::screens().at(0);
+            qreal pixRatio = defaultScreen->devicePixelRatio();
+
+            screen = defaultScreen->size();
             // Workaround https://trac.ffmpeg.org/ticket/4574 by choping 1 px bottom and right
             // Actually, let's chop two pixels, toxav hates odd resolutions (off by one stride)
-            screen.setWidth(screen.width()-2);
-            screen.setHeight(screen.height()-2);
+            screen.setWidth((screen.width() * pixRatio)-2);
+            screen.setHeight((screen.height() * pixRatio)-2);
         }
         av_dict_set(&options, "video_size", QString("%1x%2").arg(screen.width()).arg(screen.height()).toStdString().c_str(), 0);
         if (mode.FPS)


### PR DESCRIPTION
When attempting to use "Desktop" as the video source under HiDPI scaling, the resolution returned by Qt's `QApplication::desktop()->screenGeometry().size();` would return a resolution in device-indepedent pixels (which would be less than the actual physical number of pixels being projected by the monitor). As such, toxav ends up clipping the Desktop feed to only the given region, resulting in a subset of the desktop being displayed. This issue is examplified below:
![clipped](https://cloud.githubusercontent.com/assets/3128050/14221679/b4311918-f836-11e5-8cb0-7832b43d683a.png)

The problem is resolved by usage of the function `QScreen::devicePixelRatio()` which returns the scaling factor between the DPI pixels and the actual pixel pixels.

The one caveat with ths solution is that `devicePixelRatio()` is only available >= Qt 5.5, causing breakage when used with an older verison of Qt.
