### PR TITLE
Fixes incorrect screenshot resolution when using HiDPI

### DIFF
--- a/src/widget/tool/screenshotgrabber.h
+++ b/src/widget/tool/screenshotgrabber.h
@@ -85,6 +85,8 @@ private:
     ToolBoxGraphicsItem* helperToolbox;
     QGraphicsTextItem* helperTooltip;
 
+    qreal pixRatio = 1.0;
+
     bool mQToxVisible;
     QVector< QPointer<QWidget> >   mHiddenWindows;
 };


### PR DESCRIPTION
When attemping to take a screenshot using the screenshot tool under HiDPI scaling, the maximum resolution returned by Qt does not represent the full screen resolution, instead, only a crop (as a function of the scale factor). This issue is related and resolved in the same way as PR #3091.
