### PR TITLE
fix and cleanup audio device lists

### DIFF
--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -320,7 +320,7 @@ bool Audio::autoInitOutput()
 
 bool Audio::initInput(const QString& deviceName)
 {
-    if (deviceName.toLower() == QStringLiteral("none"))
+    if (!Settings::getInstance().getAudioInDevEnabled())
         return false;
 
     qDebug() << "Opening audio input" << deviceName;
@@ -363,7 +363,7 @@ bool Audio::initOutput(const QString& deviceName)
     outSources.clear();
 
     outputInitialized = false;
-    if (deviceName.toLower() == QStringLiteral("none"))
+    if (!Settings::getInstance().getAudioOutDevEnabled())
         return false;
 
     qDebug() << "Opening audio output" << deviceName;

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -74,8 +74,8 @@ public:
     bool isInputReady() const;
     bool isOutputReady() const;
 
-    static const char* outDeviceNames();
-    static const char* inDeviceNames();
+    static QStringList outDeviceNames();
+    static QStringList inDeviceNames();
     void subscribeOutput(ALuint& sid);
     void unsubscribeOutput(ALuint& sid);
     void subscribeInput();

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -104,8 +104,8 @@ private:
 
     bool autoInitInput();
     bool autoInitOutput();
-    bool initInput(QString inDevDescr);
-    bool initOutput(QString outDevDescr);
+    bool initInput(const QString& deviceName);
+    bool initOutput(const QString& outDevDescr);
     void cleanupInput();
     void cleanupOutput();
     /// Called after a mono16 sound stopped playing

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -242,7 +242,9 @@ void Settings::loadGlobal()
 
     s.beginGroup("Audio");
         inDev = s.value("inDev", "").toString();
+        audioInDevEnabled = s.value("audioInDevEnabled", true).toBool();
         outDev = s.value("outDev", "").toString();
+        audioOutDevEnabled = s.value("audioOutDevEnabled", true).toBool();
         audioInGainDecibel = s.value("inGain", 0).toReal();
         outVolume = s.value("outVolume", 100).toInt();
     s.endGroup();
@@ -478,7 +480,9 @@ void Settings::saveGlobal()
 
     s.beginGroup("Audio");
         s.setValue("inDev", inDev);
+        s.setValue("audioInDevEnabled", audioInDevEnabled);
         s.setValue("outDev", outDev);
+        s.setValue("audioOutDevEnabled", audioOutDevEnabled);
         s.setValue("inGain", audioInGainDecibel);
         s.setValue("outVolume", outVolume);
     s.endGroup();
@@ -1389,6 +1393,18 @@ void Settings::setInDev(const QString& deviceSpecifier)
     inDev = deviceSpecifier;
 }
 
