### PR TITLE
fix(widget): properly open chat window

### DIFF
--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1195,7 +1195,7 @@ bool Widget::newFriendMessageAlert(int friendId, bool sound)
     }
     else
     {
-        if (Settings::getInstance().getSeparateWindow())
+        if (Settings::getInstance().getSeparateWindow() && Settings::getInstance().getShowWindow())
         {
             if (Settings::getInstance().getDontGroupWindows())
             {


### PR DESCRIPTION
No need to create new chat window when not going to open it.
Sorry for that.

Closes #3386
