### PR TITLE
chore(qtox.pro): enable maximum ressource compression

### DIFF
--- a/qtox.pro
+++ b/qtox.pro
@@ -41,6 +41,7 @@ CONFIG   += c++11
 CONFIG   += link_pkgconfig
 
 QMAKE_CXXFLAGS += -fno-exceptions
+QMAKE_RESOURCE_FLAGS += -compress 9 -threshold 0
 
 # Rules for creating/updating {ts|qm}-files
 include(translations/i18n.pri)


### PR DESCRIPTION
This change reduces memory usage during compilation from ~1.2GB to ~600MB.
Additionally it reduces the size of a dynamically linked qTox binary from
~10MB to ~6MB.
