### PR TITLE
fix(i18n): remove duplicated text with HTML tags from translations

### DIFF
--- a/src/widget/form/settings/aboutsettings.ui
+++ b/src/widget/form/settings/aboutsettings.ui
@@ -319,9 +319,6 @@ p, li { white-space: pre-wrap; }
               <family>Sans Serif</family>
              </font>
             </property>
-            <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;A list of all known issues may be found at our &lt;a href=&quot;https://github.com/tux3/qTox/issues&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;bug-tracker&lt;/span&gt;&lt;/a&gt; at Github. If you discover a bug or security vulnerability within qTox, please &lt;a href=&quot;https://github.com/tux3/qTox/issues/new?body=%0A%0A%0A%0A---%0A%0AqTox:+$GIT_DESCRIBE%0ACommit+hash:+$GIT_VERSION%0Atoxcore:+$TOXCOREVERSION%0AQt:+$QTVERSION%0AOS+version:&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;report it&lt;/span&gt;&lt;/a&gt; according to the guidelines in our &lt;a href=&quot;https://github.com/tux3/qTox/wiki/Writing-Useful-Bug-Reports&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Writing Useful Bug Reports&lt;/span&gt;&lt;/a&gt; wiki article.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
             <property name="wordWrap">
              <bool>true</bool>
             </property>


### PR DESCRIPTION
Starting from d121bd839b1ca36f201b79a9ce9cef3a78ce72e0 this string is
being set from .cpp, thus there's no need to keep a duplicate with HTML
tags that make it harder to translate in .ui file.

Duplicate pointed out in #3223 by @verycrypt.
