### PR TITLE
fix(video): do not list the same mode twice

### DIFF
--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -232,6 +232,10 @@ void AVForm::updateVideoModes(int curIndex)
     {
         int i = iter->second;
         VideoMode mode = allVideoModes[i];
+
+        if (videoModes.contains(mode))
+            continue;
+
         videoModes.append(mode);
         if (mode.width==prefRes.width() && mode.height==prefRes.height() && mode.FPS == prefFPS && prefResIndex==-1)
             prefResIndex = videoModes.size() - 1;


### PR DESCRIPTION
Do not provide more than one entry in the settings for the same actual
mode, even if it was selected for different expected resolutions.

For example, do not list 640x480 twice for both 480p and 360p if the
device doesn't have a better 360p mode, and simply skip the 360p entry.

---

Another solution could be to select the second-best match if the first-best is already used.  For example, my webcam has 640x480 and 352x288, so no real 360p mode, but 352x288 still is reasonably close (although it's beyond the hard-coded threshold of 300, as `640-352+360-288=360`), and slightly better than 240p.
This would however be a little more work, and I'm not certain it's wanted.
