### PR TITLE
feat(emoticonswidget):Keep emoticon option open

### DIFF
--- a/src/widget/emoticonswidget.cpp
+++ b/src/widget/emoticonswidget.cpp
@@ -126,9 +126,6 @@ EmoticonsWidget::EmoticonsWidget(QWidget *parent) :
 
 void EmoticonsWidget::onSmileyClicked()
 {
-    // hide the QMenu
-    hide();
-
     // emit insert emoticon
     QWidget* sender = qobject_cast<QWidget*>(QObject::sender());
     if (sender)
@@ -193,3 +190,10 @@ void EmoticonsWidget::PageButtonsUpdate()
            t_pageButton->setChecked(false);
     }
 }
+
+void EmoticonsWidget::keyPressEvent(QKeyEvent *e)
+{
+    Q_UNUSED(e)
+    hide();
+}
+

--- a/src/widget/emoticonswidget.h
+++ b/src/widget/emoticonswidget.h
@@ -42,6 +42,7 @@ protected:
     void mouseReleaseEvent(QMouseEvent *ev) final override;
     void mousePressEvent(QMouseEvent *ev) final override;
     void wheelEvent(QWheelEvent * event) final override;
+    void keyPressEvent(QKeyEvent *e) final override;
 
 private:
     QStackedWidget stack;

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -365,6 +365,7 @@ void GenericChatForm::onEmoteButtonClicked()
 
     EmoticonsWidget widget;
     connect(&widget, SIGNAL(insertEmoticon(QString)), this, SLOT(onEmoteInsertRequested(QString)));
+    widget.installEventFilter(this);
 
     QWidget* sender = qobject_cast<QWidget*>(QObject::sender());
     if (sender)
@@ -497,6 +498,15 @@ void GenericChatForm::resizeEvent(QResizeEvent* event)
 
 bool GenericChatForm::eventFilter(QObject* object, QEvent* event)
 {
+    EmoticonsWidget * ev = qobject_cast<EmoticonsWidget *>(object);
+    if (( ev) && (event->type() == QEvent::KeyPress) )
+    {
+        QKeyEvent* key = static_cast<QKeyEvent*>(event);
+        msgEdit->sendKeyEvent(key);
+        msgEdit->setFocus();
+        return false;
+    }
+
     if (object != this->fileButton && object != this->fileFlyout)
         return false;
 

--- a/src/widget/tool/chattextedit.cpp
+++ b/src/widget/tool/chattextedit.cpp
@@ -45,7 +45,10 @@ void ChatTextEdit::keyPressEvent(QKeyEvent * event)
         if (event->modifiers())
             event->ignore();
         else
+        {
             emit tabPressed();
+            event->ignore();
+        }
     }
     else if (key == Qt::Key_Up && this->toPlainText().isEmpty())
     {
@@ -68,4 +71,9 @@ void ChatTextEdit::setLastMessage(QString lm)
 void ChatTextEdit::retranslateUi()
 {
     setPlaceholderText(tr("Type your message here..."));
+}
+
+void ChatTextEdit::sendKeyEvent(QKeyEvent * event)
+{
+    emit keyPressEvent(event);
 }

--- a/src/widget/tool/chattextedit.h
+++ b/src/widget/tool/chattextedit.h
@@ -29,6 +29,7 @@ public:
     explicit ChatTextEdit(QWidget *parent = 0);
     ~ChatTextEdit();
     void setLastMessage(QString lm);
+    void sendKeyEvent(QKeyEvent * event);
 
 signals:
     void enterPressed();


### PR DESCRIPTION
Emoticon dialog remains open, and the selected emoticon is pasted into the text window
close #3043
