### PR TITLE
Redesigned VideoFrame class

### DIFF
--- a/qtox.pro
+++ b/qtox.pro
@@ -414,6 +414,7 @@ SOURCES += \
     src/persistence/db/rawdatabase.cpp \
     src/persistence/history.cpp \
     src/video/videoframe.cpp \
+    src/video/videosource.cpp \
     src/video/cameradevice.cpp \
     src/video/camerasource.cpp \
     src/video/corevideosource.cpp \

--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -362,7 +362,12 @@ void CoreAV::sendCallVideo(uint32_t callId, std::shared_ptr<VideoFrame> vframe)
 
     // This frame shares vframe's buffers, we don't call vpx_img_free but just delete it
     vpx_image* frame = vframe->toVpxImage();
-    if (frame->fmt == VPX_IMG_FMT_NONE)
+
+    if(!frame)
+    {
+        return;
+    }
+    if(frame->fmt == VPX_IMG_FMT_NONE)
     {
         qWarning() << "Invalid frame";
         vpx_img_free(frame);

--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -362,7 +362,7 @@ void CoreAV::sendCallVideo(uint32_t callId, std::shared_ptr<VideoFrame> vframe)
 
     ToxYUVFrame frame = vframe->toToxYUVFrame();
 
-    if(frame.width == 0 || frame.height == 0)
+    if(!frame)
     {
         return;
     }

--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -360,7 +360,7 @@ void CoreAV::sendCallVideo(uint32_t callId, std::shared_ptr<VideoFrame> vframe)
         call.nullVideoBitrate = false;
     }
 
-    ToxYUVFrame frame = vframe->toToxAVFrame();
+    ToxYUVFrame frame = vframe->toToxYUVFrame();
 
     if(frame.width == 0 || frame.height == 0)
     {

--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -361,7 +361,7 @@ void CoreAV::sendCallVideo(uint32_t callId, std::shared_ptr<VideoFrame> vframe)
     }
 
     // This frame shares vframe's buffers, we don't call vpx_img_free but just delete it
-    ToxAVFrame frame = vframe->toToxAVFrame();
+    ToxYUVFrame frame = vframe->toToxAVFrame();
 
     if(frame.width == 0 || frame.height == 0)
     {

--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -360,7 +360,6 @@ void CoreAV::sendCallVideo(uint32_t callId, std::shared_ptr<VideoFrame> vframe)
         call.nullVideoBitrate = false;
     }
 
-    // This frame shares vframe's buffers, we don't call vpx_img_free but just delete it
     ToxYUVFrame frame = vframe->toToxAVFrame();
 
     if(frame.width == 0 || frame.height == 0)

--- a/src/video/camerasource.h
+++ b/src/video/camerasource.h
@@ -55,20 +55,16 @@ private:
     CameraSource();
     ~CameraSource();
     void stream();
-    void freelistCallback(int freelistIndex);
-    int getFreelistSlotLockless();
     bool openDevice();
     void closeDevice();
 
 private:
-    QVector<std::weak_ptr<VideoFrame>> freelist;
     QFuture<void> streamFuture;
     QString deviceName;
     CameraDevice* device;
     VideoMode mode;
     AVCodecContext* cctx, *cctxOrig;
     int videoStreamIndex;
-    QMutex biglock, freelistLock;
     std::atomic_bool _isOpen;
     std::atomic_bool streamBlocker;
     std::atomic_int subscriptions;

--- a/src/video/camerasource.h
+++ b/src/video/camerasource.h
@@ -65,6 +65,7 @@ private:
     VideoMode mode;
     AVCodecContext* cctx, *cctxOrig;
     int videoStreamIndex;
+    QMutex biglock;
     std::atomic_bool _isOpen;
     std::atomic_bool streamBlocker;
     std::atomic_int subscriptions;

--- a/src/video/camerasource.h
+++ b/src/video/camerasource.h
@@ -24,6 +24,7 @@
 #include <QString>
 #include <QFuture>
 #include <QVector>
+#include <QReadWriteLock>
 #include <atomic>
 #include "src/video/videosource.h"
 #include "src/video/videomode.h"
@@ -65,7 +66,7 @@ private:
     VideoMode mode;
     AVCodecContext* cctx, *cctxOrig;
     int videoStreamIndex;
-    QMutex biglock;
+    QReadWriteLock streamMutex;
     std::atomic_bool _isOpen;
     std::atomic_bool streamBlocker;
     std::atomic_int subscriptions;

--- a/src/video/corevideosource.cpp
+++ b/src/video/corevideosource.cpp
@@ -77,7 +77,7 @@ void CoreVideoSource::pushFrame(const vpx_image_t* vpxframe)
 
     int bufSize = av_image_alloc(avframe->data, avframe->linesize,
                                  width, height,
-                                 static_cast<AVPixelFormat>(AV_PIX_FMT_YUV420P), VideoFrame::frameAlignment);
+                                 static_cast<AVPixelFormat>(AV_PIX_FMT_YUV420P), VideoFrame::dataAlignment);
 
     if(bufSize < 0){
         av_frame_free(&avframe);

--- a/src/video/corevideosource.cpp
+++ b/src/video/corevideosource.cpp
@@ -99,7 +99,7 @@ void CoreVideoSource::pushFrame(const vpx_image_t* vpxframe)
         }
     }
 
-    vframe = std::make_shared<VideoFrame>(avframe, true);
+    vframe = std::make_shared<VideoFrame>(id, avframe, true);
     emit frameAvailable(vframe);
 }
 

--- a/src/video/videoframe.cpp
+++ b/src/video/videoframe.cpp
@@ -162,7 +162,7 @@ QImage VideoFrame::toQImage(QSize frameSize)
     return ret;
 }
 
