### PR TITLE
feat(chat): add settings to alter the chat view's base font

### DIFF
--- a/src/chatlog/content/text.cpp
+++ b/src/chatlog/content/text.cpp
@@ -31,10 +31,13 @@
 #include <QDesktopServices>
 #include <QTextFragment>
 
-Text::Text(const QString& txt, QFont font, bool enableElide, const QString &rwText, const QColor c)
+Text::Text(const QString& txt, const QFont& font, bool enableElide, const QString &rwText, const QColor c)
     : rawText(rwText)
     , elide(enableElide)
     , defFont(font)
+    , defStyleSheet(QString::fromUtf8("body{font: '%1' %2px %3;}")
+                    .arg(font.family()).arg(font.pixelSize())
+                    .arg(font.bold() ? "bold" : QString()))
     , color(c)
 {
     setText(txt);
@@ -247,9 +250,14 @@ void Text::regenerate()
         doc->setDefaultFont(defFont);
 
         if (!elide)
+        {
+            doc->setDefaultStyleSheet(defStyleSheet);
             doc->setHtml(text);
+        }
         else
+        {
             doc->setPlainText(elidedText);
+        }
 
         // wrap mode
         QTextOption opt;

--- a/src/chatlog/content/text.h
+++ b/src/chatlog/content/text.h
@@ -31,7 +31,7 @@ class Text : public ChatLineContent
 public:
     // txt: may contain html code
     // rawText: does not contain html code
-    Text(const QString& txt = "", QFont font = QFont(), bool enableElide = false, const QString& rawText = QString(), const QColor c = Qt::black);
+    Text(const QString& txt = "", const QFont& font = QFont(), bool enableElide = false, const QString& rawText = QString(), const QColor c = Qt::black);
     virtual ~Text();
 
     void setText(const QString& txt);
@@ -87,6 +87,7 @@ private:
     qreal ascent = 0.0;
     qreal width = 0.0;
     QFont defFont;
+    QString defStyleSheet;
     QColor color;
 
 };

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -24,6 +24,7 @@
 #include "src/core/corestructs.h"
 #include "src/core/core.h"
 #include "src/widget/gui.h"
+#include "src/widget/style.h"
 #include "src/persistence/profilelocker.h"
 #include "src/persistence/settingsserializer.h"
 #include "src/nexus.h"
@@ -222,6 +223,12 @@ void Settings::loadGlobal()
             else
                 style = "None";
         }
+    s.endGroup();
+
+    s.beginGroup("Chat");
+    {
+        chatMessageFont = s.value("chatMessageFont", Style::getFont(Style::Big)).value<QFont>();
+    }
     s.endGroup();
 
     s.beginGroup("State");
@@ -452,6 +459,12 @@ void Settings::saveGlobal()
         s.setValue("themeColor", themeColor);
         s.setValue("style", style);
         s.setValue("statusChangeNotificationEnabled", statusChangeNotificationEnabled);
+    s.endGroup();
+
+    s.beginGroup("Chat");
+    {
+        s.setValue("chatMessageFont", chatMessageFont);
+    }
     s.endGroup();
 
     s.beginGroup("State");
@@ -1132,6 +1145,18 @@ void Settings::setGlobalAutoAcceptDir(const QString& newValue)
 {
     QMutexLocker locker{&bigLock};
     globalAutoAcceptDir = newValue;
+}
+
+const QFont& Settings::getChatMessageFont() const
+{
+    QMutexLocker locker(&bigLock);
+    return chatMessageFont;
+}
+
+void Settings::setChatMessageFont(const QFont& font)
+{
+    QMutexLocker locker(&bigLock);
+    chatMessageFont = font;
 }
 
 void Settings::setWidgetData(const QString& uniqueName, const QByteArray& data)

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -21,6 +21,7 @@
 #ifndef SETTINGS_HPP
 #define SETTINGS_HPP
 
+#include <QFont>
 #include <QHash>
 #include <QObject>
 #include <QPixmap>
@@ -224,6 +225,9 @@ public:
     void setGlobalAutoAcceptDir(const QString& dir);
 
     // ChatView
