### PR TITLE
feat(widget): add support for QtKeychain to store/retrieve passwords

### DIFF
--- a/.travis/build-ubuntu-14-04.sh
+++ b/.travis/build-ubuntu-14-04.sh
@@ -51,6 +51,18 @@ sudo apt-get install -y --force-yes \
 # Qt
 source /opt/qt53/bin/qt53-env.sh || yes
 
+# QtKeychain
+QTKEYCHAIN_VERSION=0.6.2
+wget https://github.com/frankosterfeld/qtkeychain/archive/v${QTKEYCHAIN_VERSION}.tar.gz -O QtKeychain-${QTKEYCHAIN_VERSION}.tar.gz
+tar xf QtKeychain-${QTKEYCHAIN_VERSION}.tar.gz
+cd qtkeychain-${QTKEYCHAIN_VERSION}
+cmake -DCMAKE_INSTALL_PREFIX:PATH="/usr/local"
+make -j$(nproc)
+# Translations get installed into Qt5's directory structure,
+# thus root/sudo permissions necessary
+sudo make install
+cd ..
+
 # ffmpeg
 if [ ! -e "libs" ]; then mkdir libs; fi
 if [ ! -e "ffmpeg" ]; then mkdir ffmpeg; fi
@@ -127,7 +139,7 @@ export PKG_CONFIG_PATH="$PWD/libs/lib/pkgconfig"
 
 # first build qTox without support for optional dependencies
 echo '*** BUILDING "MINIMAL" VERSION ***'
-qmake qtox.pro QMAKE_CC="$CC" QMAKE_CXX="$CXX" ENABLE_SYSTRAY_STATUSNOTIFIER_BACKEND=NO ENABLE_SYSTRAY_GTK_BACKEND=NO DISABLE_PLATFORM_EXT=YES
+qmake qtox.pro QMAKE_CC="$CC" QMAKE_CXX="$CXX" ENABLE_SYSTRAY_STATUSNOTIFIER_BACKEND=NO ENABLE_SYSTRAY_GTK_BACKEND=NO DISABLE_PLATFORM_EXT=YES DISABLE_QTKEYCHAIN=YES
 # ↓ with $(nproc) fails, since travis gives 32 threads, and it leads to OOM
 make -j10
 # clean it up, and build normal version

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -50,6 +50,7 @@
 | libXScrnSaver | >= 1.2      |                                                   |
 | pkg-config    | >= 0.28     |                                                   |
 | libX11        | >= 1.6.0    |                                                   |
+| QtKeychain    | >= 0.6.2    |                                                   |
 
 
 <a name="linux" />

