### PR TITLE
fix(Settings): write settings to disk when they change

### DIFF
--- a/qtox.pro
+++ b/qtox.pro
@@ -484,7 +484,8 @@ SOURCES += \
     src/persistence/db/rawdatabase.cpp \
     src/persistence/history.cpp \
     src/widget/form/groupinviteform.cpp \
-    src/widget/tool/profileimporter.cpp
+    src/widget/tool/profileimporter.cpp \
+    src/persistence/settingstransaction.cpp
 
 HEADERS += \
     src/audio/audio.h \
@@ -542,4 +543,5 @@ HEADERS += \
     src/persistence/db/rawdatabase.h \
     src/persistence/history.h \
     src/widget/form/groupinviteform.h \
-    src/widget/tool/profileimporter.h
+    src/widget/tool/profileimporter.h \
+    src/persistence/settingstransaction.h

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -1210,6 +1210,7 @@ void Core::setNospam(uint32_t nospam)
     uint8_t *nspm = reinterpret_cast<uint8_t*>(&nospam);
     std::reverse(nspm, nspm + 4);
     tox_self_set_nospam(tox, nospam);
+    profile.saveToxSave();
 
     emit idSet(getSelfId().toString());
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -167,9 +167,9 @@ int main(int argc, char *argv[])
     if (QFileInfo(logfile).size() > 1000000)
     {
         qDebug() << "Log file over 1MB, rotating...";
-		
+
         QDir dir (logFileDir);
-		
+
         // Check if log.1 already exists, and if so, delete it
         if (dir.remove(logFileDir + "qtox.log.1"))
             qDebug() << "Removed old log successfully";

--- a/src/persistence/settingstransaction.cpp
+++ b/src/persistence/settingstransaction.cpp
@@ -1,0 +1,114 @@
+/*
+    Copyright © 2016 by The qTox Project
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "settingstransaction.h"
+#include "settings.h"
+#include <climits>
+
+/*
+ * This family of classes represents an intent to make changes to
+ * settings that need to be saved to disk after the changes have
+ * been made. To use it, simply instantiate a local object before
+ * making changes and let it fall out of scope afterwards.
+ *
+ * The motivation behind this design is to easily prevent cascading
+ * changes from triggering multiple writes to disk. The destructor
+ * function only makes a save call if the object being destroyed
+ * was the last instance of its class alive.
+ *
+ * Think: "last one out closes the door."
+ */
+SettingsTransaction::SettingsTransaction()
+{
+    qDebug() << "created" << this;
+}
+
+QSemaphore PersonalSettingsTransaction::activeTransactions(INT_MAX);
+QMutex PersonalSettingsTransaction::lock;
+
+PersonalSettingsTransaction::PersonalSettingsTransaction()
+{
+    QMutexLocker locker(&lock);
+
+    activeTransactions.acquire();
+}
+
+PersonalSettingsTransaction::~PersonalSettingsTransaction()
+{
+    if (canceled)
+        return;
+
+    QMutexLocker locker(&lock);
+
+    activeTransactions.release();
+
+    bool save = activeTransactions.available() == INT_MAX;
+
+    qDebug() << "destroyed" << this << "save:" << save;
+
+    if (save)
+        Settings::getInstance().savePersonal();
+}
+
+void PersonalSettingsTransaction::cancel()
+{
+    QMutexLocker locker(&lock);
+
+    activeTransactions.release();
+    canceled = true;
+
+    qDebug() << "canceled" << this;
+}
+
+QSemaphore GlobalSettingsTransaction::activeTransactions(INT_MAX);
+QMutex GlobalSettingsTransaction::lock;
+
+GlobalSettingsTransaction::GlobalSettingsTransaction()
+{
+    QMutexLocker locker(&lock);
+
+    activeTransactions.acquire();
+}
+
+GlobalSettingsTransaction::~GlobalSettingsTransaction()
+{
+    if (canceled)
+        return;
+
+    QMutexLocker locker(&lock);
+
+    activeTransactions.release();
+
+    bool save = activeTransactions.available() == INT_MAX;
+
+    qDebug() << "destroyed" << this << "save:" << save;
+
+    if (save)
+        Settings::getInstance().saveGlobal();
+}
+
+void GlobalSettingsTransaction::cancel()
+{
+    QMutexLocker locker(&lock);
+
+    activeTransactions.release();
+    canceled = true;
+
+    qDebug() << "canceled" << this;
+}

--- a/src/persistence/settingstransaction.cpp
+++ b/src/persistence/settingstransaction.cpp
@@ -35,9 +35,7 @@
  * Think: "last one out closes the door."
  */
 SettingsTransaction::SettingsTransaction()
-{
-    qDebug() << "created" << this;
-}
+{}
 
 QSemaphore PersonalSettingsTransaction::activeTransactions(INT_MAX);
 QMutex PersonalSettingsTransaction::lock;
@@ -60,8 +58,6 @@ PersonalSettingsTransaction::~PersonalSettingsTransaction()
 
     bool save = activeTransactions.available() == INT_MAX;
 
-    qDebug() << "destroyed" << this << "save:" << save;
-
     if (save)
         Settings::getInstance().savePersonal();
 }
