### PR TITLE
Checks the return value for sodium_init()

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -150,7 +150,11 @@ int main(int argc, char *argv[])
     IPC& ipc = IPC::getInstance();
 #endif
 
-    sodium_init(); // For the auto-updater
+    if(sodium_init() < 0) // For the auto-updater
+    {
+        qCritical() << "libsodium initialization failed!";
+        return EXIT_FAILURE;
+    }
 
 #ifdef LOG_TO_FILE
     QString logFileDir = Settings::getInstance().getAppCacheDirPath();


### PR DESCRIPTION
This commit checks the return value for sodium_init() and emits a "critical" message if initialization failed. Also gets rid of the warning for unused return value.
