### PR TITLE
fix(profile): change password buttons behaviour

### DIFF
--- a/src/widget/form/profileform.cpp
+++ b/src/widget/form/profileform.cpp
@@ -393,15 +393,15 @@ void ProfileForm::onLogoutClicked()
 
 void ProfileForm::setPasswordButtonsText()
 {
-    if (!Nexus::getProfile()->isEncrypted())
-    {
-        bodyUI->changePassButton->setText(tr("Set profile password", "button text"));
-        bodyUI->deletePassButton->setVisible(false);
-    }
-    else
+    if (Nexus::getProfile()->isEncrypted())
     {
         bodyUI->changePassButton->setText(tr("Change password", "button text"));
         bodyUI->deletePassButton->setVisible(true);
+    }
+    else
+    {
+        bodyUI->changePassButton->setText(tr("Set profile password", "button text"));
+        bodyUI->deletePassButton->setVisible(false);
     }
 }
 

--- a/src/widget/form/profileform.cpp
+++ b/src/widget/form/profileform.cpp
@@ -122,6 +122,8 @@ ProfileForm::ProfileForm(QWidget *parent) :
     connect(bodyUI->logoutButton, &QPushButton::clicked, this, &ProfileForm::onLogoutClicked);
     connect(bodyUI->deletePassButton, &QPushButton::clicked, this, &ProfileForm::onDeletePassClicked);
     connect(bodyUI->changePassButton, &QPushButton::clicked, this, &ProfileForm::onChangePassClicked);
+    connect(bodyUI->deletePassButton, &QPushButton::clicked, this, &ProfileForm::setPasswordButtonsText);
+    connect(bodyUI->changePassButton, &QPushButton::clicked, this, &ProfileForm::setPasswordButtonsText);
     connect(bodyUI->saveQr, &QPushButton::clicked, this, &ProfileForm::onSaveQrClicked);
     connect(bodyUI->copyQr, &QPushButton::clicked, this, &ProfileForm::onCopyQrClicked);
     connect(bodyUI->toxmeRegisterButton, &QPushButton::clicked, this, &ProfileForm::onRegisterButtonClicked);
@@ -389,6 +391,20 @@ void ProfileForm::onLogoutClicked()
     nexus.showLogin();
 }
 
+void ProfileForm::setPasswordButtonsText()
+{
+    if (!Nexus::getProfile()->isEncrypted())
+    {
+        bodyUI->changePassButton->setText(tr("Set profile password", "button text"));
+        bodyUI->deletePassButton->setVisible(false);
+    }
+    else
+    {
+        bodyUI->changePassButton->setText(tr("Change password", "button text"));
+        bodyUI->deletePassButton->setVisible(true);
+    }
+}
+
 void ProfileForm::onCopyQrClicked()
 {
     QApplication::clipboard()->setImage(*qr->getImage());
@@ -444,6 +460,7 @@ void ProfileForm::retranslateUi()
 {
     bodyUI->retranslateUi(this);
     nameLabel->setText(tr("User Profile"));
+    setPasswordButtonsText();
     // We have to add the toxId tooltip here and not in the .ui or Qt won't know how to translate it dynamically
     toxId->setToolTip(tr("This bunch of characters tells other Tox clients how to contact you.\nShare it with your friends to communicate."));
 }

--- a/src/widget/form/profileform.h
+++ b/src/widget/form/profileform.h
@@ -67,6 +67,7 @@ public slots:
     void onLogoutClicked();
 
 private slots:
+    void setPasswordButtonsText();
     void setToxId(const QString& id);
     void copyIdClicked();
     void onUserNameEdited();


### PR DESCRIPTION
When profile is encrypted:
![1](https://cloud.githubusercontent.com/assets/12549653/15268264/f82bcbca-19e9-11e6-93d9-6c13e64be1cc.png)
Not encrypted:
![2](https://cloud.githubusercontent.com/assets/12549653/15268265/f82e1e2a-19e9-11e6-8096-cb3bde889b50.png)

Closes #3300