+    const QFont& getChatMessageFont() const;
+    void setChatMessageFont(const QFont& font);
+
     int getFirstColumnHandlePos() const;
     void setFirstColumnHandlePos(const int pos);
 
@@ -415,6 +419,7 @@ private:
     bool showSystemTray;
 
     // ChatView
+    QFont chatMessageFont;
     MarkdownType markdownPreference;
     int firstColumnHandlePos;
     int secondColumnHandlePosFromRight;

--- a/src/widget/form/settings/generalform.cpp
+++ b/src/widget/form/settings/generalform.cpp
@@ -113,74 +113,74 @@ GeneralForm::GeneralForm(SettingsWidget *myParent) :
     Settings& s = Settings::getInstance();
 
     bodyUI->checkUpdates->setVisible(AUTOUPDATE_ENABLED);
-    bodyUI->checkUpdates->setChecked(Settings::getInstance().getCheckUpdates());
+    bodyUI->checkUpdates->setChecked(s.getCheckUpdates());
 
-    bodyUI->cbEnableIPv6->setChecked(Settings::getInstance().getEnableIPv6());
+    bodyUI->cbEnableIPv6->setChecked(s.getEnableIPv6());
     for (int i = 0; i < langs.size(); i++)
         bodyUI->transComboBox->insertItem(i, langs[i]);
 
-    bodyUI->transComboBox->setCurrentIndex(locales.indexOf(Settings::getInstance().getTranslation()));
+    bodyUI->transComboBox->setCurrentIndex(locales.indexOf(s.getTranslation()));
 
     bodyUI->txtChatFont->setCurrentFont(s.getChatMessageFont());
     bodyUI->txtChatFontSize->setValue(s.getChatMessageFont().pixelSize());
-    bodyUI->markdownComboBox->setCurrentIndex(Settings::getInstance().getMarkdownPreference());
-    bodyUI->cbAutorun->setChecked(Settings::getInstance().getAutorun());
+    bodyUI->markdownComboBox->setCurrentIndex(s.getMarkdownPreference());
+    bodyUI->cbAutorun->setChecked(s.getAutorun());
 
-    bool showSystemTray = Settings::getInstance().getShowSystemTray();
+    bool showSystemTray = s.getShowSystemTray();
 
     bodyUI->showSystemTray->setChecked(showSystemTray);
-    bodyUI->startInTray->setChecked(Settings::getInstance().getAutostartInTray());
+    bodyUI->startInTray->setChecked(s.getAutostartInTray());
     bodyUI->startInTray->setEnabled(showSystemTray);
-    bodyUI->closeToTray->setChecked(Settings::getInstance().getCloseToTray());
+    bodyUI->closeToTray->setChecked(s.getCloseToTray());
     bodyUI->closeToTray->setEnabled(showSystemTray);
-    bodyUI->minimizeToTray->setChecked(Settings::getInstance().getMinimizeToTray());
+    bodyUI->minimizeToTray->setChecked(s.getMinimizeToTray());
     bodyUI->minimizeToTray->setEnabled(showSystemTray);
-    bodyUI->lightTrayIcon->setChecked(Settings::getInstance().getLightTrayIcon());
+    bodyUI->lightTrayIcon->setChecked(s.getLightTrayIcon());
 
-    bodyUI->statusChanges->setChecked(Settings::getInstance().getStatusChangeNotificationEnabled());
-    bodyUI->useEmoticons->setChecked(Settings::getInstance().getUseEmoticons());
-    bodyUI->autoacceptFiles->setChecked(Settings::getInstance().getAutoSaveEnabled());
-    bodyUI->autoSaveFilesDir->setText(Settings::getInstance().getGlobalAutoAcceptDir());
+    bodyUI->statusChanges->setChecked(s.getStatusChangeNotificationEnabled());
+    bodyUI->useEmoticons->setChecked(s.getUseEmoticons());
+    bodyUI->autoacceptFiles->setChecked(s.getAutoSaveEnabled());
+    bodyUI->autoSaveFilesDir->setText(s.getGlobalAutoAcceptDir());
 
-    bool showWindow = Settings::getInstance().getShowWindow();
+    bool showWindow = s.getShowWindow();
 
     bodyUI->showWindow->setChecked(showWindow);
