### PR TITLE
fix(file transfer widget): QPushButton allows image to overflow

### DIFF
--- a/src/chatlog/content/filetransferwidget.h
+++ b/src/chatlog/content/filetransferwidget.h
@@ -73,6 +73,9 @@ private slots:
     void onPreviewButtonClicked();
 
 private:
+    static QPixmap scaleCropIntoSquare(const QPixmap &source, int targetSize);
+
+private:
     Ui::FileTransferWidget *ui;
     ToxFile fileInfo;
     QTime lastTick;

--- a/src/chatlog/content/filetransferwidget.ui
+++ b/src/chatlog/content/filetransferwidget.ui
@@ -292,6 +292,9 @@
           <property name="cursor">
            <cursorShape>PointingHandCursor</cursorShape>
           </property>
+          <property name="styleSheet">
+           <string notr="true">QPushButton{ border: 2px solid white }</string>
+          </property>
           <property name="icon">
            <iconset resource="../../../res.qrc">
             <normaloff>:/ui/fileTransferInstance/no.svg</normaloff>:/ui/fileTransferInstance/no.svg</iconset>


### PR DESCRIPTION
Regression was due to fact that QPushButton allows icon to overflow.
This patch does:
1. Scale and crop icon to fit into button.
2. Avoid upscaling small images.
3. Refactor FileTransferWidget::showPreview() to load image from file only once.

Fixes #3042 

Screenshot:
https://github.com/tux3/qTox/issues/3042#issuecomment-209565743
