### PR TITLE
fix(chatform): regression in detecting `tox:` type IDs

### DIFF
--- a/src/chatlog/chatmessage.cpp
+++ b/src/chatlog/chatmessage.cpp
@@ -250,7 +250,7 @@ QString ChatMessage::detectAnchors(const QString &str)
                 // http://ONEORMOREALHPA-DIGIT
                 "\\w+\\S+)" // any other character, lets domains and other
                 "|(?:\\b)(file:///)([\\S| ]*)" //link to a local file, valid until the end of the line
-                "|(?:\\b)(tox:[a-zA-Z\\d]{76}$)" //link with full user address
+                "|(?:\\b)(tox:[a-zA-Z\\d]{76})" //link with full user address
                 "|(?:\\b)(mailto:\\S+@\\S+\\.\\S+)" //@mail link
                 "|(?:\\b)(tox:\\S+@\\S+)"); // starts with `tox` then : and only alpha-digits till the end
                 // also accepts tox:agilob@net as simplified TOX ID


### PR DESCRIPTION
Introduced in d3434087495faeeaed324fc52d0f5634bc248567 / #3044.

Without fix:
![no fix](https://cloud.githubusercontent.com/assets/3148759/14232349/f618155a-f9a0-11e5-87df-83dc7e1ae8b6.png)
Note that this ↑ is also without #3077 applied.

With fix:
![fixed](https://cloud.githubusercontent.com/assets/3148759/14232341/db1be3c6-f9a0-11e5-80e0-7c3f52b50d71.png)
