### PR TITLE
Simplifies retrieval of primary screen

### DIFF
--- a/src/video/cameradevice.cpp
+++ b/src/video/cameradevice.cpp
@@ -133,7 +133,7 @@ CameraDevice* CameraDevice::open(QString devName, VideoMode mode)
         }
         else
         {
-            QScreen* defaultScreen = static_cast<QGuiApplication*>(QGuiApplication::instance())->primaryScreen();
+            QScreen* defaultScreen = QApplication::primaryScreen();
             qreal pixRatio;
 
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 5, 0))


### PR DESCRIPTION
This PR is directly related to #3091.

I didn't know the `primaryScreen()` function from `QApplication` was static (read: I derped up). This commit simply retrieves using static access (i.e. `QApplication::primaryScreen()`) as opposed to obtaining an instance, casting it and then accessing it.
