### PR TITLE
fix(.gitattributes): bootstrap.sh execution fails on MSYS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,8 @@
 # Fix GitHub thinking our translations are TypeScript
 *.ts linguist-language=XML
 
+# fix bootstrap.sh on Windows MSYS
+*.sh eol=lf
+
 # Don't count the translation files in the language stats
 translations/* linguist-vendored


### PR DESCRIPTION
Running bootstrap.bat results in error:

```
C:\qTox>bootstrap.bat
bootstrap.sh: line 2: $'\r': command not found
bootstrap.sh: line 19: $'\r': command not found
```

This is due to that by default line endings converted to \r\n on Windows, though .sh are executed by MSYS sh which needs \n only.

This PR fixes that by forcing unix line ending on Windows too for *.sh files.
