### PR TITLE
Fixes incorrect desktop video resolution when using HiDPI

### DIFF
--- a/src/video/cameradevice.cpp
+++ b/src/video/cameradevice.cpp
@@ -133,7 +133,7 @@ CameraDevice* CameraDevice::open(QString devName, VideoMode mode)
         }
         else
         {
-            QScreen* defaultScreen = QApplication::screens().at(0);
+            QScreen* defaultScreen = static_cast<QGuiApplication*>(QGuiApplication::instance())->primaryScreen();
             qreal pixRatio;
 
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 5, 0))


### PR DESCRIPTION
When attempting to use "Desktop" as the video source under HiDPI scaling, the resolution returned by Qt's `QApplication::desktop()->screenGeometry().size()` would return a resolution in device-indepedent pixels (which would be less than the actual physical number of pixels being projected by the monitor). As such, toxav ends up clipping the desktop feed to only the given region, resulting in a subset of the desktop being displayed. This issue is examplified below:
![clipped](https://cloud.githubusercontent.com/assets/3128050/14221679/b4311918-f836-11e5-8cb0-7832b43d683a.png)

The problem is resolved by usage of the function `QScreen::devicePixelRatio()` which returns the scaling factor between the DPI pixels and the actual pixel pixels.

The one caveat with ths solution is that `devicePixelRatio()` is only available >= Qt 5.5. A temporary solution is to assume a default of no scaling when compiling with Qt < 5.5.0 (matches current behaviour).
