### PR TITLE
fix(genericchatform):separate messages from different days

### DIFF
--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -315,6 +315,9 @@ ChatMessage::Ptr GenericChatForm::addMessage(const ToxId& author, const QString 
     bool authorIsActiveProfile = author.isSelf();
     QString authorStr = authorIsActiveProfile ? Core::getInstance()->getUsername() : resolveToxId(author);
 
+    if (getLatestDate() != QDate::currentDate())
+        addSystemInfoMessage(QDate::currentDate().toString(Settings::getInstance().getDateFormat()), ChatMessage::INFO, QDateTime());
+
     ChatMessage::Ptr msg;
     if (isAction)
     {


### PR DESCRIPTION
Before this new cut-off days is only shown when the load history, now added a feature which in the current chat checks the last post date and if the date does not coincide with current - output a system message about the new date.
