### PR TITLE
refactor(audio): remove obsolete signal "groupAudioPlayed"

### DIFF
--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -93,7 +93,6 @@ public:
     static constexpr uint32_t AUDIO_CHANNELS = 2;
 
 signals:
-    void groupAudioPlayed(int group, int peer, unsigned short volume);
     void frameAvailable(const int16_t *pcm, size_t sample_count, uint8_t channels, uint32_t sampling_rate);
 
 private:

--- a/src/video/groupnetcamview.cpp
+++ b/src/video/groupnetcamview.cpp
@@ -140,22 +140,20 @@ GroupNetCamView::GroupNetCamView(int group, QWidget *parent)
     splitter->addWidget(scrollArea);
     scrollArea->setWidget(widget);
 
-    connect(&Audio::getInstance(), &Audio::groupAudioPlayed, this, &GroupNetCamView::groupAudioPlayed);
-
     QTimer* timer = new QTimer(this);
     timer->setInterval(1000);
-    connect(timer, &QTimer::timeout, this, &GroupNetCamView::findActivePeer);
+    connect(timer, &QTimer::timeout, this, &GroupNetCamView::onUpdateActivePeer);
     timer->start();
 
     connect(Core::getInstance(), &Core::selfAvatarChanged, [this](const QPixmap& pixmap)
     {
         selfVideoSurface->getVideoSurface()->setAvatar(pixmap);
-        findActivePeer();
+        setActive();
     });
     connect(Core::getInstance(), &Core::usernameSet, [this](const QString& username)
     {
         selfVideoSurface->setText(username);
-        findActivePeer();
+        setActive();
     });
     connect(Core::getInstance(), &Core::friendAvatarChanged, this, &GroupNetCamView::friendAvatarChanged);
 
@@ -180,7 +178,7 @@ void GroupNetCamView::addPeer(int peer, const QString& name)
     peerVideo.video = labeledVideo;
     videoList.insert(peer, peerVideo);
 
-    findActivePeer();
+    setActive();
 }
 
 void GroupNetCamView::removePeer(int peer)
@@ -194,8 +192,13 @@ void GroupNetCamView::removePeer(int peer)
         labeledVideo->deleteLater();
         videoList.remove(peer);
 
-        findActivePeer();
+        setActive();
     }
+}
+
+void GroupNetCamView::onUpdateActivePeer()
+{
+    setActive();
 }
 
 void GroupNetCamView::setActive(int peer)
@@ -228,34 +231,6 @@ void GroupNetCamView::setActive(int peer)
     }
 }
 
-void GroupNetCamView::groupAudioPlayed(int Group, int peer, unsigned short volume)
-{
-    if (group != Group)
-        return;
-
-    auto peerVideo = videoList.find(peer);
-
-    if (peerVideo != videoList.end())
-        peerVideo.value().volume = volume;
-}
-
-void GroupNetCamView::findActivePeer()
-{
-    int candidate = -1;
-    int maximum = 0;
-
-    for (auto peer = videoList.begin(); peer != videoList.end(); ++peer)
-    {
-        if (peer.value().volume > maximum)
-        {
-            maximum = peer.value().volume;
-            candidate = peer.key();
-        }
-    }
-
-    setActive(candidate);
-}
-
 void GroupNetCamView::friendAvatarChanged(int FriendId, const QPixmap &pixmap)
 {
     Friend* f = FriendList::findFriend(FriendId);
@@ -269,7 +244,7 @@ void GroupNetCamView::friendAvatarChanged(int FriendId, const QPixmap &pixmap)
             if (peerVideo != videoList.end())
             {
                 peerVideo.value().video->getVideoSurface()->setAvatar(pixmap);
-                findActivePeer();
+                setActive();
             }
 
             break;

--- a/src/video/groupnetcamview.h
+++ b/src/video/groupnetcamview.h
@@ -38,17 +38,16 @@ public slots:
     void groupAudioPlayed(int group, int peer, unsigned short volume);
 
 private slots:
-    void findActivePeer();
+    void onUpdateActivePeer();
     void friendAvatarChanged(int FriendId, const QPixmap& pixmap);
 
 private:
     struct PeerVideo
     {
         LabeledVideo* video;
-        unsigned short volume = 0;
     };
 
-    void setActive(int peer);
+    void setActive(int peer = -1);
 
     QHBoxLayout* horLayout;
     QMap<int, PeerVideo> videoList;


### PR DESCRIPTION
Removed the unconnected (broken) and now obsolete `Audio::groupAudioPlayed` signal, which got replaced by the single `Core::groupAudioPlaying` signal. This signal is emitted correctly from within `CoreAV::groupCallCallback`.

Following the code flow, I found the former implementation is pretty much bullshit and - for whatever reason - the "active (group & audio & video) peer" was assumed to be the "loudest" peer. This is completely wrong. However if anyone gets the intention behind this, I'd be glad to hear about what it should actually do and I'll do my very best to reimplement it.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3309)

<!-- Reviewable:end -->