@@ -72,8 +68,6 @@ void PersonalSettingsTransaction::cancel()
 
     activeTransactions.release();
     canceled = true;
-
-    qDebug() << "canceled" << this;
 }
 
 QSemaphore GlobalSettingsTransaction::activeTransactions(INT_MAX);
@@ -97,8 +91,6 @@ GlobalSettingsTransaction::~GlobalSettingsTransaction()
 
     bool save = activeTransactions.available() == INT_MAX;
 
-    qDebug() << "destroyed" << this << "save:" << save;
-
     if (save)
         Settings::getInstance().saveGlobal();
 }
@@ -109,6 +101,4 @@ void GlobalSettingsTransaction::cancel()
 
     activeTransactions.release();
     canceled = true;
-
-    qDebug() << "canceled" << this;
 }

--- a/src/persistence/settingstransaction.h
+++ b/src/persistence/settingstransaction.h
@@ -1,0 +1,64 @@
+/*
+    Copyright © 2016 by The qTox Project
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef SETTINGSSAVETRANSACTION_H
+#define SETTINGSSAVETRANSACTION_H
+
+#include <QObject>
+#include <QMutex>
+#include <QSemaphore>
+
+class SettingsTransaction : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit SettingsTransaction();
+    bool canceled = false;
+};
+
+class PersonalSettingsTransaction : public SettingsTransaction
+{
+    Q_OBJECT
+
+public:
+    explicit PersonalSettingsTransaction();
+    ~PersonalSettingsTransaction();
+    void cancel();
+
+private:
+    static QSemaphore activeTransactions;
+    static QMutex lock;
+};
+
+class GlobalSettingsTransaction : public SettingsTransaction
+{
+    Q_OBJECT
+
+public:
+    explicit GlobalSettingsTransaction();
+    ~GlobalSettingsTransaction();
+    void cancel();
+
+private:
+    static QSemaphore activeTransactions;
+    static QMutex lock;
+};
+
+#endif // SETTINGSSAVETRANSACTION_H

--- a/src/widget/circlewidget.cpp
+++ b/src/widget/circlewidget.cpp
@@ -22,6 +22,7 @@
 #include "friendlistwidget.h"
 #include "tool/croppinglabel.h"
 #include "src/persistence/settings.h"
+#include "src/persistence/settingstransaction.h"
 #include "src/friendlist.h"
 #include "src/friend.h"
 #include "src/widget/contentdialog.h"
@@ -100,6 +101,8 @@ void CircleWidget::contextMenuEvent(QContextMenuEvent* event)
         }
         else if (selectedItem == removeAction)
         {
+            PersonalSettingsTransaction transaction;
+
             FriendListWidget* friendList = static_cast<FriendListWidget*>(parentWidget());
             moveFriendWidgets(friendList);
 
@@ -192,13 +195,14 @@ void CircleWidget::dropEvent(QDropEvent* event)
 
 void CircleWidget::onSetName()
 {
+    PersonalSettingsTransaction transaction;
     Settings::getInstance().setCircleName(id, getName());
 }
 
 void CircleWidget::onExpand()
 {
+    PersonalSettingsTransaction transaction;
     Settings::getInstance().setCircleExpanded(id, isExpanded());
-    Settings::getInstance().savePersonal();
 }
 
 void CircleWidget::onAddFriendWidget(FriendWidget* w)
@@ -213,6 +217,8 @@ void CircleWidget::updateID(int index)
 
     if (id == index)
         return;
+
+    PersonalSettingsTransaction transaction;
 
     id = index;
     circleList[id] = this;

--- a/src/widget/form/addfriendform.cpp
+++ b/src/widget/form/addfriendform.cpp
@@ -33,6 +33,7 @@
 #include "src/net/toxdns.h"
 #include "src/net/toxme.h"
 #include "src/persistence/settings.h"
+#include "src/persistence/settingstransaction.h"
 #include "src/widget/gui.h"
 #include "src/widget/translator.h"
 #include "src/widget/contentlayout.h"
@@ -239,6 +240,8 @@ void AddFriendForm::deleteFriendRequest(const QString& toxId)
 
 void AddFriendForm::onFriendRequestAccepted()
 {
+    PersonalSettingsTransaction transaction;
+
     QPushButton* acceptButton = static_cast<QPushButton*>(sender());
     QWidget* friendWidget = acceptButton->parentWidget();
     int index = requestsLayout->indexOf(friendWidget);
@@ -246,25 +249,26 @@ void AddFriendForm::onFriendRequestAccepted()
     Settings::Request request = Settings::getInstance().getFriendRequest(requestsLayout->count() - index - 1);
     emit friendRequestAccepted(request.address);
     Settings::getInstance().removeFriendRequest(requestsLayout->count() - index - 1);
-    Settings::getInstance().savePersonal();
 }
 
 void AddFriendForm::onFriendRequestRejected()
 {
+    PersonalSettingsTransaction transaction;
+
     QPushButton* rejectButton = static_cast<QPushButton*>(sender());
     QWidget* friendWidget = rejectButton->parentWidget();
     int index = requestsLayout->indexOf(friendWidget);
     removeFriendRequestWidget(friendWidget);
     Settings::getInstance().removeFriendRequest(requestsLayout->count() - index - 1);
-    Settings::getInstance().savePersonal();
 }
 
 void AddFriendForm::onCurrentChanged(int index)
 {
+    PersonalSettingsTransaction transaction;
+
     if (index == FriendRequest && Settings::getInstance().getUnreadFriendRequests() != 0)
     {
         Settings::getInstance().clearUnreadFriendRequests();
-        Settings::getInstance().savePersonal();
         emit friendRequestsSeen();
     }
 }

--- a/src/widget/form/settings/advancedform.cpp
+++ b/src/widget/form/settings/advancedform.cpp
@@ -32,7 +32,7 @@ AdvancedForm::AdvancedForm() :
 
     bodyUI->cbMakeToxPortable->setChecked(Settings::getInstance().getMakeToxPortable());
 
-    connect(bodyUI->cbMakeToxPortable, &QCheckBox::stateChanged, this, &AdvancedForm::onMakeToxPortableUpdated);
+    connect_global_saver(bodyUI->cbMakeToxPortable, &QCheckBox::stateChanged, this, &AdvancedForm::onMakeToxPortableUpdated);
     connect(bodyUI->resetButton, SIGNAL(clicked()), this, SLOT(resetToDefault()));
 
     for (QCheckBox *cb : findChildren<QCheckBox*>()) // this one is to allow scrolling on checkboxes

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -50,10 +50,10 @@ AVForm::AVForm() :
 
     auto qcbxIndexChangedStr = (void(QComboBox::*)(const QString&)) &QComboBox::currentIndexChanged;
     auto qcbxIndexChangedInt = (void(QComboBox::*)(int)) &QComboBox::currentIndexChanged;
-    connect(bodyUI->inDevCombobox, qcbxIndexChangedStr, this, &AVForm::onInDevChanged);
-    connect(bodyUI->outDevCombobox, qcbxIndexChangedStr, this, &AVForm::onOutDevChanged);
-    connect(bodyUI->videoDevCombobox, qcbxIndexChangedInt, this, &AVForm::onVideoDevChanged);
-    connect(bodyUI->videoModescomboBox, qcbxIndexChangedInt, this, &AVForm::onVideoModesIndexChanged);
+    connect_global_saver(bodyUI->inDevCombobox, qcbxIndexChangedStr, this, &AVForm::onInDevChanged);
+    connect_global_saver(bodyUI->outDevCombobox, qcbxIndexChangedStr, this, &AVForm::onOutDevChanged);
+    connect_global_saver(bodyUI->videoDevCombobox, qcbxIndexChangedInt, this, &AVForm::onVideoDevChanged);
+    connect_global_saver(bodyUI->videoModescomboBox, qcbxIndexChangedInt, this, &AVForm::onVideoModesIndexChanged);
     connect(bodyUI->rescanButton, &QPushButton::clicked, this, [=]()
     {
         getAudioInDevices();
@@ -63,11 +63,11 @@ AVForm::AVForm() :
 
     bodyUI->playbackSlider->setTracking(false);
     bodyUI->playbackSlider->installEventFilter(this);
-    connect(bodyUI->playbackSlider, &QSlider::valueChanged,
+    connect_global_saver(bodyUI->playbackSlider, &QSlider::valueChanged,
             this, &AVForm::onPlaybackValueChanged);
     bodyUI->microphoneSlider->setTracking(false);
     bodyUI->microphoneSlider->installEventFilter(this);
-    connect(bodyUI->microphoneSlider, &QSlider::valueChanged,
+    connect_global_saver(bodyUI->microphoneSlider, &QSlider::valueChanged,
             this, &AVForm::onMicrophoneValueChanged);
 
     for (QComboBox* cb : findChildren<QComboBox*>())

--- a/src/widget/form/settings/generalform.cpp
+++ b/src/widget/form/settings/generalform.cpp
@@ -19,6 +19,7 @@
 
 #include "ui_generalsettings.h"
 #include "generalform.h"
+#include "genericsettings.h"
 #include "src/widget/form/settingswidget.h"
 #include "src/widget/widget.h"
 #include "src/persistence/settings.h"
@@ -203,43 +204,43 @@ GeneralForm::GeneralForm(SettingsWidget *myParent) :
     onUseProxyUpdated();
 
     //general
-    connect(bodyUI->checkUpdates, &QCheckBox::stateChanged, this, &GeneralForm::onCheckUpdateChanged);
-    connect(bodyUI->transComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(onTranslationUpdated()));
-    connect(bodyUI->cbAutorun, &QCheckBox::stateChanged, this, &GeneralForm::onAutorunUpdated);
-    connect(bodyUI->lightTrayIcon, &QCheckBox::stateChanged, this, &GeneralForm::onSetLightTrayIcon);
-    connect(bodyUI->showSystemTray, &QCheckBox::stateChanged, this, &GeneralForm::onSetShowSystemTray);
-    connect(bodyUI->startInTray, &QCheckBox::stateChanged, this, &GeneralForm::onSetAutostartInTray);
-    connect(bodyUI->closeToTray, &QCheckBox::stateChanged, this, &GeneralForm::onSetCloseToTray);
-    connect(bodyUI->minimizeToTray, &QCheckBox::stateChanged, this, &GeneralForm::onSetMinimizeToTray);
-    connect(bodyUI->statusChanges, &QCheckBox::stateChanged, this, &GeneralForm::onSetStatusChange);
-    connect(bodyUI->autoAwaySpinBox, SIGNAL(editingFinished()), this, SLOT(onAutoAwayChanged()));
-    connect(bodyUI->showWindow, &QCheckBox::stateChanged, this, &GeneralForm::onShowWindowChanged);
-    connect(bodyUI->showInFront, &QCheckBox::stateChanged, this, &GeneralForm::onSetShowInFront);
-    connect(bodyUI->notifySound, &QCheckBox::stateChanged, this, &GeneralForm::onSetNotifySound);
-    connect(bodyUI->markdownComboBox, &QComboBox::currentTextChanged, this, &GeneralForm::onMarkdownUpdated);
-    connect(bodyUI->groupAlwaysNotify, &QCheckBox::stateChanged, this, &GeneralForm::onSetGroupAlwaysNotify);
-    connect(bodyUI->autoacceptFiles, &QCheckBox::stateChanged, this, &GeneralForm::onAutoAcceptFileChange);
-    connect(bodyUI->autoSaveFilesDir, SIGNAL(clicked()), this, SLOT(onAutoSaveDirChange()));
+    connect_global_saver(bodyUI->checkUpdates, &QCheckBox::stateChanged, this, &GeneralForm::onCheckUpdateChanged);
+    connect_global_saver(bodyUI->transComboBox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &GeneralForm::onTranslationUpdated);
+    connect_global_saver(bodyUI->cbAutorun, &QCheckBox::stateChanged, this, &GeneralForm::onAutorunUpdated);
+    connect_global_saver(bodyUI->lightTrayIcon, &QCheckBox::stateChanged, this, &GeneralForm::onSetLightTrayIcon);
+    connect_global_saver(bodyUI->showSystemTray, &QCheckBox::stateChanged, this, &GeneralForm::onSetShowSystemTray);
+    connect_global_saver(bodyUI->startInTray, &QCheckBox::stateChanged, this, &GeneralForm::onSetAutostartInTray);
+    connect_global_saver(bodyUI->closeToTray, &QCheckBox::stateChanged, this, &GeneralForm::onSetCloseToTray);
+    connect_global_saver(bodyUI->minimizeToTray, &QCheckBox::stateChanged, this, &GeneralForm::onSetMinimizeToTray);
+    connect_global_saver(bodyUI->statusChanges, &QCheckBox::stateChanged, this, &GeneralForm::onSetStatusChange);
+    connect_global_saver(bodyUI->autoAwaySpinBox, &QSpinBox::editingFinished, this, &GeneralForm::onAutoAwayChanged);
+    connect_global_saver(bodyUI->showWindow, &QCheckBox::stateChanged, this, &GeneralForm::onShowWindowChanged);
+    connect_global_saver(bodyUI->showInFront, &QCheckBox::stateChanged, this, &GeneralForm::onSetShowInFront);
+    connect_global_saver(bodyUI->notifySound, &QCheckBox::stateChanged, this, &GeneralForm::onSetNotifySound);
+    connect_global_saver(bodyUI->markdownComboBox, &QComboBox::currentTextChanged, this, &GeneralForm::onMarkdownUpdated);
+    connect_global_saver(bodyUI->groupAlwaysNotify, &QCheckBox::stateChanged, this, &GeneralForm::onSetGroupAlwaysNotify);
+    connect_global_saver(bodyUI->autoacceptFiles, &QCheckBox::stateChanged, this, &GeneralForm::onAutoAcceptFileChange);
+    connect_global_saver(bodyUI->autoSaveFilesDir, &QPushButton::clicked, this, &GeneralForm::onAutoSaveDirChange);
     //theme
-    connect(bodyUI->useEmoticons, &QCheckBox::stateChanged, this, &GeneralForm::onUseEmoticonsChange);
-    connect(bodyUI->smileyPackBrowser, SIGNAL(currentIndexChanged(int)), this, SLOT(onSmileyBrowserIndexChanged(int)));
-    connect(bodyUI->styleBrowser, SIGNAL(currentTextChanged(QString)), this, SLOT(onStyleSelected(QString)));
-    connect(bodyUI->themeColorCBox, SIGNAL(currentIndexChanged(int)), this, SLOT(onThemeColorChanged(int)));
-    connect(bodyUI->emoticonSize, SIGNAL(editingFinished()), this, SLOT(onEmoticonSizeChanged()));
-    connect(bodyUI->timestamp, SIGNAL(currentIndexChanged(int)), this, SLOT(onTimestampSelected(int)));
-    connect(bodyUI->dateFormats, SIGNAL(currentIndexChanged(int)), this, SLOT(onDateFormatSelected(int)));
+    connect_global_saver(bodyUI->useEmoticons, &QCheckBox::stateChanged, this, &GeneralForm::onUseEmoticonsChange);
+    connect_global_saver(bodyUI->smileyPackBrowser, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &GeneralForm::onSmileyBrowserIndexChanged);
+    connect_global_saver(bodyUI->styleBrowser, &QComboBox::currentTextChanged, this, &GeneralForm::onStyleSelected);
+    connect_global_saver(bodyUI->themeColorCBox, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &GeneralForm::onThemeColorChanged);
+    connect_global_saver(bodyUI->emoticonSize, &QSpinBox::editingFinished, this, &GeneralForm::onEmoticonSizeChanged);
+    connect_global_saver(bodyUI->timestamp, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &GeneralForm::onTimestampSelected);
+    connect_global_saver(bodyUI->dateFormats, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &GeneralForm::onDateFormatSelected);
     //connection
-    connect(bodyUI->cbEnableIPv6, &QCheckBox::stateChanged, this, &GeneralForm::onEnableIPv6Updated);
-    connect(bodyUI->cbEnableUDP, &QCheckBox::stateChanged, this, &GeneralForm::onUDPUpdated);
-    connect(bodyUI->proxyType, SIGNAL(currentIndexChanged(int)), this, SLOT(onUseProxyUpdated()));
-    connect(bodyUI->proxyAddr, &QLineEdit::editingFinished, this, &GeneralForm::onProxyAddrEdited);
-    connect(bodyUI->proxyPort, SIGNAL(valueChanged(int)), this, SLOT(onProxyPortEdited(int)));
+    connect_global_saver(bodyUI->cbEnableIPv6, &QCheckBox::stateChanged, this, &GeneralForm::onEnableIPv6Updated);
+    connect_global_saver(bodyUI->cbEnableUDP, &QCheckBox::stateChanged, this, &GeneralForm::onUDPUpdated);
+    connect_global_saver(bodyUI->proxyType, static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &GeneralForm::onUseProxyUpdated);
+    connect_global_saver(bodyUI->proxyAddr, &QLineEdit::editingFinished, this, &GeneralForm::onProxyAddrEdited);
+    connect_global_saver(bodyUI->proxyPort, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged), this, &GeneralForm::onProxyPortEdited);
     connect(bodyUI->reconnectButton, &QPushButton::clicked, this, &GeneralForm::onReconnectClicked);
-    connect(bodyUI->cbFauxOfflineMessaging, &QCheckBox::stateChanged, this, &GeneralForm::onFauxOfflineMessaging);
-    connect(bodyUI->cbCompactLayout, &QCheckBox::stateChanged, this, &GeneralForm::onCompactLayout);
-    connect(bodyUI->cbSeparateWindow, &QCheckBox::stateChanged, this, &GeneralForm::onSeparateWindowChanged);
-    connect(bodyUI->cbDontGroupWindows, &QCheckBox::stateChanged, this, &GeneralForm::onDontGroupWindowsChanged);
-    connect(bodyUI->cbGroupchatPosition, &QCheckBox::stateChanged, this, &GeneralForm::onGroupchatPositionChanged);
+    connect_global_saver(bodyUI->cbFauxOfflineMessaging, &QCheckBox::stateChanged, this, &GeneralForm::onFauxOfflineMessaging);
+    connect_personal_saver(bodyUI->cbCompactLayout, &QCheckBox::stateChanged, this, &GeneralForm::onCompactLayout);
+    connect_global_saver(bodyUI->cbSeparateWindow, &QCheckBox::stateChanged, this, &GeneralForm::onSeparateWindowChanged);
+    connect_global_saver(bodyUI->cbDontGroupWindows, &QCheckBox::stateChanged, this, &GeneralForm::onDontGroupWindowsChanged);
+    connect_global_saver(bodyUI->cbGroupchatPosition, &QCheckBox::stateChanged, this, &GeneralForm::onGroupchatPositionChanged);
 
     // prevent stealing mouse wheel scroll
     // scrolling event won't be transmitted to comboboxes or qspinboxes when scrolling

--- a/src/widget/form/settings/generalform.h
+++ b/src/widget/form/settings/generalform.h
@@ -22,8 +22,9 @@
 
 #include "genericsettings.h"
 
-namespace Ui {
-class GeneralSettings;
+namespace Ui
+{
+    class GeneralSettings;
 }
 
 class SettingsWidget;

--- a/src/widget/form/settings/genericsettings.h
+++ b/src/widget/form/settings/genericsettings.h
@@ -32,6 +32,16 @@ public:
 
 protected:
     QPixmap formIcon;
+
+    template<typename Sender, typename Signal, typename... Rest>
+    static QMetaObject::Connection connect_global_saver(const Sender sender, const Signal signal, const Rest... receiver);
+
+    template<typename Sender, typename Signal, typename... Rest>
+    static QMetaObject::Connection connect_personal_saver(const Sender sender, const Signal signal, const Rest... receiver);
 };
+
+// Because these are template functions they must be included into the header, otherwise
+// the linker will not have references to the concrete instantiations of the template.
+#include "genericsettings.tpp"
 
 #endif

--- a/src/widget/form/settings/genericsettings.tpp
+++ b/src/widget/form/settings/genericsettings.tpp
@@ -1,0 +1,49 @@
+/*
+    Copyright © 2016 by The qTox Project
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "genericsettings.h"
+#include "src/persistence/settings.h"
+
+/*
+ * Convenience wrapper for ::connect that also creates a secondary
+ * connection to call `Settings::getInstance().saveGlobal();` after
+ * the requested callback.
+ */
+template<typename Sender, typename Signal, typename... Rest>
+QMetaObject::Connection GenericForm::connect_global_saver(const Sender sender, const Signal signal, const Rest... receiver)
+{
+    connect(sender, signal, receiver...);
+    return connect(sender, signal, []() {
+        Settings::getInstance().saveGlobal();
+    });
+}
+
+/*
+ * Convenience wrapper for ::connect that also creates a secondary
+ * connection to call `Settings::getInstance().savePersonal();` after
+ * the requested callback.
+ */
+template<typename Sender, typename Signal, typename... Rest>
+QMetaObject::Connection GenericForm::connect_personal_saver(const Sender sender, const Signal signal, const Rest... receiver)
+{
+    connect(sender, signal, receiver...);
+    return connect(sender, signal, []() {
+        Settings::getInstance().savePersonal();
+    });
+}

