### PR TITLE
Show warning on failure to delete profile files

### DIFF
--- a/src/persistence/history.cpp
+++ b/src/persistence/history.cpp
@@ -42,9 +42,9 @@ void History::rename(const QString &newName)
     db.rename(getDbPath(newName));
 }
 
-void History::remove()
+bool History::remove()
 {
-    db.remove();
+    return db.remove();
 }
 
 void History::eraseHistory()

--- a/src/persistence/history.h
+++ b/src/persistence/history.h
@@ -47,7 +47,7 @@ public:
     /// Moves the database file on disk to match the new name
     void rename(const QString& newName);
     /// Deletes the on-disk database file
-    void remove();
+    bool remove();
 
     /// Erases all the chat history from the database
     void eraseHistory();
@@ -61,11 +61,11 @@ public:
     QList<HistMessage> getChatHistory(const QString& friendPk, const QDateTime &from, const QDateTime &to);
     /// Marks a message as sent, removing it from the faux-offline pending messages list
     void markAsSent(qint64 id);
-
+    /// Retrieves the path to the database file for a given profile.
+    static QString getDbPath(const QString& profileName);
 protected:
     /// Makes sure the history tables are created
     void init();
-    static QString getDbPath(const QString& profileName);
     QVector<RawDatabase::Query> generateNewMessageQueries(const QString& friendPk, const QString& message,
                                     const QString& sender, const QDateTime &time, bool isSent, QString dispName,
                                                           std::function<void(int64_t)> insertIdCallback={});

--- a/src/persistence/profile.cpp
+++ b/src/persistence/profile.cpp
@@ -483,12 +483,12 @@ bool Profile::isEncrypted(QString name)
     return tox_is_data_encrypted(data);
 }
 
-bool Profile::remove()
+QVector<QString> Profile::remove()
 {
     if (isRemoved)
     {
         qWarning() << "Profile " << name << " is already removed!";
-        return true;
+        return {};
     }
     isRemoved = true;
 
@@ -509,27 +509,27 @@ bool Profile::remove()
     QFile historyLegacyUnencrypted {HistoryKeeper::getHistoryPath(name, 0)};
     QFile historyLegacyEncrypted {HistoryKeeper::getHistoryPath(name, 1)};
 
-    bool isDeleted = true;
+    QVector<QString> ret;
 
     if(!profileMain.remove() && profileMain.exists())
     {
-        isDeleted = false;
+        ret.push_back(profileMain.fileName());
         qWarning() << "Could not remove file " << profileMain.fileName();
     }
     if(!profileConfig.remove() && profileConfig.exists())
     {
-        isDeleted = false;
+        ret.push_back(profileConfig.fileName());
         qWarning() << "Could not remove file " << profileConfig.fileName();
     }
 
     if(!historyLegacyUnencrypted.remove() && historyLegacyUnencrypted.exists())
     {
-        isDeleted = false;
+        ret.push_back(historyLegacyUnencrypted.fileName());
         qWarning() << "Could not remove file " << historyLegacyUnencrypted.fileName();
     }
     if(!historyLegacyEncrypted.remove() && historyLegacyEncrypted.exists())
     {
-        isDeleted = false;
+        ret.push_back(historyLegacyEncrypted.fileName());
         qWarning() << "Could not remove file " << historyLegacyUnencrypted.fileName();
     }
 
@@ -537,13 +537,13 @@ bool Profile::remove()
     {
         if(!history->remove() && QFile::exists(History::getDbPath(name)))
         {
-            isDeleted = false;
+            ret.push_back(History::getDbPath(name));
             qWarning() << "Could not remove file " << History::getDbPath(name);
         }
         history.release();
     }
 
-    return isDeleted;
+    return ret;
 }
 
 bool Profile::rename(QString newName)

--- a/src/persistence/profile.cpp
+++ b/src/persistence/profile.cpp
@@ -483,12 +483,12 @@ bool Profile::isEncrypted(QString name)
     return tox_is_data_encrypted(data);
 }
 