--- a/osx/qTox-Mac-Deployer-ULTIMATE.sh
+++ b/osx/qTox-Mac-Deployer-ULTIMATE.sh
@@ -104,6 +104,9 @@ function install() {
 		fcho "Installing homebrew ..."
 		ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 	fi
+	fcho "Adding ownCloud's repository"
+	# ...  to get 'qtkeychain'
+	brew tap owncloud/owncloud
 	if [[ $TRAVIS != true ]]; then
 		fcho "Updating brew formulas ..."
 		brew update
@@ -158,7 +161,7 @@ function install() {
 		fcho "Updating brew formulas ..."
 		brew update > /dev/null
 	fi
-	brew install ffmpeg qrencode qt5 sqlcipher
+	brew install ffmpeg qrencode qt5 sqlcipher qtkeychain
 
 	QT_VER=($(ls ${QT_DIR} | sed -n -e 's/^\([0-9]*\.([0-9]*\.([0-9]*\).*/\1/' -e '1p;$p'))
 	QT_DIR_VER="${QT_DIR}/${QT_VER[1]}"

--- a/qtox.pro
+++ b/qtox.pro
@@ -69,6 +69,25 @@ contains(DISABLE_PLATFORM_EXT, YES) {
     DEFINES += QTOX_PLATFORM_EXT
 }
 
+!contains(DISABLE_QTKEYCHAIN, YES) {
+    DEFINES += QTOX_QTKEYCHAIN
+}
+
+contains(DEFINES, QTOX_QTKEYCHAIN) {
+    LIBS += -lqt5keychain
+    HEADERS += src/widget/passwordstorage.h
+    SOURCES += src/widget/passwordstorage.cpp
+    macx {
+        # Locating QtKeychain on Mac OS X installed with brew
+        QTKEYCHAIN_CELLAR_LIB_LIST = $$files(/usr/local/Cellar/qtkeychain/*/lib/qt5keychain.dylib)
+        QTKEYCHAIN_CELLAR_LIB_FIRST = $$first(QTKEYCHAIN_CELLAR_LIB_LIST)
+        QTKEYCHAIN_CELLAR_PREFIX = $$replace(QTKEYCHAIN_CELLAR_LIB_FIRST, /lib/qt5keychain.dylib, )
+        message("Cellar's QtKeychain prefix is" $$QTKEYCHAIN_CELLAR_PREFIX)
+        LIBS += -L$$QTKEYCHAIN_CELLAR_PREFIX/lib
+        INCLUDEPATH += $$QTKEYCHAIN_CELLAR_PREFIX/include
+    }
+}
+
 contains(JENKINS,YES) {
     INCLUDEPATH += ./libs/include/
 } else {

--- a/src/loginscreen.ui
+++ b/src/loginscreen.ui
@@ -7,19 +7,19 @@
     <x>0</x>
     <y>0</y>
     <width>410</width>
-    <height>200</height>
+    <height>221</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
     <width>410</width>
-    <height>200</height>
+    <height>221</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
     <width>415</width>
-    <height>200</height>
+    <height>221</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -35,7 +35,7 @@
      <x>160</x>
      <y>0</y>
      <width>250</width>
-     <height>200</height>
+     <height>221</height>
     </rect>
    </property>
    <property name="autoFillBackground">
@@ -155,7 +155,7 @@
            </property>
           </widget>
          </item>
-         <item row="9" column="0" colspan="2">
+         <item row="10" column="0" colspan="2">
           <layout class="QHBoxLayout" name="horizontalLayout">
            <item>
             <spacer name="horizontalSpacer">
@@ -204,6 +204,16 @@
             </size>
            </property>
           </spacer>
+         </item>
+         <item row="9" column="0" colspan="2">
+          <widget class="QCheckBox" name="storePasswordInKeychain2CB">
+           <property name="text">
+            <string>Store password</string>
+           </property>
+           <property name="toolTip">
+            <string>Store password in keychain</string>
+           </property>
+          </widget>
          </item>
         </layout>
        </item>
@@ -303,6 +313,16 @@
            </property>
            <property name="text">
             <string>Load automatically</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="storePasswordInKeychain1CB">
+           <property name="text">
+            <string>Store password</string>
+           </property>
+           <property name="toolTip">
+            <string>Store password in keychain</string>
            </property>
           </widget>
          </item>

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -142,6 +142,9 @@ void Settings::loadGlobal()
     s.beginGroup("Login");
     {
         autoLogin = s.value("autoLogin", false).toBool();
+#ifdef QTOX_QTKEYCHAIN
+        storePasswordInKeychain = s.value("storePasswordInKeychain", false).toBool();
+#endif // QTOX_QTKEYCHAIN
     }
     s.endGroup();
 
@@ -496,6 +499,9 @@ void Settings::saveGlobal()
     s.beginGroup("Login");
     {
         s.setValue("autoLogin", autoLogin);
+#ifdef QTOX_QTKEYCHAIN
+        s.setValue("storePasswordInKeychain", storePasswordInKeychain);
+#endif // QTOX_QTKEYCHAIN
     }
     s.endGroup();
 
@@ -2324,6 +2330,20 @@ void Settings::setAutoLogin(bool state)
         emit autoLoginChanged(autoLogin);
     }
 }
+
+#ifdef QTOX_QTKEYCHAIN
+bool Settings::getPasswordFromKeychain() const
+{
+    QMutexLocker locker{&bigLock};
+    return storePasswordInKeychain;
+}
+
+void Settings::setPasswordInKeychain(bool newValue)
+{
+    QMutexLocker locker{&bigLock};
+    storePasswordInKeychain = newValue;
+}
+#endif // QTOX_QTKEYCHAIN
 
 /**
  * @brief Write a default personal .ini settings file for a profile.

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -473,6 +473,11 @@ public:
     bool getAutoLogin() const;
     void setAutoLogin(bool state);
 
+#ifdef QTOX_QTKEYCHAIN
+    bool getPasswordFromKeychain() const;
+    void setPasswordInKeychain(bool newValue);
+#endif // QTOX_QTKEYCHAIN
+
     int getCircleCount() const;
     int addCircle(const QString& name = QString());
     int removeCircle(int id);
@@ -527,6 +532,10 @@ private:
     bool dontShowDhtDialog;
 
     bool autoLogin;
+#ifdef QTOX_QTKEYCHAIN
+    bool storePasswordInKeychain;
+#endif // QTOX_QTKEYCHAIN
+
     bool fauxOfflineMessaging;
     bool compactLayout;
     bool groupchatPosition;

--- a/src/widget/form/profileform.cpp
+++ b/src/widget/form/profileform.cpp
@@ -34,6 +34,9 @@
 #include "src/persistence/profile.h"
 #include "src/persistence/settings.h"
 #include "src/net/toxme.h"
+#ifdef QTOX_QTKEYCHAIN
+#include "src/widget/passwordstorage.h"
+#endif
 #include <QLabel>
 #include <QLineEdit>
 #include <QGroupBox>
@@ -454,6 +457,10 @@ void ProfileForm::onDeletePassClicked()
                       tr("Are you sure you want to delete your password?","deletion confirmation text")))
         return;
 
+#ifdef QTOX_QTKEYCHAIN
+    if (Settings::getInstance().getPasswordFromKeychain())
+        deletePassword(Nexus::getProfile()->getName());
+#endif // QTOX_QTKEYCHAIN
     Nexus::getProfile()->setPassword(QString());
 }
 
@@ -465,6 +472,10 @@ void ProfileForm::onChangePassClicked()
         return;
 
     QString newPass = dialog->getPassword();
+#ifdef QTOX_QTKEYCHAIN
+    if (Settings::getInstance().getPasswordFromKeychain())
+        storePassword(Nexus::getProfile()->getName(), newPass);
+#endif // QTOX_QTKEYCHAIN
     Nexus::getProfile()->setPassword(newPass);
 }
 
@@ -560,3 +571,46 @@ void ProfileForm::onRegisterButtonClicked()
         bodyUI->toxmeUpdateButton->setText(tr("Update"));
     }
 }
+
+#ifdef QTOX_QTKEYCHAIN
+void ProfileForm::storePassword(const QString& profileName, const QString& password)
+{
+    bodyUI->changePassButton->setEnabled(false);
+    bodyUI->deletePassButton->setEnabled(false);
+    QKeychain::Job *job = new WriteToXPasswordJob(profileName,password,this);
+    connect(job, &WriteToXPasswordJob::finished, this, &ProfileForm::onStorePasswordFinished);
+    job->start();
+}
+
+void ProfileForm::deletePassword(const QString& profileName)
+{
+    bodyUI->changePassButton->setEnabled(false);
+    bodyUI->deletePassButton->setEnabled(false);
+    QKeychain::Job *job = new DeleteToXPasswordJob(profileName,this);
+    connect(job, &DeleteToXPasswordJob::finished, this, &ProfileForm::onDeletePasswordFinished);
+    job->start();
+}
+
+void ProfileForm::onStorePasswordFinished()
+{
+    bodyUI->changePassButton->setEnabled(true);
+    bodyUI->deletePassButton->setEnabled(true);
+    WriteToXPasswordJob *job = static_cast<WriteToXPasswordJob*>(sender());
+    if (job->error())
+        GUI::showWarning(tr("Storing password in keychain failed", "Title of QtKeychain error message"),
+                         tr("Storing the password in keychain failed: %1", "Text of QtKeychain error message")
+                           .arg(job->errorString()));
+}
+
+void ProfileForm::onDeletePasswordFinished()
+{
+    bodyUI->changePassButton->setEnabled(true);
+    bodyUI->deletePassButton->setEnabled(true);
+    DeleteToXPasswordJob *job = static_cast<DeleteToXPasswordJob*>(sender());
+    if (job->error())
+        GUI::showWarning(tr("Deleting password from keychain failed", "Title of QtKeychain error message"),
+                         tr("Deleting the password from keychain failed: %1", "Text of QtKeychain error message")
+                           .arg(job->errorString()));
+}
+
+#endif // QTOX_QTKEYCHAIN

--- a/src/widget/form/profileform.h
+++ b/src/widget/form/profileform.h
@@ -85,11 +85,19 @@ private slots:
     void onAvatarClicked();
     void showProfilePictureContextMenu(const QPoint &point);
     void onRegisterButtonClicked();
+#ifdef QTOX_QTKEYCHAIN
+    void onStorePasswordFinished();
+    void onDeletePasswordFinished();
+#endif // QTOX_QTKEYCHAIN
 
 private:
     void showExistingToxme();
     void retranslateUi();
     void prFileLabelUpdate();
+#ifdef QTOX_QTKEYCHAIN
+    void storePassword(const QString& profileName, const QString& password);
+    void deletePassword(const QString& profileName);
+#endif // QTOX_QTKEYCHAIN
 
 private:
     bool eventFilter(QObject *object, QEvent *event);

--- a/src/widget/form/settings/privacyform.cpp
+++ b/src/widget/form/settings/privacyform.cpp
@@ -26,6 +26,9 @@
 
 #include "src/core/core.h"
 #include "src/core/recursivesignalblocker.h"
+#ifdef QTOX_QTKEYCHAIN
+#include "src/widget/passwordstorage.h"
+#endif // QTOX_QTKEYCHAIN
 #include "src/nexus.h"
 #include "src/persistence/history.h"
 #include "src/persistence/profile.h"
@@ -46,6 +49,11 @@ PrivacyForm::PrivacyForm()
     const RecursiveSignalBlocker signalBlocker(this);
 
     eventsInit();
+
+#ifndef QTOX_QTKEYCHAIN
+    bodyUI->pbClearKeychain->hide();
+#endif // QTOX_QTKEYCHAIN
+
     Translator::registerHandler(std::bind(&PrivacyForm::retranslateUi, this), this);
 }
 
@@ -92,6 +100,9 @@ void PrivacyForm::showEvent(QShowEvent*)
     bodyUI->nospamLineEdit->setText(Core::getInstance()->getSelfId().noSpam);
     bodyUI->cbTypingNotification->setChecked(s.getTypingNotification());
     bodyUI->cbKeepHistory->setChecked(Settings::getInstance().getEnableLogging());
+#ifndef QTOX_QTKEYCHAIN
+    bodyUI->pbClearKeychain->setVisible(false);
+#endif // not QTOX_QTKEYCHAIN
 }
 
 void PrivacyForm::on_randomNosapamButton_clicked()
@@ -118,6 +129,22 @@ void PrivacyForm::on_nospamLineEdit_textChanged()
         bodyUI->nospamLineEdit->setCursorPosition(curs);
     };
 }
+
+#ifdef QTOX_QTKEYCHAIN
+void PrivacyForm::on_pbClearKeychain_clicked()
+{
+    QKeychain::Job *job = new DeleteToXPasswordJob(Nexus::getProfile()->getName(), this);
+    connect(job, &DeleteToXPasswordJob::finished, this, &PrivacyForm::onDeletePasswordFinished);
+    job->start();
+}
+
+void PrivacyForm::onDeletePasswordFinished()
+{
+    DeleteToXPasswordJob *job = static_cast<DeleteToXPasswordJob*>(sender());
+    if (job->error())
+        GUI::showWarning(tr("Deleting password failed", "Title of QtKeychain error message"), tr("Deleting the password failed: %1", "text of QtKeychain error message").arg(job->errorString()));
+}
+#endif // QTOX_QTKEYCHAIN
 
 void PrivacyForm::retranslateUi()
 {

--- a/src/widget/form/settings/privacyform.h
+++ b/src/widget/form/settings/privacyform.h
@@ -43,6 +43,10 @@ private slots:
     void on_nospamLineEdit_editingFinished();
     void on_randomNosapamButton_clicked();
     void on_nospamLineEdit_textChanged();
+#ifdef QTOX_QTKEYCHAIN
+    void on_pbClearKeychain_clicked();
+    void onDeletePasswordFinished();
+#endif // QTOX_QTKEYCHAIN
     virtual void showEvent(QShowEvent*) final override;
 
 private:

--- a/src/widget/form/settings/privacysettings.ui
+++ b/src/widget/form/settings/privacysettings.ui
@@ -71,6 +71,16 @@ Save format changes are possible, which may result in data loss.</string>
          </layout>
         </widget>
        </item>
+       <item>
+        <widget class="QPushButton" name="pbClearKeychain">
+         <property name="toolTip">
+          <string>Clear this profile's password from the keychain password storage</string>
+         </property>
+         <property name="text">
+          <string>Clear Password from Keychain</string>
+         </property>
+        </widget>
+       </item>
        <item alignment="Qt::AlignTop">
         <widget class="QGroupBox" name="nospamGroup">
          <property name="toolTip">

--- a/src/widget/loginscreen.cpp
+++ b/src/widget/loginscreen.cpp
@@ -28,6 +28,10 @@
 #include "src/widget/translator.h"
 #include "src/widget/style.h"
 #include "src/widget/tool/profileimporter.h"
+#ifdef QTOX_QTKEYCHAIN
+#include "src/widget/gui.h"
+#include "src/widget/passwordstorage.h"
+#endif
 #include <QMessageBox>
 #include <QToolButton>
 #include <QDebug>
@@ -56,6 +60,13 @@ LoginScreen::LoginScreen(QWidget *parent) :
     connect(ui->newPass, &QLineEdit::textChanged, this, &LoginScreen::onPasswordEdited);
     connect(ui->newPassConfirm, &QLineEdit::textChanged, this, &LoginScreen::onPasswordEdited);
     connect(ui->autoLoginCB, &QCheckBox::stateChanged, this, &LoginScreen::onAutoLoginToggled);
+#ifdef QTOX_QTKEYCHAIN
+    connect(ui->storePasswordInKeychain1CB, &QCheckBox::stateChanged, this, &LoginScreen::onStorePasswordInKeychainToggle);
+    connect(ui->storePasswordInKeychain2CB, &QCheckBox::stateChanged, this, &LoginScreen::onStorePasswordInKeychainToggle);
+#else // QTOX_QTKEYCHAIN
+    ui->storePasswordInKeychain1CB->hide();
+    ui->storePasswordInKeychain2CB->hide();
+#endif // QTOX_QTKEYCHAIN
     connect(ui->importButton,  &QPushButton::clicked, this, &LoginScreen::onImportProfile);
 
     reset();
@@ -100,12 +111,28 @@ void LoginScreen::reset()
     else
     {
         ui->stackedWidget->setCurrentIndex(1);
+#ifdef QTOX_QTKEYCHAIN
+        if (!lastUsed.isEmpty() && Settings::getInstance().getPasswordFromKeychain())
+            recallPassword(lastUsed);
+        else
+            ui->loginPassword->setFocus();
+#else // QTOX_QTKEYCHAIN
         ui->loginPassword->setFocus();
+#endif // QTOX_QTKEYCHAIN
     }
 
     ui->autoLoginCB->blockSignals(true);
     ui->autoLoginCB->setChecked(Settings::getInstance().getAutoLogin());
     ui->autoLoginCB->blockSignals(false);
+#ifdef QTOX_QTKEYCHAIN
+    const bool doStorePasswordInKeychain = Settings::getInstance().getPasswordFromKeychain();
+    ui->storePasswordInKeychain1CB->blockSignals(true);
+    ui->storePasswordInKeychain1CB->setChecked(doStorePasswordInKeychain);
+    ui->storePasswordInKeychain1CB->blockSignals(false);
+    ui->storePasswordInKeychain2CB->blockSignals(true);
+    ui->storePasswordInKeychain2CB->setChecked(doStorePasswordInKeychain);
+    ui->storePasswordInKeychain2CB->blockSignals(false);
+#endif // QTOX_QTKEYCHAIN
 }
 
 bool LoginScreen::event(QEvent* event)
@@ -173,6 +200,11 @@ void LoginScreen::onCreateNewProfile()
         return;
     }
 
+#ifdef QTOX_QTKEYCHAIN
+    if (Settings::getInstance().getPasswordFromKeychain())
+        storePassword(name, pass);
+#endif // QTOX_QTKEYCHAIN
+
     Nexus& nexus = Nexus::getInstance();
 
     nexus.setProfile(profile);
@@ -189,10 +221,18 @@ void LoginScreen::onLoginUsernameSelected(const QString &name)
     {
         ui->loginPasswordLabel->show();
         ui->loginPassword->show();
+#ifdef QTOX_QTKEYCHAIN
+        if (Settings::getInstance().getPasswordFromKeychain())
+            recallPassword(name);
+        else {
+#endif // QTOX_QTKEYCHAIN
         // there is no way to do autologin if profile is encrypted, and
         // visible option confuses users into thinking that it is possible,
         // thus hide it
         ui->autoLoginCB->hide();
+#ifdef QTOX_QTKEYCHAIN
+        }
+#endif // QTOX_QTKEYCHAIN
     }
     else
     {
@@ -243,6 +283,11 @@ void LoginScreen::onLogin()
         }
     }
 
+#ifdef QTOX_QTKEYCHAIN
+    if (Settings::getInstance().getPasswordFromKeychain())
+        storePassword(name, pass);
+#endif // QTOX_QTKEYCHAIN
+
     Nexus& nexus = Nexus::getInstance();
 
     nexus.setProfile(profile);
@@ -279,3 +324,52 @@ void LoginScreen::onImportProfile()
 
     delete pi;
 }
+
+#ifdef QTOX_QTKEYCHAIN
+void LoginScreen::onStorePasswordInKeychainToggle(int state)
+{
+    const Qt::CheckState cstate = static_cast<Qt::CheckState>(state);
+    Settings::getInstance().setPasswordInKeychain(cstate == Qt::CheckState::Checked);
+    Settings::getInstance().saveGlobal();
+
+    ui->storePasswordInKeychain1CB->blockSignals(true);
+    ui->storePasswordInKeychain1CB->setChecked(cstate);
+    ui->storePasswordInKeychain1CB->blockSignals(false);
+    ui->storePasswordInKeychain2CB->blockSignals(true);
+    ui->storePasswordInKeychain2CB->setChecked(cstate);
+    ui->storePasswordInKeychain2CB->blockSignals(false);
+}
+
+void LoginScreen::onPasswordRecalled()
+{
+    ReadToXPasswordJob *job = static_cast<ReadToXPasswordJob*>(sender());
+    if (!job->error())
+        ui->loginPassword->setText(job->password());
+    ui->loginPassword->setEnabled(true);
+    ui->loginPassword->setFocus();
+}
+
+void LoginScreen::onStorePasswordFinished()
+{
+    WriteToXPasswordJob *job = static_cast<WriteToXPasswordJob*>(sender());
+    if (job->error())
+        GUI::showWarning(tr("Storing password in keychain failed", "Title of QtKeychain error message"),
+                         tr("Storing the password in keychain failed: %1", "Text of QtKeychain error message")
+                           .arg(job->errorString()));
+}
+
+void LoginScreen::recallPassword(const QString& profileName)
+{
+    ui->loginPassword->setEnabled(false);
+    QKeychain::Job *job = new ReadToXPasswordJob(profileName, this);
+    connect(job, &ReadToXPasswordJob::finished, this, &LoginScreen::onPasswordRecalled);
+    job->start();
+}
+
+void LoginScreen::storePassword(const QString& profileName, const QString& password)
+{
+    QKeychain::Job *job = new WriteToXPasswordJob(profileName, password, this);
+    connect(job, &WriteToXPasswordJob::finished, this, &LoginScreen::onStorePasswordFinished);
+    job->start();
+}
+#endif // QTOX_QTKEYCHAIN

--- a/src/widget/loginscreen.h
+++ b/src/widget/loginscreen.h
@@ -56,12 +56,21 @@ private slots:
     void onCreateNewProfile();
     void onLogin();
     void onImportProfile();
+#ifdef QTOX_QTKEYCHAIN
+    void onStorePasswordInKeychainToggle(int state);
+    void onStorePasswordFinished();
+    void onPasswordRecalled();
+#endif // QTOX_QTKEYCHAIN
 
 private:
     void retranslateUi();
     void showCapsIndicator();
     void hideCapsIndicator();
     void checkCapsLock();
+#ifdef QTOX_QTKEYCHAIN
+    void recallPassword(const QString& profileName);
+    void storePassword(const QString& profileName, const QString& password);
+#endif // QTOX_QTKEYCHAIN
 
 private:
     Ui::LoginScreen *ui;

--- a/src/widget/passwordstorage.cpp
+++ b/src/widget/passwordstorage.cpp
@@ -1,0 +1,49 @@
+/*
+    Copyright © 2016 by The qTox Project
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "passwordstorage.h"
+
+static const QString serviceName(QStringLiteral("qTox"));
+
+ReadToXPasswordJob::ReadToXPasswordJob(const QString& profileName, QObject *parent)
+    : QKeychain::ReadPasswordJob(serviceName, parent)
+{
+    setAutoDelete(true);
+    setKey(profileName);
+}
+
+const QString ReadToXPasswordJob::password() const
+{
+    return textData();
+}
+
+WriteToXPasswordJob::WriteToXPasswordJob(const QString& profileName, const QString& password, QObject *parent)
+    : QKeychain::WritePasswordJob(serviceName, parent)
+{
+    setAutoDelete(true);
+    setKey(profileName);
+    setTextData(password);
+}
+
+DeleteToXPasswordJob::DeleteToXPasswordJob(const QString& profileName, QObject *parent)
+    : QKeychain::DeletePasswordJob(serviceName, parent)
+{
+    setAutoDelete(true);
+    setKey(profileName);
+}

--- a/src/widget/passwordstorage.h
+++ b/src/widget/passwordstorage.h
@@ -1,0 +1,43 @@
+/*
+    Copyright © 2016 by The qTox Project
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef PASSWORDSTORAGE_H
+#define PASSWORDSTORAGE_H
+
+#include <qt5keychain/keychain.h>
+
+class ReadToXPasswordJob : public QKeychain::ReadPasswordJob {
+public:
+    explicit ReadToXPasswordJob(const QString& profileName, QObject *parent = nullptr);
+
+    const QString password() const;
+};
+
+class WriteToXPasswordJob : public QKeychain::WritePasswordJob {
+public:
+    explicit WriteToXPasswordJob(const QString& profileName, const QString& password, QObject *parent = nullptr);
+};
+
+class DeleteToXPasswordJob : public QKeychain::DeletePasswordJob {
+public:
+    explicit DeleteToXPasswordJob(const QString& profileName, QObject *parent = nullptr);
+};
+
+#endif // PASSWORDSTORAGE_H

--- a/ui/loginScreen/loginScreen.css
+++ b/ui/loginScreen/loginScreen.css
@@ -18,11 +18,11 @@
 }
 #labelNewProfile {
   margin-top:125px;
-  margin-bottom:45px;
+  margin-bottom:66px;
 }
 #labelLoadProfile {
   margin-top:165px;
-  margin-bottom:5px;
+  margin-bottom:26px;
 }
 
 LoginScreen > QPushButton,


### PR DESCRIPTION
This commit adds support for storing to and retrieving passwords from a operating system or desktop environment-specific secure storage. It makes use of [Frank Osterfeld's QtKeychain](https://github.com/frankosterfeld/qtkeychain), which make store passwords in Mac OS X's Keychain, GNOME's keyring, KDE's wallet, or Windows' Credential Store.
Code is tested on Linux using KDE's wallet. The code is optional, to activate it, `QTOX_QTKEYCHAIN` must be defined when calling qmake.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tux3/qtox/3332)

<!-- Reviewable:end -->
