### PR TITLE
fix(passwordedit.cpp): Fix build issue with Qt 5.3

### DIFF
--- a/src/widget/passwordedit.cpp
+++ b/src/widget/passwordedit.cpp
@@ -44,7 +44,8 @@ void PasswordEdit::unregisterHandler()
 #ifdef ENABLE_CAPSLOCK_INDICATOR
     if (eventHandler && eventHandler->actions.contains(action))
     {
-        eventHandler->actions.removeOne(action);
+        //TODO: future: use removeOne() when Qt 5.3 (Debian 8) support ends.
+        eventHandler->actions.remove(eventHandler->actions.indexOf(action));
         if (eventHandler->actions.isEmpty())
         {
             delete eventHandler;


### PR DESCRIPTION
QVector<T>::removeOne() was added in Qt 5.4, and this method usage
broke build for Debian 8 whitch has Qt 5.3.2.

Add alternative implementation and comment for the future to use
removeOne() when this becomes possible.

Closes #3416
