### PR TITLE
Ignore profile build directory in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ qtox
 *.qm
 *.orig
 build-*-Release
+build-*-Profile
 build-*-Debug
 .DS_Store


### PR DESCRIPTION
Adds a entry into gitignore to ignore profile builds (from QtCreator) alongside Release and Debug.
