### PR TITLE
fix(systemtrayicon): #3419, don't activate qTox widget on tray icon click in Unity backend

### DIFF
--- a/src/widget/systemtrayicon.h
+++ b/src/widget/systemtrayicon.h
@@ -38,6 +38,7 @@ public:
     void hide();
     void setVisible(bool);
     void setIcon(QIcon &icon);
+    SystrayBackendType backend() const { return backendType; }
 
 signals:
     void activated(QSystemTrayIcon::ActivationReason);

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1801,6 +1801,7 @@ void Widget::onTryCreateTrayIcon()
             trayMenu->addAction(actionQuit);
             icon->setContextMenu(trayMenu);
 
+            // don't activate qTox widget on tray icon click in Unity backend (see #3419)
             #ifdef ENABLE_SYSTRAY_UNITY_BACKEND
             if (icon->backend() != SystrayBackendType::Unity)
                 connect(icon, &SystemTrayIcon::activated, this, &Widget::onIconClick);

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1801,7 +1801,12 @@ void Widget::onTryCreateTrayIcon()
             trayMenu->addAction(actionQuit);
             icon->setContextMenu(trayMenu);
 
+            #ifdef ENABLE_SYSTRAY_UNITY_BACKEND
+            if (icon->backend() != SystrayBackendType::Unity)
+                connect(icon, &SystemTrayIcon::activated, this, &Widget::onIconClick);
+            #else
             connect(icon, &SystemTrayIcon::activated, this, &Widget::onIconClick);
+            #endif
 
             if (Settings::getInstance().getShowSystemTray())
             {


### PR DESCRIPTION
Seems Unity has own opinion about usability and user experience :)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tux3/qtox/3423)

<!-- Reviewable:end -->
