### PR TITLE
fix(widget):show unread messages notification

### DIFF
--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1204,6 +1204,7 @@ bool Widget::newFriendMessageAlert(int friendId, bool sound)
     {
         f->setEventFlag(true);
         f->getFriendWidget()->updateStatusLight();
+        ui->friendList->trackWidget(f->getFriendWidget());
 
         if (contentDialog == nullptr)
         {


### PR DESCRIPTION
fix #3193
shows notification about unread messages from contacts that are not displayed in the current view