+bool Settings::getAudioInDevEnabled() const
+{
+    QMutexLocker locker(&bigLock);
+    return audioInDevEnabled;
+}
+
+void Settings::setAudioInDevEnabled(bool enabled)
+{
+    QMutexLocker locker(&bigLock);
+    audioInDevEnabled = enabled;
+}
+
 qreal Settings::getAudioInGain() const
 {
     QMutexLocker locker{&bigLock};
@@ -1423,6 +1439,18 @@ void Settings::setOutDev(const QString& deviceSpecifier)
 {
     QMutexLocker locker{&bigLock};
     outDev = deviceSpecifier;
+}
+
+bool Settings::getAudioOutDevEnabled() const
+{
+    QMutexLocker locker(&bigLock);
+    return audioOutDevEnabled;
+}
+
+void Settings::setAudioOutDevEnabled(bool enabled)
+{
+    QMutexLocker locker(&bigLock);
+    audioOutDevEnabled = enabled;
 }
 
 int Settings::getOutVolume() const

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -179,8 +179,14 @@ public:
     QString getInDev() const;
     void setInDev(const QString& deviceSpecifier);
 
+    bool getAudioInDevEnabled() const;
+    void setAudioInDevEnabled(bool enabled);
+
     QString getOutDev() const;
     void setOutDev(const QString& deviceSpecifier);
+
+    bool getAudioOutDevEnabled() const;
+    void setAudioOutDevEnabled(bool enabled);
 
     qreal getAudioInGain() const;
     void setAudioInGain(qreal dB);
@@ -433,8 +439,10 @@ private:
 
     // Audio
     QString inDev;
-    QString outDev;
+    bool audioInDevEnabled;
     qreal audioInGainDecibel;
+    QString outDev;
+    bool audioOutDevEnabled;
     int outVolume;
 
     // Video

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -344,52 +344,30 @@ void AVForm::getVideoDevices()
 
 void AVForm::getAudioInDevices()
 {
-    QString settingsInDev = Settings::getInstance().getInDev();
-    int inDevIndex = 0;
+    QStringList deviceNames;
+    deviceNames << tr("None") << Audio::inDeviceNames();
+
     bodyUI->inDevCombobox->blockSignals(true);
     bodyUI->inDevCombobox->clear();
-    bodyUI->inDevCombobox->addItem(tr("None"));
-    const char* pDeviceList = Audio::inDeviceNames();
-    if (pDeviceList)
-    {
-        while (*pDeviceList)
-        {
-            int len = strlen(pDeviceList);
-            QString inDev = QString::fromUtf8(pDeviceList, len);
-            bodyUI->inDevCombobox->addItem(inDev);
-            if (settingsInDev == inDev)
-                inDevIndex = bodyUI->inDevCombobox->count()-1;
-            pDeviceList += len+1;
-        }
-    }
+    bodyUI->inDevCombobox->addItems(deviceNames);
     bodyUI->inDevCombobox->blockSignals(false);
-    bodyUI->inDevCombobox->setCurrentIndex(inDevIndex);
+
+    int idx = deviceNames.indexOf(Settings::getInstance().getInDev());
+    bodyUI->inDevCombobox->setCurrentIndex(idx > 0 ? idx : 0);
 }
 
 void AVForm::getAudioOutDevices()
 {
-    QString settingsOutDev = Settings::getInstance().getOutDev();
-    int outDevIndex = 0;
+    QStringList deviceNames;
+    deviceNames << tr("None") << Audio::outDeviceNames();
+
     bodyUI->outDevCombobox->blockSignals(true);
     bodyUI->outDevCombobox->clear();
-    bodyUI->outDevCombobox->addItem(tr("None"));
-    const char* pDeviceList = Audio::outDeviceNames();
-    if (pDeviceList)
-    {
-        while (*pDeviceList)
-        {
-            int len = strlen(pDeviceList);
-            QString outDev = QString::fromUtf8(pDeviceList, len);
-            bodyUI->outDevCombobox->addItem(outDev);
-            if (settingsOutDev == outDev)
-            {
-                outDevIndex = bodyUI->outDevCombobox->count()-1;
-            }
-            pDeviceList += len+1;
-        }
-    }
+    bodyUI->outDevCombobox->addItems(deviceNames);
     bodyUI->outDevCombobox->blockSignals(false);
-    bodyUI->outDevCombobox->setCurrentIndex(outDevIndex);
+
+    int idx = deviceNames.indexOf(Settings::getInstance().getOutDev());
+    bodyUI->outDevCombobox->setCurrentIndex(idx > 0 ? idx : 0);
 }
 
 void AVForm::onInDevChanged(QString deviceDescriptor)

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -345,36 +345,42 @@ void AVForm::getVideoDevices()
 void AVForm::getAudioInDevices()
 {
     QStringList deviceNames;
-    deviceNames << tr("None") << Audio::inDeviceNames();
+    deviceNames << tr("Disabled") << Audio::inDeviceNames();
 
     bodyUI->inDevCombobox->blockSignals(true);
     bodyUI->inDevCombobox->clear();
     bodyUI->inDevCombobox->addItems(deviceNames);
     bodyUI->inDevCombobox->blockSignals(false);
 
-    int idx = deviceNames.indexOf(Settings::getInstance().getInDev());
-    bodyUI->inDevCombobox->setCurrentIndex(idx > 0 ? idx : 0);
+    int idx = Settings::getInstance().getAudioInDevEnabled()
+              ? deviceNames.indexOf(Settings::getInstance().getInDev())
+              : 0;
+    bodyUI->inDevCombobox->setCurrentIndex(idx < 0 ? 1 : idx);
 }
 
 void AVForm::getAudioOutDevices()
 {
     QStringList deviceNames;
-    deviceNames << tr("None") << Audio::outDeviceNames();
+    deviceNames << tr("Disabled") << Audio::outDeviceNames();
 
     bodyUI->outDevCombobox->blockSignals(true);
     bodyUI->outDevCombobox->clear();
     bodyUI->outDevCombobox->addItems(deviceNames);
     bodyUI->outDevCombobox->blockSignals(false);
 
-    int idx = deviceNames.indexOf(Settings::getInstance().getOutDev());
-    bodyUI->outDevCombobox->setCurrentIndex(idx > 0 ? idx : 0);
+    int idx = Settings::getInstance().getAudioOutDevEnabled()
+              ? deviceNames.indexOf(Settings::getInstance().getOutDev())
+              : 0;
+    bodyUI->outDevCombobox->setCurrentIndex(idx < 0 ? 1 : idx);
 }
 
 void AVForm::onAudioInDevChanged(int deviceIndex)
 {
-    QString deviceName = deviceIndex > 0
-                         ? bodyUI->inDevCombobox->itemText(deviceIndex)
-                         : QStringLiteral("none");
+    Settings::getInstance().setAudioInDevEnabled(deviceIndex != 0);
+
+    QString deviceName;
+    if (deviceIndex > 0)
+        deviceName = bodyUI->inDevCombobox->itemText(deviceIndex);
 
     Settings::getInstance().setInDev(deviceName);
 
@@ -386,9 +392,11 @@ void AVForm::onAudioInDevChanged(int deviceIndex)
 
 void AVForm::onAudioOutDevChanged(int deviceIndex)
 {
-    QString deviceName = deviceIndex > 0
-                         ? bodyUI->outDevCombobox->itemText(deviceIndex)
-                         : QStringLiteral("none");
+    Settings::getInstance().setAudioOutDevEnabled(deviceIndex != 0);
+
+    QString deviceName;
+    if (deviceIndex > 0)
+        deviceName = bodyUI->outDevCombobox->itemText(deviceIndex);
 
     Settings::getInstance().setOutDev(deviceName);
 

--- a/src/widget/form/settings/avform.h
+++ b/src/widget/form/settings/avform.h
@@ -54,8 +54,8 @@ private:
 private slots:
 
     // audio
-    void onInDevChanged(QString deviceDescriptor);
-    void onOutDevChanged(QString deviceDescriptor);
+    void onAudioInDevChanged(int deviceIndex);
+    void onAudioOutDevChanged(int deviceIndex);
     void onPlaybackValueChanged(int value);
     void onMicrophoneValueChanged(int value);
 


### PR DESCRIPTION
- [x] cleanup audio device list creation and usage in qTox
- [x] fix selection of default audio device on initialization
- [x] fix initialization, when no device is selected (do not initialize)
- [x] actually disable an audio device without losing the name information
- [x] **WON'T FIX**: ~~fix unicode conversion on Windows (probably only affects pre Win10 versions ??)~~
  - String encoding in OpenAL is undocumented and can lead to incorrect device names on older platforms - especially Windows. With RtAudio, this problem is solved. IMO it is not worth the effort.
