### PR TITLE
fix(markdown): Remove spaces from markdown translation

### DIFF
--- a/src/chatlog/chatmessage.cpp
+++ b/src/chatlog/chatmessage.cpp
@@ -214,19 +214,19 @@ QString ChatMessage::detectMarkdown(const QString &str)
 
             // Match captured string to corresponding md format
             if (exp.cap(1) == "**") // Bold **text**
-                htmledSnippet = QString(" <b>%1</b> ").arg(snippet.mid(mul,snippet.length()-2*mul));
+                htmledSnippet = QString("<b>%1</b>").arg(snippet.mid(mul,snippet.length()-2*mul));
             else if (exp.cap(4) == "*" && snippet.length() > 2) // Italics *text*
-                htmledSnippet = QString(" <i>%1</i> ").arg(snippet.mid(mul/2,snippet.length()-mul));
+                htmledSnippet = QString("<i>%1</i>").arg(snippet.mid(mul/2,snippet.length()-mul));
             else if (exp.cap(7) == "_" && snippet.length() > 2) // Italics _text_
-                htmledSnippet = QString(" <i>%1</i> ").arg(snippet.mid(mul/2,snippet.length()-mul));
+                htmledSnippet = QString("<i>%1</i>").arg(snippet.mid(mul/2,snippet.length()-mul));
             else if (exp.cap(10) == "__"&& snippet.length() > 4) // Bold __text__
-                htmledSnippet = QString(" <b>%1</b> ").arg(snippet.mid(mul,snippet.length()-2*mul));
+                htmledSnippet = QString("<b>%1</b>").arg(snippet.mid(mul,snippet.length()-2*mul));
             else if (exp.cap(13) == "-" && snippet.length() > 2) // Underline -text-
-                htmledSnippet = QString(" <u>%1</u> ").arg(snippet.mid(mul/2,snippet.length()-mul));
+                htmledSnippet = QString("<u>%1</u>").arg(snippet.mid(mul/2,snippet.length()-mul));
             else if (exp.cap(16) == "~" && snippet.length() > 2) // Strikethrough ~text~
-                htmledSnippet = QString(" <s>%1</s> ").arg(snippet.mid(mul/2,snippet.length()-mul));
+                htmledSnippet = QString("<s>%1</s>").arg(snippet.mid(mul/2,snippet.length()-mul));
             else if (exp.cap(19) == "~~" && snippet.length() > 4) // Strikethrough ~~text~~
-                htmledSnippet = QString(" <s>%1</s> ").arg(snippet.mid(mul,snippet.length()-2*mul));
+                htmledSnippet = QString("<s>%1</s>").arg(snippet.mid(mul,snippet.length()-2*mul));
             else if (exp.cap(22) == "`" && snippet.length() > 2) // Codeblock `text`
                 htmledSnippet = QString("<font color=#595959><code>%1</code></font>").arg(snippet.mid(mul/2,snippet.length()-mul));
             else


### PR DESCRIPTION
Spaces were being inserted before and after markdown translated code which could potentially change intended meaning and/or presentation of the user's message. I believe these were necessary for dealing with an earlier bug but from my testing they are no longer needed.

Address #3429 
