### PR TITLE
fix(settings): make it clear that `Markdown` is about text formatting

### DIFF
--- a/src/widget/form/settings/generalsettings.ui
+++ b/src/widget/form/settings/generalsettings.ui
@@ -367,7 +367,7 @@ instead of closing itself.</string>
                <string>New Markdown preference may not load until qTox restarts.</string>
               </property>
               <property name="text">
-               <string>Markdown:</string>
+               <string>Text formatting (Markdown):</string>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
Without change:
![without change](https://cloud.githubusercontent.com/assets/3148759/14882947/4b5c29a2-0d33-11e6-8b23-dd0e630d16fb.png)

With change:
![with change](https://cloud.githubusercontent.com/assets/3148759/14882937/3c35d3ce-0d33-11e6-95a4-83d69a53067c.png)