-void Profile::remove()
+bool Profile::remove()
 {
     if (isRemoved)
     {
         qWarning() << "Profile " << name << " is already removed!";
-        return;
+        return true;
     }
     isRemoved = true;
 
@@ -509,21 +509,27 @@ void Profile::remove()
     QFile historyLegacyUnencrypted {HistoryKeeper::getHistoryPath(name, 0)};
     QFile historyLegacyEncrypted {HistoryKeeper::getHistoryPath(name, 1)};
 
+    bool isDeleted = true;
+
     if(!profileMain.remove() && profileMain.exists())
     {
+        isDeleted = false;
         qWarning() << "Could not remove file " << profileMain.fileName();
     }
     if(!profileConfig.remove() && profileConfig.exists())
     {
+        isDeleted = false;
         qWarning() << "Could not remove file " << profileConfig.fileName();
     }
 
     if(!historyLegacyUnencrypted.remove() && historyLegacyUnencrypted.exists())
     {
+        isDeleted = false;
         qWarning() << "Could not remove file " << historyLegacyUnencrypted.fileName();
     }
     if(!historyLegacyEncrypted.remove() && historyLegacyEncrypted.exists())
     {
+        isDeleted = false;
         qWarning() << "Could not remove file " << historyLegacyUnencrypted.fileName();
     }
 
@@ -531,10 +537,13 @@ void Profile::remove()
     {
         if(!history->remove() && QFile::exists(History::getDbPath(name)))
         {
+            isDeleted = false;
             qWarning() << "Could not remove file " << History::getDbPath(name);
         }
         history.release();
     }
+
+    return isDeleted;
 }
 
 bool Profile::rename(QString newName)

--- a/src/persistence/profile.h
+++ b/src/persistence/profile.h
@@ -78,7 +78,8 @@ public:
     /// Removes the profile permanently
     /// It is invalid to call loadToxSave or saveToxSave on a deleted profile
     /// Updates the profiles vector
-    void remove();
+    /// Returns true if the underlying profile files were removed, false otherwise.
+    bool remove();
 
     /// Tries to rename the profile
     bool rename(QString newName);

--- a/src/persistence/profile.h
+++ b/src/persistence/profile.h
@@ -78,8 +78,8 @@ public:
     /// Removes the profile permanently
     /// It is invalid to call loadToxSave or saveToxSave on a deleted profile
     /// Updates the profiles vector
-    /// Returns true if the underlying profile files were removed, false otherwise.
-    bool remove();
+    /// Returns a vector of filenames that could not be removed.
+    QVector<QString> remove();
 
     /// Tries to rename the profile
     bool rename(QString newName);

--- a/src/widget/form/profileform.cpp
+++ b/src/widget/form/profileform.cpp
@@ -361,7 +361,12 @@ void ProfileForm::onDeleteClicked()
                 tr("Are you sure you want to delete this profile?", "deletion confirmation text")))
     {
         Nexus& nexus = Nexus::getInstance();
-        nexus.getProfile()->remove();
+
+        if(!nexus.getProfile()->remove())
+        {
+            GUI::showError(tr("Files could not be deleted!"), tr("Some files could not be deleted, please manually remove them."));
+        }
+
         nexus.showLogin();
     }
 }

--- a/src/widget/form/profileform.cpp
+++ b/src/widget/form/profileform.cpp
@@ -362,9 +362,20 @@ void ProfileForm::onDeleteClicked()
     {
         Nexus& nexus = Nexus::getInstance();
 
-        if(!nexus.getProfile()->remove())
+        QVector<QString> manualDeleteFiles = nexus.getProfile()->remove();
+
+        if(!manualDeleteFiles.empty())
         {
-            GUI::showError(tr("Files could not be deleted!"), tr("Some files could not be deleted, please manually remove them."));
+            QString message = tr("The following files could not be deleted:", "deletion failed text part 1") + "\n\n";
+
+            for(auto& file : manualDeleteFiles)
+            {
+                message = message + file + "\n";
+            }
+
+            message = message + "\n" + tr("Please manually remove them.", "deletion failed text part 2");
+
+            GUI::showError(tr("Files could not be deleted!", "deletion failed title"), message);
         }
 
         nexus.showLogin();


### PR DESCRIPTION
This PR adds warnings if Qt was unable to successfully delete a profile file (.tox, .ini, .db, etc). Potentially allowing users to perform manual deletion (or, in the case of bug reports regarding profile deletion [e.g. issue #3209], allows us to verify correct operation).
