### PR TITLE
fix serious type conversion warnings

### DIFF
--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -79,8 +79,6 @@ IndexedList<ToxFriendCall> CoreAV::calls;
 */
 IndexedList<ToxGroupCall> CoreAV::groupCalls;
 
-using namespace std;
-
 CoreAV::CoreAV(Tox *tox)
     : coreavThread{new QThread}, iterateTimer{new QTimer{this}},
       threadSwitchLock{false}
@@ -188,7 +186,7 @@ bool CoreAV::answerCall(uint32_t friendNum)
 
         bool ret;
         QMetaObject::invokeMethod(this, "answerCall", Qt::BlockingQueuedConnection,
-                                    Q_RETURN_ARG(bool, ret), Q_ARG(uint32_t, friendNum));
+                                  Q_RETURN_ARG(bool, ret), Q_ARG(uint32_t, friendNum));
 
         threadSwitchLock.clear(std::memory_order_release);
         return ret;
@@ -220,10 +218,12 @@ bool CoreAV::startCall(uint32_t friendNum, bool video)
             qDebug() << "CoreAV::startCall: Backed off of thread-switch lock";
             return false;
         }
-        bool ret;
 
-        (void)QMetaObject::invokeMethod(this, "startCall", Qt::BlockingQueuedConnection,
-                                    Q_RETURN_ARG(bool, ret), Q_ARG(uint32_t, friendNum), Q_ARG(bool, video));
+        bool ret;
+        QMetaObject::invokeMethod(this, "startCall", Qt::BlockingQueuedConnection,
+                                  Q_RETURN_ARG(bool, ret),
+                                  Q_ARG(uint32_t, friendNum),
+                                  Q_ARG(bool, video));
 
         threadSwitchLock.clear(std::memory_order_release);
         return ret;
@@ -256,8 +256,10 @@ bool CoreAV::cancelCall(uint32_t friendNum)
         }
 
         bool ret;
-        QMetaObject::invokeMethod(this, "cancelCall", Qt::BlockingQueuedConnection,
-                                    Q_RETURN_ARG(bool, ret), Q_ARG(uint32_t, friendNum));
+        QMetaObject::invokeMethod(this, "cancelCall",
+                                  Qt::BlockingQueuedConnection,
+                                  Q_RETURN_ARG(bool, ret),
+                                  Q_ARG(uint32_t, friendNum));
 
         threadSwitchLock.clear(std::memory_order_release);
         return ret;
@@ -338,7 +340,7 @@ bool CoreAV::sendCallAudio(uint32_t callId, const int16_t *pcm, size_t samples, 
     return true;
 }
 
