### PR TITLE
Fix SystemTrayIcon GTK implementation critical warning

### DIFF
--- a/src/widget/systemtrayicon.cpp
+++ b/src/widget/systemtrayicon.cpp
@@ -66,10 +66,7 @@ SystemTrayIcon::SystemTrayIcon()
         backendType = SystrayBackendType::GTK;
         gtk_init(nullptr, nullptr);
 
-        // No ':' needed in resource path!
-        GdkPixbuf *pixbuf = gdk_pixbuf_new_from_resource("/img/icon.png", NULL);
-        gtkIcon = gtk_status_icon_new_from_pixbuf(pixbuf);
-        g_object_unref(pixbuf);
+        gtkIcon = gtk_status_icon_new();
 
         gtkMenu = gtk_menu_new();
 

--- a/src/widget/systemtrayicon.h
+++ b/src/widget/systemtrayicon.h
@@ -44,6 +44,9 @@ signals:
 
 private:
     QString extractIconToFile(QIcon icon, QString name="icon");
+#if defined(ENABLE_SYSTRAY_GTK_BACKEND) || defined(ENABLE_SYSTRAY_STATUSNOTIFIER_BACKEND)
+    static GdkPixbuf* convertQIconToPixbuf(const QIcon &icon);
+#endif
 
 private:
     SystrayBackendType backendType;


### PR DESCRIPTION
See #3154.  This fixes the runtime warning under Xfce/GNOME/MATE and Cinnamon desktops:

```
[01:06:45.205] src/widget/systemtrayicon.cpp:65 : Debug: Using GTK backend

(qtox:28186): GLib-GObject-CRITICAL **: g_object_unref: assertion 'G_IS_OBJECT (object)' failed
```

While at it, refactor some code to avoid 4 time code duplication.