-    bodyUI->showInFront->setChecked(Settings::getInstance().getShowInFront());
+    bodyUI->showInFront->setChecked(s.getShowInFront());
     bodyUI->showInFront->setEnabled(showWindow);
 
-    bool notifySound = Settings::getInstance().getNotifySound();
+    bool notifySound = s.getNotifySound();
 
     bodyUI->notifySound->setChecked(notifySound);
-    bodyUI->busySound->setChecked(Settings::getInstance().getBusySound());
+    bodyUI->busySound->setChecked(s.getBusySound());
     bodyUI->busySound->setEnabled(notifySound);
-    bodyUI->groupAlwaysNotify->setChecked(Settings::getInstance().getGroupAlwaysNotify());
-    bodyUI->cbFauxOfflineMessaging->setChecked(Settings::getInstance().getFauxOfflineMessaging());
-    bodyUI->cbCompactLayout->setChecked(Settings::getInstance().getCompactLayout());
-    bodyUI->cbSeparateWindow->setChecked(Settings::getInstance().getSeparateWindow());
-    bodyUI->cbDontGroupWindows->setChecked(Settings::getInstance().getDontGroupWindows());
+    bodyUI->groupAlwaysNotify->setChecked(s.getGroupAlwaysNotify());
+    bodyUI->cbFauxOfflineMessaging->setChecked(s.getFauxOfflineMessaging());
+    bodyUI->cbCompactLayout->setChecked(s.getCompactLayout());
+    bodyUI->cbSeparateWindow->setChecked(s.getSeparateWindow());
+    bodyUI->cbDontGroupWindows->setChecked(s.getDontGroupWindows());
     bodyUI->cbDontGroupWindows->setEnabled(bodyUI->cbSeparateWindow->isChecked());
-    bodyUI->cbGroupchatPosition->setChecked(Settings::getInstance().getGroupchatPosition());
+    bodyUI->cbGroupchatPosition->setChecked(s.getGroupchatPosition());
 
     for (auto entry : SmileyPack::listSmileyPacks())
         bodyUI->smileyPackBrowser->addItem(entry.first, entry.second);
 
-    bodyUI->smileyPackBrowser->setCurrentIndex(bodyUI->smileyPackBrowser->findData(Settings::getInstance().getSmileyPack()));
+    bodyUI->smileyPackBrowser->setCurrentIndex(bodyUI->smileyPackBrowser->findData(s.getSmileyPack()));
     reloadSmiles();
     bodyUI->smileyPackBrowser->setEnabled(bodyUI->useEmoticons->isChecked());
 
     bodyUI->styleBrowser->addItem(tr("None"));
     bodyUI->styleBrowser->addItems(QStyleFactory::keys());
-    if (QStyleFactory::keys().contains(Settings::getInstance().getStyle()))
-        bodyUI->styleBrowser->setCurrentText(Settings::getInstance().getStyle());
+    if (QStyleFactory::keys().contains(s.getStyle()))
+        bodyUI->styleBrowser->setCurrentText(s.getStyle());
     else
         bodyUI->styleBrowser->setCurrentText(tr("None"));
 
     for (QString color : Style::getThemeColorNames())
         bodyUI->themeColorCBox->addItem(color);
 
-    bodyUI->themeColorCBox->setCurrentIndex(Settings::getInstance().getThemeColor());
+    bodyUI->themeColorCBox->setCurrentIndex(s.getThemeColor());
 
-    bodyUI->emoticonSize->setValue(Settings::getInstance().getEmojiFontPointSize());
+    bodyUI->emoticonSize->setValue(s.getEmojiFontPointSize());
 
     QStringList timestamps;
     for (QString timestamp : timeFormats)
@@ -202,19 +202,19 @@ GeneralForm::GeneralForm(SettingsWidget *myParent) :
 
     bodyUI->dateFormats->addItems(datestamps);
 
-    bodyUI->timestamp->setCurrentText(QString("%1 - %2").arg(Settings::getInstance().getTimestampFormat(), QTime::currentTime().toString(Settings::getInstance().getTimestampFormat())));
+    bodyUI->timestamp->setCurrentText(QString("%1 - %2").arg(s.getTimestampFormat(), QTime::currentTime().toString(s.getTimestampFormat())));
 
