### PR TITLE
[WIP] Added drag and drop remote file

### DIFF
--- a/src/widget/form/chatform.h
+++ b/src/widget/form/chatform.h
@@ -121,6 +121,7 @@ private:
     void disableCallButtons();
     bool isTyping;
     void SendMessageStr(QString msg);
+    QString downloadFile(QString url);
 };
 
 #endif // CHATFORM_H

--- a/src/widget/form/chatform.h
+++ b/src/widget/form/chatform.h
@@ -52,8 +52,9 @@ public:
     virtual void show(ContentLayout* contentLayout) final override;
 
 signals:
-    void sendFile(uint32_t friendId, QString, QString, long long);
+    void sendFile(uint32_t friendId, QString filename, QString filePath, long long filesize);
     void aliasChanged(const QString& alias);
+    void remoteFileDropped(const QString& url);
 
 public slots:
     void startFileSend(ToxFile file);
@@ -85,6 +86,7 @@ private slots:
     void doScreenshot();
     void onMessageInserted();
     void onCopyStatusMessage();
+    void onRemoteFileDropped(const QString &url);
 
 private:
     void retranslateUi();


### PR DESCRIPTION
When drag'n'drop remote file in qTox chat it will be downloaded in temporary directory and sent from it.

Fix #1276.
