### PR TITLE
fix(chattextedit.cpp): fix drag-and-drop to be consistent across systems

### DIFF
--- a/src/widget/tool/chattextedit.cpp
+++ b/src/widget/tool/chattextedit.cpp
@@ -26,6 +26,7 @@ ChatTextEdit::ChatTextEdit(QWidget *parent) :
 {
     retranslateUi();
     setAcceptRichText(false);
+    setAcceptDrops(false);
 
     Translator::registerHandler(std::bind(&ChatTextEdit::retranslateUi, this), this);
 }


### PR DESCRIPTION
Add explicit setAcceptDrops(false) to allow parent widget to handle
drag-and-drops consistently across various desktop environments.

Closes: #2847 

Before:
![before](https://cloud.githubusercontent.com/assets/292191/16345364/3feae9d4-3a4a-11e6-833b-8d017007a364.gif)

After:
![after](https://cloud.githubusercontent.com/assets/292191/16345378/4d5ff5a0-3a4a-11e6-9599-bd1881bd9d6a.gif)

Tested on KDE/Gnome/XFCE/Unity, now they behave the same same (previously, only later KDE accepted drag-and-drops).

Cannot build and test on Windows because of #3372  