--- a/src/widget/form/settings/privacyform.cpp
+++ b/src/widget/form/settings/privacyform.cpp
@@ -39,8 +39,8 @@ PrivacyForm::PrivacyForm() :
     bodyUI = new Ui::PrivacySettings;
     bodyUI->setupUi(this);
 
-    connect(bodyUI->cbTypingNotification, SIGNAL(stateChanged(int)), this, SLOT(onTypingNotificationEnabledUpdated()));
-    connect(bodyUI->cbKeepHistory, SIGNAL(stateChanged(int)), this, SLOT(onEnableLoggingUpdated()));
+    connect_personal_saver(bodyUI->cbTypingNotification, &QCheckBox::stateChanged, this, &PrivacyForm::onTypingNotificationEnabledUpdated);
+    connect_personal_saver(bodyUI->cbKeepHistory, &QCheckBox::stateChanged, this, &PrivacyForm::onEnableLoggingUpdated);
     connect(bodyUI->nospamLineEdit, SIGNAL(editingFinished()), this, SLOT(setNospam()));
     connect(bodyUI->randomNosapamButton, SIGNAL(clicked()), this, SLOT(generateRandomNospam()));
     connect(bodyUI->nospamLineEdit, SIGNAL(textChanged(QString)), this, SLOT(onNospamEdit()));

