### PR TITLE
fix(widget): properly show status messages

### DIFF
--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1018,9 +1018,7 @@ void Widget::onFriendStatusChanged(int friendId, Status status)
 
     ContentDialog::updateFriendStatus(friendId);
 
-    //won't print the message if there were no messages before
-    if (!f->getChatForm()->isEmpty()
-            && Settings::getInstance().getStatusChangeNotificationEnabled())
+    if (Settings::getInstance().getStatusChangeNotificationEnabled())
     {
         QString fStatus = "";
         switch (f->getStatus())


### PR DESCRIPTION
Fixes #3123 

Now we can see status updates without loading old messages.
