### PR TITLE
Enable HiDPI support if Qt supports it

### DIFF
--- a/qtox.pro
+++ b/qtox.pro
@@ -108,11 +108,6 @@ contains(DISABLE_FILTER_AUDIO, NO) {
      DEFINES += QTOX_FILTER_AUDIO
 }
 
-contains(HIGH_DPI, YES) {
-    QT_DEVICE_PIXEL_RATIO= auto
-    DEFINES += HIGH_DPI
-}
-
 contains(JENKINS,YES) {
     INCLUDEPATH += ./libs/include/
 } else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -117,6 +117,12 @@ void logMessageHandler(QtMsgType type, const QMessageLogContext& ctxt, const QSt
 
 int main(int argc, char *argv[])
 {
+
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
+    QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    QGuiApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+#endif
+
     qInstallMessageHandler(logMessageHandler);
 
     QApplication a(argc, argv);
@@ -127,10 +133,6 @@ int main(int argc, char *argv[])
 #if defined(Q_OS_OSX)
     //osx::moveToAppFolder(); TODO: Add setting to enable this feature.
     osx::migrateProfiles();
-#endif
-
-#ifdef HIGH_DPI
-    a.setAttribute(Qt::AA_UseHighDpiPixmaps, true);
 #endif
 
     qsrand(time(0));


### PR DESCRIPTION
Previously HiDPI support is conditionally enabled based on compilation parameters as well as environmental variables which makes binary distribution difficult as it requires users to either manually recompile from source and/or set environmental variables/use command-line parameters to fully enable HiDPI.

This PR automatically uses Qt's runtime HiDPI scaling as introduced with Qt 5.6, allowing automatic scaling of the application as necessary.
