### PR TITLE
fix(widget): memory issues

### DIFF
--- a/src/widget/form/profileform.cpp
+++ b/src/widget/form/profileform.cpp
@@ -93,7 +93,7 @@ ProfileForm::ProfileForm(QWidget *parent) :
     bodyUI->qrLabel->setWordWrap(true);
 
     QRegExp re("[^@ ]+");
-    QRegExpValidator* validator = new QRegExpValidator(re);
+    QRegExpValidator* validator = new QRegExpValidator(re, this);
     bodyUI->toxmeUsername->setValidator(validator);
 
     profilePicture = new MaskablePixmapWidget(this, QSize(64, 64), ":/img/avatar_mask.svg");

--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -78,7 +78,7 @@ void FriendWidget::contextMenuEvent(QContextMenuEvent * event)
     if (contentDialog == nullptr || notAlone)
         openChatWindow = menu.addAction(tr("Open chat in new window"));
 
-    if (contentDialog->hasFriendWidget(friendId, this))
+    if (contentDialog != nullptr && contentDialog->hasFriendWidget(friendId, this))
         removeChatWindow = menu.addAction(tr("Remove chat from this window"));
 
     menu.addSeparator();

--- a/src/widget/systemtrayicon.cpp
+++ b/src/widget/systemtrayicon.cpp
@@ -100,6 +100,7 @@ SystemTrayIcon::SystemTrayIcon()
 SystemTrayIcon::~SystemTrayIcon()
 {
     qDebug() << "Deleting SystemTrayIcon";
+    delete qtIcon;
 }
 
 QString SystemTrayIcon::extractIconToFile(QIcon icon, QString name)

--- a/src/widget/systemtrayicon.h
+++ b/src/widget/systemtrayicon.h
@@ -47,7 +47,7 @@ private:
 
 private:
     SystrayBackendType backendType;
-    QSystemTrayIcon* qtIcon;
+    QSystemTrayIcon* qtIcon = nullptr;
 
 #ifdef ENABLE_SYSTRAY_UNITY_BACKEND
     AppIndicator *unityIndicator;

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -507,6 +507,7 @@ Widget::~Widget()
     if (icon)
         icon->hide();
 
+    delete icon;
     delete profileForm;
     delete settingsWidget;
     delete addFriendForm;

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -234,7 +234,7 @@ private:
     void focusChatInput();
 
 private:
-    SystemTrayIcon *icon;
+    SystemTrayIcon *icon = nullptr;
     QMenu *trayMenu;
     QAction *statusOnline;
     QAction *statusAway;


### PR DESCRIPTION
Small memory leaks and uninitialized memory usage fixes. Should fix #2308 at least for disabled systray unity backend. Shouldn't create #3144 problem as cbb7eec.
