### PR TITLE
feat(widget): Disable sound notification for `busy` status

### DIFF
--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -171,6 +171,7 @@ void Settings::loadGlobal()
         showWindow = s.value("showWindow", true).toBool();
         showInFront = s.value("showInFront", false).toBool();
         notifySound = s.value("notifySound", true).toBool();
+        busySound = s.value("busySound", false).toBool();
         groupAlwaysNotify = s.value("groupAlwaysNotify", false).toBool();
         fauxOfflineMessaging = s.value("fauxOfflineMessaging", true).toBool();
         autoSaveEnabled = s.value("autoSaveEnabled", false).toBool();
@@ -417,6 +418,7 @@ void Settings::saveGlobal()
         s.setValue("showWindow", showWindow);
         s.setValue("showInFront", showInFront);
         s.setValue("notifySound", notifySound);
+        s.setValue("busySound", busySound);
         s.setValue("groupAlwaysNotify", groupAlwaysNotify);
         s.setValue("fauxOfflineMessaging", fauxOfflineMessaging);
         s.setValue("separateWindow", separateWindow);
@@ -826,6 +828,18 @@ void Settings::setNotifySound(bool newValue)
 {
     QMutexLocker locker{&bigLock};
     notifySound = newValue;
+}
+
+bool Settings::getBusySound() const
+{
+    QMutexLocker locker{&bigLock};
+    return busySound;
+}
+
+void Settings::setBusySound(bool newValue)
+{
+    QMutexLocker locker{&bigLock};
+    busySound = newValue;
 }
 
 bool Settings::getGroupAlwaysNotify() const

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -169,6 +169,9 @@ public:
     bool getNotifySound() const;
     void setNotifySound(bool newValue);
 
+    bool getBusySound() const;
+    void setBusySound(bool newValue);
+
     bool getGroupAlwaysNotify() const;
     void setGroupAlwaysNotify(bool newValue);
 
@@ -372,6 +375,7 @@ private:
     bool showWindow;
     bool showInFront;
     bool notifySound;
+    bool busySound;
     bool groupAlwaysNotify;
 
     bool forceTCP;

--- a/src/widget/form/settings/generalform.cpp
+++ b/src/widget/form/settings/generalform.cpp
@@ -138,7 +138,12 @@ GeneralForm::GeneralForm(SettingsWidget *myParent) :
     bodyUI->showWindow->setChecked(showWindow);
     bodyUI->showInFront->setChecked(Settings::getInstance().getShowInFront());
     bodyUI->showInFront->setEnabled(showWindow);
-    bodyUI->notifySound->setChecked(Settings::getInstance().getNotifySound());
+
+    bool notifySound = Settings::getInstance().getNotifySound();
+
+    bodyUI->notifySound->setChecked(notifySound);
+    bodyUI->busySound->setChecked(Settings::getInstance().getBusySound());
+    bodyUI->busySound->setEnabled(notifySound);
     bodyUI->groupAlwaysNotify->setChecked(Settings::getInstance().getGroupAlwaysNotify());
     bodyUI->cbFauxOfflineMessaging->setChecked(Settings::getInstance().getFauxOfflineMessaging());
     bodyUI->cbCompactLayout->setChecked(Settings::getInstance().getCompactLayout());
@@ -217,6 +222,7 @@ GeneralForm::GeneralForm(SettingsWidget *myParent) :
     connect(bodyUI->showWindow, &QCheckBox::stateChanged, this, &GeneralForm::onShowWindowChanged);
     connect(bodyUI->showInFront, &QCheckBox::stateChanged, this, &GeneralForm::onSetShowInFront);
     connect(bodyUI->notifySound, &QCheckBox::stateChanged, this, &GeneralForm::onSetNotifySound);
+    connect(bodyUI->busySound, &QCheckBox::stateChanged, this, &GeneralForm::onSetBusySound);
     connect(bodyUI->markdownComboBox, &QComboBox::currentTextChanged, this, &GeneralForm::onMarkdownUpdated);
     connect(bodyUI->groupAlwaysNotify, &QCheckBox::stateChanged, this, &GeneralForm::onSetGroupAlwaysNotify);
     connect(bodyUI->autoacceptFiles, &QCheckBox::stateChanged, this, &GeneralForm::onAutoAcceptFileChange);
@@ -487,6 +493,11 @@ void GeneralForm::onSetShowInFront()
 void GeneralForm::onSetNotifySound()
 {
     Settings::getInstance().setNotifySound(bodyUI->notifySound->isChecked());
+}
+
+void GeneralForm::onSetBusySound()
+{
+    Settings::getInstance().setBusySound(bodyUI->busySound->isChecked());
 }
 
 void GeneralForm::onSetGroupAlwaysNotify()

--- a/src/widget/form/settings/generalform.h
+++ b/src/widget/form/settings/generalform.h
@@ -65,6 +65,7 @@ private slots:
     void onShowWindowChanged();
     void onSetShowInFront();
     void onSetNotifySound();
+    void onSetBusySound();
     void onSetGroupAlwaysNotify();
     void onFauxOfflineMessaging();
     void onCompactLayout();

--- a/src/widget/form/settings/generalsettings.ui
+++ b/src/widget/form/settings/generalsettings.ui
@@ -39,8 +39,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>1278</width>
-        <height>1413</height>
+        <width>1270</width>
+        <height>1468</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,0,0,1">
@@ -327,6 +327,20 @@ instead of closing itself.</string>
                  <string>Play sound</string>
                 </property>
                </widget>
+              </item>
+              <item>
+               <layout class="QVBoxLayout" name="verticalLayout_13">
+                <property name="leftMargin">
+                 <number>40</number>
+                </property>
+                <item>
+                 <widget class="QCheckBox" name="busySound">
+                  <property name="text">
+                   <string>Play sound while Busy</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
               </item>
               <item>
                <widget class="QCheckBox" name="showWindow">
@@ -952,6 +966,22 @@ will be sent to them when they appear online to you.</string>
     <hint type="destinationlabel">
      <x>119</x>
      <y>177</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>notifySound</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>busySound</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>665</x>
+     <y>522</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>684</x>
+     <y>551</y>
     </hint>
    </hints>
   </connection>

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1294,7 +1294,9 @@ bool Widget::newMessageAlert(QWidget* currentWindow, bool isActive, bool sound, 
                 currentWindow->activateWindow();
         }
 
-        if (Settings::getInstance().getNotifySound() && sound)
+        bool isBusy = Nexus::getCore()->getStatus() == Status::Busy;
+
+        if (Settings::getInstance().getNotifySound() && sound && !isBusy)
             Audio::getInstance().playMono16Sound(QStringLiteral(":/audio/notification.pcm"));
     }
 

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1295,8 +1295,10 @@ bool Widget::newMessageAlert(QWidget* currentWindow, bool isActive, bool sound, 
         }
 
         bool isBusy = Nexus::getCore()->getStatus() == Status::Busy;
+        bool busySound = Settings::getInstance().getBusySound();
+        bool notifySound = Settings::getInstance().getNotifySound();
 
-        if (Settings::getInstance().getNotifySound() && sound && !isBusy)
+        if (notifySound && sound && (!isBusy || busySound))
             Audio::getInstance().playMono16Sound(QStringLiteral(":/audio/notification.pcm"));
     }
 


### PR DESCRIPTION
Fix #2893.

BREAKING CHANGE: Disabling notification sound for `busy` status
