### PR TITLE
Prevent right click from opening chat window

### DIFF
--- a/src/widget/genericchatroomwidget.cpp
+++ b/src/widget/genericchatroomwidget.cpp
@@ -181,9 +181,16 @@ void GenericChatroomWidget::reloadTheme()
     setPalette(p);
 }
 
-void GenericChatroomWidget::mouseReleaseEvent(QMouseEvent*)
+void GenericChatroomWidget::mouseReleaseEvent(QMouseEvent* event)
 {
-    emit chatroomWidgetClicked(this);
+    if(event->button() == Qt::LeftButton)
+    {
+        emit chatroomWidgetClicked(this);
+    }
+    else
+    {
+        event->ignore();
+    }
 }
 
 void GenericChatroomWidget::enterEvent(QEvent*)


### PR DESCRIPTION
Prevent a right click mouse release event from triggering a chat window switch/launch under Windows. This solves the issue where opening a context menu simultaneously causes a switch to (or in the case of multi window mode, launching of) the chat window under selection.

This PR closes issue #3205
