### PR TITLE
feat(video): add setting for 120p very-low-res video

### DIFF
--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -173,8 +173,11 @@ void AVForm::updateVideoModes(int curIndex)
 
     // Identify the best resolutions available for the supposed XXXXp resolutions.
     std::map<int, VideoMode> idealModes;
-    idealModes[240] = {460,240,0,0}; idealModes[360] = {640,360,0,0};
-    idealModes[480] = {854,480,0,0}; idealModes[720] = {1280,720,0,0};
+    idealModes[120] = {160,120,0,0};
+    idealModes[240] = {460,240,0,0};
+    idealModes[360] = {640,360,0,0};
+    idealModes[480] = {854,480,0,0};
+    idealModes[720] = {1280,720,0,0};
     idealModes[1080] = {1920,1080,0,0};
     std::map<int, int> bestModeInds;
 


### PR DESCRIPTION
At least some webcams have such low-res modes, and even if they are very low res, they still give a meaningful image and they can be useful with very limited connections.
