### PR TITLE
chore: remove not needed `dialogs.ini` file

### DIFF
--- a/dialogs.ini
+++ b/dialogs.ini
@@ -1,3 +1,0 @@
-[General]
-geometry=@Rect(147 345 604 375)
-maximized=false


### PR DESCRIPTION
Doesn't seem to be used by anything, removal doesn't seem to cause any
changes.

The only file in `~/.config/tox/` that has ~similar content to it that I
have is named `windowSettings.ini`, has in it different values, and last
time that it was modified was 2014-07-31.

File was introduced in b394372ad005d32ae9a74ca3941c308a29276a53, and was
not modified since.
