### PR TITLE
feat(emoticons): add ASCII-less version of emojione emoticons

### DIFF
--- a/smileys/ASCII+emojione/emoticons.xml
+++ b/smileys/ASCII+emojione/emoticons.xml
@@ -1,0 +1,2529 @@
+<?xml version = '1.0' encoding = 'UTF-8'?>
+<messaging-emoticon-map>
+    <emoticon file="../emojione/263a">
+        <string>☺</string>
+	<string>:smile:</string>
+    </emoticon>
+    <emoticon file="../emojione/1f600">
+        <string>😀</string>
+	<string>:grinning:</string>
+    </emoticon>
+    <emoticon file="../emojione/1f601">
+        <string>😁</string>
+    </emoticon>
+    <emoticon file="../emojione/1f602">
+        <string>😂</string>
+	<string>:tearsofjoy:</string>
+    </emoticon>
+    <emoticon file="../emojione/1f603">
+        <string>😃</string>
+    </emoticon>
+    <emoticon file="../emojione/1f604">
+        <string>😄</string>
+	<string>:happy:</string>
+    </emoticon>
+    <emoticon file="../emojione/1f605">
+        <string>😅</string>
+    </emoticon>
+    <emoticon file="../emojione/1f606">
+        <string>😆</string>
+    </emoticon>
+    <emoticon file="../emojione/1f607">
+        <string>😇</string>
+    </emoticon>
+    <emoticon file="../emojione/1f608">
+        <string>😈</string>
+    </emoticon>
+    <emoticon file="../emojione/1f609">
+        <string>😉</string>
+    </emoticon>
+    <emoticon file="../emojione/1f60a">
+        <string>😊</string>
+    </emoticon>
+    <emoticon file="../emojione/1f60b">
+        <string>😋</string>
+    </emoticon>
+    <emoticon file="../emojione/1f60c">
+        <string>😌</string>
+    </emoticon>
+    <emoticon file="../emojione/1f60d">
+        <string>😍</string>
+    </emoticon>
+    <emoticon file="../emojione/1f60e">
+        <string>😎</string>
+	<string>:cool:</string>
+    </emoticon>
+    <emoticon file="../emojione/1f60f">
+        <string>😏</string>
+    </emoticon>
+    <emoticon file="../emojione/1f610">
+        <string>😐</string>
+	<string>:disappointed:</string>
+    </emoticon>
+    <emoticon file="../emojione/1f611">
+        <string>😑</string>
+    </emoticon>
+    <emoticon file="../emojione/1f612">
+        <string>😒</string>
+    </emoticon>
+    <emoticon file="../emojione/1f613">
+        <string>😓</string>
+    </emoticon>
+    <emoticon file="../emojione/1f614">
+        <string>😔</string>
+    </emoticon>
+    <emoticon file="../emojione/1f615">
+        <string>😕</string>
+    </emoticon>
+    <emoticon file="../emojione/1f616">
+        <string>😖</string>
+	<string>:oops:</string>
+    </emoticon>
+    <emoticon file="../emojione/1f617">
+        <string>😗</string>
+    </emoticon>
+    <emoticon file="../emojione/1f618">
+        <string>😘</string>
+    </emoticon>
+    <emoticon file="../emojione/1f619">
+        <string>😙</string>
+    </emoticon>
+    <emoticon file="../emojione/1f61a">
+        <string>😚</string>
+    </emoticon>
+    <emoticon file="../emojione/1f61b">
+        <string>😛</string>
+    </emoticon>
+    <emoticon file="../emojione/1f61c">
+        <string>😜</string>
+    </emoticon>
+    <emoticon file="../emojione/1f61d">
+        <string>😝</string>
+    </emoticon>
+    <emoticon file="../emojione/1f61e">
+        <string>😞</string>
+	<string>:sad:</string>
+    </emoticon>
+    <emoticon file="../emojione/1f61f">
+        <string>😟</string>
+    </emoticon>
+    <emoticon file="../emojione/1f620">
+        <string>😠</string>
+	<string>:angry:</string>
+    </emoticon>
+    <emoticon file="../emojione/1f621">
+        <string>😡</string>
+    </emoticon>
+    <emoticon file="../emojione/1f622">
+        <string>😢</string>
+	<string>:cry:</string>
+    </emoticon>
+    <emoticon file="../emojione/1f623">
+        <string>😣</string>
+    </emoticon>
+    <emoticon file="../emojione/1f624">
+        <string>😤</string>
+    </emoticon>
+    <emoticon file="../emojione/1f625">
+        <string>😥</string>
+    </emoticon>
+    <emoticon file="../emojione/1f626">
+        <string>😦</string>
+    </emoticon>
+    <emoticon file="../emojione/1f627">
+        <string>😧</string>
+    </emoticon>
+    <emoticon file="../emojione/1f628">
+        <string>😨</string>
+    </emoticon>
+    <emoticon file="../emojione/1f629">
+        <string>😩</string>
+    </emoticon>
+    <emoticon file="../emojione/1f62a">
+        <string>😪</string>
+    </emoticon>
+    <emoticon file="../emojione/1f62b">
+        <string>😫</string>
+    </emoticon>
+    <emoticon file="../emojione/1f62c">
+        <string>😬</string>
+    </emoticon>
+    <emoticon file="../emojione/1f62d">
+        <string>😭</string>
+    </emoticon>
+    <emoticon file="../emojione/1f62e">
+        <string>😮</string>
+    </emoticon>
+    <emoticon file="../emojione/1f62f">
+        <string>😯</string>
+    </emoticon>
+    <emoticon file="../emojione/1f630">
+        <string>😰</string>
+    </emoticon>
+    <emoticon file="../emojione/1f631">
+        <string>😱</string>
+    </emoticon>
+    <emoticon file="../emojione/1f632">
+        <string>😲</string>
+    </emoticon>
+    <emoticon file="../emojione/1f633">
+        <string>😳</string>
+    </emoticon>
+    <emoticon file="../emojione/1f634">
+        <string>😴</string>
+	<string>:sleep:</string>
+	<string>:sleeping:</string>
+    </emoticon>
+    <emoticon file="../emojione/1f635">
+        <string>😵</string>
+    </emoticon>
+    <emoticon file="../emojione/1f636">
+        <string>😶</string>
+    </emoticon>
+    <emoticon file="../emojione/1f637">
+        <string>😷</string>
+    </emoticon>
+    <emoticon file="../emojione/1f638">
+        <string>😸</string>
+    </emoticon>
+    <emoticon file="../emojione/1f639">
+        <string>😹</string>
+    </emoticon>
+    <emoticon file="../emojione/1f63a">
+        <string>😺</string>
+    </emoticon>
+    <emoticon file="../emojione/1f63b">
+        <string>😻</string>
+    </emoticon>
+    <emoticon file="../emojione/1f63c">
+        <string>😼</string>
+    </emoticon>
+    <emoticon file="../emojione/1f63d">
+        <string>😽</string>
+    </emoticon>
+    <emoticon file="../emojione/1f63e">
+        <string>😾</string>
+    </emoticon>
+    <emoticon file="../emojione/1f63f">
+        <string>😿</string>
+    </emoticon>
+    <emoticon file="../emojione/1f640">
+        <string>🙀</string>
+    </emoticon>
+    <emoticon file="../emojione/1f645">
+        <string>🙅</string>
+    </emoticon>
+    <emoticon file="../emojione/1f646">
+        <string>🙆</string>
+    </emoticon>
+    <emoticon file="../emojione/1f647">
+        <string>🙇</string>
+    </emoticon>
+    <emoticon file="../emojione/1f648">
+        <string>🙈</string>
+    </emoticon>
+    <emoticon file="../emojione/1f649">
+        <string>🙉</string>
+    </emoticon>
+    <emoticon file="../emojione/1f64a">
+        <string>🙊</string>
+	<string>:silence:</string>
+    </emoticon>
+    <emoticon file="../emojione/1f64b">
+        <string>🙋</string>
+	<string>:hi:</string>
+    </emoticon>
+    <emoticon file="../emojione/1f64c">
+        <string>🙌</string>
+    </emoticon>
+    <emoticon file="../emojione/1f64d">
+        <string>🙍</string>
+    </emoticon>
+    <emoticon file="../emojione/1f64e">
+        <string>🙎</string>
+    </emoticon>
+    <emoticon file="../emojione/1f64f">
+        <string>🙏</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4a9">
+	<string>💩</string>
+    </emoticon>
+    <emoticon file="../emojione/1f300">
+	<string>🌀</string>
+    </emoticon>
+    <emoticon file="../emojione/1f301">
+	<string>🌁</string>
+    </emoticon>
+    <emoticon file="../emojione/1f302">
+	<string>🌂</string>
+    </emoticon>
+    <emoticon file="../emojione/1f303">
+	<string>🌃</string>
+    </emoticon>
+    <emoticon file="../emojione/1f304">
+	<string>🌄</string>
+    </emoticon>
+    <emoticon file="../emojione/1f305">
+	<string>🌅</string>
+    </emoticon>
+    <emoticon file="../emojione/1f306">
+	<string>🌆</string>
+    </emoticon>
+    <emoticon file="../emojione/1f307">
+	<string>🌇</string>
+    </emoticon>
+    <emoticon file="../emojione/1f308">
+	<string>🌈</string>
+    </emoticon>
+    <emoticon file="../emojione/1f309">
+	<string>🌉</string>
+    </emoticon>
+    <emoticon file="../emojione/1f30a">
+	<string>🌊</string>
+    </emoticon>
+    <emoticon file="../emojione/1f30b">
+	<string>🌋</string>
+    </emoticon>
+    <emoticon file="../emojione/1f30c">
+	<string>🌌</string>
+    </emoticon>
+    <emoticon file="../emojione/1f30d">
+	<string>🌍</string>
+    </emoticon>
+    <emoticon file="../emojione/1f30e">
+	<string>🌎</string>
+    </emoticon>
+    <emoticon file="../emojione/1f30f">
+	<string>🌏</string>
+    </emoticon>
+    <emoticon file="../emojione/1f310">
+	<string>🌐</string>
+    </emoticon>
+    <emoticon file="../emojione/1f311">
+	<string>🌑</string>
+    </emoticon>
+    <emoticon file="../emojione/1f312">
+	<string>🌒</string>
+    </emoticon>
+    <emoticon file="../emojione/1f313">
+	<string>🌓</string>
+    </emoticon>
+    <emoticon file="../emojione/1f314">
+	<string>🌔</string>
+    </emoticon>
+    <emoticon file="../emojione/1f315">
+	<string>🌕</string>
+    </emoticon>
+    <emoticon file="../emojione/1f316">
+	<string>🌖</string>
+    </emoticon>
+    <emoticon file="../emojione/1f317">
+	<string>🌗</string>
+    </emoticon>
+    <emoticon file="../emojione/1f318">
+	<string>🌘</string>
+    </emoticon>
+    <emoticon file="../emojione/1f319">
+	<string>🌙</string>
+    </emoticon>
+    <emoticon file="../emojione/1f31a">
+	<string>🌚</string>
+    </emoticon>
+    <emoticon file="../emojione/1f31b">
+	<string>🌛</string>
+    </emoticon>
+    <emoticon file="../emojione/1f31c">
+	<string>🌜</string>
+    </emoticon>
+    <emoticon file="../emojione/1f31d">
+	<string>🌝</string>
+    </emoticon>
+    <emoticon file="../emojione/1f31e">
+	<string>🌞</string>
+    </emoticon>
+    <emoticon file="../emojione/1f31f">
+	<string>🌟</string>
+    </emoticon>
+    <emoticon file="../emojione/1f320">
+	<string>🌠</string>
+    </emoticon>
+    <emoticon file="../emojione/1f330">
+	<string>🌰</string>
+    </emoticon>
+    <emoticon file="../emojione/1f331">
+	<string>🌱</string>
+    </emoticon>
+    <emoticon file="../emojione/1f332">
+	<string>🌲</string>
+    </emoticon>
+    <emoticon file="../emojione/1f333">
+	<string>🌳</string>
+    </emoticon>
+    <emoticon file="../emojione/1f334">
+	<string>🌴</string>
+    </emoticon>
+    <emoticon file="../emojione/1f335">
+	<string>🌵</string>
+    </emoticon>
+    <emoticon file="../emojione/1f337">
+      <string>🌷</string>
+    </emoticon>
+    <emoticon file="../emojione/1f338">
+	<string>🌸</string>
+    </emoticon>
+    <emoticon file="../emojione/1f339">
+	<string>🌹</string>
+    </emoticon>
+    <emoticon file="../emojione/1f33a">
+	<string>🌺</string>
+    </emoticon>
+    <emoticon file="../emojione/1f33b">
+	<string>🌻</string>
+    </emoticon>
+    <emoticon file="../emojione/1f33c">
+	<string>🌼</string>
+    </emoticon>
+    <emoticon file="../emojione/1f33d">
+	<string>🌽</string>
+    </emoticon>
+    <emoticon file="../emojione/1f33e">
+	<string>🌾</string>
+    </emoticon>
+    <emoticon file="../emojione/1f33f">
+	<string>🌿</string>
+    </emoticon>
+    <emoticon file="../emojione/1f340">
+	<string>🍀</string>
+    </emoticon>
+    <emoticon file="../emojione/1f341">
+	<string>🍁</string>
+    </emoticon>
+    <emoticon file="../emojione/1f342">
+	<string>🍂</string>
+    </emoticon>
+    <emoticon file="../emojione/1f343">
+	<string>🍃</string>
+    </emoticon>
+    <emoticon file="../emojione/1f344">
+	<string>🍄</string>
+    </emoticon>
+    <emoticon file="../emojione/1f345">
+	<string>🍅</string>
+    </emoticon>
+    <emoticon file="../emojione/1f346">
+	<string>🍆</string>
+    </emoticon>
+    <emoticon file="../emojione/1f347">
+	<string>🍇</string>
+    </emoticon>
+    <emoticon file="../emojione/1f348">
+	<string>🍈</string>
+    </emoticon>
+    <emoticon file="../emojione/1f349">
+	<string>🍉</string>
+    </emoticon>
+    <emoticon file="../emojione/1f34a">
+	<string>🍊</string>
+    </emoticon>
+    <emoticon file="../emojione/1f34b">
+	<string>🍋</string>
+    </emoticon>
+    <emoticon file="../emojione/1f34c">
+	<string>🍌</string>
+    </emoticon>
+    <emoticon file="../emojione/1f34d">
+	<string>🍍</string>
+    </emoticon>
+    <emoticon file="../emojione/1f34e">
+	<string>🍎</string>
+    </emoticon>
+    <emoticon file="../emojione/1f34f">
+	<string>🍏</string>
+    </emoticon>
+    <emoticon file="../emojione/1f350">
+	<string>🍐</string>
+    </emoticon>
+    <emoticon file="../emojione/1f351">
+	<string>🍑</string>
+    </emoticon>
+    <emoticon file="../emojione/1f352">
+	<string>🍒</string>
+    </emoticon>
+    <emoticon file="../emojione/1f353">
+	<string>🍓</string>
+    </emoticon>
+    <emoticon file="../emojione/1f354">
+	<string>🍔</string>
+    </emoticon>
+    <emoticon file="../emojione/1f355">
+	<string>🍕</string>
+    </emoticon>
+    <emoticon file="../emojione/1f356">
+	<string>🍖</string>
+    </emoticon>
+    <emoticon file="../emojione/1f357">
+	<string>🍗</string>
+    </emoticon>
+    <emoticon file="../emojione/1f358">
+	<string>🍘</string>
+    </emoticon>
+    <emoticon file="../emojione/1f359">
+	<string>🍙</string>
+    </emoticon>
+    <emoticon file="../emojione/1f35a">
+	<string>🍚</string>
+    </emoticon>
+    <emoticon file="../emojione/1f35b">
+	<string>🍛</string>
+    </emoticon>
+    <emoticon file="../emojione/1f35c">
+	<string>🍜</string>
+    </emoticon>
+    <emoticon file="../emojione/1f35d">
+	<string>🍝</string>
+    </emoticon>
+    <emoticon file="../emojione/1f35e">
+	<string>🍞</string>
+    </emoticon>
+    <emoticon file="../emojione/1f35f">
+	<string>🍟</string>
+    </emoticon>
+    <emoticon file="../emojione/1f360">
+	<string>🍠</string>
+    </emoticon>
+    <emoticon file="../emojione/1f361">
+	<string>🍡</string>
+    </emoticon>
+    <emoticon file="../emojione/1f362">
+	<string>🍢</string>
+    </emoticon>
+    <emoticon file="../emojione/1f363">
+	<string>🍣</string>
+    </emoticon>
+    <emoticon file="../emojione/1f364">
+	<string>🍤</string>
+    </emoticon>
+    <emoticon file="../emojione/1f365">
+	<string>🍥</string>
+    </emoticon>
+    <emoticon file="../emojione/1f366">
+	<string>🍦</string>
+    </emoticon>
+    <emoticon file="../emojione/1f367">
+	<string>🍧</string>
+    </emoticon>
+    <emoticon file="../emojione/1f368">
+	<string>🍨</string>
+    </emoticon>
+    <emoticon file="../emojione/1f369">
+	<string>🍩</string>
+    </emoticon>
+    <emoticon file="../emojione/1f36a">
+	<string>🍪</string>
+	<string>:cookie:</string>
+    </emoticon>
+    <emoticon file="../emojione/1f36b">
+	<string>🍫</string>
+    </emoticon>
+    <emoticon file="../emojione/1f36c">
+	<string>🍬</string>
+    </emoticon>
+    <emoticon file="../emojione/1f36d">
+	<string>🍭</string>
+    </emoticon>
+    <emoticon file="../emojione/1f36e">
+	<string>🍮</string>
+    </emoticon>
+    <emoticon file="../emojione/1f36f">
+	<string>🍯</string>
+    </emoticon>
+    <emoticon file="../emojione/1f370">
+	<string>🍰</string>
+    </emoticon>
+    <emoticon file="../emojione/1f371">
+	<string>🍱</string>
+    </emoticon>
+    <emoticon file="../emojione/1f372">
+	<string>🍲</string>
+    </emoticon>
+    <emoticon file="../emojione/1f373">
+	<string>🍳</string>
+    </emoticon>
+    <emoticon file="../emojione/1f374">
+	<string>🍴</string>
+    </emoticon>
+    <emoticon file="../emojione/1f375">
+	<string>🍵</string>
+    </emoticon>
+    <emoticon file="../emojione/1f376">
+	<string>🍶</string>
+    </emoticon>
+    <emoticon file="../emojione/1f377">
+	<string>🍷</string>
+    </emoticon>
+    <emoticon file="../emojione/1f378">
+	<string>🍸</string>
+    </emoticon>
+    <emoticon file="../emojione/1f379">
+	<string>🍹</string>
+    </emoticon>
+    <emoticon file="../emojione/1f37a">
+	<string>🍺</string>
+	<string>:beer:</string>
+    </emoticon>
+    <emoticon file="../emojione/1f37b">
+	<string>🍻</string>
+	<string>:beers:</string>
+    </emoticon>
+    <emoticon file="../emojione/1f37c">
+	<string>🍼</string>
+    </emoticon>
+    <emoticon file="../emojione/1f380">
+	<string>🎀</string>
+    </emoticon>
+    <emoticon file="../emojione/1f381">
+	<string>🎁</string>
+    </emoticon>
+    <emoticon file="../emojione/1f382">
+	<string>🎂</string>
+    </emoticon>
+    <emoticon file="../emojione/1f383">
+	<string>🎃</string>
+    </emoticon>
+    <emoticon file="../emojione/1f384">
+	<string>🎄</string>
+    </emoticon>
+    <emoticon file="../emojione/1f385">
+	<string>🎅</string>
+    </emoticon>
+    <emoticon file="../emojione/1f386">
+	<string>🎆</string>
+    </emoticon>
+    <emoticon file="../emojione/1f387">
+	<string>🎇</string>
+    </emoticon>
+    <emoticon file="../emojione/1f388">
+	<string>🎈</string>
+    </emoticon>
+    <emoticon file="../emojione/1f389">
+	<string>🎉</string>
+    </emoticon>
+    <emoticon file="../emojione/1f38a">
+	<string>🎊</string>
+    </emoticon>
+    <emoticon file="../emojione/1f38b">
+	<string>🎋</string>
+    </emoticon>
+    <emoticon file="../emojione/1f38c">
+	<string>🎌</string>
+    </emoticon>
+    <emoticon file="../emojione/1f38d">
+	<string>🎍</string>
+    </emoticon>
+    <emoticon file="../emojione/1f38e">
+	<string>🎎</string>
+    </emoticon>
+    <emoticon file="../emojione/1f38f">
+	<string>🎏</string>
+    </emoticon>
+    <emoticon file="../emojione/1f390">
+	<string>🎐</string>
+    </emoticon>
+    <emoticon file="../emojione/1f391">
+	<string>🎑</string>
+    </emoticon>
+    <emoticon file="../emojione/1f392">
+	<string>🎒</string>
+    </emoticon>
+    <emoticon file="../emojione/1f393">
+	<string>🎓</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3a0">
+	<string>🎠</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3a1">
+	<string>🎡</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3a2">
+	<string>🎢</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3a3">
+	<string>🎣</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3a4">
+	<string>🎤</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3a5">
+	<string>🎥</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3a6">
+	<string>🎦</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3a7">
+	<string>🎧</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3a8">
+	<string>🎨</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3a9">
+	<string>🎩</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3aa">
+	<string>🎪</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3ab">
+	<string>🎫</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3ac">
+	<string>🎬</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3ad">
+	<string>🎭</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3ae">
+	<string>🎮</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3af">
+	<string>🎯</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3b0">
+	<string>🎰</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3b1">
+	<string>🎱</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3b2">
+	<string>🎲</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3b3">
+	<string>🎳</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3b4">
+	<string>🎴</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3b5">
+	<string>🎵</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3b6">
+	<string>🎶</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3b7">
+	<string>🎷</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3b8">
+	<string>🎸</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3b9">
+	<string>🎹</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3ba">
+	<string>🎺</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3bb">
+	<string>🎻</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3bc">
+	<string>🎼</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3bd">
+	<string>🎽</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3be">
+	<string>🎾</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3bf">
+	<string>🎿</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3c0">
+	<string>🏀</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3c1">
+	<string>🏁</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3c2">
+	<string>🏂</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3c3">
+	<string>🏃</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3c4">
+	<string>🏄</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3c6">
+	<string>🏆</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3c7">
+	<string>🏇</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3c8">
+	<string>🏈</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3c9">
+	<string>🏉</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3ca">
+	<string>🏊</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3e0">
+	<string>🏠</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3e1">
+	<string>🏡</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3e2">
+	<string>🏢</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3e3">
+	<string>🏣</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3e4">
+	<string>🏤</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3e5">
+	<string>🏥</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3e6">
+	<string>🏦</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3e7">
+	<string>🏧</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3e8">
+	<string>🏨</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3e9">
+	<string>🏩</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3ea">
+	<string>🏪</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3eb">
+	<string>🏫</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3ec">
+	<string>🏬</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3ed">
+	<string>🏭</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3ee">
+	<string>🏮</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3ef">
+	<string>🏯</string>
+    </emoticon>
+    <emoticon file="../emojione/1f3f0">
+	<string>🏰</string>
+    </emoticon>
+    <emoticon file="../emojione/1f400">
+	<string>🐀</string>
+    </emoticon>
+    <emoticon file="../emojione/1f401">
+	<string>🐁</string>
+    </emoticon>
+    <emoticon file="../emojione/1f402">
+	<string>🐂</string>
+    </emoticon>
+    <emoticon file="../emojione/1f403">
+	<string>🐃</string>
+    </emoticon>
+    <emoticon file="../emojione/1f404">
+	<string>🐄</string>
+    </emoticon>
+    <emoticon file="../emojione/1f405">
+	<string>🐅</string>
+    </emoticon>
+    <emoticon file="../emojione/1f406">
+	<string>🐆</string>
+    </emoticon>
+    <emoticon file="../emojione/1f407">
+	<string>🐇</string>
+    </emoticon>
+    <emoticon file="../emojione/1f408">
+	<string>🐈</string>
+    </emoticon>
+    <emoticon file="../emojione/1f409">
+	<string>🐉</string>
+    </emoticon>
+    <emoticon file="../emojione/1f40a">
+	<string>🐊</string>
+    </emoticon>
+    <emoticon file="../emojione/1f40b">
+	<string>🐋</string>
+    </emoticon>
+    <emoticon file="../emojione/1f40c">
+	<string>🐌</string>
+    </emoticon>
+    <emoticon file="../emojione/1f40d">
+	<string>🐍</string>
+    </emoticon>
+    <emoticon file="../emojione/1f40e">
+	<string>🐎</string>
+    </emoticon>
+    <emoticon file="../emojione/1f40f">
+	<string>🐏</string>
+    </emoticon>
+    <emoticon file="../emojione/1f410">
+	<string>🐐</string>
+    </emoticon>
+    <emoticon file="../emojione/1f411">
+	<string>🐑</string>
+    </emoticon>
+    <emoticon file="../emojione/1f412">
+	<string>🐒</string>
+    </emoticon>
+    <emoticon file="../emojione/1f413">
+	<string>🐓</string>
+    </emoticon>
+    <emoticon file="../emojione/1f414">
+	<string>🐔</string>
+    </emoticon>
+    <emoticon file="../emojione/1f415">
+	<string>🐕</string>
+    </emoticon>
+    <emoticon file="../emojione/1f416">
+	<string>🐖</string>
+    </emoticon>
+    <emoticon file="../emojione/1f417">
+	<string>🐗</string>
+    </emoticon>
+    <emoticon file="../emojione/1f418">
+	<string>🐘</string>
+    </emoticon>
+    <emoticon file="../emojione/1f419">
+	<string>🐙</string>
+    </emoticon>
+    <emoticon file="../emojione/1f41a">
+	<string>🐚</string>
+    </emoticon>
+    <emoticon file="../emojione/1f41b">
+	<string>🐛</string>
+    </emoticon>
+    <emoticon file="../emojione/1f41c">
+	<string>🐜</string>
+    </emoticon>
+    <emoticon file="../emojione/1f41d">
+	<string>🐝</string>
+    </emoticon>
+    <emoticon file="../emojione/1f41e">
+	<string>🐞</string>
+    </emoticon>
+    <emoticon file="../emojione/1f41f">
+	<string>🐟</string>
+    </emoticon>
+    <emoticon file="../emojione/1f420">
+	<string>🐠</string>
+    </emoticon>
+    <emoticon file="../emojione/1f421">
+	<string>🐡</string>
+    </emoticon>
+    <emoticon file="../emojione/1f422">
+	<string>🐢</string>
+    </emoticon>
+    <emoticon file="../emojione/1f423">
+	<string>🐣</string>
+    </emoticon>
+    <emoticon file="../emojione/1f424">
+	<string>🐤</string>
+    </emoticon>
+    <emoticon file="../emojione/1f425">
+	<string>🐥</string>
+    </emoticon>
+    <emoticon file="../emojione/1f426">
+	<string>🐦</string>
+    </emoticon>
+    <emoticon file="../emojione/1f427">
+	<string>🐧</string>
+    </emoticon>
+    <emoticon file="../emojione/1f428">
+	<string>🐨</string>
+    </emoticon>
+    <emoticon file="../emojione/1f429">
+	<string>🐩</string>
+    </emoticon>
+    <emoticon file="../emojione/1f42a">
+	<string>🐪</string>
+    </emoticon>
+    <emoticon file="../emojione/1f42b">
+	<string>🐫</string>
+    </emoticon>
+    <emoticon file="../emojione/1f42c">
+	<string>🐬</string>
+    </emoticon>
+    <emoticon file="../emojione/1f42d">
+	<string>🐭</string>
+    </emoticon>
+    <emoticon file="../emojione/1f42e">
+	<string>🐮</string>
+    </emoticon>
+    <emoticon file="../emojione/1f42f">
+	<string>🐯</string>
+    </emoticon>
+    <emoticon file="../emojione/1f430">
+	<string>🐰</string>
+    </emoticon>
+    <emoticon file="../emojione/1f431">
+	<string>🐱</string>
+    </emoticon>
+    <emoticon file="../emojione/1f432">
+	<string>🐲</string>
+    </emoticon>
+    <emoticon file="../emojione/1f433">
+	<string>🐳</string>
+    </emoticon>
+    <emoticon file="../emojione/1f434">
+	<string>🐴</string>
+    </emoticon>
+    <emoticon file="../emojione/1f435">
+	<string>🐵</string>
+    </emoticon>
+    <emoticon file="../emojione/1f436">
+	<string>🐶</string>
+    </emoticon>
+    <emoticon file="../emojione/1f437">
+	<string>🐷</string>
+    </emoticon>
+    <emoticon file="../emojione/1f438">
+	<string>🐸</string>
+    </emoticon>
+    <emoticon file="../emojione/1f439">
+	<string>🐹</string>
+    </emoticon>
+    <emoticon file="../emojione/1f43a">
+	<string>🐺</string>
+    </emoticon>
+    <emoticon file="../emojione/1f43b">
+	<string>🐻</string>
+    </emoticon>
+    <emoticon file="../emojione/1f43c">
+	<string>🐼</string>
+    </emoticon>
+    <emoticon file="../emojione/1f43d">
+	<string>🐽</string>
+    </emoticon>
+    <emoticon file="../emojione/1f43e">
+	<string>🐾</string>
+    </emoticon>
+    <emoticon file="../emojione/1f440">
+	<string>👀</string>
+    </emoticon>
+    <emoticon file="../emojione/1f442">
+	<string>👂</string>
+    </emoticon>
+    <emoticon file="../emojione/1f443">
+	<string>👃</string>
+    </emoticon>
+    <emoticon file="../emojione/1f444">
+	<string>👄</string>
+    </emoticon>
+    <emoticon file="../emojione/1f445">
+	<string>👅</string>
+    </emoticon>
+    <emoticon file="../emojione/1f595">
+	<string>🖕</string>
+	<string>:finger:</string>
+	<string>:fuck:</string>
+    </emoticon>
+    <emoticon file="../emojione/1f446">
+	<string>👆</string>
+    </emoticon>
+    <emoticon file="../emojione/1f447">
+	<string>👇</string>
+    </emoticon>
+    <emoticon file="../emojione/1f448">
+	<string>👈</string>
+    </emoticon>
+    <emoticon file="../emojione/1f449">
+	<string>👉</string>
+    </emoticon>
+    <emoticon file="../emojione/1f44a">
+	<string>👊</string>
+    </emoticon>
+    <emoticon file="../emojione/1f44b">
+	<string>👋</string>
+    </emoticon>
+    <emoticon file="../emojione/1f44c">
+	<string>👌</string>
+    </emoticon>
+    <emoticon file="../emojione/1f44d">
+	<string>👍</string>
+    </emoticon>
+    <emoticon file="../emojione/1f44e">
+	<string>👎</string>
+    </emoticon>
+    <emoticon file="../emojione/1f44f">
+	<string>👏</string>
+    </emoticon>
+    <emoticon file="../emojione/1f450">
+	<string>👐</string>
+    </emoticon>
+    <emoticon file="../emojione/1f451">
+	<string>👑</string>
+    </emoticon>
+    <emoticon file="../emojione/1f452">
+	<string>👒</string>
+    </emoticon>
+    <emoticon file="../emojione/1f453">
+	<string>👓</string>
+    </emoticon>
+    <emoticon file="../emojione/1f454">
+	<string>👔</string>
+    </emoticon>
+    <emoticon file="../emojione/1f455">
+	<string>👕</string>
+    </emoticon>
+    <emoticon file="../emojione/1f456">
+	<string>👖</string>
+    </emoticon>
+    <emoticon file="../emojione/1f457">
+	<string>👗</string>
+    </emoticon>
+    <emoticon file="../emojione/1f458">
+	<string>👘</string>
+    </emoticon>
+    <emoticon file="../emojione/1f459">
+	<string>👙</string>
+    </emoticon>
+    <emoticon file="../emojione/1f45a">
+	<string>👚</string>
+    </emoticon>
+    <emoticon file="../emojione/1f45b">
+	<string>👛</string>
+    </emoticon>
+    <emoticon file="../emojione/1f45c">
+	<string>👜</string>
+    </emoticon>
+    <emoticon file="../emojione/1f45d">
+	<string>👝</string>
+    </emoticon>
+    <emoticon file="../emojione/1f45e">
+	<string>👞</string>
+    </emoticon>
+    <emoticon file="../emojione/1f45f">
+	<string>👟</string>
+    </emoticon>
+    <emoticon file="../emojione/1f460">
+	<string>👠</string>
+    </emoticon>
+    <emoticon file="../emojione/1f461">
+	<string>👡</string>
+    </emoticon>
+    <emoticon file="../emojione/1f462">
+	<string>👢</string>
+    </emoticon>
+    <emoticon file="../emojione/1f463">
+	<string>👣</string>
+    </emoticon>
+    <emoticon file="../emojione/1f464">
+	<string>👤</string>
+    </emoticon>
+    <emoticon file="../emojione/1f465">
+	<string>👥</string>
+    </emoticon>
+    <emoticon file="../emojione/1f466">
+	<string>👦</string>
+    </emoticon>
+    <emoticon file="../emojione/1f467">
+	<string>👧</string>
+    </emoticon>
+    <emoticon file="../emojione/1f468">
+	<string>👨</string>
+    </emoticon>
+    <emoticon file="../emojione/1f469">
+	<string>👩</string>
+    </emoticon>
+    <emoticon file="../emojione/1f46a">
+	<string>👪</string>
+    </emoticon>
+    <emoticon file="../emojione/1f46b">
+	<string>👫</string>
+    </emoticon>
+    <emoticon file="../emojione/1f46c">
+	<string>👬</string>
+    </emoticon>
+    <emoticon file="../emojione/1f46d">
+	<string>👭</string>
+    </emoticon>
+    <emoticon file="../emojione/1f46e">
+	<string>👮</string>
+    </emoticon>
+    <emoticon file="../emojione/1f46f">
+	<string>👯</string>
+    </emoticon>
+    <emoticon file="../emojione/1f470">
+	<string>👰</string>
+    </emoticon>
+    <emoticon file="../emojione/1f471">
+	<string>👱</string>
+    </emoticon>
+    <emoticon file="../emojione/1f472">
+	<string>👲</string>
+    </emoticon>
+    <emoticon file="../emojione/1f473">
+	<string>👳</string>
+    </emoticon>
+    <emoticon file="../emojione/1f474">
+	<string>👴</string>
+    </emoticon>
+    <emoticon file="../emojione/1f475">
+	<string>👵</string>
+    </emoticon>
+    <emoticon file="../emojione/1f476">
+	<string>👶</string>
+    </emoticon>
+    <emoticon file="../emojione/1f477">
+	<string>👷</string>
+    </emoticon>
+    <emoticon file="../emojione/1f478">
+	<string>👸</string>
+    </emoticon>
+    <emoticon file="../emojione/1f479">
+	<string>👹</string>
+    </emoticon>
+    <emoticon file="../emojione/1f47a">
+	<string>👺</string>
+    </emoticon>
+    <emoticon file="../emojione/1f47b">
+	<string>👻</string>
+    </emoticon>
+    <emoticon file="../emojione/1f47c">
+	<string>👼</string>
+	<string>:angel:</string>
+    </emoticon>
+    <emoticon file="../emojione/1f47d">
+	<string>👽</string>
+    </emoticon>
+    <emoticon file="../emojione/1f47e">
+	<string>👾</string>
+    </emoticon>
+    <emoticon file="../emojione/1f47f">
+	<string>👿</string>
+	<string>:devil:</string>
+	<string>:666:</string>
+    </emoticon>
+    <emoticon file="../emojione/1f480">
+	<string>💀</string>
+	<string>:skull:</string>
+    </emoticon>
+    <emoticon file="../emojione/1f481">
+	<string>💁</string>
+    </emoticon>
+    <emoticon file="../emojione/1f482">
+	<string>💂</string>
+    </emoticon>
+    <emoticon file="../emojione/1f483">
+	<string>💃</string>
+    </emoticon>
+    <emoticon file="../emojione/1f484">
+	<string>💄</string>
+    </emoticon>
+    <emoticon file="../emojione/1f485">
+	<string>💅</string>
+    </emoticon>
+    <emoticon file="../emojione/1f486">
+	<string>💆</string>
+    </emoticon>
+    <emoticon file="../emojione/1f487">
+	<string>💇</string>
+    </emoticon>
+    <emoticon file="../emojione/1f488">
+	<string>💈</string>
+    </emoticon>
+    <emoticon file="../emojione/1f489">
+	<string>💉</string>
+	<string>:syringe:</string>
+	<string>:injection:</string>
+    </emoticon>
+    <emoticon file="../emojione/1f48a">
+	<string>💊</string>
+    </emoticon>
+    <emoticon file="../emojione/1f48b">
+	<string>💋</string>
+    </emoticon>
+    <emoticon file="../emojione/1f48c">
+	<string>💌</string>
+    </emoticon>
+    <emoticon file="../emojione/1f48d">
+	<string>💍</string>
+    </emoticon>
+    <emoticon file="../emojione/1f48e">
+	<string>💎</string>
+    </emoticon>
+    <emoticon file="../emojione/1f48f">
+	<string>💏</string>
+    </emoticon>
+    <emoticon file="../emojione/1f490">
+	<string>💐</string>
+    </emoticon>
+    <emoticon file="../emojione/1f491">
+	<string>💑</string>
+    </emoticon>
+    <emoticon file="../emojione/1f492">
+	<string>💒</string>
+    </emoticon>
+    <emoticon file="../emojione/1f493">
+	<string>💓</string>
+    </emoticon>
+    <emoticon file="../emojione/1f494">
+	<string>💔</string>
+    </emoticon>
+    <emoticon file="../emojione/1f495">
+	<string>💕</string>
+    </emoticon>
+    <emoticon file="../emojione/1f496">
+	<string>💖</string>
+    </emoticon>
+    <emoticon file="../emojione/1f497">
+	<string>💗</string>
+    </emoticon>
+    <emoticon file="../emojione/1f498">
+	<string>💘</string>
+    </emoticon>
+    <emoticon file="../emojione/1f499">
+	<string>💙</string>
+    </emoticon>
+    <emoticon file="../emojione/1f49a">
+	<string>💚</string>
+    </emoticon>
+    <emoticon file="../emojione/1f49b">
+	<string>💛</string>
+    </emoticon>
+    <emoticon file="../emojione/1f49c">
+	<string>💜</string>
+    </emoticon>
+    <emoticon file="../emojione/1f49d">
+	<string>💝</string>
+    </emoticon>
+    <emoticon file="../emojione/1f49e">
+	<string>💞</string>
+    </emoticon>
+    <emoticon file="../emojione/1f49f">
+	<string>💟</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4a0">
+	<string>💠</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4a1">
+	<string>💡</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4a2">
+	<string>💢</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4a3">
+	<string>💣</string>
+	<string>:bomb:</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4a4">
+	<string>💤</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4a5">
+	<string>💥</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4a6">
+	<string>💦</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4a7">
+	<string>💧</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4a8">
+	<string>💨</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4aa">
+	<string>💪</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4ab">
+	<string>💫</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4ac">
+	<string>💬</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4ad">
+	<string>💭</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4ae">
+	<string>💮</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4af">
+	<string>💯</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4b0">
+	<string>💰</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4b1">
+	<string>💱</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4b2">
+	<string>💲</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4b3">
+	<string>💳</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4b4">
+	<string>💴</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4b5">
+	<string>💵</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4b6">
+	<string>💶</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4b7">
+	<string>💷</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4b8">
+	<string>💸</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4b9">
+	<string>💹</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4ba">
+	<string>💺</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4bb">
+	<string>💻</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4bc">
+	<string>💼</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4bd">
+	<string>💽</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4be">
+	<string>💾</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4bf">
+	<string>💿</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4c0">
+	<string>📀</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4c1">
+	<string>📁</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4c2">
+	<string>📂</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4c3">
+	<string>📃</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4c4">
+	<string>📄</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4c5">
+	<string>📅</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4c6">
+	<string>📆</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4c7">
+	<string>📇</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4c8">
+	<string>📈</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4c9">
+	<string>📉</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4ca">
+	<string>📊</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4cb">
+	<string>📋</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4cc">
+	<string>📌</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4cd">
+	<string>📍</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4ce">
+	<string>📎</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4cf">
+	<string>📏</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4d0">
+	<string>📐</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4d1">
+	<string>📑</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4d2">
+	<string>📒</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4d3">
+	<string>📓</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4d4">
+	<string>📔</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4d5">
+	<string>📕</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4d6">
+	<string>📖</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4d7">
+	<string>📗</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4d8">
+	<string>📘</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4d9">
+	<string>📙</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4da">
+	<string>📚</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4db">
+	<string>📛</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4dc">
+	<string>📜</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4dd">
+	<string>📝</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4de">
+	<string>📞</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4df">
+	<string>📟</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4e0">
+	<string>📠</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4e1">
+	<string>📡</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4e2">
+	<string>📢</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4e3">
+	<string>📣</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4e4">
+	<string>📤</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4e5">
+	<string>📥</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4e6">
+	<string>📦</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4e7">
+	<string>📧</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4e8">
+	<string>📨</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4e9">
+	<string>📩</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4ea">
+	<string>📪</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4eb">
+	<string>📫</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4ec">
+	<string>📬</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4ed">
+	<string>📭</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4ee">
+	<string>📮</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4ef">
+	<string>📯</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4f0">
+	<string>📰</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4f1">
+	<string>📱</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4f2">
+	<string>📲</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4f3">
+	<string>📳</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4f4">
+	<string>📴</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4f5">
+	<string>📵</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4f6">
+	<string>📶</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4f7">
+	<string>📷</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4f9">
+	<string>📹</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4fa">
+	<string>📺</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4fb">
+	<string>📻</string>
+    </emoticon>
+    <emoticon file="../emojione/1f4fc">
+	<string>📼</string>
+    </emoticon>
+    <emoticon file="../emojione/1f500">
+	<string>🔀</string>
+    </emoticon>
+    <emoticon file="../emojione/1f501">
+	<string>🔁</string>
+    </emoticon>
+    <emoticon file="../emojione/1f502">
+	<string>🔂</string>
+    </emoticon>
+    <emoticon file="../emojione/1f503">
+	<string>🔃</string>
+    </emoticon>
+    <emoticon file="../emojione/1f504">
+	<string>🔄</string>
+    </emoticon>
+    <emoticon file="../emojione/1f505">
+	<string>🔅</string>
+    </emoticon>
+    <emoticon file="../emojione/1f506">
+	<string>🔆</string>
+    </emoticon>
+    <emoticon file="../emojione/1f507">
+	<string>🔇</string>
+    </emoticon>
+    <emoticon file="../emojione/1f508">
+	<string>🔈</string>
+    </emoticon>
+    <emoticon file="../emojione/1f509">
+	<string>🔉</string>
+    </emoticon>
+    <emoticon file="../emojione/1f50a">
+	<string>🔊</string>
+    </emoticon>
+    <emoticon file="../emojione/1f50b">
+	<string>🔋</string>
+    </emoticon>
+    <emoticon file="../emojione/1f50c">
+	<string>🔌</string>
+    </emoticon>
+    <emoticon file="../emojione/1f50d">
+	<string>🔍</string>
+    </emoticon>
+    <emoticon file="../emojione/1f50e">
+	<string>🔎</string>
+    </emoticon>
+    <emoticon file="../emojione/1f50f">
+	<string>🔏</string>
+    </emoticon>
+    <emoticon file="../emojione/1f510">
+	<string>🔐</string>
+    </emoticon>
+    <emoticon file="../emojione/1f511">
+	<string>🔑</string>
+    </emoticon>
+    <emoticon file="../emojione/1f512">
+	<string>🔒</string>
+    </emoticon>
+    <emoticon file="../emojione/1f513">
+	<string>🔓</string>
+    </emoticon>
+    <emoticon file="../emojione/1f514">
+	<string>🔔</string>
+    </emoticon>
+    <emoticon file="../emojione/1f515">
+	<string>🔕</string>
+    </emoticon>
+    <emoticon file="../emojione/1f516">
+	<string>🔖</string>
+    </emoticon>
+    <emoticon file="../emojione/1f517">
+	<string>🔗</string>
+    </emoticon>
+    <emoticon file="../emojione/1f518">
+	<string>🔘</string>
+    </emoticon>
+    <emoticon file="../emojione/1f519">
+	<string>🔙</string>
+    </emoticon>
+    <emoticon file="../emojione/1f51a">
+	<string>🔚</string>
+    </emoticon>
+    <emoticon file="../emojione/1f51b">
+	<string>🔛</string>
+    </emoticon>
+    <emoticon file="../emojione/1f51c">
+	<string>🔜</string>
+    </emoticon>
+    <emoticon file="../emojione/1f51d">
+	<string>🔝</string>
+    </emoticon>
+    <emoticon file="../emojione/1f51e">
+	<string>🔞</string>
+    </emoticon>
+    <emoticon file="../emojione/1f51f">
+	<string>🔟</string>
+    </emoticon>
+    <emoticon file="../emojione/1f520">
+	<string>🔠</string>
+    </emoticon>
+    <emoticon file="../emojione/1f521">
+	<string>🔡</string>
+    </emoticon>
+    <emoticon file="../emojione/1f522">
+	<string>🔢</string>
+    </emoticon>
+    <emoticon file="../emojione/1f523">
+	<string>🔣</string>
+    </emoticon>
+    <emoticon file="../emojione/1f524">
+	<string>🔤</string>
+    </emoticon>
+    <emoticon file="../emojione/1f525">
+	<string>🔥</string>
+    </emoticon>
+    <emoticon file="../emojione/1f526">
+	<string>🔦</string>
+    </emoticon>
+    <emoticon file="../emojione/1f527">
+	<string>🔧</string>
+    </emoticon>
+    <emoticon file="../emojione/1f528">
+	<string>🔨</string>
+    </emoticon>
+    <emoticon file="../emojione/1f529">
+	<string>🔩</string>
+    </emoticon>
+    <emoticon file="../emojione/1f52a">
+	<string>🔪</string>
+    </emoticon>
+    <emoticon file="../emojione/1f52b">
+	<string>🔫</string>
+    </emoticon>
+    <emoticon file="../emojione/1f52c">
+	<string>🔬</string>
+    </emoticon>
+    <emoticon file="../emojione/1f52d">
+	<string>🔭</string>
+    </emoticon>
+    <emoticon file="../emojione/1f52e">
+	<string>🔮</string>
+    </emoticon>
+    <emoticon file="../emojione/1f52f">
+	<string>🔯</string>
+    </emoticon>
+    <emoticon file="../emojione/1f530">
+	<string>🔰</string>
+    </emoticon>
+    <emoticon file="../emojione/1f531">
+	<string>🔱</string>
+    </emoticon>
+    <emoticon file="../emojione/1f532">
+	<string>🔲</string>
+    </emoticon>
+    <emoticon file="../emojione/1f533">
+	<string>🔳</string>
+    </emoticon>
+    <emoticon file="../emojione/1f534">
+	<string>🔴</string>
+    </emoticon>
+    <emoticon file="../emojione/1f535">
+	<string>🔵</string>
+    </emoticon>
+    <emoticon file="../emojione/1f536">
+	<string>🔶</string>
+    </emoticon>
+    <emoticon file="../emojione/1f537">
+	<string>🔷</string>
+    </emoticon>
+    <emoticon file="../emojione/1f538">
+	<string>🔸</string>
+    </emoticon>
+    <emoticon file="../emojione/1f539">
+	<string>🔹</string>
+    </emoticon>
+    <emoticon file="../emojione/1f53a">
+	<string>🔺</string>
+    </emoticon>
+    <emoticon file="../emojione/1f53b">
+	<string>🔻</string>
+    </emoticon>
+    <emoticon file="../emojione/1f53c">
+	<string>🔼</string>
+    </emoticon>
+    <emoticon file="../emojione/1f53d">
+	<string>🔽</string>
+    </emoticon>
+    <emoticon file="../emojione/1f550">
+	<string>🕐</string>
+    </emoticon>
+    <emoticon file="../emojione/1f551">
+	<string>🕑</string>
+    </emoticon>
+    <emoticon file="../emojione/1f552">
+	<string>🕒</string>
+    </emoticon>
+    <emoticon file="../emojione/1f553">
+	<string>🕓</string>
+    </emoticon>
+    <emoticon file="../emojione/1f554">
+	<string>🕔</string>
+    </emoticon>
+    <emoticon file="../emojione/1f555">
+	<string>🕕</string>
+    </emoticon>
+    <emoticon file="../emojione/1f556">
+	<string>🕖</string>
+    </emoticon>
+    <emoticon file="../emojione/1f557">
+	<string>🕗</string>
+    </emoticon>
+    <emoticon file="../emojione/1f558">
+	<string>🕘</string>
+    </emoticon>
+    <emoticon file="../emojione/1f559">
+	<string>🕙</string>
+    </emoticon>
+    <emoticon file="../emojione/1f55a">
+	<string>🕚</string>
+    </emoticon>
+    <emoticon file="../emojione/1f55b">
+	<string>🕛</string>
+    </emoticon>
+    <emoticon file="../emojione/1f55c">
+	<string>🕜</string>
+    </emoticon>
+    <emoticon file="../emojione/1f55d">
+	<string>🕝</string>
+    </emoticon>
+    <emoticon file="../emojione/1f55e">
+	<string>🕞</string>
+    </emoticon>
+    <emoticon file="../emojione/1f55f">
+	<string>🕟</string>
+    </emoticon>
+    <emoticon file="../emojione/1f560">
+	<string>🕠</string>
+    </emoticon>
+    <emoticon file="../emojione/1f561">
+	<string>🕡</string>
+    </emoticon>
+    <emoticon file="../emojione/1f562">
+	<string>🕢</string>
+    </emoticon>
+    <emoticon file="../emojione/1f563">
+	<string>🕣</string>
+    </emoticon>
+    <emoticon file="../emojione/1f564">
+	<string>🕤</string>
+    </emoticon>
+    <emoticon file="../emojione/1f565">
+	<string>🕥</string>
+    </emoticon>
+    <emoticon file="../emojione/1f566">
+	<string>🕦</string>
+    </emoticon>
+    <emoticon file="../emojione/1f567">
+	<string>🕧</string>
+    </emoticon>
+    <emoticon file="../emojione/1f5fb">
+	<string>🗻</string>
+    </emoticon>
+    <emoticon file="../emojione/1f5fc">
+	<string>🗼</string>
+    </emoticon>
+    <emoticon file="../emojione/1f5fd">
+	<string>🗽</string>
+    </emoticon>
+    <emoticon file="../emojione/1f5fe">
+	<string>🗾</string>
+    </emoticon>
+    <emoticon file="../emojione/1f5ff">
+	<string>🗿</string>
+    </emoticon>
+    <emoticon file="../emojione/1f004">
+	<string>🀄</string>
+    </emoticon>
+    <emoticon file="../emojione/1f0cf">
+	<string>🃏</string>
+    </emoticon>
+    <emoticon file="../emojione/2600">
+	<string>☀</string>
+    </emoticon>
+    <emoticon file="../emojione/2601">
+	<string>☁</string>
+    </emoticon>
+    <emoticon file="../emojione/260e">
+	<string>☎</string>
+    </emoticon>
+    <emoticon file="../emojione/2611">
+	<string>☑</string>
+    </emoticon>
+    <emoticon file="../emojione/2614">
+	<string>☔</string>
+    </emoticon>
+    <emoticon file="../emojione/2615">
+	<string>☕</string>
+    </emoticon>
+    <emoticon file="../emojione/261d">
+	<string>☝</string>
+    </emoticon>
+    <emoticon file="../emojione/2648">
+	<string>♈</string>
+    </emoticon>
+    <emoticon file="../emojione/2649">
+	<string>♉</string>
+    </emoticon>
+    <emoticon file="../emojione/2648">
+	<string>♈</string>
+    </emoticon>
+    <emoticon file="../emojione/2649">
+	<string>♉</string>
+    </emoticon>
+    <emoticon file="../emojione/264a">
+	<string>♊</string>
+    </emoticon>
+    <emoticon file="../emojione/264b">
+	<string>♋</string>
+    </emoticon>
+    <emoticon file="../emojione/264c">
+	<string>♌</string>
+    </emoticon>
+    <emoticon file="../emojione/264d">
+	<string>♍</string>
+    </emoticon>
+    <emoticon file="../emojione/264e">
+	<string>♎</string>
+    </emoticon>
+    <emoticon file="../emojione/264f">
+	<string>♏</string>
+    </emoticon>
+    <emoticon file="../emojione/264a">
+	<string>♊</string>
+    </emoticon>
+    <emoticon file="../emojione/264b">
+	<string>♋</string>
+    </emoticon>
+    <emoticon file="../emojione/264c">
+	<string>♌</string>
+    </emoticon>
+    <emoticon file="../emojione/264d">
+	<string>♍</string>
+    </emoticon>
+    <emoticon file="../emojione/264e">
+	<string>♎</string>
+    </emoticon>
+    <emoticon file="../emojione/264f">
+	<string>♏</string>
+    </emoticon>
+    <emoticon file="../emojione/2650">
+	<string>♐</string>
+    </emoticon>
+    <emoticon file="../emojione/2651">
+	<string>♑</string>
+    </emoticon>
+    <emoticon file="../emojione/2652">
+	<string>♒</string>
+    </emoticon>
+    <emoticon file="../emojione/2653">
+	<string>♓</string>
+    </emoticon>
+    <emoticon file="../emojione/2660">
+	<string>♠</string>
+    </emoticon>
+    <emoticon file="../emojione/2663">
+	<string>♣</string>
+    </emoticon>
+    <emoticon file="../emojione/2665">
+	<string>♥</string>
+    </emoticon>
+    <emoticon file="../emojione/2666">
+	<string>♦</string>
+    </emoticon>
+    <emoticon file="../emojione/2668">
+	<string>♨</string>
+    </emoticon>
+    <emoticon file="../emojione/267b">
+	<string>♻</string>
+    </emoticon>
+    <emoticon file="../emojione/267f">
+	<string>♿</string>
+    </emoticon>
+    <emoticon file="../emojione/2693">
+	<string>⚓</string>
+    </emoticon>
+    <emoticon file="../emojione/26a0">
+	<string>⚠</string>
+    </emoticon>
+    <emoticon file="../emojione/26a1">
+	<string>⚡</string>
+    </emoticon>
+    <emoticon file="../emojione/26aa">
+	<string>⚪</string>
+    </emoticon>
+    <emoticon file="../emojione/26ab">
+	<string>⚫</string>
+    </emoticon>
+    <emoticon file="../emojione/26bd">
+	<string>⚽</string>
+    </emoticon>
+    <emoticon file="../emojione/26be">
+	<string>⚾</string>
+    </emoticon>
+    <emoticon file="../emojione/26c4">
+	<string>⛄</string>
+    </emoticon>
+    <emoticon file="../emojione/26c5">
+	<string>⛅</string>
+    </emoticon>
+    <emoticon file="../emojione/26ce">
+	<string>⛎</string>
+    </emoticon>
+    <emoticon file="../emojione/26d4">
+	<string>⛔</string>
+    </emoticon>
+    <emoticon file="../emojione/26ea">
+	<string>⛪</string>
+    </emoticon>
+    <emoticon file="../emojione/26f2">
+	<string>⛲</string>
+    </emoticon>
+    <emoticon file="../emojione/26f3">
+	<string>⛳</string>
+    </emoticon>
+    <emoticon file="../emojione/26f5">
+	<string>⛵</string>
+    </emoticon>
+    <emoticon file="../emojione/26fa">
+	<string>⛺</string>
+    </emoticon>
+    <emoticon file="../emojione/26fd">
+	<string>⛽</string>
+    </emoticon>
+    <emoticon file="../emojione/1f680">
+	<string>🚀</string>
+    </emoticon>
+    <emoticon file="../emojione/1f681">
+	<string>🚁</string>
+    </emoticon>
+    <emoticon file="../emojione/1f682">
+	<string>🚂</string>
+    </emoticon>
+    <emoticon file="../emojione/1f683">
+	<string>🚃</string>
+    </emoticon>
+    <emoticon file="../emojione/1f684">
+	<string>🚄</string>
+    </emoticon>
+    <emoticon file="../emojione/1f685">
+	<string>🚅</string>
+    </emoticon>
+    <emoticon file="../emojione/1f686">
+	<string>🚆</string>
+    </emoticon>
+    <emoticon file="../emojione/1f687">
+	<string>🚇</string>
+    </emoticon>
+    <emoticon file="../emojione/1f688">
+	<string>🚈</string>
+    </emoticon>
+    <emoticon file="../emojione/1f689">
+	<string>🚉</string>
+    </emoticon>
+    <emoticon file="../emojione/1f68a">
+	<string>🚊</string>
+    </emoticon>
+    <emoticon file="../emojione/1f68b">
+	<string>🚋</string>
+    </emoticon>
+    <emoticon file="../emojione/1f68c">
+	<string>🚌</string>
+    </emoticon>
+    <emoticon file="../emojione/1f68d">
+	<string>🚍</string>
+    </emoticon>
+    <emoticon file="../emojione/1f68e">
+	<string>🚎</string>
+    </emoticon>
+    <emoticon file="../emojione/1f68f">
+	<string>🚏</string>
+    </emoticon>
+    <emoticon file="../emojione/1f690">
+	<string>🚐</string>
+    </emoticon>
+    <emoticon file="../emojione/1f691">
+	<string>🚑</string>
+    </emoticon>
+    <emoticon file="../emojione/1f692">
+	<string>🚒</string>
+    </emoticon>
+    <emoticon file="../emojione/1f693">
+	<string>🚓</string>
+    </emoticon>
+    <emoticon file="../emojione/1f694">
+	<string>🚔</string>
+    </emoticon>
+    <emoticon file="../emojione/1f695">
+	<string>🚕</string>
+    </emoticon>
+    <emoticon file="../emojione/1f696">
+	<string>🚖</string>
+    </emoticon>
+    <emoticon file="../emojione/1f697">
+	<string>🚗</string>
+    </emoticon>
+    <emoticon file="../emojione/1f698">
+	<string>🚘</string>
+    </emoticon>
+    <emoticon file="../emojione/1f699">
+	<string>🚙</string>
+    </emoticon>
+    <emoticon file="../emojione/1f69a">
+	<string>🚚</string>
+    </emoticon>
+    <emoticon file="../emojione/1f69b">
+	<string>🚛</string>
+    </emoticon>
+    <emoticon file="../emojione/1f69c">
+	<string>🚜</string>
+    </emoticon>
+    <emoticon file="../emojione/1f69d">
+	<string>🚝</string>
+    </emoticon>
+    <emoticon file="../emojione/1f69e">
+	<string>🚞</string>
+    </emoticon>
+    <emoticon file="../emojione/1f69f">
+	<string>🚟</string>
+    </emoticon>
+    <emoticon file="../emojione/1f6a0">
+	<string>🚠</string>
+    </emoticon>
+    <emoticon file="../emojione/1f6a1">
+	<string>🚡</string>
+    </emoticon>
+    <emoticon file="../emojione/1f6a2">
+	<string>🚢</string>
+    </emoticon>
+    <emoticon file="../emojione/1f6a3">
+	<string>🚣</string>
+    </emoticon>
+    <emoticon file="../emojione/1f6a4">
+	<string>🚤</string>
+    </emoticon>
+    <emoticon file="../emojione/1f6a5">
+	<string>🚥</string>
+    </emoticon>
+    <emoticon file="../emojione/1f6a6">
+	<string>🚦</string>
+    </emoticon>
+    <emoticon file="../emojione/1f6a7">
+	<string>🚧</string>
+    </emoticon>
+    <emoticon file="../emojione/1f6a8">
+	<string>🚨</string>
+    </emoticon>
+    <emoticon file="../emojione/1f6a9">
+	<string>🚩</string>
+    </emoticon>
+    <emoticon file="../emojione/1f6aa">
+	<string>🚪</string>
+    </emoticon>
+    <emoticon file="../emojione/1f6ab">
+	<string>🚫</string>
+    </emoticon>
+    <emoticon file="../emojione/1f6ac">
+	<string>🚬</string>
+    </emoticon>
+    <emoticon file="../emojione/1f6ad">
+	<string>🚭</string>
+    </emoticon>
+    <emoticon file="../emojione/1f6ae">
+	<string>🚮</string>
+    </emoticon>
+    <emoticon file="../emojione/1f6af">
+	<string>🚯</string>
+    </emoticon>
+    <emoticon file="../emojione/1f6b0">
+	<string>🚰</string>
+    </emoticon>
+    <emoticon file="../emojione/1f6b1">
+	<string>🚱</string>
+    </emoticon>
+    <emoticon file="../emojione/1f6b2">
+	<string>🚲</string>
+    </emoticon>
+    <emoticon file="../emojione/1f6b3">
+	<string>🚳</string>
+    </emoticon>
+    <emoticon file="../emojione/1f6b4">
+	<string>🚴</string>
+    </emoticon>
+    <emoticon file="../emojione/1f6b5">
+	<string>🚵</string>
+    </emoticon>
+    <emoticon file="../emojione/1f6b6">
+	<string>🚶</string>
+    </emoticon>
+    <emoticon file="../emojione/1f6b7">
+	<string>🚷</string>
+    </emoticon>
+    <emoticon file="../emojione/1f6b8">
+	<string>🚸</string>
+    </emoticon>
+    <emoticon file="../emojione/1f6b9">
+	<string>🚹</string>
+    </emoticon>
+    <emoticon file="../emojione/1f6ba">
+	<string>🚺</string>
+    </emoticon>
+    <emoticon file="../emojione/1f6bb">
+	<string>🚻</string>
+    </emoticon>
+    <emoticon file="../emojione/1f6bc">
+	<string>🚼</string>
+    </emoticon>
+    <emoticon file="../emojione/1f6bd">
+	<string>🚽</string>
+    </emoticon>
+    <emoticon file="../emojione/1f6be">
+	<string>🚾</string>
+    </emoticon>
+    <emoticon file="../emojione/1f6bf">
+	<string>🚿</string>
+    </emoticon>
+    <emoticon file="../emojione/1f6c0">
+	<string>🛀</string>
+    </emoticon>
+    <emoticon file="../emojione/1f6c1">
+	<string>🛁</string>
+    </emoticon>
+    <emoticon file="../emojione/1f6c2">
+	<string>🛂</string>
+    </emoticon>
+    <emoticon file="../emojione/1f6c3">
+	<string>🛃</string>
+    </emoticon>
+    <emoticon file="../emojione/1f6c4">
+	<string>🛄</string>
+    </emoticon>
+    <emoticon file="../emojione/1f6c5">
+	<string>🛅</string>
+    </emoticon>
+    <emoticon file="../emojione/2702">
+	<string>✂</string>
+    </emoticon>
+    <emoticon file="../emojione/2705">
+	<string>✅</string>
+    </emoticon>
+    <emoticon file="../emojione/2708">
+	<string>✈</string>
+    </emoticon>
+    <emoticon file="../emojione/2709">
+	<string>✉</string>
+    </emoticon>
+    <emoticon file="../emojione/270a">
+	<string>✊</string>
+    </emoticon>
+    <emoticon file="../emojione/270b">
+	<string>✋</string>
+    </emoticon>
+    <emoticon file="../emojione/270c">
+	<string>✌</string>
+    </emoticon>
+    <emoticon file="../emojione/270f">
+	<string>✏</string>
+    </emoticon>
+    <emoticon file="../emojione/2712">
+	<string>✒</string>
+    </emoticon>
+    <emoticon file="../emojione/2714">
+	<string>✔</string>
+    </emoticon>
+    <emoticon file="../emojione/2716">
+	<string>✖</string>
+    </emoticon>
+    <emoticon file="../emojione/2728">
+	<string>✨</string>
+    </emoticon>
+    <emoticon file="../emojione/2733">
+	<string>✳</string>
+    </emoticon>
+    <emoticon file="../emojione/2734">
+	<string>✴</string>
+    </emoticon>
+    <emoticon file="../emojione/2744">
+	<string>❄</string>
+    </emoticon>
+    <emoticon file="../emojione/2747">
+	<string>❇</string>
+    </emoticon>
+    <emoticon file="../emojione/274c">
+	<string>❌</string>
+    </emoticon>
+    <emoticon file="../emojione/274e">
+	<string>❎</string>
+    </emoticon>
+    <emoticon file="../emojione/2753">
+	<string>❓</string>
+    </emoticon>
+    <emoticon file="../emojione/2754">
+	<string>❔</string>
+    </emoticon>
+    <emoticon file="../emojione/2755">
+	<string>❕</string>
+    </emoticon>
+    <emoticon file="../emojione/2757">
+	<string>❗</string>
+    </emoticon>
+    <emoticon file="../emojione/2764">
+	<string>❤</string>
+	<string>&lt;3</string>
+	<string>:heart:</string>
+	<string>:love:</string>
+    </emoticon>
+    <emoticon file="../emojione/2795">
+	<string>➕</string>
+    </emoticon>
+    <emoticon file="../emojione/2796">
+	<string>➖</string>
+    </emoticon>
+    <emoticon file="../emojione/2797">
+	<string>➗</string>
+    </emoticon>
+    <emoticon file="../emojione/27a1">
+	<string>➡</string>
+    </emoticon>
+    <emoticon file="../emojione/27b0">
+	<string>➰</string>
+    </emoticon>
+    <emoticon file="../emojione/27bf">
+	<string>➿</string>
+    </emoticon>
+    <emoticon file="../emojione/2934">
+	<string>⤴</string>
+    </emoticon>
+    <emoticon file="../emojione/2935">
+	<string>⤵</string>
+    </emoticon>
+    <emoticon file="../emojione/3030">
+	<string>〰</string>
+    </emoticon>
+    <emoticon file="../emojione/3297">
+	<string>祝</string>
+    </emoticon>
+    <emoticon file="../emojione/3299">
+	<string>秘</string>
+    </emoticon>
+    <emoticon file="../emojione/00a9">
+	<string>©</string>
+    </emoticon>
+    <emoticon file="../emojione/00ae">
+	<string>®</string>
+    </emoticon>
+    <emoticon file="../emojione/1f21a">
+	<string>🈚</string>
+    </emoticon>
+    <emoticon file="../emojione/1f22f">
+	<string>🈯</string>
+    </emoticon>
+    <emoticon file="../emojione/1f23a">
+	<string>🈺</string>
+    </emoticon>
+    <emoticon file="../emojione/1f201">
+	<string>🈁</string>
+    </emoticon>
+    <emoticon file="../emojione/1f202">
+	<string>🈂</string>
+    </emoticon>
+    <emoticon file="../emojione/1f232">
+	<string>🈲</string>
+    </emoticon>
+    <emoticon file="../emojione/1f233">
+	<string>🈳</string>
+    </emoticon>
+    <emoticon file="../emojione/1f234">
+	<string>🈴</string>
+    </emoticon>
+    <emoticon file="../emojione/1f235">
+	<string>🈵</string>
+    </emoticon>
+    <emoticon file="../emojione/1f236">
+	<string>🈶</string>
+    </emoticon>
+    <emoticon file="../emojione/1f237">
+	<string>🈷</string>
+    </emoticon>
+    <emoticon file="../emojione/1f238">
+	<string>🈸</string>
+    </emoticon>
+    <emoticon file="../emojione/1f239">
+	<string>🈹</string>
+    </emoticon>
+    <emoticon file="../emojione/1f250">
+	<string>🉐</string>
+    </emoticon>
+    <emoticon file="../emojione/1f251">
+	<string>🉑</string>
+    </emoticon>
+    <emoticon file="../emojione/1f170">
+	<string>🅰</string>
+    </emoticon>
+    <emoticon file="../emojione/1f171">
+	<string>🅱</string>
+    </emoticon>
+    <emoticon file="../emojione/1f17e">
+	<string>🅾</string>
+    </emoticon>
+    <emoticon file="../emojione/1f17f">
+	<string>🅿</string>
+    </emoticon>
+    <emoticon file="../emojione/1f18e">
+	<string>🆎</string>
+    </emoticon>
+    <emoticon file="../emojione/1f191">
+	<string>🆑</string>
+    </emoticon>
+    <emoticon file="../emojione/1f192">
+	<string>🆒</string>
+    </emoticon>
+    <emoticon file="../emojione/1f193">
+	<string>🆓</string>
+    </emoticon>
+    <emoticon file="../emojione/1f194">
+	<string>🆔</string>
+    </emoticon>
+    <emoticon file="../emojione/1f195">
+	<string>🆕</string>
+    </emoticon>
+    <emoticon file="../emojione/1f196">
+	<string>🆖</string>
+    </emoticon>
+    <emoticon file="../emojione/1f197">
+	<string>🆗</string>
+    </emoticon>
+    <emoticon file="../emojione/1f198">
+	<string>🆘</string>
+    </emoticon>
+    <emoticon file="../emojione/1f199">
+	<string>🆙</string>
+    </emoticon>
+    <emoticon file="../emojione/1f19a">
+	<string>🆚</string>
+    </emoticon>
+    <emoticon file="../emojione/1f1e6">
+	<string>🇦</string>
+    </emoticon>
+    <emoticon file="../emojione/1f1e7">
+	<string>🇧</string>
+    </emoticon>
+    <emoticon file="../emojione/1f1e8">
+	<string>🇨</string>
+    </emoticon>
+    <emoticon file="../emojione/1f1e9">
+	<string>🇩</string>
+    </emoticon>
+    <emoticon file="../emojione/1f1ea">
+	<string>🇪</string>
+    </emoticon>
+    <emoticon file="../emojione/1f1eb">
+	<string>🇫</string>
+    </emoticon>
+    <emoticon file="../emojione/1f1ec">
+	<string>🇬</string>
+    </emoticon>
+    <emoticon file="../emojione/1f1ed">
+	<string>🇭</string>
+    </emoticon>
+    <emoticon file="../emojione/1f1ee">
+	<string>🇮</string>
+    </emoticon>
+    <emoticon file="../emojione/1f1ef">
+	<string>🇯</string>
+    </emoticon>
+    <emoticon file="../emojione/1f1f0">
+	<string>🇰</string>
+    </emoticon>
+    <emoticon file="../emojione/1f1f1">
+	<string>🇱</string>
+    </emoticon>
+    <emoticon file="../emojione/1f1f2">
+	<string>🇲</string>
+    </emoticon>
+    <emoticon file="../emojione/1f1f3">
+	<string>🇳</string>
+    </emoticon>
+    <emoticon file="../emojione/1f1f4">
+	<string>🇴</string>
+    </emoticon>
+    <emoticon file="../emojione/1f1f5">
+	<string>🇵</string>
+    </emoticon>
+    <emoticon file="../emojione/1f1f6">
+	<string>🇶</string>
+    </emoticon>
+    <emoticon file="../emojione/1f1f7">
+	<string>🇷</string>
+    </emoticon>
+    <emoticon file="../emojione/1f1f8">
+	<string>🇸</string>
+    </emoticon>
+    <emoticon file="../emojione/1f1f9">
+	<string>🇹</string>
+    </emoticon>
+    <emoticon file="../emojione/1f1fa">
+	<string>🇺</string>
+    </emoticon>
+    <emoticon file="../emojione/1f1fb">
+	<string>🇻</string>
+    </emoticon>
+    <emoticon file="../emojione/1f1fc">
+	<string>🇼</string>
+    </emoticon>
+    <emoticon file="../emojione/1f1fd">
+	<string>🇽</string>
+    </emoticon>
+    <emoticon file="../emojione/1f1fe">
+	<string>🇾</string>
+    </emoticon>
+    <emoticon file="../emojione/1f1ff">
+	<string>🇿</string>
+    </emoticon>
+    <emoticon file="../emojione/1f1e8-1f1f3">
+	<string>🇨🇳</string>
+    </emoticon>
+    <emoticon file="../emojione/1f1e9-1f1ea">
+	<string>🇩🇪</string>
+    </emoticon>
+    <emoticon file="../emojione/1f1ea-1f1f8">
+	<string>🇪🇸</string>
+    </emoticon>
+    <emoticon file="../emojione/1f1eb-1f1f7">
+	<string>🇫🇷</string>
+    </emoticon>
+    <emoticon file="../emojione/1f1ec-1f1e7">
+	<string>🇬🇧</string>
+    </emoticon>
+    <emoticon file="../emojione/1f1ee-1f1f9">
+	<string>🇮🇹</string>
+    </emoticon>
+    <emoticon file="../emojione/1f1ef-1f1f5">
+	<string>🇯🇵</string>
+    </emoticon>
+    <emoticon file="../emojione/1f1f0-1f1f7">
+	<string>🇰🇷</string>
+    </emoticon>
+    <emoticon file="../emojione/1f1f7-1f1fa">
+	<string>🇷🇺</string>
+    </emoticon>
+    <emoticon file="../emojione/1f1fa-1f1f8">
+	<string>🇺🇸</string>
+    </emoticon>
+    
+</messaging-emoticon-map>

--- a/smileys/smileys.qrc
+++ b/smileys/smileys.qrc
@@ -2730,5 +2730,6 @@
         <file>emojione/3297.svg</file>
         <file>emojione/3299.svg</file>
         <file>emojione/emoticons.xml</file>
+        <file>ASCII+emojione/emoticons.xml</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
`ASCII+emojione` doesn't turn ASCII smileys into emoticons.
E.g. `:)` would be left alone as it is.

Closes #3398.
