### PR TITLE
fix(bootstrap.sh):Re-add /usr/local/locallibs

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -170,8 +170,8 @@ if [[ $INSTALL_TOX = "true" ]]; then
         make install
     else
         sudo make install
-    echo '/usr/local/lib/' | sudo tee -a /etc/ld.so.conf.d/locallib.conf
-	sudo ldconfig
+    	 echo '/usr/local/lib/' | sudo tee -a /etc/ld.so.conf.d/locallib.conf
+	 sudo ldconfig
     fi
 
     popd

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -170,7 +170,8 @@ if [[ $INSTALL_TOX = "true" ]]; then
         make install
     else
         sudo make install
-        sudo ldconfig
+    	echo '/usr/local/lib/' | sudo tee -a /etc/ld.so.conf.d/locallib.conf
+	sudo ldconfig
     fi
 
     popd

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -170,7 +170,7 @@ if [[ $INSTALL_TOX = "true" ]]; then
         make install
     else
         sudo make install
-    	echo '/usr/local/lib/' | sudo tee -a /etc/ld.so.conf.d/locallib.conf
+    echo '/usr/local/lib/' | sudo tee -a /etc/ld.so.conf.d/locallib.conf
 	sudo ldconfig
     fi
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -170,8 +170,8 @@ if [[ $INSTALL_TOX = "true" ]]; then
         make install
     else
         sudo make install
-    	 echo '/usr/local/lib/' | sudo tee -a /etc/ld.so.conf.d/locallib.conf
-	 sudo ldconfig
+    	    echo '/usr/local/lib/' | sudo tee -a /etc/ld.so.conf.d/locallib.conf
+	sudo ldconfig
     fi
 
     popd


### PR DESCRIPTION
Somewhere in the  optimization of bootstrap.sh recently  the  following line as removed:

> ```
> echo '/usr/local/lib/' | sudo tee -a /etc/ld.so.conf.d/locallib.conf
> ```

This  commit  reverts that omission so  a  compile  works properly  after  a  sudo make install && qtox &