--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -30,6 +30,7 @@
 #include "src/widget/tool/croppinglabel.h"
 #include "src/widget/style.h"
 #include "src/persistence/settings.h"
+#include "src/persistence/settingstransaction.h"
 #include "src/widget/widget.h"
 #include "src/widget/about/aboutuser.h"
 #include <QContextMenuEvent>
@@ -216,9 +217,16 @@ void FriendWidget::contextMenuEvent(QContextMenuEvent * event)
                 circleWidget->updateStatus();
 
             if (friendList != nullptr)
+            {
+                PersonalSettingsTransaction transaction;
+
                 friendList->addCircleWidget(FriendList::findFriend(friendId)->getFriendWidget());
+            }
             else
+            {
+                PersonalSettingsTransaction transaction;
                 Settings::getInstance().setFriendCircleID(id, Settings::getInstance().addCircle());
+            }
         }
         else if (groupActions.contains(selectedItem))
         {
@@ -413,9 +421,10 @@ void FriendWidget::mouseMoveEvent(QMouseEvent *ev)
 
 void FriendWidget::setAlias(const QString& _alias)
 {
+    PersonalSettingsTransaction transaction;
+
     QString alias = _alias.left(128); // same as TOX_MAX_NAME_LENGTH
     Friend* f = FriendList::findFriend(friendId);
     f->setAlias(alias);
     Settings::getInstance().setFriendAlias(f->getToxId(), alias);
-    Settings::getInstance().savePersonal();
 }


### PR DESCRIPTION
This prevents losing settings changes when qTox is terminated abnormally,
such as by power loss or crash.

issue #1969

I have another branch in progress with unix signal handlers to quit gracefully when the system is shutting down as well.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3192)

<!-- Reviewable:end -->
