### PR TITLE
Delete widget from traced widgets list after reading message

### DIFF
--- a/src/widget/contentdialog.cpp
+++ b/src/widget/contentdialog.cpp
@@ -484,18 +484,18 @@ bool ContentDialog::event(QEvent* event)
                 updateTitle(activeChatroomWidget);
 
                 Friend* frnd = activeChatroomWidget->getFriend();
+                Group* group = activeChatroomWidget->getGroup();
+
+                GenericChatroomWidget *widget = nullptr;
 
                 if (frnd)
-                {
-                    frnd->getFriendWidget()->resetEventFlags();
-                    frnd->getFriendWidget()->updateStatusLight();
-                }
+                    widget = frnd->getFriendWidget();
                 else
-                {
-                    Group* g = activeChatroomWidget->getGroup();
-                    g->getGroupWidget()->resetEventFlags();
-                    g->getGroupWidget()->updateStatusLight();
-                }
+                    widget = group->getGroupWidget();
+
+                widget->resetEventFlags();
+                widget->updateStatusLight();
+
                 Widget::getInstance()->resetIcon();
             }
 

--- a/src/widget/contentdialog.cpp
+++ b/src/widget/contentdialog.cpp
@@ -496,6 +496,7 @@ bool ContentDialog::event(QEvent* event)
                 widget->resetEventFlags();
                 widget->updateStatusLight();
 
+                Widget::getInstance()->updateScroll(widget);
                 Widget::getInstance()->resetIcon();
             }
 

--- a/src/widget/notificationscrollarea.cpp
+++ b/src/widget/notificationscrollarea.cpp
@@ -25,8 +25,8 @@
 NotificationScrollArea::NotificationScrollArea(QWidget* parent)
     : AdjustingScrollArea(parent)
 {
-    connect(verticalScrollBar(), &QAbstractSlider::valueChanged, this, &NotificationScrollArea::updateTracking);
-    connect(verticalScrollBar(), &QAbstractSlider::rangeChanged, this, &NotificationScrollArea::updateTracking);
+    connect(verticalScrollBar(), &QAbstractSlider::valueChanged, this, &NotificationScrollArea::updateVisualTracking);
+    connect(verticalScrollBar(), &QAbstractSlider::rangeChanged, this, &NotificationScrollArea::updateVisualTracking);
 }
 
 void NotificationScrollArea::trackWidget(GenericChatroomWidget* widget)
@@ -66,12 +66,23 @@ void NotificationScrollArea::trackWidget(GenericChatroomWidget* widget)
     }
 }
 
-void NotificationScrollArea::updateTracking()
+/**
+ * @brief Delete notification bar to visible elements on scroll area
+ */
+void NotificationScrollArea::updateVisualTracking() {
+    updateTracking(nullptr);
+}
+
+/**
+ * @brief Delete notification bar from visible elements and widget on scroll area
+ * @param widget Chatroom widget to remove from tracked widgets
+ */
+void NotificationScrollArea::updateTracking(GenericChatroomWidget *widget)
 {
     QHash<GenericChatroomWidget*, Visibility>::iterator i = trackedWidgets.begin();
     while (i != trackedWidgets.end())
     {
-        if (widgetVisible(i.key()) == Visible)
+        if (i.key() == widget || widgetVisible(i.key()) == Visible)
         {
             if (i.value() == Above)
             {

--- a/src/widget/notificationscrollarea.h
+++ b/src/widget/notificationscrollarea.h
@@ -33,7 +33,8 @@ public:
 
 public slots:
     void trackWidget(GenericChatroomWidget* widget);
-    void updateTracking();
+    void updateVisualTracking();
+    void updateTracking(GenericChatroomWidget *widget);
 
 protected:
     void resizeEvent(QResizeEvent *event) final override;

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1386,6 +1386,11 @@ void Widget::clearContactsList()
         removeGroup(g, true);
 }
 
+void Widget::updateScroll(GenericChatroomWidget *widget) {
+    ui->friendList->updateTracking(widget);
+}
+
+
 ContentDialog* Widget::createContentDialog() const
 {
     ContentDialog* contentDialog = new ContentDialog(settingsWidget);
@@ -1682,6 +1687,9 @@ bool Widget::event(QEvent * e)
         case QEvent::MouseButtonPress:
         case QEvent::MouseButtonDblClick:
             focusChatInput();
+            break;
+        case QEvent::Paint:
+            ui->friendList->updateVisualTracking();
             break;
         case QEvent::WindowActivate:
             if (activeChatroomWidget != nullptr)

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -75,6 +75,7 @@ public:
     bool getIsWindowMinimized();
     void updateIcons();
     void clearContactsList();
+    void updateScroll(GenericChatroomWidget *widget);
 
     enum DialogType
     {


### PR DESCRIPTION
Added public method Wigdet::updateScroll, which needed to update "Unread message" bar.

Fix #2247.
