### PR TITLE
fix(profile): Fix for importing profile using Nautilus file manager

### DIFF
--- a/src/chatlog/content/filetransferwidget.cpp
+++ b/src/chatlog/content/filetransferwidget.cpp
@@ -478,7 +478,10 @@ void FileTransferWidget::handleButton(QPushButton *btn)
         {
             QString path = QFileDialog::getSaveFileName(parentWidget(),
                                                         tr("Save a file", "Title of the file saving dialog"),
-                                                        Settings::getInstance().getGlobalAutoAcceptDir() + "/" + fileInfo.fileName);
+                                                        Settings::getInstance().getGlobalAutoAcceptDir() + "/" + fileInfo.fileName,
+                                                        0,
+                                                        0,
+                                                        QFileDialog::DontUseNativeDialog);
             acceptTransfer(path);
         }
     }

--- a/src/widget/about/aboutuser.cpp
+++ b/src/widget/about/aboutuser.cpp
@@ -60,8 +60,10 @@ void AboutUser::onAutoAcceptClicked()
     }
     else if (ui->autoaccept->isChecked())
     {
-        dir = QFileDialog::getExistingDirectory(this, tr("Choose an auto accept directory",
-                                                         "popup title"), dir);
+        dir = QFileDialog::getExistingDirectory(this,
+                                                tr("Choose an auto accept directory", "popup title"),
+                                                dir,
+                                                QFileDialog::DontUseNativeDialog);
         if(dir.isEmpty())
         {
             ui->autoaccept->setChecked(false);
@@ -77,8 +79,10 @@ void AboutUser::onAutoAcceptClicked()
 void AboutUser::onSelectDirClicked()
 {
     QString dir;
-    dir = QFileDialog::getExistingDirectory(this, tr("Choose an auto accept directory",
-                                                     "popup title"), dir);
+    dir = QFileDialog::getExistingDirectory(this,
+                                            tr("Choose an auto accept directory", "popup title"),
+                                            dir,
+                                            QFileDialog::DontUseNativeDialog);
     ui->autoaccept->setChecked(true);
     Settings::getInstance().setAutoAcceptDir(this->toxId, dir);
     Settings::getInstance().saveGlobal();

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -187,7 +187,11 @@ void ChatForm::onTextEditChanged()
 void ChatForm::onAttachClicked()
 {
     QStringList paths = QFileDialog::getOpenFileNames(this,
-                                                      tr("Send a file"));
+                                                      tr("Send a file"),
+                                                      QDir::homePath(),
+                                                      0,
+                                                      0,
+                                                      QFileDialog::DontUseNativeDialog);
     if (paths.isEmpty())
         return;
 

--- a/src/widget/form/profileform.cpp
+++ b/src/widget/form/profileform.cpp
@@ -264,9 +264,11 @@ void ProfileForm::onAvatarClicked()
     };
 
     QString filename = QFileDialog::getOpenFileName(this,
-        tr("Choose a profile picture"),
-        QDir::homePath(),
-        Nexus::getSupportedImageFilter());
+                                                    tr("Choose a profile picture"),
+                                                    QDir::homePath(),
+                                                    Nexus::getSupportedImageFilter(),
+                                                    0,
+                                                    QFileDialog::DontUseNativeDialog);
     if (filename.isEmpty())
         return;
 
@@ -342,8 +344,10 @@ void ProfileForm::onExportClicked()
     QString current = Nexus::getProfile()->getName() + Core::TOX_EXT;
     QString path = QFileDialog::getSaveFileName(this,
                                                 tr("Export profile", "save dialog title"),
-                    QDir::home().filePath(current),
-                    tr("Tox save file (*.tox)", "save dialog filter"));
+                                                QDir::home().filePath(current),
+                                                tr("Tox save file (*.tox)", "save dialog filter"),
+                                                0,
+                                                QFileDialog::DontUseNativeDialog);
     if (!path.isEmpty())
     {
         if (!Nexus::tryRemoveFile(path))
@@ -415,8 +419,10 @@ void ProfileForm::onSaveQrClicked()
     QString current = Nexus::getProfile()->getName() + ".png";
     QString path = QFileDialog::getSaveFileName(this,
                                                 tr("Save", "save qr image"),
-                   QDir::home().filePath(current),
-                   tr("Save QrCode (*.png)", "save dialog filter"));
+                                                QDir::home().filePath(current),
+                                                tr("Save QrCode (*.png)", "save dialog filter"),
+                                                0,
+                                                QFileDialog::DontUseNativeDialog);
     if (!path.isEmpty())
     {
         if (!Nexus::tryRemoveFile(path))

--- a/src/widget/form/settings/generalform.cpp
+++ b/src/widget/form/settings/generalform.cpp
@@ -378,8 +378,8 @@ void GeneralForm::onAutoSaveDirChange()
     QString previousDir = Settings::getInstance().getGlobalAutoAcceptDir();
     QString directory = QFileDialog::getExistingDirectory(0,
                                                           tr("Choose an auto accept directory", "popup title"),  //opens in home directory
-                                                             QStandardPaths::locate(QStandardPaths::HomeLocation, QString(), QStandardPaths::LocateDirectory)
-                                                          );
+                                                          QDir::homePath(),
+                                                          QFileDialog::DontUseNativeDialog);
     if (directory.isEmpty())  // cancel was pressed
         directory = previousDir;
 

--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -199,7 +199,10 @@ void FriendWidget::contextMenuEvent(QContextMenuEvent * event)
             }
             else if (autoAccept->isChecked())
             {
-                dir = QFileDialog::getExistingDirectory(0, tr("Choose an auto accept directory","popup title"), dir);
+                dir = QFileDialog::getExistingDirectory(0,
+                                                        tr("Choose an auto accept directory","popup title"),
+                                                        dir,
+                                                        QFileDialog::DontUseNativeDialog);
                 autoAccept->setChecked(true);
                 qDebug() << "setting auto accept dir for" << friendId << "to" << dir;
                 Settings::getInstance().setAutoAcceptDir(id, dir);

--- a/src/widget/tool/profileimporter.cpp
+++ b/src/widget/tool/profileimporter.cpp
@@ -36,11 +36,12 @@ ProfileImporter::ProfileImporter(QWidget *parent) : QWidget(parent)
 
 bool ProfileImporter::importProfile()
 {
-    QString path = QFileDialog::getOpenFileName( this,
+    QString path = QFileDialog::getOpenFileName(this,
                                                 tr("Import profile", "import dialog title"),
                                                 QDir::homePath(),
-                                                tr("Tox save file (*.tox)", "import dialog filter") );
-
+                                                tr("Tox save file (*.tox)", "import dialog filter"),
+                                                0,
+                                                QFileDialog::DontUseNativeDialog);
     if (path.isEmpty())
          return false;
 


### PR DESCRIPTION
Importing a profile using Nautilus as the default file manager, which many users use, was causing a hang in Qt's  method. Setting Qt to use it's own file manager in this circumstance fixes the issue. Closes #3436, closes #3443.
