### PR TITLE
feat(genericchatform): add "Quote selected text" feature to chat window

### DIFF
--- a/doc/user_manual_en.md
+++ b/doc/user_manual_en.md
@@ -6,6 +6,7 @@
 * [Settings](#settings)
 * [Groupchats](#groupchats)
 * [Message Styling](#message-styling)
+* [Quotes](#quotes)
 * [Multi Window Mode](#multi-window-mode)
 * [Keyboard Shortcuts](#keyboard-shortcuts)
 
@@ -239,6 +240,14 @@ Additionally, qTox supports three modes of Markdown parsing:
 
 *Note that any change in Markdown preference will require a restart.*
 
+## Quotes
+
+qTox has feature to quote selected text in chat window:
+
+1. Select the text you want to quote.
+2. Right-click on the selected text and choose "Quote selected text" in the context menu. Also you can use `ALT` + `q` shortcut.
+3. Selected text will be automatically quoted into a message input area in a pretty formatting.
+
 ## Multi Window Mode
 
 In this mode, qTox will separate its main window into a single contact list and
@@ -260,3 +269,4 @@ The following shortcuts are currently supported:
 | `CTRL` + `Page Up` | Switch to the previous contact|
 | `CTRL` + `TAB` | Switch to the next contact |
 | `CTRL` + `SHIFT` + `TAB` | Switch to the previous contact|
+| `ALT` + `q` | Quote selected text |

--- a/doc/user_manual_en.md
+++ b/doc/user_manual_en.md
@@ -245,8 +245,10 @@ Additionally, qTox supports three modes of Markdown parsing:
 qTox has feature to quote selected text in chat window:
 
 1. Select the text you want to quote.
-2. Right-click on the selected text and choose "Quote selected text" in the context menu. Also you can use `ALT` + `q` shortcut.
-3. Selected text will be automatically quoted into a message input area in a pretty formatting.
+2. Right-click on the selected text and choose "Quote selected text" in the
+context menu. You also can use `ALT` + `q` shortcut.
+3. Selected text will be automatically quoted into the message input area in a
+pretty formatting.
 
 ## Multi Window Mode
 

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -191,6 +191,10 @@ GenericChatForm::GenericChatForm(QWidget *parent)
                                     QString(), this, SLOT(onSaveLogClicked()));
     clearAction = menu.addAction(QIcon::fromTheme("edit-clear"),
                                  QString(), this, SLOT(clearChatArea(bool)));
+
+    quoteAction = menu.addAction(QIcon(),
+                                 QString(), this, SLOT(quoteSelectedText()));
+
     menu.addSeparator();
 
     connect(emoteButton, &QPushButton::clicked,
@@ -199,6 +203,7 @@ GenericChatForm::GenericChatForm(QWidget *parent)
             this, &GenericChatForm::onChatContextMenuRequested);
 
     new QShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_L, this, SLOT(clearChatArea()));
+    new QShortcut(Qt::ALT + Qt::Key_Q, this, SLOT(quoteSelectedText()));
 
     chatWidget->setStyleSheet(Style::getStylesheet(":/ui/chatArea/chatArea.css"));
     headWidget->setStyleSheet(Style::getStylesheet(":/ui/chatArea/chatHead.css"));
@@ -562,6 +567,26 @@ void GenericChatForm::onShowMessagesClicked()
     }
 }
 
+void GenericChatForm::quoteSelectedText()
+{
+    QString selectedText = chatWidget->getSelectedText();
+
+    if (selectedText.isEmpty())
+        return;
+
+    // forming pretty quote text
+    // 1. insert "> " to the begining of quote;
+    // 2. replace all possible line terminators with "\n> ";
+    // 3. append new line to the end of quote.
+    QString quote = selectedText;
+
+    quote.insert(0, "> ");
+    quote.replace(QRegExp(QString("\r\n|[\r\n\u2028\u2029]")), QString("\n> "));
+    quote.append("\n");
+
+    msgEdit->append(quote);
+}
+
 void GenericChatForm::retranslateUi()
 {
     QString callObjectName = callButton->objectName();
@@ -587,6 +612,7 @@ void GenericChatForm::retranslateUi()
     screenshotButton->setToolTip(tr("Send a screenshot"));
     saveChatAction->setText(tr("Save chat log"));
     clearAction->setText(tr("Clear displayed messages"));
+    quoteAction->setText(tr("Quote selected text"));
 }
 
 void GenericChatForm::showNetcam()

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -91,6 +91,7 @@ protected slots:
     void hideFileMenu();
     void onShowMessagesClicked();
     void onSplitterMoved(int pos, int index);
+    void quoteSelectedText();
 
 private:
     void retranslateUi();
@@ -109,7 +110,7 @@ protected:
     virtual bool eventFilter(QObject* object, QEvent* event) final override;
 
 protected:
-    QAction* saveChatAction, *clearAction;
+    QAction* saveChatAction, *clearAction, *quoteAction;
     ToxId previousId;
     QDateTime prevMsgDateTime;
     Widget *parent;

--- a/translations/ru.ts
+++ b/translations/ru.ts
@@ -1176,6 +1176,10 @@ will be sent to them when they appear online to you.</source>
         <translation>Очистить показываемые сообщения</translation>
     </message>
     <message>
+        <source>Quote selected text</source>
+        <translation>Цитировать выделенное</translation>
+    </message>
+    <message>
         <source>Not sent</source>
         <translation>Не отправлено</translation>
     </message>


### PR DESCRIPTION
This commit adds feature to quote selected text in chat window.
How-To:
1. Select text in chat window
2. Press RMB and click "Quote selected text" OR press "ALT+Q"
3. Selected text will be automatically inserted in input text area

Animated screenshot instead of a thousand words:

![quote](https://cloud.githubusercontent.com/assets/3247291/15835404/dcae6e20-2c40-11e6-9190-62a4a2799271.gif)