-void CoreAV::sendCallVideo(uint32_t callId, shared_ptr<VideoFrame> vframe)
+void CoreAV::sendCallVideo(uint32_t callId, std::shared_ptr<VideoFrame> vframe)
 {
     // We might be running in the FFmpeg thread and holding the CameraSource lock
     // So be careful not to deadlock with anything while toxav locks in toxav_video_send_frame

--- a/src/core/indexedlist.h
+++ b/src/core/indexedlist.h
@@ -11,24 +11,37 @@ public:
     explicit IndexedList() = default;
 
     // Qt
-    bool isEmpty()
+    inline bool isEmpty()
     {
         return v.empty();
     }
 
-    bool contains(int i)
+    template <typename cmp_type>
+    bool contains(cmp_type i)
     {
-        return std::find_if(begin(), end(), [i](T& t){return (int)t == i;}) != end();
+        return std::find_if(begin(), end(), [i](T& t)
+        {
+            return static_cast<cmp_type>(t) == i;
+        }) != end();
     }
 
-    void remove(int i)
+    template <typename cmp_type>
+    void remove(cmp_type i)
     {
-        v.erase(std::remove_if(begin(), end(), [i](T& t){return (int)t == i;}), end());
+        v.erase(std::remove_if(begin(), end(), [i](T& t)
+        {
+            return static_cast<cmp_type>(t) == i;
+        }), end());
     }
 
-    T &operator[](int i)
+    template <typename cmp_type>
+    T& operator[](cmp_type i)
     {
-        iterator it = std::find_if(begin(), end(), [i](T& t){return (int)t == i;});
+        iterator it = std::find_if(begin(), end(), [i](T& t)
+        {
+            return static_cast<cmp_type>(t) == i;
+        });
+
         if (it == end())
             it = insert({});
 
@@ -44,34 +57,32 @@ public:
     {
         return v.begin();
     }
-    inline const_iterator begin() const
-    {
-        return v.begin();
-    }
+
     inline const_iterator cbegin() const
     {
         return v.cbegin();
     }
+
     inline iterator end()
     {
         return v.end();
     }
-    inline const_iterator end() const
-    {
-        return v.end();
-    }
+
     inline const_iterator cend() const
     {
         return v.cend();
     }
+
     inline iterator erase(iterator pos)
     {
         return v.erase(pos);
     }
+
     inline iterator erase(iterator first, iterator last)
     {
         return v.erase(first, last);
     }
+
     inline iterator insert(T&& value)
     {
         v.push_back(std::move(value));

--- a/src/persistence/serialize.cpp
+++ b/src/persistence/serialize.cpp
@@ -67,18 +67,19 @@ float dataToFloat(QByteArray data)
 }
 
 // Converts a string into PNet string data
-QByteArray stringToData(QString str)
+QByteArray stringToData(const QString& str)
 {
     QByteArray data(4,0);
     // Write the size in a Uint of variable lenght (8-32 bits)
     int i=0;
-    uint num1 = (uint)str.toUtf8().size();
+    int num1 = str.toUtf8().size();
     while (num1 >= 0x80)
     {
-        data[i] = (unsigned char)(num1 | 0x80); i++;
+        data[i] = static_cast<char>(num1 | 0x80);
+        i++;
         num1 = num1 >> 7;
     }
-    data[i]=num1;
+    data[i] = static_cast<char>(num1);
     data.resize(i+1);
     data+=str.toUtf8();
     return data;
@@ -86,24 +87,24 @@ QByteArray stringToData(QString str)
 
 QString dataToString(QByteArray data)
 {
-    // Variable UInt32
-    unsigned char num3;
-    int num = 0;
+    char num3;
+    int strlen = 0;
     int num2 = 0;
     int i=0;
     do
     {
-        num3 = data[i]; i++;
-        num |= (num3 & 0x7f) << num2;
+        num3 = data[i++];
+        strlen |= (num3 & 0x7f) << num2;
         num2 += 7;
     } while ((num3 & 0x80) != 0);
-    unsigned int strlen = (uint) num;
 
-    if (!strlen)
+    if (strlen <= 0)
         return QString();
 
-    data = data.right(data.size()-i); // Remove the strlen
+    // Remove the strlen
+    data.remove(0, i - 1);
     data.truncate(strlen);
+
     return QString(data);
 }
 
@@ -113,35 +114,35 @@ float dataToRangedSingle(float min, float max, int numberOfBits, QByteArray data
     uint value=0;
     if (numberOfBits <= 8)
     {
-        endvalue = (uchar)data[0];
+        endvalue = static_cast<uchar>(data[0]);
         goto done;
     }
-    value = (uchar)data[0];
+    value = static_cast<uchar>(data[0]);
     numberOfBits -= 8;
     if (numberOfBits <= 8)
     {
-        endvalue = (value | ((uint) ((uchar)data[1]) << 8));
+        endvalue = value | (static_cast<uint>(data[1]) << 8);
         goto done;
     }
-    value |= (uint) (((uchar)data[1]) << 8);
+    value |= static_cast<uint>(data[1]) << 8;
     numberOfBits -= 8;
     if (numberOfBits <= 8)
     {
-        uint num2 = (uint) (((uchar)data[2]) << 0x10);
+        uint num2 = static_cast<uint>(data[2]) << 0x10;
         endvalue = (value | num2);
         goto done;
     }
-    value |= (uint) (((uchar)data[2]) << 0x10);
+    value |= static_cast<uint>(data[2]) << 0x10;
     numberOfBits -= 8;
-    endvalue =  (value | ((uint) (((uchar)data[3]) << 0x18)));
+    endvalue = value | (static_cast<uint>(data[3]) << 0x18);
     goto done;
 
     done:
 
     float num = max - min;
-    int num2 = (((int) 1) << numberOfBits) - 1;
+    int num2 = (static_cast<int>(1) << numberOfBits) - 1;
     float num3 = endvalue;
-    float num4 = num3 / ((float) num2);
+    float num4 = num3 / num2;
     return (min + (num4 * num));
 }
 
@@ -150,75 +151,90 @@ QByteArray rangedSingleToData(float value, float min, float max, int numberOfBit
     QByteArray data;
     float num = max - min;
     float num2 = (value - min) / num;
-    int num3 = (((int) 1) << numberOfBits) - 1;
-    uint source = num3 * num2;
+    int num3 = (static_cast<int>(1) << numberOfBits) - 1;
+    uint source = static_cast<uint>(num3 * num2);
 
     if (numberOfBits <= 8)
     {
-        data += (unsigned char)source;
+        data += static_cast<char>(source);
         return data;
     }
-    data += (unsigned char)source;
+    data += static_cast<char>(source);
     numberOfBits -= 8;
     if (numberOfBits <= 8)
     {
-        data += (unsigned char)(source>>8);
+        data += static_cast<char>(source >> 8);
         return data;
     }
-    data += (unsigned char)(source>>8);
+    data += static_cast<char>(source >> 8);
     numberOfBits -= 8;
     if (numberOfBits <= 8)
     {
-        data += (unsigned char)(source>>16);
+        data += static_cast<char>(source >> 16);
         return data;
     }
-    data += (unsigned char)(source>>16);
-    data += (unsigned char)(source>>24);
+    data += static_cast<char>(source >> 16);
+    data += static_cast<char>(source >> 24);
 
     return data;
 }
 
-uint8_t dataToUint8(QByteArray data)
+uint8_t dataToUint8(const QByteArray& data)
 {
-    return (uint8_t)data[0];
+    return static_cast<uint8_t>(data[0]);
 }
 
-uint16_t dataToUint16(QByteArray data)
+uint16_t dataToUint16(const QByteArray& data)
 {
-    return ((uint16_t)(uint8_t)data[0])
-            +(((uint16_t)(uint8_t)data[1])<<8);
+    return static_cast<uint16_t>(data[0])
+            | static_cast<uint16_t>(data[1] << 8);
 }
 
-uint32_t dataToUint32(QByteArray data)
+uint32_t dataToUint32(const QByteArray& data)
 {
-    return ((uint32_t)(uint8_t)data[0])
-            +(((uint32_t)(uint8_t)data[1])<<8)
-            +(((uint32_t)(uint8_t)data[2])<<16)
-            +(((uint32_t)(uint8_t)data[3])<<24);
+    return static_cast<uint32_t>(data[0])
+            | (static_cast<uint32_t>(data[1]) << 8)
+            | (static_cast<uint32_t>(data[2]) << 16)
+            | (static_cast<uint32_t>(data[3]) << 24);
 }
 
-uint64_t dataToUint64(QByteArray data)
+uint64_t dataToUint64(const QByteArray& data)
 {
-    return ((uint64_t)(uint8_t)data[0])
-            +(((uint64_t)(uint8_t)data[1])<<8)
-            +(((uint64_t)(uint8_t)data[2])<<16)
-            +(((uint64_t)(uint8_t)data[3])<<24)
-            +(((uint64_t)(uint8_t)data[4])<<32)
-            +(((uint64_t)(uint8_t)data[5])<<40)
-            +(((uint64_t)(uint8_t)data[6])<<48)
-            +(((uint64_t)(uint8_t)data[7])<<56);
+    return static_cast<uint64_t>(data[0])
+            | (static_cast<uint64_t>(data[1]) << 8)
+            | (static_cast<uint64_t>(data[2]) << 16)
+            | (static_cast<uint64_t>(data[3]) << 24)
+            | (static_cast<uint64_t>(data[4]) << 32)
+            | (static_cast<uint64_t>(data[5]) << 40)
+            | (static_cast<uint64_t>(data[6]) << 48)
+            | (static_cast<uint64_t>(data[7]) << 56);
+}
+
+int dataToVInt(const QByteArray& data)
+{
+    char num3;
+    int num = 0;
+    int num2 = 0;
+    int i=0;
+    do
+    {
+        num3 = data[i++];
+        num |= static_cast<int>(num3 & 0x7f) << num2;
+        num2 += 7;
+    } while ((num3 & 0x80) != 0);
+    return num;
 }
 
 size_t dataToVUint(const QByteArray& data)
 {
-    unsigned char num3;
+    char num3;
     size_t num = 0;
     int num2 = 0;
     int i=0;
     do
     {
-        num3 = data[i]; i++;
-        num |= (num3 & 0x7f) << num2;
+        num3 = data[i++];
+        num |= static_cast<size_t>(num3 & 0x7f) << num2;
         num2 += 7;
     } while ((num3 & 0x80) != 0);
     return num;
@@ -227,52 +243,66 @@ size_t dataToVUint(const QByteArray& data)
 unsigned getVUint32Size(QByteArray data)
 {
     unsigned lensize=0;
-    {
-        unsigned char num3;
-        do {
-            num3 = data[lensize];
-            lensize++;
-        } while ((num3 & 0x80) != 0);
-    }
+
+    char num3;
+    do {
+        num3 = data[lensize];
+        lensize++;
+    } while ((num3 & 0x80) != 0);
+
     return lensize;
 }
 
 QByteArray uint8ToData(uint8_t num)
 {
-    QByteArray data(1,0);
-    data[0] = (uint8_t)num;
-    return data;
+    return QByteArray(1, static_cast<char>(num));
 }
 
 QByteArray uint16ToData(uint16_t num)
 {
     QByteArray data(2,0);
-    data[0] = (uint8_t)(num & 0xFF);
-    data[1] = (uint8_t)((num>>8) & 0xFF);
+    data[0] = static_cast<char>(num & 0xFF);
+    data[1] = static_cast<char>((num>>8) & 0xFF);
     return data;
 }
 
 QByteArray uint32ToData(uint32_t num)
 {
     QByteArray data(4,0);
-    data[0] = (uint8_t)(num & 0xFF);
-    data[1] = (uint8_t)((num>>8) & 0xFF);
-    data[2] = (uint8_t)((num>>16) & 0xFF);
-    data[3] = (uint8_t)((num>>24) & 0xFF);
+    data[0] = static_cast<char>(num & 0xFF);
+    data[1] = static_cast<char>((num>>8) & 0xFF);
+    data[2] = static_cast<char>((num>>16) & 0xFF);
+    data[3] = static_cast<char>((num>>24) & 0xFF);
     return data;
 }
 
 QByteArray uint64ToData(uint64_t num)
 {
     QByteArray data(8,0);
-    data[0] = (uint8_t)(num & 0xFF);
-    data[1] = (uint8_t)((num>>8) & 0xFF);
-    data[2] = (uint8_t)((num>>16) & 0xFF);
-    data[3] = (uint8_t)((num>>24) & 0xFF);
-    data[4] = (uint8_t)((num>>32) & 0xFF);
-    data[5] = (uint8_t)((num>>40) & 0xFF);
-    data[6] = (uint8_t)((num>>48) & 0xFF);
-    data[7] = (uint8_t)((num>>56) & 0xFF);
+    data[0] = static_cast<char>(num & 0xFF);
+    data[1] = static_cast<char>((num>>8) & 0xFF);
+    data[2] = static_cast<char>((num>>16) & 0xFF);
+    data[3] = static_cast<char>((num>>24) & 0xFF);
+    data[4] = static_cast<char>((num>>32) & 0xFF);
+    data[5] = static_cast<char>((num>>40) & 0xFF);
+    data[6] = static_cast<char>((num>>48) & 0xFF);
+    data[7] = static_cast<char>((num>>56) & 0xFF);
+    return data;
+}
+
+QByteArray vintToData(int num)
+{
+    QByteArray data(sizeof(int), 0);
+    // Write the size in a Uint of variable lenght (8-32 bits)
+    int i=0;
+    while (num >= 0x80)
+    {
+        data[i] = static_cast<char>(num | 0x80);
+        i++;
+        num = num >> 7;
+    }
+    data[i] = static_cast<char>(num);
+    data.resize(i+1);
     return data;
 }
 
@@ -283,10 +313,11 @@ QByteArray vuintToData(size_t num)
     int i=0;
     while (num >= 0x80)
     {
-        data[i] = (unsigned char)(num | 0x80); i++;
+        data[i] = static_cast<char>(num | 0x80);
+        i++;
         num = num >> 7;
     }
-    data[i]=num;
+    data[i] = static_cast<char>(num);
     data.resize(i+1);
     return data;
 }

--- a/src/persistence/serialize.cpp
+++ b/src/persistence/serialize.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2014-2015 by The qTox Project
+    Copyright © 2014-2016 by The qTox Project
 
     This file is part of qTox, a Qt-based graphical interface for Tox.
 

--- a/src/persistence/serialize.h
+++ b/src/persistence/serialize.h
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2014 by The qTox Project
+    Copyright © 2014-2016 by The qTox Project
 
     This file is part of qTox, a Qt-based graphical interface for Tox.
 

--- a/src/persistence/serialize.h
+++ b/src/persistence/serialize.h
@@ -27,21 +27,23 @@
 
 QByteArray doubleToData(double num);
 QByteArray floatToData(float num);
-float dataToFloat(QByteArray data);
-QByteArray stringToData(QString str);
+float dataToFloat(const QByteArray& data);
+QByteArray stringToData(const QString& str);
 QString dataToString(QByteArray data);
 float dataToRangedSingle(float min, float max, int numberOfBits, QByteArray data);
 QByteArray rangedSingleToData(float value, float min, float max, int numberOfBits);
-uint8_t dataToUint8(QByteArray data);
-uint16_t dataToUint16(QByteArray data);
-uint32_t dataToUint32(QByteArray data);
-uint64_t dataToUint64(QByteArray data);
+uint8_t dataToUint8(const QByteArray& data);
+uint16_t dataToUint16(const QByteArray& data);
+uint32_t dataToUint32(const QByteArray& data);
+uint64_t dataToUint64(const QByteArray& data);
+int dataToVInt(const QByteArray& data);
 size_t dataToVUint(const QByteArray& data);
 unsigned getVUint32Size(QByteArray data);
 QByteArray uint8ToData(uint8_t num);
 QByteArray uint16ToData(uint16_t num);
 QByteArray uint32ToData(uint32_t num);
 QByteArray uint64ToData(uint64_t num);
+QByteArray vintToData(int num);
 QByteArray vuintToData(size_t num);
 
 #endif // SERIALIZE_H

--- a/src/persistence/serialize.h
+++ b/src/persistence/serialize.h
@@ -25,24 +25,11 @@
 #include <QByteArray>
 #include <QString>
 
-QByteArray doubleToData(double num);
-QByteArray floatToData(float num);
-float dataToFloat(const QByteArray& data);
-QByteArray stringToData(const QString& str);
 QString dataToString(QByteArray data);
-float dataToRangedSingle(float min, float max, int numberOfBits, QByteArray data);
-QByteArray rangedSingleToData(float value, float min, float max, int numberOfBits);
-uint8_t dataToUint8(const QByteArray& data);
-uint16_t dataToUint16(const QByteArray& data);
-uint32_t dataToUint32(const QByteArray& data);
 uint64_t dataToUint64(const QByteArray& data);
 int dataToVInt(const QByteArray& data);
 size_t dataToVUint(const QByteArray& data);
 unsigned getVUint32Size(QByteArray data);
-QByteArray uint8ToData(uint8_t num);
-QByteArray uint16ToData(uint16_t num);
-QByteArray uint32ToData(uint32_t num);
-QByteArray uint64ToData(uint64_t num);
 QByteArray vintToData(int num);
 QByteArray vuintToData(size_t num);
 

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -47,8 +47,6 @@
 #include <QThread>
 #include <QNetworkProxy>
 
-#define SHOW_SYSTEM_TRAY_DEFAULT (bool) true
-
 /**
 @var QHash<QString, QByteArray> Settings::widgetSettings
 @brief Assume all widgets have unique names
@@ -154,7 +152,7 @@ void Settings::loadGlobal()
                 server.name = s.value("name").toString();
                 server.userId = s.value("userId").toString();
                 server.address = s.value("address").toString();
-                server.port = s.value("port").toInt();
+                server.port = static_cast<quint16>(s.value("port").toUInt());
                 dhtServerList << server;
             }
             s.endArray();
@@ -168,14 +166,14 @@ void Settings::loadGlobal()
     s.beginGroup("General");
         enableIPv6 = s.value("enableIPv6", true).toBool();
         translation = s.value("translation", "en").toString();
-        showSystemTray = s.value("showSystemTray", SHOW_SYSTEM_TRAY_DEFAULT).toBool();
+        showSystemTray = s.value("showSystemTray", true).toBool();
         makeToxPortable = s.value("makeToxPortable", false).toBool();
         autostartInTray = s.value("autostartInTray", false).toBool();
         closeToTray = s.value("closeToTray", false).toBool();
         forceTCP = s.value("forceTCP", false).toBool();
         setProxyType(s.value("proxyType", static_cast<int>(ProxyType::ptNone)).toInt());
         proxyAddr = s.value("proxyAddr", "").toString();
-        proxyPort = s.value("proxyPort", 0).toInt();
+        proxyPort = static_cast<quint16>(s.value("proxyPort", 0).toUInt());
         if (currentProfile.isEmpty())
         {
             currentProfile = s.value("currentProfile", "").toString();
@@ -268,7 +266,7 @@ void Settings::loadGlobal()
         camVideoRes = s.value("camVideoRes", QRect()).toRect();
         screenRegion = s.value("screenRegion", QRect()).toRect();
         screenGrabbed = s.value("screenGrabbed", false).toBool();
-        camVideoFPS = s.value("camVideoFPS", 0).toUInt();
+        camVideoFPS = static_cast<quint16>(s.value("camVideoFPS", 0).toUInt());
     s.endGroup();
 
     // Read the embedded DHT bootstrap nodes list if needed
@@ -285,7 +283,7 @@ void Settings::loadGlobal()
                 server.name = rcs.value("name").toString();
                 server.userId = rcs.value("userId").toString();
                 server.address = rcs.value("address").toString();
-                server.port = rcs.value("port").toInt();
+                server.port = static_cast<quint16>(rcs.value("port").toUInt());
                 dhtServerList << server;
             }
             rcs.endArray();
@@ -620,7 +618,7 @@ void Settings::savePersonal(QString profileName, const QString &password)
 uint32_t Settings::makeProfileId(const QString& profile)
 {
     QByteArray data = QCryptographicHash::hash(profile.toUtf8(), QCryptographicHash::Md5);
-    const uint32_t* dwords = (uint32_t*)data.constData();
+    const uint32_t* dwords = reinterpret_cast<const uint32_t*>(data.constData());
     return dwords[0] ^ dwords[1] ^ dwords[2] ^ dwords[3];
 }
 
@@ -925,7 +923,7 @@ void Settings::deleteToxme()
 {
     setToxmeInfo("");
     setToxmeBio("");
-    setToxmePriv("");
+    setToxmePriv(false);
     setToxmePass("");
 }
 
@@ -1016,7 +1014,9 @@ QNetworkProxy Settings::getProxy() const
         default:
             proxy.setType(QNetworkProxy::NoProxy);
             qWarning() << "Invalid Proxy type, setting to NoProxy";
+            break;
     }
+
     proxy.setHostName(Settings::getProxyAddr());
     proxy.setPort(Settings::getProxyPort());
     return proxy;
@@ -1049,13 +1049,13 @@ void Settings::setProxyAddr(const QString& newValue)
     proxyAddr = newValue;
 }
 
-int Settings::getProxyPort() const
+quint16 Settings::getProxyPort() const
 {
     QMutexLocker locker{&bigLock};
     return proxyPort;
 }
 
-void Settings::setProxyPort(int newValue)
+void Settings::setProxyPort(quint16 newValue)
 {
     QMutexLocker locker{&bigLock};
     proxyPort = newValue;

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -145,8 +145,8 @@ public:
     ProxyType getProxyType() const;
     void setProxyType(int newValue);
 
-    int getProxyPort() const;
-    void setProxyPort(int newValue);
+    quint16 getProxyPort() const;
+    void setProxyPort(quint16 newValue);
 
     bool getEnableLogging() const;
     void setEnableLogging(bool newValue);
@@ -390,7 +390,7 @@ private:
 
     ProxyType proxyType;
     QString proxyAddr;
-    int proxyPort;
+    quint16 proxyPort;
 
     QString currentProfile;
     uint32_t currentProfileId;

--- a/src/persistence/settingsserializer.h
+++ b/src/persistence/settingsserializer.h
@@ -41,7 +41,7 @@ public:
     int beginReadArray(const QString &prefix);
     void beginWriteArray(const QString &prefix, int size = -1);
     void endArray();
-    void setArrayIndex(unsigned i);
+    void setArrayIndex(int i);
 
     void setValue(const QString &key, const QVariant &value);
     QVariant value(const QString &key, const QVariant &defaultValue = QVariant()) const;
@@ -61,10 +61,11 @@ private:
     struct Value
     {
         Value() : group{-2},array{-2},key{QString()},value{}{}
-        Value(qint64 group, qint64 array, qint64 arrayIndex, QString key, QVariant value)
+        Value(qint64 group, qint64 array, int arrayIndex, QString key, QVariant value)
             : group{group}, array{array}, arrayIndex{arrayIndex}, key{key}, value{value} {}
         qint64 group;
-        qint64 array, arrayIndex;
+        qint64 array;
+        int arrayIndex;
         QString key;
         QVariant value;
     };
@@ -72,9 +73,9 @@ private:
     struct Array
     {
         qint64 group;
-        quint64 size;
+        int size;
         QString name;
-        QVector<quint64> values;
+        QVector<int> values;
     };
 
 private:


### PR DESCRIPTION
The used var types in the qTox Settings class require some cleanup. For some weeks (months?) now, LLVM's static code analysis is available in Qt Creator and helps a bit. It moans about lots of missing type casts, which is also an indicator, that those types do not match well and need to be changed.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tux3/qtox/3380)

<!-- Reviewable:end -->
