### PR TITLE
fix(loginscreen.cpp): fix password input focus after mouse click

### DIFF
--- a/src/widget/loginscreen.cpp
+++ b/src/widget/loginscreen.cpp
@@ -235,6 +235,7 @@ void LoginScreen::onLogin()
         {
             QMessageBox::critical(this, tr("Couldn't load this profile"),
                                   tr("Wrong password."));
+            ui->loginPassword->setFocus();
             ui->loginPassword->selectAll();
             return;
         }


### PR DESCRIPTION
Add setFocus() call to make password input focus work after user
clicks Load button (hence losing focus) with invalid password.
Without this patch, focus only works when using Enter key to login.
