### PR TITLE
fix(persistence): pass by reference to const

### DIFF
--- a/src/persistence/db/rawdatabase.cpp
+++ b/src/persistence/db/rawdatabase.cpp
@@ -312,7 +312,7 @@ bool RawDatabase::remove()
 }
 
 
-QString RawDatabase::deriveKey(QString password)
+QString RawDatabase::deriveKey(const QString &password)
 {
     if (password.isEmpty())
         return {};

--- a/src/persistence/db/rawdatabase.h
+++ b/src/persistence/db/rawdatabase.h
@@ -89,7 +89,7 @@ protected slots:
 
 protected:
     /// Derives a 256bit key from the password and returns it hex-encoded
-    static QString deriveKey(QString password);
+    static QString deriveKey(const QString &password);
     /// Extracts a variant from one column of a result row depending on the column type
     static QVariant extractData(sqlite3_stmt* stmt, int col);
 

--- a/src/persistence/profile.cpp
+++ b/src/persistence/profile.cpp
@@ -37,7 +37,7 @@
 
 QVector<QString> Profile::profiles;
 
-Profile::Profile(QString name, QString password, bool isNewProfile)
+Profile::Profile(QString name, const QString &password, bool isNewProfile)
     : name{name}, password{password},
       newProfile{isNewProfile}, isRemoved{false}
 {
@@ -65,7 +65,7 @@ Profile::Profile(QString name, QString password, bool isNewProfile)
     QObject::connect(coreThread, &QThread::started, core, &Core::start);
 }
 
-Profile* Profile::loadProfile(QString name, QString password)
+Profile* Profile::loadProfile(QString name, const QString &password)
 {
     if (ProfileLocker::hasLock())
     {
@@ -594,7 +594,7 @@ void Profile::restartCore()
     QMetaObject::invokeMethod(core, "reset");
 }
 
-void Profile::setPassword(QString newPassword)
+void Profile::setPassword(const QString &newPassword)
 {
     QByteArray avatar = loadAvatarData(core->getSelfId().publicKey);
     QString oldPassword = password;

--- a/src/persistence/profile.h
+++ b/src/persistence/profile.h
@@ -38,7 +38,7 @@ class Profile
 public:
     /// Locks and loads an existing profile and create the associate Core* instance
     /// Returns a nullptr on error, for example if the profile is already in use
-    static Profile* loadProfile(QString name, QString password = QString());
+    static Profile* loadProfile(QString name, const QString &password = QString());
     /// Creates a new profile and the associated Core* instance
     /// If password is not empty, the profile will be encrypted
     /// Returns a nullptr on error, for example if the profile already exists
@@ -54,7 +54,7 @@ public:
     bool isEncrypted() const; ///< Returns true if we have a password set (doesn't check the actual file on disk)
     bool checkPassword(); ///< Checks whether the password is valid
     QString getPassword() const;
-    void setPassword(QString newPassword); ///< Changes the encryption password and re-saves everything with it
+    void setPassword(const QString &newPassword); ///< Changes the encryption password and re-saves everything with it
     const TOX_PASS_KEY& getPasskey() const;
 
     QByteArray loadToxSave(); ///< Loads the profile's .tox save from file, unencrypted
@@ -93,7 +93,7 @@ public:
     static bool isEncrypted(QString name); ///< Returns false on error. Checks the actual file on disk.
 
 private:
-    Profile(QString name, QString password, bool newProfile);
+    Profile(QString name, const QString &password, bool newProfile);
     /// Lists all the files in the config dir with a given extension
     /// Pass the raw extension, e.g. "jpeg" not ".jpeg".
     static QVector<QString> getFilesByExt(QString extension);

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -492,7 +492,7 @@ void Settings::savePersonal(Profile* profile)
     savePersonal(profile->getName(), profile->getPassword());
 }
 
-void Settings::savePersonal(QString profileName, QString password)
+void Settings::savePersonal(QString profileName, const QString &password)
 {
     if (QThread::currentThread() != settingsThread)
         return (void) QMetaObject::invokeMethod(&getInstance(), "savePersonal",
@@ -924,7 +924,7 @@ QString Settings::getToxmePass() const
     return toxmePass;
 }
 
-void Settings::setToxmePass(QString pass)
+void Settings::setToxmePass(const QString &pass)
 {
     QMutexLocker locker{&bigLock};
     toxmePass = pass;

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -129,7 +129,7 @@ public:
     void setToxmePriv(bool priv);
     
     QString getToxmePass() const;
-    void setToxmePass(QString pass);
+    void setToxmePass(const QString &pass);
     
     void setAutoSaveEnabled(bool newValue);
     bool getAutoSaveEnabled() const;
@@ -344,7 +344,7 @@ private:
     Settings& operator=(const Settings&) = delete;
 
 private slots:
-    void savePersonal(QString profileName, QString password);
+    void savePersonal(QString profileName, const QString &password);
 
 private:
     bool loaded;

--- a/src/persistence/settingsserializer.cpp
+++ b/src/persistence/settingsserializer.cpp
@@ -72,7 +72,7 @@ QDataStream& readStream(QDataStream& dataStream, QByteArray& data)
     return dataStream;
 }
 
-SettingsSerializer::SettingsSerializer(QString filePath, QString password)
+SettingsSerializer::SettingsSerializer(QString filePath, const QString &password)
     : path{filePath}, password{password},
       group{-1}, array{-1}, arrayIndex{-1}
 {

--- a/src/persistence/settingsserializer.h
+++ b/src/persistence/settingsserializer.h
@@ -34,7 +34,7 @@
 class SettingsSerializer
 {
 public:
-    SettingsSerializer(QString filePath, QString password=QString());
+    SettingsSerializer(QString filePath, const QString &password=QString());
 
     static bool isSerializedFormat(QString filePath); ///< Check if the file is serialized settings. False on error.
 


### PR DESCRIPTION
This commit changes passing by value behavior for password occurrences to pass by reference to const.
I've noticed great inconsistency in codebase about how "in" parameters of large (with sizeof(T) > 8 bytes) non-trivial types are passed around. For example QString, QByteArray, QList, std::function, IPCEventHandler, ToxFile sometimes are passed around by value, sometimes, by reference to const. I think all of them should be passed by reference to const by default. This advice can be found in [CoreGuidelines](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#f16-for-in-parameters-pass-cheaply-copied-types-by-value-and-others-by-reference-to-const). This must be applied to Qt types with implicit sharing as well (you can see how Qt library itself pass it's types). Exceptions to this can be intentional moving around types, [copy-and-swap idiom](https://en.wikibooks.org/wiki/More_C%2B%2B_Idioms/Copy-and-swap), or copy for modification.
   If everybody agree on this, i can help with fixing ~400 occurrences of this issue in codebase. Please discuss.