-vpx_image* VideoFrame::toVpxImage(QSize frameSize)
+ToxAVFrame VideoFrame::toToxAVFrame(QSize frameSize)
 {
     frameLock.lockForRead();
 
@@ -170,7 +170,7 @@ vpx_image* VideoFrame::toVpxImage(QSize frameSize)
     if(frameBuffer.size() == 0)
     {
         frameLock.unlock();
-        return nullptr;
+        return {0, 0, nullptr, nullptr, nullptr};
     }
 
     if(frameSize.width() == 0 && frameSize.height() == 0)
@@ -182,20 +182,7 @@ vpx_image* VideoFrame::toVpxImage(QSize frameSize)
 
     if(frame)
     {
-        vpx_image* ret = new vpx_image {};
-        memset(ret, 0, sizeof(vpx_image));
-
-        ret->w = ret->d_w = frameSize.width();
-        ret->h = ret->d_h = frameSize.height();
-        ret->fmt = VPX_IMG_FMT_I420;
-        ret->planes[0] = frame->data[0];
-        ret->planes[1] = frame->data[1];
-        ret->planes[2] = frame->data[2];
-        ret->planes[3] = nullptr;
-        ret->stride[0] = frame->linesize[0];
-        ret->stride[1] = frame->linesize[1];
-        ret->stride[2] = frame->linesize[2];
-        ret->stride[3] = frame->linesize[3];
+        ToxAVFrame ret {frameSize.width(), frameSize.height(), frame->data[0], frame->data[1], frame->data[2]};
 
         frameLock.unlock();
         return ret;
@@ -216,20 +203,7 @@ vpx_image* VideoFrame::toVpxImage(QSize frameSize)
 
     storeAVFrame(frame, frameSize, static_cast<int>(AV_PIX_FMT_YUV420P));
 
-    vpx_image* ret = new vpx_image {};
-    memset(ret, 0, sizeof(vpx_image));
-
-    ret->w = ret->d_w = frameSize.width();
-    ret->h = ret->d_h = frameSize.height();
-    ret->fmt = VPX_IMG_FMT_I420;
-    ret->planes[0] = frame->data[0];
-    ret->planes[1] = frame->data[1];
-    ret->planes[2] = frame->data[2];
-    ret->planes[3] = nullptr;
-    ret->stride[0] = frame->linesize[0];
-    ret->stride[1] = frame->linesize[1];
-    ret->stride[2] = frame->linesize[2];
-    ret->stride[3] = frame->linesize[3];
+    ToxAVFrame ret {frameSize.width(), frameSize.height(), frame->data[0], frame->data[1], frame->data[2]};
 
     frameLock.unlock();
     return ret;

--- a/src/video/videoframe.cpp
+++ b/src/video/videoframe.cpp
@@ -97,6 +97,46 @@ VideoFrame::VideoFrame(IDType sourceID, AVFrame* sourceFrame, QRect dimensions, 
       sourceFrameKey(getFrameKey(dimensions.size(), pixFmt, sourceFrame->linesize[0])),
       freeSourceFrame(freeSourceFrame)
 {
+
+    // We override the pixel format in the case a deprecated one is used
+    switch(pixFmt)
+    {
+    case AV_PIX_FMT_YUVJ420P:
+    {
+        pixFmt = AV_PIX_FMT_YUV420P;
+        sourceFrame->color_range = AVCOL_RANGE_MPEG;
+        break;
+    }
+
+    case AV_PIX_FMT_YUVJ411P:
+    {
+        pixFmt = AV_PIX_FMT_YUV411P;
+        sourceFrame->color_range = AVCOL_RANGE_MPEG;
+        break;
+    }
+
+    case AV_PIX_FMT_YUVJ422P:
+    {
+        pixFmt = AV_PIX_FMT_YUV422P;
+        sourceFrame->color_range = AVCOL_RANGE_MPEG;
+        break;
+    }
+
+    case AV_PIX_FMT_YUVJ444P:
+    {
+        pixFmt = AV_PIX_FMT_YUV444P;
+        sourceFrame->color_range = AVCOL_RANGE_MPEG;
+        break;
+    }
+
+    case AV_PIX_FMT_YUVJ440P:
+    {
+        pixFmt = AV_PIX_FMT_YUV440P;
+        sourceFrame->color_range = AVCOL_RANGE_MPEG;
+        break;
+    }
+    }
+
     frameBuffer[sourceFrameKey] = sourceFrame;
 }
 

--- a/src/video/videoframe.cpp
+++ b/src/video/videoframe.cpp
@@ -293,8 +293,8 @@ void VideoFrame::releaseFrame()
  * If a given frame does not exist, this function will perform appropriate conversions to
  * return a frame that fulfills the given parameters.
  *
- * @param frameSize the dimensions of the frame to get. If frame size is 0, defaults to source
- * frame size.
+ * @param frameSize the dimensions of the frame to get. Defaults to source frame size if frameSize
+ * is invalid.
  * @param pixelFormat the desired pixel format of the frame.
  * @param requireAligned true if the returned frame must be frame aligned, false if not.
  * @return a pointer to a AVFrame with the given parameters or nullptr if the VideoFrame is no
@@ -302,6 +302,11 @@ void VideoFrame::releaseFrame()
  */
 const AVFrame* VideoFrame::getAVFrame(QSize frameSize, const int pixelFormat, const bool requireAligned)
 {
+    if(!frameSize.isValid())
+    {
+        frameSize = sourceDimensions.size();
+    }
+
     // Since we are retrieving the AVFrame* directly, we merely need to pass the arguement through
     const std::function<AVFrame*(AVFrame* const)> converter = [](AVFrame* const frame)
     {
@@ -321,14 +326,14 @@ const AVFrame* VideoFrame::getAVFrame(QSize frameSize, const int pixelFormat, co
  * The VideoFrame will be scaled into the RGB24 pixel format along with the given
  * dimension.
  *
- * @param frameSize the given frame size of QImage to generate. If frame size is 0, defaults to
- * source frame size.
+ * @param frameSize the given frame size of QImage to generate. Defaults to source frame size if
+ * frameSize is invalid.
  * @return a QImage that represents this VideoFrame, sharing it's buffers or a null image if
  * this VideoFrame is no longer valid.
  */
 QImage VideoFrame::toQImage(QSize frameSize)
 {
-    if(frameSize.width() == 0 && frameSize.height() == 0)
+    if(!frameSize.isValid())
     {
         frameSize = sourceDimensions.size();
     }
@@ -349,14 +354,15 @@ QImage VideoFrame::toQImage(QSize frameSize)
  * The given ToxAVFrame will be frame aligned under a pixel format of planar YUV with a chroma
  * subsampling format of 4:2:0 (i.e. AV_PIX_FMT_YUV420P).
  *
- * @param frameSize the given frame size of ToxAVFrame to generate. If frame size is 0, defaults
+ * @param frameSize the given frame size of ToxAVFrame to generate. Defaults to source frame size
+ * if frameSize is invalid.
  * to source frame size.
  * @return a ToxAVFrame structure that represents this VideoFrame, sharing it's buffers or an
  * empty structure if this VideoFrame is no longer valid.
  */
-ToxYUVFrame VideoFrame::toToxAVFrame(QSize frameSize)
+ToxYUVFrame VideoFrame::toToxYUVFrame(QSize frameSize)
 {
-    if(frameSize.width() == 0 && frameSize.height() == 0)
+    if(!frameSize.isValid())
     {
         frameSize = sourceDimensions.size();
     }
@@ -386,7 +392,7 @@ ToxYUVFrame VideoFrame::toToxAVFrame(QSize frameSize)
  * Note: this function differs from getAVFrame() in that it returns a nullptr if no frame was
  * found.
  *
- * @param dimensions the dimensions of the frame.
+ * @param dimensions the dimensions of the frame, must be valid.
  * @param pixelFormat the desired pixel format of the frame.
  * @param requireAligned true if the frame must be frame aligned, false otherwise.
  * @return a pointer to a AVFrame with the given parameters or nullptr if no such frame was
@@ -425,7 +431,7 @@ AVFrame* VideoFrame::retrieveAVFrame(const QSize& dimensions, const int pixelFor
  *
  * This function is not thread-safe and must be called from a thread-safe context.
  *
- * @param dimensions the required dimensions for the frame.
+ * @param dimensions the required dimensions for the frame, must be valid.
  * @param pixelFormat the required pixel format for the frame.
  * @param requireAligned true if the generated frame needs to be frame aligned, false otherwise.
  * @return an AVFrame with the given specifications.
@@ -499,7 +505,7 @@ AVFrame* VideoFrame::generateAVFrame(const QSize& dimensions, const int pixelFor
  * This function is not thread-safe and must be called from a thread-safe context.
  *
  * @param frame the given frame to store.
- * @param dimensions the dimensions of the frame.
+ * @param dimensions the dimensions of the frame, must be valid.
  * @param pixelFormat the pixel format of the frame.
  */
 void VideoFrame::storeAVFrame(AVFrame* frame, const QSize& dimensions, const int pixelFormat)

--- a/src/video/videoframe.cpp
+++ b/src/video/videoframe.cpp
@@ -36,9 +36,8 @@ extern "C"{
  *
  * The creation of this structure was done to replace existing code which mis-used vpx_image
  * structs when passing frame data to toxcore.
- */
-
-/**
+ *
+ *
  * @class VideoFrame
  * @brief An ownernship and management class for AVFrames.
  *
@@ -57,19 +56,17 @@ extern "C"{
  *
  * Frame alignment is an important concept because ToxAV does not support frames with linesizes not
  * directly equal to the width.
- */
-
-/**
+ *
+ *
  * @var dataAlignment
  * @brief Data alignment parameter used to populate AVFrame buffers.
  *
- * This field is public in effort to standardized the data alignment parameter for all AVFrame
+ * This field is public in effort to standardize the data alignment parameter for all AVFrame
  * allocations.
  *
  * It's currently set to 32-byte alignment for AVX2 support.
- */
-
-/**
+ *
+ *
  * @class FrameBufferKey
  * @brief A class representing a structure that stores frame properties to be used as the key
  * value for a std::unordered_map.

--- a/src/video/videoframe.cpp
+++ b/src/video/videoframe.cpp
@@ -90,7 +90,7 @@ QReadWriteLock VideoFrame::refsLock {};
  * @param freeSourceFrame whether to free the source frame buffers or not.
  */
 VideoFrame::VideoFrame(IDType sourceID, AVFrame* sourceFrame, QRect dimensions, int pixFmt, bool freeSourceFrame)
-    : frameID(frameIDs.fetch_add(std::memory_order_relaxed)),
+    : frameID(frameIDs++),
       sourceID(sourceID),
       sourceDimensions(dimensions),
       sourcePixelFormat(pixFmt),
@@ -483,6 +483,11 @@ void VideoFrame::storeAVFrame(AVFrame* frame, const QSize& dimensions, const int
  */
 void VideoFrame::deleteFrameBuffer()
 {
+    // An empty framebuffer represents a frame that's already been freed
+    if(frameBuffer.empty()){
+        return;
+    }
+
     for(const auto& frameIterator : frameBuffer)
     {
         AVFrame* frame = frameIterator.second;

--- a/src/video/videoframe.cpp
+++ b/src/video/videoframe.cpp
@@ -410,12 +410,12 @@ void VideoFrame::storeAVFrame(AVFrame* frame, const QSize& dimensions, const int
 
 void VideoFrame::deleteFrameBuffer()
 {
-    for(auto frameIterator = frameBuffer.begin(); frameIterator != frameBuffer.end(); ++frameIterator)
+    for(const auto& frameIterator : frameBuffer)
     {
-        AVFrame* frame = frameIterator->second;
+        AVFrame* frame = frameIterator.second;
 
         // Treat source frame and derived frames separately
-        if(sourceFrameKey == frameIterator->first)
+        if(sourceFrameKey == frameIterator.first)
         {
             if(freeSourceFrame)
             {

--- a/src/video/videoframe.cpp
+++ b/src/video/videoframe.cpp
@@ -93,7 +93,6 @@ VideoFrame::VideoFrame(IDType sourceID, AVFrame* sourceFrame, QRect dimensions, 
     : frameID(frameIDs++),
       sourceID(sourceID),
       sourceDimensions(dimensions),
-      sourcePixelFormat(pixFmt),
       sourceFrameKey(getFrameKey(dimensions.size(), pixFmt, sourceFrame->linesize[0])),
       freeSourceFrame(freeSourceFrame)
 {
@@ -103,40 +102,41 @@ VideoFrame::VideoFrame(IDType sourceID, AVFrame* sourceFrame, QRect dimensions, 
     {
     case AV_PIX_FMT_YUVJ420P:
     {
-        pixFmt = AV_PIX_FMT_YUV420P;
+        sourcePixelFormat = AV_PIX_FMT_YUV420P;
         sourceFrame->color_range = AVCOL_RANGE_MPEG;
         break;
     }
 
     case AV_PIX_FMT_YUVJ411P:
     {
-        pixFmt = AV_PIX_FMT_YUV411P;
+        sourcePixelFormat = AV_PIX_FMT_YUV411P;
         sourceFrame->color_range = AVCOL_RANGE_MPEG;
         break;
     }
 
     case AV_PIX_FMT_YUVJ422P:
     {
-        pixFmt = AV_PIX_FMT_YUV422P;
+        sourcePixelFormat = AV_PIX_FMT_YUV422P;
         sourceFrame->color_range = AVCOL_RANGE_MPEG;
         break;
     }
 
     case AV_PIX_FMT_YUVJ444P:
     {
-        pixFmt = AV_PIX_FMT_YUV444P;
+        sourcePixelFormat = AV_PIX_FMT_YUV444P;
         sourceFrame->color_range = AVCOL_RANGE_MPEG;
         break;
     }
 
     case AV_PIX_FMT_YUVJ440P:
     {
-        pixFmt = AV_PIX_FMT_YUV440P;
+        sourcePixelFormat = AV_PIX_FMT_YUV440P;
         sourceFrame->color_range = AVCOL_RANGE_MPEG;
         break;
     }
 
     default:{
+        sourcePixelFormat = pixFmt;
         sourceFrame->color_range = AVCOL_RANGE_UNSPECIFIED;
     }
     }

--- a/src/video/videoframe.cpp
+++ b/src/video/videoframe.cpp
@@ -135,6 +135,10 @@ VideoFrame::VideoFrame(IDType sourceID, AVFrame* sourceFrame, QRect dimensions, 
         sourceFrame->color_range = AVCOL_RANGE_MPEG;
         break;
     }
+
+    default:{
+        sourceFrame->color_range = AVCOL_RANGE_UNSPECIFIED;
+    }
     }
 
     frameBuffer[sourceFrameKey] = sourceFrame;

--- a/src/video/videoframe.cpp
+++ b/src/video/videoframe.cpp
@@ -250,7 +250,7 @@ AVFrame* VideoFrame::generateAVFrame(const QSize& dimensions, const int pixelFor
 
     int bufSize = av_image_alloc(ret->data, ret->linesize,
                                  dimensions.width(), dimensions.height(),
-                                 static_cast<AVPixelFormat>(pixelFormat), data_alignment);
+                                 static_cast<AVPixelFormat>(pixelFormat), frameAlignment);
 
     if(bufSize < 0){
         av_frame_free(&ret);

--- a/src/video/videoframe.cpp
+++ b/src/video/videoframe.cpp
@@ -185,7 +185,7 @@ QImage VideoFrame::toQImage(QSize frameSize)
     return toGenericObject(frameSize, AV_PIX_FMT_RGB24, false, converter, QImage {});
 }
 
-ToxAVFrame VideoFrame::toToxAVFrame(QSize frameSize)
+ToxYUVFrame VideoFrame::toToxAVFrame(QSize frameSize)
 {
     if(frameSize.width() == 0 && frameSize.height() == 0)
     {
@@ -193,9 +193,9 @@ ToxAVFrame VideoFrame::toToxAVFrame(QSize frameSize)
     }
 
     // Converter function (constructs ToxAVFrame out of AVFrame*)
-    const std::function<ToxAVFrame(AVFrame* const)> converter = [&](AVFrame* const frame)
+    const std::function<ToxYUVFrame(AVFrame* const)> converter = [&](AVFrame* const frame)
     {
-        ToxAVFrame ret
+        ToxYUVFrame ret
         {
             static_cast<std::uint16_t>(frameSize.width()),
             static_cast<std::uint16_t>(frameSize.height()),
@@ -205,7 +205,7 @@ ToxAVFrame VideoFrame::toToxAVFrame(QSize frameSize)
         return ret;
     };
 
-    return toGenericObject(frameSize, AV_PIX_FMT_YUV420P, true, converter, ToxAVFrame {0, 0, nullptr, nullptr, nullptr});
+    return toGenericObject(frameSize, AV_PIX_FMT_YUV420P, true, converter, ToxYUVFrame {0, 0, nullptr, nullptr, nullptr});
 }
 
 AVFrame* VideoFrame::retrieveAVFrame(const QSize& dimensions, const int pixelFormat, const bool requireAligned)

--- a/src/video/videoframe.cpp
+++ b/src/video/videoframe.cpp
@@ -356,7 +356,6 @@ QImage VideoFrame::toQImage(QSize frameSize)
  *
  * @param frameSize the given frame size of ToxAVFrame to generate. Defaults to source frame size
  * if frameSize is invalid.
- * to source frame size.
  * @return a ToxAVFrame structure that represents this VideoFrame, sharing it's buffers or an
  * empty structure if this VideoFrame is no longer valid.
  */
@@ -784,4 +783,24 @@ T VideoFrame::toGenericObject(const QSize& dimensions, const int pixelFormat, co
 template QImage VideoFrame::toGenericObject<QImage>(const QSize& dimensions, const int pixelFormat, const bool requireAligned,
                                                     const std::function<QImage(AVFrame* const)> objectConstructor, const QImage& nullObject);
 template ToxYUVFrame VideoFrame::toGenericObject<ToxYUVFrame>(const QSize& dimensions, const int pixelFormat, const bool requireAligned,
-                                                              const std::function<ToxYUVFrame(AVFrame* const)> objectConstructor, const ToxYUVFrame& nullObject);
+const std::function<ToxYUVFrame(AVFrame* const)> objectConstructor, const ToxYUVFrame& nullObject);
+
+/**
+ * @brief Returns whether the given ToxYUVFrame represents a valid frame or not.
+ *
+ * Valid frames are frames in which both width and height are greater than zero.
+ *
+ * @return true if the frame is valid, false otherwise.
+ */
+bool ToxYUVFrame::isValid() const
+{
+    return width > 0 && height > 0;
+}
+
+/**
+ * @brief Checks if the given ToxYUVFrame is valid or not, delegates to isValid().
+ */
+ToxYUVFrame::operator bool() const
+{
+    return isValid();
+}

--- a/src/video/videoframe.cpp
+++ b/src/video/videoframe.cpp
@@ -24,6 +24,57 @@ extern "C"{
 #include <libswscale/swscale.h>
 }
 
+/**
+ * @struct ToxYUVFrame
+ * @brief A simple structure to represent a ToxYUV video frame (corresponds to a frame encoded
+ * under format: AV_PIX_FMT_YUV420P [FFmpeg] or VPX_IMG_FMT_I420 [WebM]).
+ *
+ * This structure exists for convenience and code clarity when ferrying YUV420 frames from one
+ * source to another. The buffers pointed to by the struct should not be owned by the struct nor
+ * should they be freed from the struct, instead this struct functions only as a simple alias to a
+ * more complicated frame container like AVFrame.
+ *
+ * The creation of this structure was done to replace existing code which mis-used vpx_image
+ * structs when passing frame data to toxcore.
+ */
+
+/**
+ * @class VideoFrame
+ * @brief An ownernship and management class for AVFrames.
+ *
+ * VideoFrame takes ownership of an AVFrame* and allows fast conversions to other formats.
+ * Ownership of all video frame buffers is kept by the VideoFrame, even after conversion. All
+ * references to the frame data become invalid when the VideoFrame is deleted. We try to avoid
+ * pixel format conversions as much as possible, at the cost of some memory.
+ *
+ * Every function in this class is thread safe apart from concurrent construction and deletion of
+ * the object.
+ *
+ * This class uses the phrase "frame alignment" to specify the property that each frame's width is
+ * equal to it's maximum linesize. Note: this is NOT "data alignment" which specifies how allocated
+ * buffers are aligned in memory. Though internally the two are related, unless otherwise specified
+ * all instances of the term "alignment" exposed from public functions refer to frame alignment.
+ *
+ * Frame alignment is an important concept because ToxAV does not support frames with linesizes not
+ * directly equal to the width.
+ */
+
+/**
+ * @var dataAlignment
+ * @brief Data alignment parameter used to populate AVFrame buffers.
+ *
+ * This field is public in effort to standardized the data alignment parameter for all AVFrame
+ * allocations.
+ *
+ * It's currently set to 32-byte alignment for AVX2 support.
+ */
+
+/**
+ * @class FrameBufferKey
+ * @brief A class representing a structure that stores frame properties to be used as the key
+ * value for a std::unordered_map.
+ */
+
 // Initialize static fields
 VideoFrame::AtomicIDType VideoFrame::frameIDs {0};
 
@@ -32,6 +83,15 @@ std::unordered_map<VideoFrame::IDType, std::unordered_map<VideoFrame::IDType, st
 
 QReadWriteLock VideoFrame::refsLock {};
 
+/**
+ * @brief Constructs a new instance of a VideoFrame, sourced by a given AVFrame pointer.
+ * 
+ * @param sourceID the VideoSource's ID to track the frame under.
+ * @param sourceFrame the source AVFrame pointer to use, must be valid.
+ * @param dimensions the dimensions of the AVFrame, obtained from the AVFrame if not given.
+ * @param pixFmt the pixel format of the AVFrame, obtained from the AVFrame if not given.
+ * @param freeSourceFrame whether to free the source frame buffers or not.
+ */
 VideoFrame::VideoFrame(IDType sourceID, AVFrame* sourceFrame, QRect dimensions, int pixFmt, bool freeSourceFrame)
     : frameID(frameIDs.fetch_add(std::memory_order_relaxed)),
       sourceID(sourceID),
@@ -46,6 +106,9 @@ VideoFrame::VideoFrame(IDType sourceID, AVFrame* sourceFrame, QRect dimensions, 
 VideoFrame::VideoFrame(IDType sourceID, AVFrame* sourceFrame, bool freeSourceFrame)
     : VideoFrame(sourceID, sourceFrame, QRect {0, 0, sourceFrame->width, sourceFrame->height}, sourceFrame->format, freeSourceFrame){}
 
+/**
+ * @brief Destructor for VideoFrame.
+ */
 VideoFrame::~VideoFrame()
 {
     // Release frame
@@ -70,6 +133,14 @@ VideoFrame::~VideoFrame()
     refsLock.unlock();
 }
 
+/**
+ * @brief Returns the validity of this VideoFrame.
+ *
+ * A VideoFrame is valid if it manages at least one AVFrame. A VideoFrame can be invalidated
+ * by calling releaseFrame() on it.
+ *
+ * @return true if the VideoFrame is valid, false otherwise.
+ */
 bool VideoFrame::isValid()
 {
     frameLock.lockForRead();
@@ -79,6 +150,14 @@ bool VideoFrame::isValid()
     return retValue;
 }
 
+/**
+ * @brief Causes the VideoFrame class to maintain an internal reference for the frame.
+ *
+ * The internal reference is managed via a std::weak_ptr such that it doesn't inhibit
+ * destruction of the object once all external references are no longer reachable.
+ *
+ * @return a std::shared_ptr holding a reference to this frame.
+ */
 std::shared_ptr<VideoFrame> VideoFrame::trackFrame()
 {
     // Add frame to tracked reference list
@@ -105,6 +184,17 @@ std::shared_ptr<VideoFrame> VideoFrame::trackFrame()
     return ret;
 }
 
+/**
+ * @brief Untracks all the frames for the given VideoSource, releasing them if specified.
+ *
+ * This function causes all internally tracked frames for the given VideoSource to be dropped.
+ * If the releaseFrames option is set to true, the frames are sequentially released on the
+ * caller's thread in an unspecified order.
+ *
+ * @param sourceID the ID of the VideoSource to untrack frames from.
+ * @param releaseFrames true to release the frames as necessary, false otherwise. Defaults to
+ * false.
+ */
 void VideoFrame::untrackFrames(const VideoFrame::IDType& sourceID, bool releaseFrames)
 {
     refsLock.lockForWrite();
@@ -144,6 +234,9 @@ void VideoFrame::untrackFrames(const VideoFrame::IDType& sourceID, bool releaseF
     refsLock.unlock();
 }
 
+/**
+ * @brief Releases all frames managed by this VideoFrame and invalidates it.
+ */
 void VideoFrame::releaseFrame()
 {
     frameLock.lockForWrite();
@@ -153,6 +246,19 @@ void VideoFrame::releaseFrame()
     frameLock.unlock();
 }
 
+/**
+ * @brief Retrieves an AVFrame derived from the source based on the given parameters.
+ *
+ * If a given frame does not exist, this function will perform appropriate conversions to
+ * return a frame that fulfills the given parameters.
+ *
+ * @param frameSize the dimensions of the frame to get. If frame size is 0, defaults to source
+ * frame size.
+ * @param pixelFormat the desired pixel format of the frame.
+ * @param requireAligned true if the returned frame must be frame aligned, false if not.
+ * @return a pointer to a AVFrame with the given parameters or nullptr if the VideoFrame is no
+ * longer valid.
+ */
 const AVFrame* VideoFrame::getAVFrame(QSize frameSize, const int pixelFormat, const bool requireAligned)
 {
     // Since we are retrieving the AVFrame* directly, we merely need to pass the arguement through
@@ -168,6 +274,17 @@ const AVFrame* VideoFrame::getAVFrame(QSize frameSize, const int pixelFormat, co
     return toGenericObject(frameSize, pixelFormat, requireAligned, converter, nullPointer);
 }
 
+/**
+ * @brief Converts this VideoFrame to a QImage that shares this VideoFrame's buffer.
+ *
+ * The VideoFrame will be scaled into the RGB24 pixel format along with the given
+ * dimension.
+ *
+ * @param frameSize the given frame size of QImage to generate. If frame size is 0, defaults to
+ * source frame size.
+ * @return a QImage that represents this VideoFrame, sharing it's buffers or a null image if
+ * this VideoFrame is no longer valid.
+ */
 QImage VideoFrame::toQImage(QSize frameSize)
 {
     if(frameSize.width() == 0 && frameSize.height() == 0)
@@ -185,6 +302,17 @@ QImage VideoFrame::toQImage(QSize frameSize)
     return toGenericObject(frameSize, AV_PIX_FMT_RGB24, false, converter, QImage {});
 }
 
+/**
+ * @brief Converts this VideoFrame to a ToxAVFrame that shares this VideoFrame's buffer.
+ *
+ * The given ToxAVFrame will be frame aligned under a pixel format of planar YUV with a chroma
+ * subsampling format of 4:2:0 (i.e. AV_PIX_FMT_YUV420P).
+ *
+ * @param frameSize the given frame size of ToxAVFrame to generate. If frame size is 0, defaults
+ * to source frame size.
+ * @return a ToxAVFrame structure that represents this VideoFrame, sharing it's buffers or an
+ * empty structure if this VideoFrame is no longer valid.
+ */
 ToxYUVFrame VideoFrame::toToxAVFrame(QSize frameSize)
 {
     if(frameSize.width() == 0 && frameSize.height() == 0)
@@ -208,6 +336,21 @@ ToxYUVFrame VideoFrame::toToxAVFrame(QSize frameSize)
     return toGenericObject(frameSize, AV_PIX_FMT_YUV420P, true, converter, ToxYUVFrame {0, 0, nullptr, nullptr, nullptr});
 }
 
+/**
+ * @brief Retrieves an AVFrame derived from the source based on the given parameters without
+ * obtaining a lock.
+ *
+ * This function is not thread-safe and must be called from a thread-safe context.
+ *
+ * Note: this function differs from getAVFrame() in that it returns a nullptr if no frame was
+ * found.
+ *
+ * @param dimensions the dimensions of the frame.
+ * @param pixelFormat the desired pixel format of the frame.
+ * @param requireAligned true if the frame must be frame aligned, false otherwise.
+ * @return a pointer to a AVFrame with the given parameters or nullptr if no such frame was
+ * found.
+ */
 AVFrame* VideoFrame::retrieveAVFrame(const QSize& dimensions, const int pixelFormat, const bool requireAligned)
 {
     if(!requireAligned)
@@ -236,6 +379,16 @@ AVFrame* VideoFrame::retrieveAVFrame(const QSize& dimensions, const int pixelFor
     }
 }
 
+/**
+ * @brief Generates an AVFrame based on the given specifications.
+ *
+ * This function is not thread-safe and must be called from a thread-safe context.
+ *
+ * @param dimensions the required dimensions for the frame.
+ * @param pixelFormat the required pixel format for the frame.
+ * @param requireAligned true if the generated frame needs to be frame aligned, false otherwise.
+ * @return an AVFrame with the given specifications.
+ */
 AVFrame* VideoFrame::generateAVFrame(const QSize& dimensions, const int pixelFormat, const bool requireAligned)
 {
     AVFrame* ret = av_frame_alloc();
@@ -299,6 +452,15 @@ AVFrame* VideoFrame::generateAVFrame(const QSize& dimensions, const int pixelFor
     return ret;
 }
 
+/**
+ * @brief Stores a given AVFrame within the frameBuffer map.
+ *
+ * This function is not thread-safe and must be called from a thread-safe context.
+ *
+ * @param frame the given frame to store.
+ * @param dimensions the dimensions of the frame.
+ * @param pixelFormat the pixel format of the frame.
+ */
 void VideoFrame::storeAVFrame(AVFrame* frame, const QSize& dimensions, const int pixelFormat)
 {
     FrameBufferKey frameKey = getFrameKey(dimensions, pixelFormat, frame->linesize[0]);
@@ -317,6 +479,11 @@ void VideoFrame::storeAVFrame(AVFrame* frame, const QSize& dimensions, const int
     frameBuffer[frameKey] = frame;
 }
 
+/**
+ * @brief Releases all frames within the frame buffer.
+ *
+ * This function is not thread-safe and must be called from a thread-safe context.
+ */
 void VideoFrame::deleteFrameBuffer()
 {
     for(const auto& frameIterator : frameBuffer)
@@ -344,6 +511,14 @@ void VideoFrame::deleteFrameBuffer()
     frameBuffer.clear();
 }
 
+/**
+ * @brief Constructs a new FrameBufferKey with the given attributes.
+ *
+ * @param width the width of the frame.
+ * @param height the height of the frame.
+ * @param pixFmt the pixel format of the frame.
+ * @param lineAligned whether the linesize matches the width of the image.
+ */
 VideoFrame::FrameBufferKey::FrameBufferKey(const int pixFmt, const int width, const int height, const bool lineAligned)
     : frameWidth(width),
       frameHeight(height),

--- a/src/video/videoframe.cpp
+++ b/src/video/videoframe.cpp
@@ -182,7 +182,12 @@ ToxAVFrame VideoFrame::toToxAVFrame(QSize frameSize)
 
     if(frame)
     {
-        ToxAVFrame ret {frameSize.width(), frameSize.height(), frame->data[0], frame->data[1], frame->data[2]};
+        ToxAVFrame ret
+        {
+            static_cast<std::uint16_t>(frameSize.width()),
+            static_cast<std::uint16_t>(frameSize.height()),
+            frame->data[0], frame->data[1], frame->data[2]
+        };
 
         frameLock.unlock();
         return ret;
@@ -203,7 +208,12 @@ ToxAVFrame VideoFrame::toToxAVFrame(QSize frameSize)
 
     storeAVFrame(frame, frameSize, static_cast<int>(AV_PIX_FMT_YUV420P));
 
-    ToxAVFrame ret {frameSize.width(), frameSize.height(), frame->data[0], frame->data[1], frame->data[2]};
+    ToxAVFrame ret
+    {
+        static_cast<std::uint16_t>(frameSize.width()),
+        static_cast<std::uint16_t>(frameSize.height()),
+        frame->data[0], frame->data[1], frame->data[2]
+    };
 
     frameLock.unlock();
     return ret;

--- a/src/video/videoframe.cpp
+++ b/src/video/videoframe.cpp
@@ -361,7 +361,8 @@ AVFrame* VideoFrame::generateAVFrame(const QSize& dimensions, const int pixelFor
                                  static_cast<AVPixelFormat>(pixelFormat), 1);
     }
 
-    if(bufSize < 0){
+    if(bufSize < 0)
+    {
         av_frame_free(&ret);
         return nullptr;
     }

--- a/src/video/videoframe.cpp
+++ b/src/video/videoframe.cpp
@@ -17,294 +17,315 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <iostream>
+#include "videoframe.h"
 
-#include <QMutexLocker>
-#include <QDebug>
-#include <vpx/vpx_image.h>
-extern "C" {
-#include <libavcodec/avcodec.h>
+extern "C"{
 #include <libavutil/imgutils.h>
 #include <libswscale/swscale.h>
 }
-#include "videoframe.h"
-#include "camerasource.h"
 
-/**
-@class VideoFrame
-
-VideoFrame takes ownership of an AVFrame* and allows fast conversions to other formats
-Ownership of all video frame buffers is kept by the VideoFrame, even after conversion
-All references to the frame data become invalid when the VideoFrame is deleted
-We try to avoid pixel format conversions as much as possible, at the cost of some memory
-All methods are thread-safe. If provided freelistCallback will be called by the destructor,
-unless releaseFrame was called in between.
-*/
-
-VideoFrame::VideoFrame(AVFrame* frame, int w, int h, int fmt, std::function<void()> freelistCallback)
-    : freelistCallback{freelistCallback},
-      frameOther{nullptr}, frameYUV420{nullptr}, frameRGB24{nullptr},
-      width{w}, height{h}, pixFmt{fmt}
+VideoFrame::VideoFrame(AVFrame* sourceFrame, QRect dimensions, int pixFmt, std::function<void ()> destructCallback)
+    : sourceDimensions(dimensions),
+      sourcePixelFormat(pixFmt),
+      destructCallback(destructCallback)
 {
-    // Silences pointless swscale warning spam
-    // See libswscale/utils.c:1153 @ 74f0bd3
-    frame->color_range = AVCOL_RANGE_MPEG;
-    if (pixFmt == AV_PIX_FMT_YUVJ420P)
-        pixFmt = AV_PIX_FMT_YUV420P;
-    else if (pixFmt == AV_PIX_FMT_YUVJ411P)
-        pixFmt = AV_PIX_FMT_YUV411P;
-    else if (pixFmt == AV_PIX_FMT_YUVJ422P)
-        pixFmt = AV_PIX_FMT_YUV422P;
-    else if (pixFmt == AV_PIX_FMT_YUVJ444P)
-        pixFmt = AV_PIX_FMT_YUV444P;
-    else if (pixFmt == AV_PIX_FMT_YUVJ440P)
-        pixFmt = AV_PIX_FMT_YUV440P;
-    else
-        frame->color_range = AVCOL_RANGE_UNSPECIFIED;
-
-    if (pixFmt == AV_PIX_FMT_YUV420P) {
-        frameYUV420 = frame;
-    } else if (pixFmt == AV_PIX_FMT_RGB24) {
-        frameRGB24 = frame;
-    } else {
-        frameOther = frame;
-    }
+    frameBuffer[pixFmt][dimensionsToKey(dimensions.size())] = sourceFrame;
 }
 
-VideoFrame::VideoFrame(AVFrame* frame, std::function<void()> freelistCallback)
-    : VideoFrame{frame, frame->width, frame->height, frame->format, freelistCallback}
-{
-}
+VideoFrame::VideoFrame(AVFrame* sourceFrame, std::function<void ()> destructCallback)
+    : VideoFrame(sourceFrame, QRect {0, 0, sourceFrame->width, sourceFrame->height}, sourceFrame->format, destructCallback){}
 
-VideoFrame::VideoFrame(AVFrame* frame)
-    : VideoFrame{frame, frame->width, frame->height, frame->format, nullptr}
-{
-}
+VideoFrame::VideoFrame(AVFrame* sourceFrame)
+    : VideoFrame(sourceFrame, QRect {0, 0, sourceFrame->width, sourceFrame->height}, sourceFrame->format, nullptr){}
 
-/**
-@brief VideoFrame constructor. Disable copy.
-@note Use a shared_ptr if you need copies.
-*/
 VideoFrame::~VideoFrame()
 {
-    if (freelistCallback)
-        freelistCallback();
+    frameLock.lockForWrite();
 
-    releaseFrameLockless();
+    if(destructCallback && frameBuffer.size() > 0)
+    {
+        destructCallback();
+    }
+
+    deleteFrameBuffer();
+
+    frameLock.unlock();
 }
 
-/**
-@brief Converts the VideoFrame to a QImage that shares our internal video buffer.
-@param size Size of resulting image.
-@return Converted image to RGB24 color model.
-*/
-QImage VideoFrame::toQImage(QSize size)
+bool VideoFrame::isValid()
 {
-    if (!convertToRGB24(size))
-        return QImage();
+    frameLock.lockForRead();
+    bool retValue = frameBuffer.size() > 0;
+    frameLock.unlock();
 
-    QMutexLocker locker(&biglock);
-
-    return QImage(*frameRGB24->data, frameRGB24->width, frameRGB24->height, *frameRGB24->linesize, QImage::Format_RGB888);
+    return retValue;
 }
 
-/**
-@brief Converts the VideoFrame to a vpx_image_t.
-Converts the VideoFrame to a vpx_image_t that shares our internal video buffer.
-@return Converted image to vpx_image format.
-*/
-vpx_image *VideoFrame::toVpxImage()
+const AVFrame* VideoFrame::getAVFrame(const QSize& dimensions, const int pixelFormat)
 {
-    vpx_image* img = vpx_img_alloc(nullptr, VPX_IMG_FMT_I420, width, height, 0);
+    frameLock.lockForRead();
 
-    if (!convertToYUV420())
-        return img;
-
-    for (int i = 0; i < 3; i++)
+    // We return nullptr if the VideoFrame is no longer valid
+    if(frameBuffer.size() == 0)
     {
-        int dstStride = img->stride[i];
-        int srcStride = frameYUV420->linesize[i];
-        int minStride = std::min(dstStride, srcStride);
-        int size = (i == 0) ? img->d_h : img->d_h / 2;
-
-        for (int j = 0; j < size; j++)
-        {
-            uint8_t *dst = img->planes[i] + dstStride * j;
-            uint8_t *src = frameYUV420->data[i] + srcStride * j;
-            memcpy(dst, src, minStride);
-        }
+        frameLock.unlock();
+        return nullptr;
     }
-    return img;
+
+    AVFrame* ret = retrieveAVFrame(dimensions, pixelFormat);
+
+    if(ret)
+    {
+        frameLock.unlock();
+        return ret;
+    }
+
+    // VideoFrame does not contain an AVFrame to spec, generate one here
+    ret = generateAVFrame(dimensions, pixelFormat);
+
+    /*
+     * We need to "upgrade" the lock to a write lock so we can update our frameBuffer map.
+     *
+     * It doesn't matter if another thread obtains the write lock before we finish since it is
+     * likely writing to somewhere else. Absolute worst-case scenario, we merely perform the
+     * generation process twice, and discard the old result.
+     */
+    frameLock.unlock();
+    frameLock.lockForWrite();
+
+    storeAVFrame(ret, dimensions, pixelFormat);
+
+    frameLock.unlock();
+    return ret;
 }
 
-bool VideoFrame::convertToRGB24(QSize size)
-{
-    QMutexLocker locker(&biglock);
-
-    AVFrame* sourceFrame;
-    if (frameOther)
-    {
-        sourceFrame = frameOther;
-    }
-    else if (frameYUV420)
-    {
-        sourceFrame = frameYUV420;
-    }
-    else
-    {
-        qWarning() << "None of the frames are valid! Did someone release us?";
-        return false;
-    }
-    //std::cout << "converting to RGB24" << std::endl;
-
-    if (size.isEmpty())
-    {
-        size.setWidth(sourceFrame->width);
-        size.setHeight(sourceFrame->height);
-    }
-
-    if (frameRGB24)
-    {
-        if (frameRGB24->width == size.width() && frameRGB24->height == size.height())
-            return true;
-
-        av_free(frameRGB24->opaque);
-        av_frame_unref(frameRGB24);
-        av_frame_free(&frameRGB24);
-    }
-
-    frameRGB24=av_frame_alloc();
-    if (!frameRGB24)
-    {
-        qCritical() << "av_frame_alloc failed";
-        return false;
-    }
-
-    int imgBufferSize = av_image_get_buffer_size(AV_PIX_FMT_RGB24, size.width(), size.height(), 1);
-    uint8_t* buf = (uint8_t*)av_malloc(imgBufferSize);
-    if (!buf)
-    {
-        qCritical() << "av_malloc failed";
-        av_frame_free(&frameRGB24);
-        return false;
-    }
-    frameRGB24->opaque = buf;
-
-    uint8_t** data = frameRGB24->data;
-    int* linesize = frameRGB24->linesize;
-    av_image_fill_arrays(data, linesize, buf, AV_PIX_FMT_RGB24, size.width(), size.height(), 1);
-    frameRGB24->width = size.width();
-    frameRGB24->height = size.height();
-
-    // Bilinear is better for shrinking, bicubic better for upscaling
-    int resizeAlgo = size.width()<=width ? SWS_BILINEAR : SWS_BICUBIC;
-
-    SwsContext *swsCtx =  sws_getContext(width, height, (AVPixelFormat)pixFmt,
-                                          size.width(), size.height(), AV_PIX_FMT_RGB24,
-                                          resizeAlgo, nullptr, nullptr, nullptr);
-    sws_scale(swsCtx, (uint8_t const * const *)sourceFrame->data,
-                sourceFrame->linesize, 0, height,
-                frameRGB24->data, frameRGB24->linesize);
-    sws_freeContext(swsCtx);
-
-    return true;
-}
-
-bool VideoFrame::convertToYUV420()
-{
-    QMutexLocker locker(&biglock);
-
-    if (frameYUV420)
-        return true;
-
-    AVFrame* sourceFrame;
-    if (frameOther)
-    {
-        sourceFrame = frameOther;
-    }
-    else if (frameRGB24)
-    {
-        sourceFrame = frameRGB24;
-    }
-    else
-    {
-        qCritical() << "None of the frames are valid! Did someone release us?";
-        return false;
-    }
-    //std::cout << "converting to YUV420" << std::endl;
-
-    frameYUV420=av_frame_alloc();
-    if (!frameYUV420)
-    {
-        qCritical() << "av_frame_alloc failed";
-        return false;
-    }
-
-    int imgBufferSize = av_image_get_buffer_size(AV_PIX_FMT_RGB24, width, height, 1);
-    uint8_t* buf = (uint8_t*)av_malloc(imgBufferSize);
-    if (!buf)
-    {
-        qCritical() << "av_malloc failed";
-        av_frame_free(&frameYUV420);
-        return false;
-    }
-    frameYUV420->opaque = buf;
-
-    uint8_t** data = frameYUV420->data;
-    int* linesize = frameYUV420->linesize;
-    av_image_fill_arrays(data, linesize, buf, AV_PIX_FMT_YUV420P, width, height, 1);
-
-    SwsContext *swsCtx =  sws_getContext(width, height, (AVPixelFormat)pixFmt,
-                                          width, height, AV_PIX_FMT_YUV420P,
-                                          SWS_BILINEAR, nullptr, nullptr, nullptr);
-    sws_scale(swsCtx, (uint8_t const * const *)sourceFrame->data,
-                sourceFrame->linesize, 0, height,
-                frameYUV420->data, frameYUV420->linesize);
-    sws_freeContext(swsCtx);
-
-    return true;
-}
-
-/**
-@brief Frees all frame memory.
-
-Frees all internal buffers and frame data, removes the freelistCallback
-This makes all converted objects that shares our internal buffers invalid.
-*/
 void VideoFrame::releaseFrame()
 {
-    QMutexLocker locker(&biglock);
-    freelistCallback = nullptr;
-    releaseFrameLockless();
+    frameLock.lockForWrite();
+
+    deleteFrameBuffer();
+
+    frameLock.unlock();
 }
 
-void VideoFrame::releaseFrameLockless()
+QImage VideoFrame::toQImage(QSize frameSize)
 {
-    if (frameOther)
+    frameLock.lockForRead();
+
+    // We return an empty QImage if the VideoFrame is no longer valid
+    if(frameBuffer.size() == 0)
     {
-        av_free(frameOther->opaque);
-        av_frame_unref(frameOther);
-        av_frame_free(&frameOther);
+        frameLock.unlock();
+        return QImage {};
     }
-    if (frameYUV420)
+
+    if(frameSize.width() == 0 && frameSize.height() == 0)
     {
-        av_free(frameYUV420->opaque);
-        av_frame_unref(frameYUV420);
-        av_frame_free(&frameYUV420);
+        frameSize = sourceDimensions.size();
     }
-    if (frameRGB24)
+
+    AVFrame* frame = retrieveAVFrame(frameSize, static_cast<int>(AV_PIX_FMT_RGB24));
+
+    if(frame)
     {
-        av_free(frameRGB24->opaque);
-        av_frame_unref(frameRGB24);
-        av_frame_free(&frameRGB24);
+        QImage ret {*(frame->data), frameSize.width(), frameSize.height(), *(frame->linesize), QImage::Format_RGB888};
+
+        frameLock.unlock();
+        return ret;
+    }
+
+    // VideoFrame does not contain an AVFrame to spec, generate one here
+    frame = generateAVFrame(frameSize, static_cast<int>(AV_PIX_FMT_RGB24));
+
+    /*
+     * We need to "upgrade" the lock to a write lock so we can update our frameBuffer map.
+     *
+     * It doesn't matter if another thread obtains the write lock before we finish since it is
+     * likely writing to somewhere else. Absolute worst-case scenario, we merely perform the
+     * generation process twice, and discard the old result.
+     */
+    frameLock.unlock();
+    frameLock.lockForWrite();
+
+    storeAVFrame(frame, frameSize, static_cast<int>(AV_PIX_FMT_RGB24));
+
+    QImage ret {*(frame->data), frameSize.width(), frameSize.height(), *(frame->linesize), QImage::Format_RGB888};
+
+    frameLock.unlock();
+    return ret;
+}
+
+vpx_image* VideoFrame::toVpxImage(QSize frameSize)
+{
+    frameLock.lockForRead();
+
+    // We return nullptr if the VideoFrame is no longer valid
+    if(frameBuffer.size() == 0)
+    {
+        frameLock.unlock();
+        return nullptr;
+    }
+
+    if(frameSize.width() == 0 && frameSize.height() == 0)
+    {
+        frameSize = sourceDimensions.size();
+    }
+
+    AVFrame* frame = retrieveAVFrame(frameSize, static_cast<int>(AV_PIX_FMT_YUV420P));
+
+    if(frame)
+    {
+        vpx_image* ret = new vpx_image {};
+        memset(ret, 0, sizeof(vpx_image));
+
+        ret->w = ret->d_w = frameSize.width();
+        ret->h = ret->d_h = frameSize.height();
+        ret->fmt = VPX_IMG_FMT_I420;
+        ret->planes[0] = frame->data[0];
+        ret->planes[1] = frame->data[1];
+        ret->planes[2] = frame->data[2];
+        ret->planes[3] = nullptr;
+        ret->stride[0] = frame->linesize[0];
+        ret->stride[1] = frame->linesize[1];
+        ret->stride[2] = frame->linesize[2];
+        ret->stride[3] = frame->linesize[3];
+
+        frameLock.unlock();
+        return ret;
+    }
+
+    // VideoFrame does not contain an AVFrame to spec, generate one here
+    frame = generateAVFrame(frameSize, static_cast<int>(AV_PIX_FMT_YUV420P));
+
+    /*
+     * We need to "upgrade" the lock to a write lock so we can update our frameBuffer map.
+     *
+     * It doesn't matter if another thread obtains the write lock before we finish since it is
+     * likely writing to somewhere else. Absolute worst-case scenario, we merely perform the
+     * generation process twice, and discard the old result.
+     */
+    frameLock.unlock();
+    frameLock.lockForWrite();
+
+    storeAVFrame(frame, frameSize, static_cast<int>(AV_PIX_FMT_YUV420P));
+
+    vpx_image* ret = new vpx_image {};
+    memset(ret, 0, sizeof(vpx_image));
+
+    ret->w = ret->d_w = frameSize.width();
+    ret->h = ret->d_h = frameSize.height();
+    ret->fmt = VPX_IMG_FMT_I420;
+    ret->planes[0] = frame->data[0];
+    ret->planes[1] = frame->data[1];
+    ret->planes[2] = frame->data[2];
+    ret->planes[3] = nullptr;
+    ret->stride[0] = frame->linesize[0];
+    ret->stride[1] = frame->linesize[1];
+    ret->stride[2] = frame->linesize[2];
+    ret->stride[3] = frame->linesize[3];
+
+    frameLock.unlock();
+    return ret;
+}
+
+AVFrame* VideoFrame::retrieveAVFrame(const QSize& dimensions, const int pixelFormat)
+{
+    if(frameBuffer.contains(pixelFormat) && frameBuffer[pixelFormat].contains(dimensionsToKey(dimensions)))
+    {
+        return frameBuffer[pixelFormat][dimensionsToKey(dimensions)];
+    }
+    else
+    {
+        return nullptr;
     }
 }
 
-/**
-@brief Return the size of the original frame
-@return The size of the original frame
-*/
-QSize VideoFrame::getSize()
+AVFrame* VideoFrame::generateAVFrame(const QSize& dimensions, const int pixelFormat)
 {
-    return {width, height};
+    AVFrame* ret = av_frame_alloc();
+
+    if(!ret){
+        return nullptr;
+    }
+
+    int bufSize = av_image_alloc(ret->data, ret->linesize,
+                                 dimensions.width(), dimensions.height(),
+                                 static_cast<AVPixelFormat>(pixelFormat), data_alignment);
+
+    if(bufSize < 0){
+        av_frame_free(&ret);
+        return nullptr;
+    }
+
+    // Bilinear is better for shrinking, bicubic better for upscaling
+    int resizeAlgo = sourceDimensions.width() > dimensions.width() ? SWS_BILINEAR : SWS_BICUBIC;
+
+    SwsContext* swsCtx =  sws_getContext(sourceDimensions.width(), sourceDimensions.height(),
+                                         static_cast<AVPixelFormat>(sourcePixelFormat),
+                                         dimensions.width(), dimensions.height(),
+                                         static_cast<AVPixelFormat>(pixelFormat),
+                                         resizeAlgo, nullptr, nullptr, nullptr);
+
+    if(!swsCtx){
+        av_frame_free(&ret);
+        return nullptr;
+    }
+
+    AVFrame* source = frameBuffer[sourcePixelFormat][dimensionsToKey(sourceDimensions.size())];
+
+    sws_scale(swsCtx, source->data, source->linesize, 0, sourceDimensions.height(), ret->data, ret->linesize);
+
+    // Populate AVFrame fields
+    ret->width = dimensions.width();
+    ret->height = dimensions.height();
+    ret->format = pixelFormat;
+
+    sws_freeContext(swsCtx);
+    return ret;
+}
+
+void VideoFrame::storeAVFrame(AVFrame* frame, const QSize& dimensions, const int pixelFormat)
+{
+    // We check the prescence of the frame in case of double-computation
+    if(frameBuffer.contains(pixelFormat) && frameBuffer[pixelFormat].contains(dimensionsToKey(dimensions)))
+    {
+        AVFrame* old_ret = frameBuffer[pixelFormat][dimensionsToKey(dimensions)];
+
+        // Free old frame
+        av_freep(&frame->data[0]);
+        av_frame_unref(old_ret);
+        av_frame_free(&old_ret);
+    }
+
+    frameBuffer[pixelFormat].insert(dimensionsToKey(dimensions), frame);
+}
+
+void VideoFrame::deleteFrameBuffer()
+{
+    const quint64 sourceKey = dimensionsToKey(sourceDimensions.size());
+
+    for(auto pixFmtIter = frameBuffer.begin(); pixFmtIter != frameBuffer.end(); ++pixFmtIter)
+    {
+        const auto& pixFmtMap = pixFmtIter.value();
+
+        for(auto dimKeyIter = pixFmtMap.begin(); dimKeyIter != pixFmtMap.end(); ++dimKeyIter)
+        {
+            AVFrame* frame = dimKeyIter.value();
+
+            // We only need to free allocated buffers for derived frames and not the original source
+            if(pixFmtIter.key() == sourcePixelFormat && dimKeyIter.key() == sourceKey)
+            {
+                av_frame_unref(frame);
+                av_frame_free(&frame);
+            }
+            else
+            {
+                av_freep(&frame->data[0]);
+                av_frame_unref(frame);
+                av_frame_free(&frame);
+            }
+        }
+    }
+
+    frameBuffer.clear();
 }

--- a/src/video/videoframe.h
+++ b/src/video/videoframe.h
@@ -120,7 +120,7 @@ private:
 
     AVFrame* retrieveAVFrame(const QSize& dimensions, const int pixelFormat, const bool requireAligned);
     AVFrame* generateAVFrame(const QSize& dimensions, const int pixelFormat, const bool requireAligned);
-    void storeAVFrame(AVFrame* frame, const QSize& dimensions, const int pixelFormat);
+    AVFrame* storeAVFrame(AVFrame* frame, const QSize& dimensions, const int pixelFormat);
 
     void deleteFrameBuffer();
 

--- a/src/video/videoframe.h
+++ b/src/video/videoframe.h
@@ -79,44 +79,10 @@ public:
     QImage toQImage(QSize frameSize = {});
     ToxYUVFrame toToxYUVFrame(QSize frameSize = {});
 
-    /**
-     * @brief Returns the ID for the given frame.
-     *
-     * Frame IDs are globally unique (with respect to the running instance).
-     *
-     * @return an integer representing the ID of this frame.
-     */
-    inline IDType getFrameID() const
-    {
-        return frameID;
-    }
-
-    /**
-     * @brief Returns the ID for the VideoSource which created this frame.
-     * @return an integer representing the ID of the VideoSource which created this frame.
-     */
-    inline IDType getSourceID() const
-    {
-        return sourceID;
-    }
-
-    /**
-     * @brief Retrieves a copy of the source VideoFrame's dimensions.
-     * @return QRect copy representing the source VideoFrame's dimensions.
-     */
-    inline QRect getSourceDimensions() const
-    {
-        return sourceDimensions;
-    }
-
-    /**
-     * @brief Retrieves a copy of the source VideoFormat's pixel format.
-     * @return integer copy represetning the source VideoFrame's pixel format.
-     */
-    inline int getSourcePixelFormat() const
-    {
-        return sourcePixelFormat;
-    }
+    IDType getFrameID() const;
+    IDType getSourceID() const;
+    QRect getSourceDimensions() const;
+    int getSourcePixelFormat() const;
 
     static constexpr int dataAlignment = 32;
 
@@ -136,54 +102,10 @@ private:
         const FrameBufferKey& operator=(const FrameBufferKey&) = delete;
         const FrameBufferKey& operator=(FrameBufferKey&&) = delete;
 
-        /**
-         * @brief Comparison operator for FrameBufferKey.
-         *
-         * @param other instance to compare against.
-         * @return true if instances are equivilent, false otherwise.
-         */
-        inline bool operator==(const FrameBufferKey& other) const
-        {
-            return pixelFormat == other.pixelFormat &&
-                   frameWidth == other.frameWidth &&
-                   frameHeight == other.frameHeight &&
-                   linesizeAligned == other.linesizeAligned;
-        }
+        bool operator==(const FrameBufferKey& other) const;
+        bool operator!=(const FrameBufferKey& other) const;
 
-        /**
-         * @brief Not equal to operator for FrameBufferKey.
-         *
-         * @param other instance to compare against
-         * @return true if instances are not equivilent, false otherwise.
-         */
-        inline bool operator!=(const FrameBufferKey& other) const
-        {
-            return !operator==(other);
-        }
-
-        /**
-         * @brief Hash function for class.
-         *
-         * This function computes a hash value for use with std::unordered_map.
-         *
-         * @param key the given instance to compute hash value of.
-         * @return the hash of the given instance.
-         */
-        static inline size_t hash(const FrameBufferKey& key)
-        {
-            std::hash<int> intHasher;
-            std::hash<bool> boolHasher;
-
-            // Use java-style hash function to combine fields
-            size_t ret = 47;
-
-            ret = 37 * ret + intHasher(key.frameWidth);
-            ret = 37 * ret + intHasher(key.frameHeight);
-            ret = 37 * ret + intHasher(key.pixelFormat);
-            ret = 37 * ret + boolHasher(key.linesizeAligned);
-
-            return ret;
-        }
+        static size_t hash(const FrameBufferKey& key);
 
     public:
         const int frameWidth;
@@ -193,31 +115,8 @@ private:
     };
 
 private:
-    /**
-     * @brief Generates a key object based on given parameters.
-     *
-     * @param frameSize the given size of the frame.
-     * @param pixFmt the pixel format of the frame.
-     * @param linesize the maximum linesize of the frame, may be larger than the width.
-     * @return a FrameBufferKey object representing the key for the frameBuffer map.
-     */
-    static inline FrameBufferKey getFrameKey(const QSize& frameSize, const int pixFmt, const int linesize)
-    {
-        return getFrameKey(frameSize, pixFmt, frameSize.width() == linesize);
-    }
-
-    /**
-     * @brief Generates a key object based on given parameters.
-     *
-     * @param frameSize the given size of the frame.
-     * @param pixFmt the pixel format of the frame.
-     * @param frameAligned true if the frame is aligned, false otherwise.
-     * @return a FrameBufferKey object representing the key for the frameBuffer map.
-     */
-    static inline FrameBufferKey getFrameKey(const QSize& frameSize, const int pixFmt, const bool frameAligned)
-    {
-        return {frameSize.width(), frameSize.height(), pixFmt, frameAligned};
-    }
+    static FrameBufferKey getFrameKey(const QSize& frameSize, const int pixFmt, const int linesize);
+    static FrameBufferKey getFrameKey(const QSize& frameSize, const int pixFmt, const bool frameAligned);
 
     AVFrame* retrieveAVFrame(const QSize& dimensions, const int pixelFormat, const bool requireAligned);
     AVFrame* generateAVFrame(const QSize& dimensions, const int pixelFormat, const bool requireAligned);
@@ -225,69 +124,9 @@ private:
 
     void deleteFrameBuffer();
 
-    /**
-     * @brief Converts this VideoFrame to a generic type T based on the given parameters and
-     * supplied converter functions.
-     *
-     * This function is used internally to create various toXObject functions that all follow the
-     * same generation pattern (where XObject is some existing type like QImage).
-     *
-     * In order to create such a type, a object constructor function is required that takes the
-     * generated AVFrame object and creates type T out of it. This function additionally requires
-     * a null object of type T that represents an invalid/null object for when the generation
-     * process fails (e.g. when the VideoFrame is no longer valid).
-     *
-     * @param dimensions the dimensions of the frame, must be valid.
-     * @param pixelFormat the pixel format of the frame.
-     * @param requireAligned true if the generated frame needs to be frame aligned, false otherwise.
-     * @param objectConstructor a std::function that takes the generated AVFrame and converts it
-     * to an object of type T.
-     * @param nullObject an object of type T that represents the null/invalid object to be used
-     * when the generation process fails.
-     */
     template <typename T>
     T toGenericObject(const QSize& dimensions, const int pixelFormat, const bool requireAligned,
-                      const std::function<T(AVFrame* const)> objectConstructor, const T& nullObject)
-    {
-        frameLock.lockForRead();
-
-        // We return nullObject if the VideoFrame is no longer valid
-        if(frameBuffer.size() == 0)
-        {
-            frameLock.unlock();
-            return nullObject;
-        }
-
-        AVFrame* frame = retrieveAVFrame(dimensions, static_cast<int>(pixelFormat), requireAligned);
-
-        if(frame)
-        {
-            T ret = objectConstructor(frame);
-
-            frameLock.unlock();
-            return ret;
-        }
-
-        // VideoFrame does not contain an AVFrame to spec, generate one here
-        frame = generateAVFrame(dimensions, static_cast<int>(pixelFormat), requireAligned);
-
-        /*
-         * We need to "upgrade" the lock to a write lock so we can update our frameBuffer map.
-         *
-         * It doesn't matter if another thread obtains the write lock before we finish since it is
-         * likely writing to somewhere else. Worst-case scenario, we merely perform the generation
-         * process twice, and discard the old result.
-         */
-        frameLock.unlock();
-        frameLock.lockForWrite();
-
-        storeAVFrame(frame, dimensions, static_cast<int>(pixelFormat));
-
-        T ret = objectConstructor(frame);
-
-        frameLock.unlock();
-        return ret;
-    }
+                      const std::function<T(AVFrame* const)> objectConstructor, const T& nullObject);
 
 private:
     // ID

--- a/src/video/videoframe.h
+++ b/src/video/videoframe.h
@@ -76,8 +76,8 @@ public:
     void releaseFrame();
 
     const AVFrame* getAVFrame(QSize frameSize, const int pixelFormat, const bool requireAligned);
-    QImage toQImage(QSize frameSize = {0, 0});
-    ToxYUVFrame toToxAVFrame(QSize frameSize = {0, 0});
+    QImage toQImage(QSize frameSize = {});
+    ToxYUVFrame toToxYUVFrame(QSize frameSize = {});
 
     /**
      * @brief Returns the ID for the given frame.
@@ -237,7 +237,7 @@ private:
      * a null object of type T that represents an invalid/null object for when the generation
      * process fails (e.g. when the VideoFrame is no longer valid).
      *
-     * @param dimensions the dimensions of the frame.
+     * @param dimensions the dimensions of the frame, must be valid.
      * @param pixelFormat the pixel format of the frame.
      * @param requireAligned true if the generated frame needs to be frame aligned, false otherwise.
      * @param objectConstructor a std::function that takes the generated AVFrame and converts it

--- a/src/video/videoframe.h
+++ b/src/video/videoframe.h
@@ -71,6 +71,8 @@ public:
  */
 class VideoFrame
 {
+public:
+    // Declare type aliases
     using IDType = std::uint_fast64_t;
     using AtomicIDType = std::atomic_uint_fast64_t;
 

--- a/src/video/videoframe.h
+++ b/src/video/videoframe.h
@@ -56,10 +56,11 @@ public:
      * @param destructCallback callback function to run upon destruction of the VideoFrame
      * this callback is only run when destroying a valid VideoFrame (e.g. a VideoFrame instance in
      * which releaseFrame() was called upon it will not call the callback).
+     * @param freeSourceFrame whether to free the source frame buffers or not.
      */
-    VideoFrame(AVFrame* sourceFrame, QRect dimensions, int pixFmt, std::function<void()> destructCallback);
-    VideoFrame(AVFrame* sourceFrame, std::function<void()> destructCallback);
-    VideoFrame(AVFrame* sourceFrame);
+    VideoFrame(AVFrame* sourceFrame, QRect dimensions, int pixFmt, std::function<void()> destructCallback, bool freeSourceFrame = false);
+    VideoFrame(AVFrame* sourceFrame, std::function<void()> destructCallback, bool freeSourceFrame = false);
+    VideoFrame(AVFrame* sourceFrame, bool freeSourceFrame = false);
 
     /**
      * Destructor for VideoFrame.
@@ -218,6 +219,7 @@ private:
     // Source frame
     const QRect sourceDimensions;
     const int sourcePixelFormat;
+    const bool freeSourceFrame;
 
     // Destructor callback
     const std::function<void ()> destructCallback;

--- a/src/video/videoframe.h
+++ b/src/video/videoframe.h
@@ -20,44 +20,203 @@
 #ifndef VIDEOFRAME_H
 #define VIDEOFRAME_H
 
-#include <QMutex>
+#include <QHash>
 #include <QImage>
+#include <QReadWriteLock>
+#include <QRect>
+#include <QSize>
+
+extern "C"{
+#include <libavcodec/avcodec.h>
+}
+
+#include <vpx/vpx_image.h>
 #include <functional>
+#include <memory>
 
-struct AVFrame;
-struct AVCodecContext;
-struct vpx_image;
-
+/**
+ * @brief An ownernship and management class for AVFrames.
+ *
+ * VideoFrame takes ownership of an AVFrame* and allows fast conversions to other formats.
+ * Ownership of all video frame buffers is kept by the VideoFrame, even after conversion. All
+ * references to the frame data become invalid when the VideoFrame is deleted. We try to avoid
+ * pixel format conversions as much as possible, at the cost of some memory.
+ *
+ * Every function in this class is thread safe apart from concurrent construction and deletion of
+ * the object.
+ */
 class VideoFrame
 {
 public:
-    explicit VideoFrame(AVFrame* frame);
-    VideoFrame(AVFrame* frame, std::function<void()> freelistCallback);
-    VideoFrame(AVFrame* frame, int w, int h, int fmt, std::function<void()> freelistCallback);
+    /**
+     * @brief Constructs a new instance of a VideoFrame, sourced by a given AVFrame pointer.
+     * @param sourceFrame the source AVFrame pointer to use, must be valid.
+     * @param dimensions the dimensions of the AVFrame, obtained from the AVFrame if not given.
+     * @param pixFmt the pixel format of the AVFrame, obtained from the AVFrame if not given.
+     * @param destructCallback callback function to run upon destruction of the VideoFrame
+     * this callback is only run when destroying a valid VideoFrame (e.g. a VideoFrame instance in
+     * which releaseFrame() was called upon it will not call the callback).
+     */
+    VideoFrame(AVFrame* sourceFrame, QRect dimensions, int pixFmt, std::function<void()> destructCallback);
+    VideoFrame(AVFrame* sourceFrame, std::function<void()> destructCallback);
+    VideoFrame(AVFrame* sourceFrame);
+
+    /**
+     * Destructor for VideoFrame.
+     */
     ~VideoFrame();
 
-    QSize getSize();
+    // Copy/Move operations are disabled for the VideoFrame, encapsulate with a std::shared_ptr to manage.
 
+    VideoFrame(const VideoFrame& other) = delete;
+    VideoFrame(VideoFrame&& other) = delete;
+
+    const VideoFrame& operator=(const VideoFrame& other) = delete;
+    const VideoFrame& operator=(VideoFrame&& other) = delete;
+
+    /**
+     * @brief Returns the validity of this VideoFrame.
+     *
+     * A VideoFrame is valid if it manages at least one AVFrame. A VideoFrame can be invalidated
+     * by calling releaseFrame() on it.
+     *
+     * @return true if the VideoFrame is valid, false otherwise.
+     */
+    bool isValid();
+
+    /**
+     * @brief Retrieves an AVFrame derived from the source based on the given parameters.
+     *
+     * If a given frame does not exist, this function will perform appropriate conversions to
+     * return a frame that fulfills the given parameters.
+     *
+     * @param dimensions the dimensions of the frame.
+     * @param pixelFormat the desired pixel format of the frame.
+     * @return a pointer to a AVFrame with the given parameters or nullptr if the VideoFrame is no
+     * longer valid.
+     */
+    const AVFrame* getAVFrame(const QSize& dimensions, const int pixelFormat);
+
+    /**
+     * @brief Releases all frames managed by this VideoFrame and invalidates it.
+     */
     void releaseFrame();
 
-    QImage toQImage(QSize size = QSize());
-    vpx_image* toVpxImage();
+    /**
+     * @brief Retrieves a copy of the source VideoFrame's dimensions.
+     * @return QRect copy representing the source VideoFrame's dimensions.
+     */
+    inline QRect getSourceDimensions()
+    {
+        return sourceDimensions;
+    }
 
-protected:
-    bool convertToRGB24(QSize size = QSize());
-    bool convertToYUV420();
-    void releaseFrameLockless();
+    /**
+     * @brief Retrieves a copy of the source VideoFormat's pixel format.
+     * @return integer copy represetning the source VideoFrame's pixel format.
+     */
+    inline int getSourcePixelFormat()
+    {
+        return sourcePixelFormat;
+    }
 
+    /**
+     * @brief Converts this VideoFrame to a QImage that shares this VideoFrame's buffer.
+     *
+     * The VideoFrame will be scaled into the RGB24 pixel format along with the given
+     * dimension.
+     *
+     * @param frameSize the given frame size of QImage to generate. If frame size is 0, defaults to
+     * source frame size.
+     * @return a QImage that represents this VideoFrame, sharing it's buffers or a null image if
+     * this VideoFrame is no longer valid.
+     */
+    QImage toQImage(QSize frameSize = {0, 0});
+
+    /**
+     * @brief Converts this VideoFrame to a vpx_image that shares this VideoFrame's buffer.
+     *
+     * Given that libvpx does not provide a way to create vpx_images that uses external buffers,
+     * the vpx_image constructed by this function is done in a non-compliant way, requiring the
+     * use of the C++ delete keyword to properly deallocate memory associated with this image.
+     *
+     * @param frameSize the given frame size of vpx_image to generate. If frame size is 0, defaults
+     * to source frame size.
+     * @return a vpx_image that represents this VideoFrame, sharing it's buffers or nullptr if this
+     * VideoFrame is no longer valid.
+     */
+    vpx_image* toVpxImage(QSize frameSize = {0, 0});
 private:
-    VideoFrame(const VideoFrame& other)=delete;
-    VideoFrame& operator=(const VideoFrame& other)=delete;
+    /**
+     * @brief A function to create a hashable key from a given QSize dimension.
+     * @param dimensions the dimensions to hash.
+     * @return a hashable unsigned 64-bit number representing the dimension.
+     */
+    static inline quint64 dimensionsToKey(const QSize& dimensions)
+    {
+        return (static_cast<quint64>(dimensions.width()) << 32) | dimensions.height();
+    }
 
+    /**
+     * @brief Retrieves an AVFrame derived from the source based on the given parameters without
+     * obtaining a lock.
+     *
+     * This function is not thread-safe and must be called from a thread-safe context.
+     *
+     * Note: this function differs from getAVFrame() in that it returns a nullptr if no frame was
+     * found.
+     *
+     * @param dimensions the dimensions of the frame.
+     * @param pixelFormat the desired pixel format of the frame.
+     * @return a pointer to a AVFrame with the given parameters or nullptr if no such frame was
+     * found.
+     */
+    AVFrame* retrieveAVFrame(const QSize& dimensions, const int pixelFormat);
+
+    /**
+     * @brief Generates an AVFrame based on the given specifications.
+     *
+     * This function is not thread-safe and must be called from a thread-safe context.
+     *
+     * @param dimensions the required dimensions for the frame.
+     * @param pixelFormat the required pixel format for the frame.
+     * @return an AVFrame with the given specifications.
+     */
+    AVFrame* generateAVFrame(const QSize& dimensions, const int pixelFormat);
+
+    /**
+     * @brief Stores a given AVFrame within the frameBuffer map.
+     *
+     * This function is not thread-safe and must be called from a thread-safe context.
+     *
+     * @param frame the given frame to store.
+     * @param dimensions the dimensions of the frame.
+     * @param pixelFormat the pixel format of the frame.
+     */
+    void storeAVFrame(AVFrame* frame, const QSize& dimensions, const int pixelFormat);
+
+    /**
+     * @brief Releases all frames within the frame buffer.
+     *
+     * This function is not thread-safe and must be called from a thread-safe context.
+     */
+    void deleteFrameBuffer();
 private:
-    std::function<void()> freelistCallback;
-    QMutex biglock;
-    AVFrame* frameOther, *frameYUV420, *frameRGB24;
-    int width, height;
-    int pixFmt;
+    // Data alignment for framebuffers
+    static constexpr int data_alignment = 32;
+
+    // Main framebuffer store
+    QHash<int, QHash<quint64, AVFrame*>> frameBuffer {};
+
+    // Source frame
+    const QRect sourceDimensions;
+    const int sourcePixelFormat;
+
+    // Destructor callback
+    const std::function<void ()> destructCallback;
+
+    // Concurrency
+    QReadWriteLock frameLock {};
 };
 
 #endif // VIDEOFRAME_H

--- a/src/video/videoframe.h
+++ b/src/video/videoframe.h
@@ -37,9 +37,18 @@ extern "C"{
 #include <unordered_map>
 
 /**
- * @brief A simple structure to represent a ToxAV frame.
+ * @brief A simple structure to represent a ToxYUV video frame (corresponds to a frame encoded
+ * under format: AV_PIX_FMT_YUV420P [FFmpeg] or VPX_IMG_FMT_I420 [WebM]).
+ *
+ * This structure exists for convenience and code clarity when ferrying YUV420 frames from one
+ * source to another. The buffers pointed to by the struct should not be owned by the struct nor
+ * should they be freed from the struct, instead this struct functions only as a simple alias to a
+ * more complicated frame container like AVFrame.
+ *
+ * The creation of this structure was done to replace existing code which mis-used vpx_image
+ * structs when passing frame data to toxcore.
  */
-struct ToxAVFrame
+struct ToxYUVFrame
 {
 public:
     const std::uint16_t width;
@@ -217,7 +226,7 @@ public:
      * @return a ToxAVFrame structure that represents this VideoFrame, sharing it's buffers or an
      * empty structure if this VideoFrame is no longer valid.
      */
-    ToxAVFrame toToxAVFrame(QSize frameSize = {0, 0});
+    ToxYUVFrame toToxAVFrame(QSize frameSize = {0, 0});
 
     /**
      * @brief Data alignment parameter used to populate AVFrame buffers.

--- a/src/video/videoframe.h
+++ b/src/video/videoframe.h
@@ -39,6 +39,9 @@ extern "C"{
 struct ToxYUVFrame
 {
 public:
+    bool isValid() const;
+    explicit operator bool() const;
+
     const std::uint16_t width;
     const std::uint16_t height;
 

--- a/src/video/videoframe.h
+++ b/src/video/videoframe.h
@@ -146,6 +146,16 @@ public:
      * VideoFrame is no longer valid.
      */
     vpx_image* toVpxImage(QSize frameSize = {0, 0});
+
+    /**
+     * @brief Data alignment parameter used to populate AVFrame buffers.
+     *
+     * This field is public in effort to standardized the frame alignment parameter for all AVFrame
+     * allocations.
+     *
+     * It's currently set to 32-byte alignment for AVX2 support.
+     */
+    static constexpr int frameAlignment = 32;
 private:
     /**
      * @brief A function to create a hashable key from a given QSize dimension.
@@ -202,9 +212,6 @@ private:
      */
     void deleteFrameBuffer();
 private:
-    // Data alignment for framebuffers
-    static constexpr int data_alignment = 32;
-
     // Main framebuffer store
     QHash<int, QHash<quint64, AVFrame*>> frameBuffer {};
 

--- a/src/video/videoframe.h
+++ b/src/video/videoframe.h
@@ -299,7 +299,7 @@ private:
 
     // Source frame
     const QRect sourceDimensions;
-    const int sourcePixelFormat;
+    int sourcePixelFormat;
     const FrameBufferKey sourceFrameKey;
     const bool freeSourceFrame;
 

--- a/src/video/videoframe.h
+++ b/src/video/videoframe.h
@@ -153,10 +153,31 @@ public:
     const AVFrame* getAVFrame(QSize frameSize, const int pixelFormat, const bool requireAligned);
 
     /**
+     * @brief Returns the ID for the given frame.
+     *
+     * Frame IDs are globally unique (with respect to the running instance).
+     *
+     * @return an integer representing the ID of this frame.
+     */
+    inline IDType getFrameID() const
+    {
+        return frameID;
+    }
+
+    /**
+     * @brief Returns the ID for the VideoSource which created this frame.
+     * @return an integer representing the ID of the VideoSource which created this frame.
+     */
+    inline IDType getSourceID() const
+    {
+        return sourceID;
+    }
+
+    /**
      * @brief Retrieves a copy of the source VideoFrame's dimensions.
      * @return QRect copy representing the source VideoFrame's dimensions.
      */
-    inline QRect getSourceDimensions()
+    inline QRect getSourceDimensions() const
     {
         return sourceDimensions;
     }
@@ -165,7 +186,7 @@ public:
      * @brief Retrieves a copy of the source VideoFormat's pixel format.
      * @return integer copy represetning the source VideoFrame's pixel format.
      */
-    inline int getSourcePixelFormat()
+    inline int getSourcePixelFormat() const
     {
         return sourcePixelFormat;
     }

--- a/src/video/videoframe.h
+++ b/src/video/videoframe.h
@@ -29,10 +29,23 @@ extern "C"{
 #include <libavcodec/avcodec.h>
 }
 
-#include <vpx/vpx_image.h>
 #include <functional>
 #include <memory>
 #include <unordered_map>
+
+/**
+ * @brief A simple structure to represent a ToxAV frame.
+ */
+struct ToxAVFrame
+{
+public:
+    const std::uint16_t width;
+    const std::uint16_t height;
+
+    const uint8_t* y;
+    const uint8_t* u;
+    const uint8_t* v;
+};
 
 /**
  * @brief An ownernship and management class for AVFrames.
@@ -145,18 +158,17 @@ public:
     QImage toQImage(QSize frameSize = {0, 0});
 
     /**
-     * @brief Converts this VideoFrame to a vpx_image that shares this VideoFrame's buffer.
+     * @brief Converts this VideoFrame to a ToxAVFrame that shares this VideoFrame's buffer.
      *
-     * Given that libvpx does not provide a way to create vpx_images that uses external buffers,
-     * the vpx_image constructed by this function is done in a non-compliant way, requiring the
-     * use of the C++ delete keyword to properly deallocate memory associated with this image.
+     * The given ToxAVFrame will be frame aligned under a pixel format of planar YUV with a chroma
+     * subsampling format of 4:2:0 (i.e. AV_PIX_FMT_YUV420P).
      *
-     * @param frameSize the given frame size of vpx_image to generate. If frame size is 0, defaults
+     * @param frameSize the given frame size of ToxAVFrame to generate. If frame size is 0, defaults
      * to source frame size.
-     * @return a vpx_image that represents this VideoFrame, sharing it's buffers or nullptr if this
-     * VideoFrame is no longer valid.
+     * @return a ToxAVFrame structure that represents this VideoFrame, sharing it's buffers or an
+     * empty structure if this VideoFrame is no longer valid.
      */
-    vpx_image* toVpxImage(QSize frameSize = {0, 0});
+    ToxAVFrame toToxAVFrame(QSize frameSize = {0, 0});
 
     /**
      * @brief Data alignment parameter used to populate AVFrame buffers.

--- a/src/video/videosource.cpp
+++ b/src/video/videosource.cpp
@@ -1,0 +1,23 @@
+/*
+    Copyright © 2016 by The qTox Project
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "videosource.h"
+
+// Initialize sourceIDs to 0
+VideoSource::AtomicIDType VideoSource::sourceIDs {0};

--- a/src/video/videosource.cpp
+++ b/src/video/videosource.cpp
@@ -19,5 +19,13 @@
 
 #include "videosource.h"
 
+/**
+ * @class VideoSource
+ * @brief An abstract source of video frames
+ *
+ * When it has at least one subscriber the source will emit new video frames.
+ * Subscribing is recursive, multiple users can subscribe to the same VideoSource.
+ */
+
 // Initialize sourceIDs to 0
 VideoSource::AtomicIDType VideoSource::sourceIDs {0};

--- a/src/video/videosource.h
+++ b/src/video/videosource.h
@@ -38,7 +38,7 @@ public:
     using AtomicIDType = std::atomic_uint_fast64_t;
 
 public:
-    VideoSource() : id(sourceIDs.fetch_add(std::memory_order_relaxed)){}
+    VideoSource() : id(sourceIDs++){}
 
     virtual ~VideoSource() = default;
     /**

--- a/src/video/videosource.h
+++ b/src/video/videosource.h
@@ -44,7 +44,7 @@ public:
     /**
      * @brief If subscribe sucessfully opens the source, it will start emitting frameAvailable signals.
      */
-    virtual bool subscribe() = 0;    
+    virtual bool subscribe() = 0;
     /**
      * @brief Stop emitting frameAvailable signals, and free associated resources if necessary.
      */

--- a/src/video/videosource.h
+++ b/src/video/videosource.h
@@ -37,6 +37,8 @@ class VideoSource : public QObject
 {
     Q_OBJECT
 
+public:
+    // Declare type aliases
     using IDType = std::uint_fast64_t;
     using AtomicIDType = std::atomic_uint_fast64_t;
 

--- a/src/video/videosource.h
+++ b/src/video/videosource.h
@@ -27,12 +27,7 @@
 
 class VideoFrame;
 
-/**
-@brief An abstract source of video frames
 
-When it has at least one subscriber the source will emit new video frames
-Subscribing is recursive, multiple users can subscribe to the same VideoSource
-*/
 class VideoSource : public QObject
 {
     Q_OBJECT
@@ -47,26 +42,26 @@ public:
 
     virtual ~VideoSource() = default;
     /**
-    If subscribe sucessfully opens the source, it will start emitting frameAvailable signals.
-    */
-    virtual bool subscribe() = 0;
+     * @brief If subscribe sucessfully opens the source, it will start emitting frameAvailable signals.
+     */
+    virtual bool subscribe() = 0;    
     /**
-    Stop emitting frameAvailable signals, and free associated resources if necessary.
-    */
+     * @brief Stop emitting frameAvailable signals, and free associated resources if necessary.
+     */
     virtual void unsubscribe() = 0;
 
     /// ID of this VideoSource
     const IDType id;
 signals:
     /**
-    Emitted when new frame available to use.
-    @param frame New frame.
-    */
+     * @brief Emitted when new frame available to use.
+     * @param frame New frame.
+     */
     void frameAvailable(std::shared_ptr<VideoFrame> frame);
     /**
-    Emitted when the source is stopped for an indefinite amount of time,
-    but might restart sending frames again later
-    */
+     * @brief Emitted when the source is stopped for an indefinite amount of time, but might restart
+     * sending frames again later
+     */
     void sourceStopped();
 private:
     /// Used to manage a global ID for all VideoSources

--- a/src/video/videosource.h
+++ b/src/video/videosource.h
@@ -21,6 +21,8 @@
 #define VIDEOSOURCE_H
 
 #include <QObject>
+
+#include <atomic>
 #include <memory>
 
 class VideoFrame;
@@ -35,7 +37,12 @@ class VideoSource : public QObject
 {
     Q_OBJECT
 
+    using IDType = std::uint_fast64_t;
+    using AtomicIDType = std::atomic_uint_fast64_t;
+
 public:
+    VideoSource() : id(sourceIDs.fetch_add(std::memory_order_relaxed)){}
+
     virtual ~VideoSource() = default;
     /**
     If subscribe sucessfully opens the source, it will start emitting frameAvailable signals.
@@ -46,6 +53,8 @@ public:
     */
     virtual void unsubscribe() = 0;
 
+    /// ID of this VideoSource
+    const IDType id;
 signals:
     /**
     Emitted when new frame available to use.
@@ -57,6 +66,9 @@ signals:
     but might restart sending frames again later
     */
     void sourceStopped();
+private:
+    /// Used to manage a global ID for all VideoSources
+    static AtomicIDType sourceIDs;
 };
 
 #endif // VIDEOSOURCE_H

--- a/src/video/videosurface.cpp
+++ b/src/video/videosurface.cpp
@@ -146,7 +146,7 @@ void VideoSurface::onNewFrameAvailable(std::shared_ptr<VideoFrame> newFrame)
 
     lock();
     lastFrame = newFrame;
-    newSize = lastFrame->getSize();
+    newSize = lastFrame->getSourceDimensions().size();
     unlock();
 
     float newRatio = getSizeRatio(newSize);


### PR DESCRIPTION
This PR redesigns the VideoFrame class to be more robust, documented and performant whilst retaining all existing functionality.

Changes in particular to the class:
- modularize functionality: generating a frame has been decoupled from "to" functions (e.g. `toQImage()`).
- better multi-threading performance: updates the mutex to a read-write lock for concurrent reads without blocking.
- more generic: now handles essentially all pixel format types and sizes (instead of hard coding 3 different frame types).
- exposes a new `getAVFrame()` function: allows retrieval of a AVFrame pointer for custom processing by users of the AVFrame object.
- exposes a `isValid()` function: now allows users of VideoFrame to tell if the frame has been released.
- exposes `trackFrame()` and `untrackFrames()` functions that allow the class to perform self-counting weak referencing (allowing mass invalidation of frames as necessary).
- stores dimensional data instead of only size: uses a `QRect` over a `QSize` to store source frame geometry.
- explictly delete move constructor/operator: ensures there is no way to accidentally copy the object without using a smart pointer.

The only functionality changes with this class are that the function `getSize()` has been removed in favor of `getSourceDimensions()` which returns a `QRect` instead of a `QSize` (in which you can call `getSize()` to get the corresponding size and that the reference tracking code in CameraSource has been integrated into the VideoFrame class.

Whilst usage-wise very little has been changed for the class, new functionality introduced with this class will form the basis required for a upcoming PR that I'm working on for a video source compositor (allows for thread-safe composition of different video sources) which will then be used for better desktop video (as well as some other stuff).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tux3/qtox/3185)

<!-- Reviewable:end -->