-    bodyUI->dateFormats->setCurrentText(QString("%1 - %2").arg(Settings::getInstance().getDateFormat(), QDate::currentDate().toString(Settings::getInstance().getDateFormat())));
+    bodyUI->dateFormats->setCurrentText(QString("%1 - %2").arg(s.getDateFormat(), QDate::currentDate().toString(s.getDateFormat())));
 
-    bodyUI->autoAwaySpinBox->setValue(Settings::getInstance().getAutoAwayTime());
+    bodyUI->autoAwaySpinBox->setValue(s.getAutoAwayTime());
 
-    bodyUI->cbEnableUDP->setChecked(!Settings::getInstance().getForceTCP());
-    bodyUI->proxyAddr->setText(Settings::getInstance().getProxyAddr());
-    int port = Settings::getInstance().getProxyPort();
+    bodyUI->cbEnableUDP->setChecked(!s.getForceTCP());
+    bodyUI->proxyAddr->setText(s.getProxyAddr());
+    int port = s.getProxyPort();
     if (port != -1)
         bodyUI->proxyPort->setValue(port);
 
-    bodyUI->proxyType->setCurrentIndex(static_cast<int>(Settings::getInstance().getProxyType()));
+    bodyUI->proxyType->setCurrentIndex(static_cast<int>(s.getProxyType()));
     onUseProxyUpdated();
 
     //general

--- a/src/widget/form/settings/generalform.cpp
+++ b/src/widget/form/settings/generalform.cpp
@@ -35,6 +35,7 @@
 #include <QStyleFactory>
 #include <QTime>
 #include <QFileDialog>
+#include <QFont>
 #include <QStandardPaths>
 #include <QDebug>
 
@@ -109,6 +110,8 @@ GeneralForm::GeneralForm(SettingsWidget *myParent) :
     bodyUI = new Ui::GeneralSettings;
     bodyUI->setupUi(this);
 
+    Settings& s = Settings::getInstance();
+
     bodyUI->checkUpdates->setVisible(AUTOUPDATE_ENABLED);
     bodyUI->checkUpdates->setChecked(Settings::getInstance().getCheckUpdates());
 
@@ -118,6 +121,8 @@ GeneralForm::GeneralForm(SettingsWidget *myParent) :
 
     bodyUI->transComboBox->setCurrentIndex(locales.indexOf(Settings::getInstance().getTranslation()));
 
+    bodyUI->txtChatFont->setCurrentFont(s.getChatMessageFont());
+    bodyUI->txtChatFontSize->setValue(s.getChatMessageFont().pixelSize());
     bodyUI->markdownComboBox->setCurrentIndex(Settings::getInstance().getMarkdownPreference());
     bodyUI->cbAutorun->setChecked(Settings::getInstance().getAutorun());
 
@@ -570,4 +575,27 @@ void GeneralForm::retranslateUi()
     }
 
     bodyUI->styleBrowser->setItemText(0, tr("None"));
+}
+
+void GeneralForm::on_txtChatFont_currentFontChanged(const QFont& f)
+{
+    QFont tmpFont = f;
+    const int fontSize = bodyUI->txtChatFontSize->value();
+
+    if (tmpFont.pixelSize() != fontSize)
+        tmpFont.setPixelSize(fontSize);
+
+    Settings::getInstance().setChatMessageFont(tmpFont);
+}
+
+void GeneralForm::on_txtChatFontSize_valueChanged(int arg1)
+{
+    Settings& s = Settings::getInstance();
+    QFont tmpFont = s.getChatMessageFont();
+
+    if (tmpFont.pixelSize() != arg1)
+    {
+        tmpFont.setPixelSize(arg1);
+        s.setChatMessageFont(tmpFont);
+    }
 }

--- a/src/widget/form/settings/generalform.h
+++ b/src/widget/form/settings/generalform.h
@@ -74,6 +74,9 @@ private slots:
     void onGroupchatPositionChanged();
     void onThemeColorChanged(int);
 
+    void on_txtChatFont_currentFontChanged(const QFont& f);
+    void on_txtChatFontSize_valueChanged(int arg1);
+
 private:
     void retranslateUi();
 

--- a/src/widget/form/settings/generalsettings.ui
+++ b/src/widget/form/settings/generalsettings.ui
@@ -305,6 +305,113 @@ instead of closing itself.</string>
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_7">
           <item>
+           <layout class="QGridLayout" name="gridLayout_2">
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_2">
+              <property name="text">
+               <string>Base font:</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QFontComboBox" name="txtChatFont"/>
+            </item>
+            <item row="0" column="2">
+             <widget class="QSpinBox" name="txtChatFontSize">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="suffix">
+               <string>px</string>
+              </property>
+              <property name="prefix">
+               <string>Size: </string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="transLabel_2">
+              <property name="toolTip">
+               <string>New Markdown preference may not load until qTox restarts.</string>
+              </property>
+              <property name="text">
+               <string>Markdown format:</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="3">
+             <spacer name="horizontalSpacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="1" column="3">
+             <spacer name="generalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="1" column="1" colspan="2">
+             <widget class="QComboBox" name="markdownComboBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="toolTip">
+               <string>Select Markdown preference.</string>
+              </property>
+              <item>
+               <property name="text">
+                <string>Plaintext</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Show formatting characters</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Don't show formatting characters</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="Line" name="line">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+           </widget>
+          </item>
+          <item>
            <layout class="QVBoxLayout" name="verticalLayout_9">
             <item>
              <widget class="QLabel" name="label_3">
@@ -374,59 +481,11 @@ instead of closing itself.</string>
            </layout>
           </item>
           <item>
-           <layout class="QHBoxLayout" name="generalLayout_2">
-            <item>
-             <widget class="QLabel" name="transLabel_2">
-              <property name="toolTip">
-               <string>New Markdown preference may not load until qTox restarts.</string>
-              </property>
-              <property name="text">
-               <string>Text formatting (Markdown):</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QComboBox" name="markdownComboBox">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="toolTip">
-               <string>Select Markdown preference.</string>
-              </property>
-              <item>
-               <property name="text">
-                <string>Plaintext</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Show formatting characters</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Don't show formatting characters</string>
-               </property>
-              </item>
-             </widget>
-            </item>
-            <item>
-             <spacer name="generalSpacer_2">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
+           <widget class="Line" name="line_2">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+           </widget>
           </item>
           <item>
            <widget class="QCheckBox" name="statusChanges">
@@ -473,6 +532,13 @@ will be sent to them when they appear online to you.</string>
             </property>
             <property name="text">
              <string>Compact contact list</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="Line" name="line_3">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
Closes #672
- [x] Introduce `Chat/chatMessageFont` settings value
  -  Defaults to GUI style font according to previous behavior.
- [x] Add Settings UI
- [x] Cleanup (chat) settings UI
- [x] Set the font censequently as the chat's base font.
  - Author, message and timestamp columns are based on a single font now. I can separate those to set a font on each column, but actually I think it is totally fine as is (See screenshots below).
# Settings UI:

![qtox-chat-base-font-settings-ui](https://cloud.githubusercontent.com/assets/440517/16413604/2f91b3c4-3d33-11e6-8e57-6901425e31c7.png)

**Note:** @zetok I moved both text format rows to the top of the group box and shorten the markdown label to something like "Markdown format" (the gap makes the dialog look like a mixed fruit salad :smile:)
# Settings UI after cleanup:

![qtox-chat-settings-ui](https://cloud.githubusercontent.com/assets/440517/16422139/95186b6a-3d57-11e6-902b-552da5bf280d.png)
# Example 1 (from WIP interims-state) for chat view with "Comic Sans MS" font (size: 18px):

![qtox-chat-base-font](https://cloud.githubusercontent.com/assets/440517/16413496/947b29ce-3d32-11e6-8409-e2fb91100f81.png)
# Example 2 (after) -> consistent appearance with same base font!

![qtox-chat-base-font-complete](https://cloud.githubusercontent.com/assets/440517/16419190/1ffd63da-3d4d-11e6-9f36-6559db7c9078.png)
