### PR TITLE
Setting rethink

### DIFF
--- a/qtox.pro
+++ b/qtox.pro
@@ -432,6 +432,7 @@ SOURCES += \
     src/widget/form/settings/privacyform.cpp \
     src/widget/form/settings/avform.cpp \
     src/widget/form/settings/userinterfaceform.cpp \
+    src/widget/form/settings/genericsettings.cpp \
     src/widget/form/profileform.cpp \
     src/widget/form/filesform.cpp \
     src/widget/tool/chattextedit.cpp \

--- a/qtox.pro
+++ b/qtox.pro
@@ -28,11 +28,12 @@ FORMS    += \
     src/widget/form/profileform.ui \
     src/widget/form/loadhistorydialog.ui \
     src/widget/form/setpassworddialog.ui \
-    src/widget/form/settings/aboutsettings.ui \
-    src/widget/form/settings/advancedsettings.ui \
-    src/widget/form/settings/avform.ui \
     src/widget/form/settings/generalsettings.ui \
+    src/widget/form/settings/userinterfacesettings.ui \
     src/widget/form/settings/privacysettings.ui \
+    src/widget/form/settings/avform.ui \
+    src/widget/form/settings/advancedsettings.ui \
+    src/widget/form/settings/aboutsettings.ui \
     src/widget/form/removefrienddialog.ui \
     src/widget/about/aboutuser.ui
 
@@ -360,7 +361,8 @@ HEADERS  += \
     src/widget/about/aboutuser.h \
     src/widget/form/groupinviteform.h \
     src/widget/tool/profileimporter.h \
-    src/widget/passwordedit.h
+    src/widget/passwordedit.h \
+    src/widget/form/settings/userinterfaceform.h
 
 SOURCES += \
     src/ipc.cpp \
@@ -423,11 +425,13 @@ SOURCES += \
     src/video/groupnetcamview.cpp \
     src/video/netcamview.cpp \
     src/video/videosurface.cpp \
+    src/video/videomode.cpp \
     src/widget/form/addfriendform.cpp \
     src/widget/form/settingswidget.cpp \
     src/widget/form/settings/generalform.cpp \
     src/widget/form/settings/privacyform.cpp \
     src/widget/form/settings/avform.cpp \
+    src/widget/form/settings/userinterfaceform.cpp \
     src/widget/form/profileform.cpp \
     src/widget/form/filesform.cpp \
     src/widget/tool/chattextedit.cpp \
@@ -479,5 +483,4 @@ SOURCES += \
     src/widget/about/aboutuser.cpp \
     src/widget/form/groupinviteform.cpp \
     src/widget/tool/profileimporter.cpp \
-    src/widget/passwordedit.cpp \
-    src/video/videomode.cpp
+    src/widget/passwordedit.cpp

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -136,10 +136,13 @@ void Settings::loadGlobal()
     QSettings s(filePath, QSettings::IniFormat);
     s.setIniCodec("UTF-8");
     s.beginGroup("Login");
+    {
         autoLogin = s.value("autoLogin", false).toBool();
+    }
     s.endGroup();
 
     s.beginGroup("DHT Server");
+    {
         if (s.value("useCustomList").toBool())
         {
             useCustomDhtList = true;
@@ -159,21 +162,17 @@ void Settings::loadGlobal()
         }
         else
         {
-            useCustomDhtList=false;
+            useCustomDhtList = false;
         }
+    }
     s.endGroup();
 
     s.beginGroup("General");
-        enableIPv6 = s.value("enableIPv6", true).toBool();
+    {
         translation = s.value("translation", "en").toString();
         showSystemTray = s.value("showSystemTray", true).toBool();
-        makeToxPortable = s.value("makeToxPortable", false).toBool();
         autostartInTray = s.value("autostartInTray", false).toBool();
         closeToTray = s.value("closeToTray", false).toBool();
-        forceTCP = s.value("forceTCP", false).toBool();
-        proxyType = static_cast<ProxyType>(s.value("proxyType", 0).toInt());
-        proxyAddr = s.value("proxyAddr", "").toString();
-        proxyPort = static_cast<quint16>(s.value("proxyPort", 0).toUInt());
         if (currentProfile.isEmpty())
         {
             currentProfile = s.value("currentProfile", "").toString();
@@ -181,41 +180,51 @@ void Settings::loadGlobal()
         }
         autoAwayTime = s.value("autoAwayTime", 10).toInt();
         checkUpdates = s.value("checkUpdates", true).toBool();
-        showWindow = s.value("showWindow", true).toBool();
-        showInFront = s.value("showInFront", false).toBool();
         notifySound = s.value("notifySound", true).toBool();
         busySound = s.value("busySound", false).toBool();
-        groupAlwaysNotify = s.value("groupAlwaysNotify", false).toBool();
         fauxOfflineMessaging = s.value("fauxOfflineMessaging", true).toBool();
         autoSaveEnabled = s.value("autoSaveEnabled", false).toBool();
-        globalAutoAcceptDir = s.value("globalAutoAcceptDir",
-                                      QStandardPaths::locate(QStandardPaths::HomeLocation, QString(), QStandardPaths::LocateDirectory)
-                                      ).toString();
-        separateWindow = s.value("separateWindow", false).toBool();
-        dontGroupWindows = s.value("dontGroupWindows", true).toBool();
-        groupchatPosition = s.value("groupchatPosition", true).toBool();
+        globalAutoAcceptDir = s.value("globalAutoAcceptDir", QStandardPaths::locate(
+                                          QStandardPaths::HomeLocation,
+                                          QString(),
+                                          QStandardPaths::LocateDirectory)).toString();
         stylePreference = static_cast<StyleType>(s.value("stylePreference", 1).toInt());
+    }
     s.endGroup();
 
     s.beginGroup("Advanced");
-        Db::syncType sType = static_cast<Db::syncType>(s.value("dbSyncType", 2).toInt());
+    {
+        makeToxPortable = s.value("makeToxPortable", false).toBool();
+        enableIPv6 = s.value("enableIPv6", true).toBool();
+        forceTCP = s.value("forceTCP", false).toBool();
+        int type = s.value("dbSyncType", static_cast<int>(Db::syncType::stFull)).toInt();
+        Db::syncType sType = static_cast<Db::syncType>(type);
         setDbSyncType(sType);
+    }
     s.endGroup();
 
     s.beginGroup("Widgets");
+    {
         QList<QString> objectNames = s.childKeys();
         for (const QString& name : objectNames)
             widgetSettings[name] = s.value(name).toByteArray();
-
+    }
     s.endGroup();
 
     s.beginGroup("GUI");
+    {
+        showWindow = s.value("showWindow", true).toBool();
+        showInFront = s.value("showInFront", false).toBool();
+        groupAlwaysNotify = s.value("groupAlwaysNotify", false).toBool();
+        groupchatPosition = s.value("groupchatPosition", true).toBool();
+        separateWindow = s.value("separateWindow", false).toBool();
+        dontGroupWindows = s.value("dontGroupWindows", true).toBool();
+
         const QString DEFAULT_SMILEYS = ":/smileys/emojione/emoticons.xml";
         smileyPack = s.value("smileyPack", DEFAULT_SMILEYS).toString();
         if (!SmileyPack::isValid(smileyPack))
-        {
             smileyPack = DEFAULT_SMILEYS;
-        }
+
         emojiFontPointSize = s.value("emojiFontPointSize", 16).toInt();
         firstColumnHandlePos = s.value("firstColumnHandlePos", 50).toInt();
         secondColumnHandlePosFromRight = s.value("secondColumnHandlePosFromRight", 50).toInt();
@@ -235,6 +244,7 @@ void Settings::loadGlobal()
             else
                 style = "None";
         }
+    }
     s.endGroup();
 
     s.beginGroup("Chat");
@@ -244,29 +254,35 @@ void Settings::loadGlobal()
     s.endGroup();
 
     s.beginGroup("State");
+    {
         windowGeometry = s.value("windowGeometry", QByteArray()).toByteArray();
         windowState = s.value("windowState", QByteArray()).toByteArray();
         splitterState = s.value("splitterState", QByteArray()).toByteArray();
         dialogGeometry = s.value("dialogGeometry", QByteArray()).toByteArray();
         dialogSplitterState = s.value("dialogSplitterState", QByteArray()).toByteArray();
         dialogSettingsGeometry = s.value("dialogSettingsGeometry", QByteArray()).toByteArray();
+    }
     s.endGroup();
 
     s.beginGroup("Audio");
+    {
         inDev = s.value("inDev", "").toString();
         audioInDevEnabled = s.value("audioInDevEnabled", true).toBool();
         outDev = s.value("outDev", "").toString();
         audioOutDevEnabled = s.value("audioOutDevEnabled", true).toBool();
         audioInGainDecibel = s.value("inGain", 0).toReal();
         outVolume = s.value("outVolume", 100).toInt();
+    }
     s.endGroup();
 
     s.beginGroup("Video");
+    {
         videoDev = s.value("videoDev", "").toString();
         camVideoRes = s.value("camVideoRes", QRect()).toRect();
         screenRegion = s.value("screenRegion", QRect()).toRect();
         screenGrabbed = s.value("screenGrabbed", false).toBool();
         camVideoFPS = static_cast<quint16>(s.value("camVideoFPS", 0).toUInt());
+    }
     s.endGroup();
 
     // Read the embedded DHT bootstrap nodes list if needed
@@ -323,11 +339,14 @@ void Settings::loadPersonal(Profile* profile)
     friendLst.clear();
 
     ps.beginGroup("Privacy");
+    {
         typingNotification = ps.value("typingNotification", true).toBool();
         enableLogging = ps.value("enableLogging", true).toBool();
+    }
     ps.endGroup();
 
     ps.beginGroup("Friends");
+    {
         int size = ps.beginReadArray("Friend");
         friendLst.reserve(size);
         for (int i = 0; i < size; i ++)
@@ -346,10 +365,12 @@ void Settings::loadPersonal(Profile* profile)
             friendLst[ToxId(fp.addr).publicKey] = fp;
         }
         ps.endArray();
+    }
     ps.endGroup();
 
     ps.beginGroup("Requests");
-        size = ps.beginReadArray("Request");
+    {
+        int size = ps.beginReadArray("Request");
         friendRequests.clear();
         friendRequests.reserve(size);
         for (int i = 0; i < size; i ++)
@@ -362,14 +383,26 @@ void Settings::loadPersonal(Profile* profile)
             friendRequests.push_back(request);
         }
         ps.endArray();
+    }
     ps.endGroup();
 
-    ps.beginGroup("General");
+    ps.beginGroup("GUI");
+    {
         compactLayout = ps.value("compactLayout", true).toBool();
+    }
+    ps.endGroup();
+
+    ps.beginGroup("Proxy");
+    {
+        setProxyType(ps.value("proxyType", static_cast<int>(ProxyType::ptNone)).toInt());
+        proxyAddr = ps.value("proxyAddr", "").toString();
+        proxyPort = static_cast<quint16>(ps.value("proxyPort", 0).toUInt());
+    }
     ps.endGroup();
 
     ps.beginGroup("Circles");
-        size = ps.beginReadArray("Circle");
+    {
+        int size = ps.beginReadArray("Circle");
         circleLst.clear();
         circleLst.reserve(size);
         for (int i = 0; i < size; i ++)
@@ -381,13 +414,16 @@ void Settings::loadPersonal(Profile* profile)
             circleLst.push_back(cp);
         }
         ps.endArray();
+    }
     ps.endGroup();
 
     ps.beginGroup("Toxme");
+    {
         toxmeInfo = ps.value("info", "").toString();
         toxmeBio  = ps.value("bio", "").toString();
         toxmePriv = ps.value("priv", false).toBool();
         toxmePass = ps.value("pass", "").toString();
+    }
     ps.endGroup();
 }
 
@@ -426,10 +462,13 @@ void Settings::saveGlobal()
     s.clear();
 
     s.beginGroup("Login");
+    {
         s.setValue("autoLogin", autoLogin);
+    }
     s.endGroup();
 
     s.beginGroup("DHT Server");
+    {
         s.setValue("useCustomList", useCustomDhtList);
         s.beginWriteArray("dhtServerList", dhtServerList.size());
         for (int i = 0; i < dhtServerList.size(); i ++)
@@ -441,47 +480,53 @@ void Settings::saveGlobal()
             s.setValue("port", dhtServerList[i].port);
         }
         s.endArray();
+    }
     s.endGroup();
 
     s.beginGroup("General");
-        s.setValue("enableIPv6", enableIPv6);
+    {
         s.setValue("translation",translation);
-        s.setValue("makeToxPortable",makeToxPortable);
         s.setValue("showSystemTray", showSystemTray);
         s.setValue("autostartInTray",autostartInTray);
         s.setValue("closeToTray", closeToTray);
-        s.setValue("proxyType", static_cast<int>(proxyType));
-        s.setValue("forceTCP", forceTCP);
-        s.setValue("proxyAddr", proxyAddr);
-        s.setValue("proxyPort", proxyPort);
         s.setValue("currentProfile", currentProfile);
         s.setValue("autoAwayTime", autoAwayTime);
         s.setValue("checkUpdates", checkUpdates);
-        s.setValue("showWindow", showWindow);
-        s.setValue("showInFront", showInFront);
         s.setValue("notifySound", notifySound);
         s.setValue("busySound", busySound);
-        s.setValue("groupAlwaysNotify", groupAlwaysNotify);
         s.setValue("fauxOfflineMessaging", fauxOfflineMessaging);
-        s.setValue("separateWindow", separateWindow);
-        s.setValue("dontGroupWindows", dontGroupWindows);
-        s.setValue("groupchatPosition", groupchatPosition);
         s.setValue("autoSaveEnabled", autoSaveEnabled);
         s.setValue("globalAutoAcceptDir", globalAutoAcceptDir);
         s.setValue("stylePreference", static_cast<int>(stylePreference));
+    }
     s.endGroup();
 
     s.beginGroup("Advanced");
+    {
+        s.setValue("makeToxPortable",makeToxPortable);
+        s.setValue("enableIPv6", enableIPv6);
+        s.setValue("forceTCP", forceTCP);
         s.setValue("dbSyncType", static_cast<int>(dbSyncType));
+    }
     s.endGroup();
 
     s.beginGroup("Widgets");
-    const QList<QString> widgetNames = widgetSettings.keys();
-    for (const QString& name : widgetNames)
-        s.setValue(name, widgetSettings.value(name));
+    {
+        const QList<QString> widgetNames = widgetSettings.keys();
+        for (const QString& name : widgetNames)
+            s.setValue(name, widgetSettings.value(name));
+    }
     s.endGroup();
 
     s.beginGroup("GUI");
+    {
+        s.setValue("showWindow", showWindow);
+        s.setValue("showInFront", showInFront);
+        s.setValue("groupAlwaysNotify", groupAlwaysNotify);
+        s.setValue("separateWindow", separateWindow);
+        s.setValue("dontGroupWindows", dontGroupWindows);
+        s.setValue("groupchatPosition", groupchatPosition);
+
         s.setValue("smileyPack", smileyPack);
         s.setValue("emojiFontPointSize", emojiFontPointSize);
         s.setValue("firstColumnHandlePos", firstColumnHandlePos);
@@ -495,6 +540,7 @@ void Settings::saveGlobal()
         s.setValue("themeColor", themeColor);
         s.setValue("style", style);
         s.setValue("statusChangeNotificationEnabled", statusChangeNotificationEnabled);
+    }
     s.endGroup();
 
     s.beginGroup("Chat");
@@ -504,29 +550,35 @@ void Settings::saveGlobal()
     s.endGroup();
 
     s.beginGroup("State");
+    {
         s.setValue("windowGeometry", windowGeometry);
         s.setValue("windowState", windowState);
         s.setValue("splitterState", splitterState);
         s.setValue("dialogGeometry", dialogGeometry);
         s.setValue("dialogSplitterState", dialogSplitterState);
         s.setValue("dialogSettingsGeometry", dialogSettingsGeometry);
+    }
     s.endGroup();
 
     s.beginGroup("Audio");
+    {
         s.setValue("inDev", inDev);
         s.setValue("audioInDevEnabled", audioInDevEnabled);
         s.setValue("outDev", outDev);
         s.setValue("audioOutDevEnabled", audioOutDevEnabled);
         s.setValue("inGain", audioInGainDecibel);
         s.setValue("outVolume", outVolume);
+    }
     s.endGroup();
 
     s.beginGroup("Video");
+    {
         s.setValue("videoDev", videoDev);
         s.setValue("camVideoRes", camVideoRes);
         s.setValue("camVideoFPS", camVideoFPS);
         s.setValue("screenRegion", screenRegion);
         s.setValue("screenGrabbed", screenGrabbed);
+    }
     s.endGroup();
 }
 
@@ -568,6 +620,7 @@ void Settings::savePersonal(QString profileName, const QString &password)
 
     SettingsSerializer ps(path, password);
     ps.beginGroup("Friends");
+    {
         ps.beginWriteArray("Friend", friendLst.size());
         int index = 0;
         for (auto& frnd : friendLst)
@@ -585,11 +638,13 @@ void Settings::savePersonal(QString profileName, const QString &password)
             ++index;
         }
         ps.endArray();
+    }
     ps.endGroup();
 
     ps.beginGroup("Requests");
+    {
         ps.beginWriteArray("Request", friendRequests.size());
-        index = 0;
+        int index = 0;
         for (auto& request : friendRequests)
         {
             ps.setArrayIndex(index);
@@ -600,15 +655,27 @@ void Settings::savePersonal(QString profileName, const QString &password)
             ++index;
         }
         ps.endArray();
+    }
     ps.endGroup();
 
-    ps.beginGroup("General");
+    ps.beginGroup("GUI");
+    {
         ps.setValue("compactLayout", compactLayout);
+    }
+    ps.endGroup();
+
+    ps.beginGroup("Proxy");
+    {
+        ps.setValue("proxyType", static_cast<int>(proxyType));
+        ps.setValue("proxyAddr", proxyAddr);
+        ps.setValue("proxyPort", proxyPort);
+    }
     ps.endGroup();
 
     ps.beginGroup("Circles");
+    {
         ps.beginWriteArray("Circle", circleLst.size());
-        index = 0;
+        int index = 0;
         for (auto& circle : circleLst)
         {
             ps.setArrayIndex(index);
@@ -617,18 +684,23 @@ void Settings::savePersonal(QString profileName, const QString &password)
             index++;
         }
         ps.endArray();
+    }
     ps.endGroup();
 
     ps.beginGroup("Privacy");
+    {
         ps.setValue("typingNotification", typingNotification);
         ps.setValue("enableLogging", enableLogging);
+    }
     ps.endGroup();
 
     ps.beginGroup("Toxme");
+    {
         ps.setValue("info", toxmeInfo);
         ps.setValue("bio", toxmeBio);
         ps.setValue("priv", toxmePriv);
         ps.setValue("pass", toxmePass);
+    }
     ps.endGroup();
 
     ps.save();

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -391,6 +391,20 @@ void Settings::loadPersonal(Profile* profile)
     ps.endGroup();
 }
 
+void Settings::resetToDefault()
+{
+    // To stop saving
+    loaded = false;
+
+    // Remove file with profile settings
+    QDir dir(getSettingsDirPath());
+    Profile *profile = Nexus::getProfile();
+    QString localPath = dir.filePath(profile->getName() + ".ini");
+    QFile local(localPath);
+    if (local.exists())
+        local.remove();
+}
+
 /**
  * @brief Asynchronous, saves the global settings.
  */
@@ -400,6 +414,9 @@ void Settings::saveGlobal()
         return (void) QMetaObject::invokeMethod(&getInstance(), "saveGlobal");
 
     QMutexLocker locker{&bigLock};
+    if (!loaded)
+        return;
+
     QString path = getSettingsDirPath() + globalSettingsFile;
     qDebug() << "Saving global settings at " + path;
 
@@ -542,6 +559,8 @@ void Settings::savePersonal(QString profileName, const QString &password)
                                                 Q_ARG(QString, profileName), Q_ARG(QString, password));
 
     QMutexLocker locker{&bigLock};
+    if (!loaded)
+        return;
 
     QString path = getSettingsDirPath() + profileName + ".ini";
 

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -394,7 +394,8 @@ void Settings::loadPersonal(Profile* profile)
 
     ps.beginGroup("Proxy");
     {
-        setProxyType(ps.value("proxyType", static_cast<int>(ProxyType::ptNone)).toInt());
+        int type = ps.value("proxyType", static_cast<int>(ProxyType::ptNone)).toInt();
+        setProxyType(static_cast<ProxyType>(type));
         proxyAddr = ps.value("proxyAddr", "").toString();
         proxyPort = static_cast<quint16>(ps.value("proxyPort", 0).toUInt());
     }

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -135,6 +135,7 @@ void Settings::loadGlobal()
 
     QSettings s(filePath, QSettings::IniFormat);
     s.setIniCodec("UTF-8");
+
     s.beginGroup("Login");
     {
         autoLogin = s.value("autoLogin", false).toBool();
@@ -169,6 +170,22 @@ void Settings::loadGlobal()
 
     s.beginGroup("General");
     {
+        {
+            // TODO: values in this block are moved -> remove in future
+            enableIPv6 = s.value("enableIPv6", true).toBool();
+            makeToxPortable = s.value("makeToxPortable", false).toBool();
+            forceTCP = s.value("forceTCP", false).toBool();
+            proxyType = static_cast<ProxyType>(s.value("proxyType", 0).toInt());
+            proxyAddr = s.value("proxyAddr", "").toString();
+            proxyPort = static_cast<quint16>(s.value("proxyPort", 0).toUInt());
+            showWindow = s.value("showWindow", true).toBool();
+            showInFront = s.value("showInFront", false).toBool();
+            groupAlwaysNotify = s.value("groupAlwaysNotify", false).toBool();
+            separateWindow = s.value("separateWindow", false).toBool();
+            dontGroupWindows = s.value("dontGroupWindows", true).toBool();
+            groupchatPosition = s.value("groupchatPosition", true).toBool();
+        }
+
         translation = s.value("translation", "en").toString();
         showSystemTray = s.value("showSystemTray", true).toBool();
         autostartInTray = s.value("autostartInTray", false).toBool();
@@ -383,6 +400,13 @@ void Settings::loadPersonal(Profile* profile)
             friendRequests.push_back(request);
         }
         ps.endArray();
+    }
+    ps.endGroup();
+
+    // TODO: values in this group are moved -> remove in future
+    ps.beginGroup("General");
+    {
+        compactLayout = ps.value("compactLayout", true).toBool();
     }
     ps.endGroup();
 

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -149,6 +149,8 @@ public:
     void loadPersonal();
     void loadPersonal(Profile *profile);
 
+    void resetToDefault();
+
     struct Request
     {
         QString address;

--- a/src/widget/form/settings/aboutform.cpp
+++ b/src/widget/form/settings/aboutform.cpp
@@ -20,12 +20,13 @@
 #include "aboutform.h"
 #include "ui_aboutsettings.h"
 
-#include <src/core/recursivesignalblocker.h>
-#include "src/widget/translator.h"
-#include "tox/tox.h"
-#include "src/net/autoupdate.h"
 #include <QTimer>
 #include <QDebug>
+#include <tox/tox.h>
+
+#include "src/core/recursivesignalblocker.h"
+#include "src/net/autoupdate.h"
+#include "src/widget/translator.h"
 
 AboutForm::AboutForm()
     : GenericForm(QPixmap(":/img/settings/general.png"))
@@ -57,8 +58,9 @@ void AboutForm::replaceVersions()
     // nightly builds from stable releases.
 
     QString TOXCORE_VERSION = QString::number(TOX_VERSION_MAJOR) + "." +
-      QString::number(TOX_VERSION_MINOR) + "." +
-      QString::number(TOX_VERSION_PATCH);
+            QString::number(TOX_VERSION_MINOR) + "." +
+            QString::number(TOX_VERSION_PATCH);
+
     bodyUI->youareusing->setText(bodyUI->youareusing->text().replace("$GIT_DESCRIBE", QString(GIT_DESCRIBE)));
     bodyUI->gitVersion->setText(bodyUI->gitVersion->text().replace("$GIT_VERSION", QString(GIT_VERSION)));
     bodyUI->toxCoreVersion->setText(bodyUI->toxCoreVersion->text().replace("$TOXCOREVERSION", TOXCORE_VERSION));

--- a/src/widget/form/settings/aboutform.cpp
+++ b/src/widget/form/settings/aboutform.cpp
@@ -28,6 +28,16 @@
 #include "src/net/autoupdate.h"
 #include "src/widget/translator.h"
 
+/**
+ * @class AboutForm
+ *
+ * This form contains information about qTox and libraries versions, external
+ * links and licence text. Shows progress during an update.
+ */
+
+/**
+ * @brief Constructor of AboutForm.
+ */
 AboutForm::AboutForm()
     : GenericForm(QPixmap(":/img/settings/general.png"))
     , bodyUI(new Ui::AboutSettings)
@@ -52,6 +62,12 @@ AboutForm::AboutForm()
     Translator::registerHandler(std::bind(&AboutForm::retranslateUi, this), this);
 }
 
+/**
+ * @brief Update versions and links.
+ *
+ * Update commit hash if built with git, show author and known issues info
+ * It also updates qTox, toxcore and Qt versions.
+ */
 void AboutForm::replaceVersions()
 {
     // TODO: When we finally have stable releases: build-in a way to tell
@@ -115,6 +131,12 @@ void AboutForm::replaceVersions()
     bodyUI->authorInfo->setText(authorInfo);
 }
 
+/**
+ * @brief Creates hyperlink with specific style.
+ * @param path The URL of the page the link goes to.
+ * @param text Text, which will be clickable.
+ * @return Hyperlink to paste.
+ */
 QString AboutForm::createLink(QString path, QString text) const
 {
     return QString::fromUtf8("<a href=\"%1\" style=\"text-decoration: underline; color:#0000ff;\">%2</a>")
@@ -127,6 +149,9 @@ AboutForm::~AboutForm()
     delete bodyUI;
 }
 
+/**
+ * @brief Update information about update.
+ */
 void AboutForm::showUpdateProgress()
 {
     QString version = AutoUpdater::getProgressVersion();
@@ -160,6 +185,9 @@ void AboutForm::showEvent(QShowEvent *)
     progressTimer->start();
 }
 
+/**
+ * @brief Retranslate all elements in the form.
+ */
 void AboutForm::retranslateUi()
 {
     bodyUI->retranslateUi(this);

--- a/src/widget/form/settings/aboutform.cpp
+++ b/src/widget/form/settings/aboutform.cpp
@@ -65,52 +65,60 @@ void AboutForm::replaceVersions()
     bodyUI->gitVersion->setText(bodyUI->gitVersion->text().replace("$GIT_VERSION", QString(GIT_VERSION)));
     bodyUI->toxCoreVersion->setText(bodyUI->toxCoreVersion->text().replace("$TOXCOREVERSION", TOXCORE_VERSION));
     bodyUI->qtVersion->setText(bodyUI->qtVersion->text().replace("$QTVERSION", QT_VERSION_STR));
+
+    QString issueBody = QString(
+            "##### Brief Description\n\n"
+            "OS: Windows / OS X / Linux (include version and/or distro)\n"
+            "qTox version: %1\n"
+            "Commit hash: %2\n"
+            "toxcore: %3\n"
+            "Qt: %4\n"
+            "Hardware: \n…\n\n"
+            "Reproducible: Always / Almost Always / Sometimes"
+            " / Rarely / Couldn't Reproduce\n\n"
+            "##### Steps to reproduce\n\n"
+            "1. \n2. \n3. …\n\n"
+            "##### Observed Behavior\n\n\n"
+            "##### Expected Behavior\n\n\n"
+            "##### Additional Info\n"
+            "(links, images, etc go here)\n\n"
+            "----\n\n"
+            "More information on how to write good bug reports in the wiki: "
+            "https://github.com/qTox/qTox/wiki/Writing-Useful-Bug-Reports.\n\n"
+            "Please remove any unnecessary template section before submitting.")
+            .arg(GIT_DESCRIBE, GIT_VERSION, TOXCORE_VERSION, QT_VERSION_STR);
+
+    issueBody.replace("#", "%23").replace(":", "%3A");
+
     bodyUI->knownIssues->setText(
                 tr("A list of all known issues may be found at our %1 at Github."
                    " If you discover a bug or security vulnerability within"
                    " qTox, please %3 according to the guidelines in our %2"
                    " wiki article.")
-                .arg(QString::fromUtf8("<a href=\"https://github.com/qTox/qTox/"
-                                       "issues\""
-                                       " style=\"text-decoration: underline;"
-                                       " color:#0000ff;\">%1</a>")
-                     .arg(tr("bug-tracker")))
-                .arg(QString::fromUtf8("<a href=\"https://github.com/qTox/qTox/"
-                                       "wiki/Writing-Useful-Bug-Reports\""
-                                       " style=\"text-decoration: underline;"
-                                       " color:#0000ff;\">%1</a>")
-                     .arg(tr("Writing Useful Bug Reports")))
-                .arg(QStringLiteral(
-                         "<a href=\"https://github.com/qTox/qTox/issues"
-                         "/new?body=%23%23%23%23%23+Brief+Description%0A%0AOS"
-                         "%3A+Windows+%2F+OS+X+%2F+Linux+(include+version+and"
-                         "%2For+distro)%0AqTox+version%3A+") +
-                     QStringLiteral(GIT_DESCRIBE) +
-                     QStringLiteral("%0ACommit+hash%3A+") +
-                     QStringLiteral(GIT_VERSION) +
-                     QStringLiteral("%0Atoxcore%3A+") + TOXCORE_VERSION +
-                     QStringLiteral("%0AQt%3A+") +
-                     QStringLiteral(QT_VERSION_STR) +
-                     QStringLiteral("%0AHardware%3A++%0A%E2%80%A6%0A%0A"
-                                    "Reproducible%3A+Always+%2F+Almost+Always+"
-                                    "%2F+Sometimes+%2F+Rarely+%2F+Couldn%27t+"
-                                    "Reproduce%0A%0A%23%23%23%23%23+Steps+to+"
-                                    "reproduce%0A%0A1.+%0A2.+%0A3.+%E2%80%A6"
-                                    "%0A%0A%23%23%23%23%23+Observed+Behavior"
-                                    "%0A%0A%0A%23%23%23%23%23+Expected+Behavior"
-                                    "%0A%0A%0A%23%23%23%23%23+Additional+Info"
-                                    "%0A(links%2C+images%2C+etc+go+here)%0A%0A"
-                                    "----%0A%0AMore+information+on+how+to+"
-                                    "write+good+bug+reports+in+the+wiki%3A+"
-                                    "https%3A%2F%2Fgithub.com%2FqTox%2FqTox%2F"
-                                    "wiki%2FWriting-Useful-Bug-Reports.%0A%0A"
-                                    "Please+remove+any+unnecessary+template+"
-                                    "section+before+submitting.\""
-                                    " style=\"text-decoration: underline;"
-                                    " color:#0000ff;\">") + tr("report it") +
-                     QStringLiteral("</a>")
-                     )
+                .arg(createLink("https://github.com/qTox/qTox/issues",
+                     tr("bug-tracker")))
+                .arg(createLink("https://github.com/qTox/qTox/wiki/Writing-Useful-Bug-Reports",
+                     tr("Writing Useful Bug Reports")))
+                .arg(createLink("https://github.com/qTox/qTox/issues/new?body="
+                                + QUrl(issueBody).toEncoded(),
+                     tr("report it")))
                 );
+
+
+    QString authorInfo = QString("<p>%1</p><p>%2</p>")
+            .arg(tr("Original author: %1")
+                 .arg(createLink("https://github.com/tux3", "tux3")))
+            .arg(tr("See a full list of %1 at Github")
+                 .arg(createLink("https://github.com/qTox/qTox/graphs/contributors",
+                                 tr("contributors"))));
+
+    bodyUI->authorInfo->setText(authorInfo);
+}
+
+QString AboutForm::createLink(QString path, QString text) const
+{
+    return QString::fromUtf8("<a href=\"%1\" style=\"text-decoration: underline; color:#0000ff;\">%2</a>")
+            .arg(path, text);
 }
 
 AboutForm::~AboutForm()

--- a/src/widget/form/settings/aboutform.cpp
+++ b/src/widget/form/settings/aboutform.cpp
@@ -47,6 +47,7 @@ AboutForm::AboutForm()
     progressTimer->setSingleShot(false);
     connect(progressTimer, &QTimer::timeout, this, &AboutForm::showUpdateProgress);
 
+    eventsInit();
     Translator::registerHandler(std::bind(&AboutForm::retranslateUi, this), this);
 }
 

--- a/src/widget/form/settings/aboutform.h
+++ b/src/widget/form/settings/aboutform.h
@@ -24,6 +24,7 @@
 
 class Core;
 class QTimer;
+class QString;
 
 namespace Ui {
 class AboutSettings;
@@ -50,6 +51,7 @@ private slots:
 private:
     void retranslateUi();
     void replaceVersions();
+    inline QString createLink(QString path, QString text) const;
 
 private:
     Ui::AboutSettings* bodyUI;

--- a/src/widget/form/settings/aboutsettings.ui
+++ b/src/widget/form/settings/aboutsettings.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>530</width>
-    <height>476</height>
+    <height>553</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -29,14 +29,14 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-72</y>
-        <width>496</width>
-        <height>648</height>
+        <y>0</y>
+        <width>514</width>
+        <height>537</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,1,0,0">
        <item>
-        <widget class="QGroupBox" name="groupBox_3">
+        <widget class="QGroupBox" name="versioGroup">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
            <horstretch>0</horstretch>
@@ -222,12 +222,12 @@
              <string notr="true">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Noto Sans'; font-size:12pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Sans Serif'; font-size:10pt; color:#000000;&quot;&gt;Copyright © 2014-2016 by The qTox Project&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:10pt;&quot;&gt;qTox is a Qt-based graphical interface for Tox.&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Sans Serif'; font-size:10pt;&quot;&gt;qTox is libre software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Sans Serif'; font-size:10pt;&quot;&gt;qTox is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details. &lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:10pt;&quot;&gt;You should have received a copy of the GNU General Public License along with this program. If not, see &lt;/span&gt;&lt;a href=&quot;https://www.gnu.org/copyleft/gpl.html&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:10pt; text-decoration: underline; color:#007af4;&quot;&gt;https://www.gnu.org/copyleft/gpl.html&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-family:'Ubuntu'; font-size:10pt;&quot;&gt;.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Noto Sans'; font-size:10pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Sans Serif'; color:#000000;&quot;&gt;Copyright © 2014-2016 by The qTox Project&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu';&quot;&gt;qTox is a Qt-based graphical interface for Tox.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Sans Serif';&quot;&gt;qTox is libre software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Sans Serif';&quot;&gt;qTox is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details. &lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu';&quot;&gt;You should have received a copy of the GNU General Public License along with this program. If not, see &lt;/span&gt;&lt;a href=&quot;https://www.gnu.org/copyleft/gpl.html&quot;&gt;&lt;span style=&quot; font-family:'Ubuntu'; text-decoration: underline; color:#007af4;&quot;&gt;https://www.gnu.org/copyleft/gpl.html&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-family:'Ubuntu';&quot;&gt;.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="searchPaths">
              <stringlist/>
@@ -244,7 +244,7 @@ p, li { white-space: pre-wrap; }
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="groupBox">
+        <widget class="QGroupBox" name="authorGroup">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
            <horstretch>0</horstretch>
@@ -262,7 +262,7 @@ p, li { white-space: pre-wrap; }
          </property>
          <layout class="QHBoxLayout" name="horizontalLayout_2">
           <item>
-           <widget class="QLabel" name="label_2">
+           <widget class="QLabel" name="authorInfo">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
               <horstretch>0</horstretch>
@@ -275,7 +275,7 @@ p, li { white-space: pre-wrap; }
              </font>
             </property>
             <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Original author: &lt;a href=&quot;https://github.com/tux3&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;tux3&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;p&gt;See a full list of &lt;a href=&quot;https://github.com/qTox/qTox/graphs/contributors&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;contributors&lt;/span&gt;&lt;/a&gt; at Github&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string notr="true">{AUTHOR INFO}</string>
             </property>
             <property name="openExternalLinks">
              <bool>true</bool>
@@ -289,7 +289,7 @@ p, li { white-space: pre-wrap; }
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="groupBox_2">
+        <widget class="QGroupBox" name="knowIssuesGroup">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
            <horstretch>0</horstretch>
@@ -318,6 +318,9 @@ p, li { white-space: pre-wrap; }
              <font>
               <family>Sans Serif</family>
              </font>
+            </property>
+            <property name="text">
+             <string notr="true">{KNOWN ISSUES TEXT}</string>
             </property>
             <property name="wordWrap">
              <bool>true</bool>

--- a/src/widget/form/settings/advancedform.cpp
+++ b/src/widget/form/settings/advancedform.cpp
@@ -35,6 +35,13 @@
 #include "src/widget/gui.h"
 #include "src/widget/translator.h"
 
+/**
+ * @class AdvancedForm
+ *
+ * This form contains all connection settings.
+ * Is also contains "Reset settings" button and "Make portable" checkbox.
+ */
+
 AdvancedForm::AdvancedForm()
   : GenericForm(QPixmap(":/img/settings/general.png"))
   , bodyUI (new Ui::AdvancedSettings)
@@ -144,6 +151,9 @@ void AdvancedForm::on_reconnectButton_clicked()
     Nexus::getProfile()->restartCore();
 }
 
+/**
+ * @brief Retranslate all elements in the form.
+ */
 void AdvancedForm::retranslateUi()
 {
     int proxyType = bodyUI->proxyType->currentIndex();

--- a/src/widget/form/settings/advancedform.cpp
+++ b/src/widget/form/settings/advancedform.cpp
@@ -57,6 +57,19 @@ AdvancedForm::AdvancedForm()
     bodyUI->proxyType->setCurrentIndex(index);
     on_proxyType_currentIndexChanged(index);
 
+    QString warningBody = tr("Unless you %1 know what you are doing, "
+                             "please do %2 change anything here. Changes "
+                             "made here may lead to problems with qTox, and even "
+                             "to loss of your data, e.g. history.</p>")
+            .arg(QString("<b>%1</b>").arg(tr("really")))
+            .arg(QString("<b>%1</b>").arg(tr("not")));
+
+    QString warning = QString("<div style=\"color:#ff0000;\">"
+                              "<p><b>%1</b></p><p>%2</p></div>")
+            .arg(tr("IMPORTANT NOTE")).arg(warningBody);
+
+    bodyUI->warningLabel->setText(warning);
+
     eventsInit();
     Translator::registerHandler(std::bind(&AdvancedForm::retranslateUi, this), this);
 }

--- a/src/widget/form/settings/advancedform.cpp
+++ b/src/widget/form/settings/advancedform.cpp
@@ -20,10 +20,10 @@
 #include "advancedform.h"
 #include "ui_advancedsettings.h"
 
+#include <QApplication>
 #include <QDir>
 #include <QMessageBox>
 #include <QProcess>
-#include <QApplication>
 
 #include "src/core/core.h"
 #include "src/core/coreav.h"
@@ -53,21 +53,9 @@ AdvancedForm::AdvancedForm()
     if (port > 0)
         bodyUI->proxyPort->setValue(port);
 
-    bodyUI->proxyType->setCurrentIndex(static_cast<int>(s.getProxyType()));
-    onUseProxyUpdated();
-
-    // portable
-    connect(bodyUI->cbMakeToxPortable, &QCheckBox::stateChanged, this, &AdvancedForm::onMakeToxPortableUpdated);
-    connect(bodyUI->resetButton, &QPushButton::clicked, this, &AdvancedForm::resetToDefault);
-    //connection
-    void (QComboBox::* currentIndexChanged)(int) = &QComboBox::currentIndexChanged;
-    void (QSpinBox::* valueChanged)(int) = &QSpinBox::valueChanged;
-    connect(bodyUI->cbEnableIPv6, &QCheckBox::stateChanged, this, &AdvancedForm::onEnableIPv6Updated);
-    connect(bodyUI->cbEnableUDP, &QCheckBox::stateChanged, this, &AdvancedForm::onUDPUpdated);
-    connect(bodyUI->proxyType, currentIndexChanged, this, &AdvancedForm::onUseProxyUpdated);
-    connect(bodyUI->proxyAddr, &QLineEdit::editingFinished, this, &AdvancedForm::onProxyAddrEdited);
-    connect(bodyUI->proxyPort, valueChanged, this, &AdvancedForm::onProxyPortEdited);
-    connect(bodyUI->reconnectButton, &QPushButton::clicked, this, &AdvancedForm::onReconnectClicked);
+    int index = static_cast<int>(s.getProxyType());
+    bodyUI->proxyType->setCurrentIndex(index);
+    on_proxyType_currentIndexChanged(index);
 
     eventsInit();
     Translator::registerHandler(std::bind(&AdvancedForm::retranslateUi, this), this);
@@ -79,12 +67,12 @@ AdvancedForm::~AdvancedForm()
     delete bodyUI;
 }
 
-void AdvancedForm::onMakeToxPortableUpdated()
+void AdvancedForm::on_cbMakeToxPortable_stateChanged()
 {
     Settings::getInstance().setMakeToxPortable(bodyUI->cbMakeToxPortable->isChecked());
 }
 
-void AdvancedForm::resetToDefault()
+void AdvancedForm::on_resetButton_clicked()
 {
     const QString titile = tr("Reset settings");
     bool result = GUI::askQuestion(titile,
@@ -98,22 +86,22 @@ void AdvancedForm::resetToDefault()
     GUI::showInfo(titile, "Changes will take effect after restart");
 }
 
-void AdvancedForm::onEnableIPv6Updated()
+void AdvancedForm::on_cbEnableIPv6_stateChanged()
 {
     Settings::getInstance().setEnableIPv6(bodyUI->cbEnableIPv6->isChecked());
 }
 
-void AdvancedForm::onUDPUpdated()
+void AdvancedForm::on_cbEnableUDP_stateChanged()
 {
     Settings::getInstance().setForceTCP(!bodyUI->cbEnableUDP->isChecked());
 }
 
-void AdvancedForm::onProxyAddrEdited()
+void AdvancedForm::on_proxyAddr_editingFinished()
 {
     Settings::getInstance().setProxyAddr(bodyUI->proxyAddr->text());
 }
 
-void AdvancedForm::onProxyPortEdited(int port)
+void AdvancedForm::on_proxyPort_valueChanged(int port)
 {
     if (port <= 0)
         port = 0;
@@ -121,17 +109,16 @@ void AdvancedForm::onProxyPortEdited(int port)
     Settings::getInstance().setProxyPort(port);
 }
 
-void AdvancedForm::onUseProxyUpdated()
+void AdvancedForm::on_proxyType_currentIndexChanged(int index)
 {
-    Settings::ProxyType proxytype =
-            static_cast<Settings::ProxyType>(bodyUI->proxyType->currentIndex());
+    Settings::ProxyType proxytype = static_cast<Settings::ProxyType>(index);
 
     bodyUI->proxyAddr->setEnabled(proxytype != Settings::ProxyType::ptNone);
     bodyUI->proxyPort->setEnabled(proxytype != Settings::ProxyType::ptNone);
     Settings::getInstance().setProxyType(proxytype);
 }
 
-void AdvancedForm::onReconnectClicked()
+void AdvancedForm::on_reconnectButton_clicked()
 {
     if (Core::getInstance()->getAv()->anyActiveCalls())
     {

--- a/src/widget/form/settings/advancedform.cpp
+++ b/src/widget/form/settings/advancedform.cpp
@@ -49,8 +49,8 @@ AdvancedForm::AdvancedForm()
     bodyUI->cbMakeToxPortable->setChecked(Settings::getInstance().getMakeToxPortable());
     bodyUI->cbEnableUDP->setChecked(!s.getForceTCP());
     bodyUI->proxyAddr->setText(s.getProxyAddr());
-    int port = s.getProxyPort();
-    if (port != -1)
+    quint16 port = s.getProxyPort();
+    if (port > 0)
         bodyUI->proxyPort->setValue(port);
 
     bodyUI->proxyType->setCurrentIndex(static_cast<int>(s.getProxyType()));
@@ -116,7 +116,7 @@ void AdvancedForm::onProxyAddrEdited()
 void AdvancedForm::onProxyPortEdited(int port)
 {
     if (port <= 0)
-        port = -1;
+        port = 0;
 
     Settings::getInstance().setProxyPort(port);
 }

--- a/src/widget/form/settings/advancedform.cpp
+++ b/src/widget/form/settings/advancedform.cpp
@@ -20,9 +20,15 @@
 #include "advancedform.h"
 #include "ui_advancedsettings.h"
 
-#include <src/core/recursivesignalblocker.h>
+#include <QMessageBox>
+
+#include "src/core/core.h"
+#include "src/core/coreav.h"
+#include "src/core/recursivesignalblocker.h"
+#include "src/nexus.h"
 #include "src/persistence/settings.h"
 #include "src/persistence/db/plaindb.h"
+#include "src/persistence/profile.h"
 #include "src/widget/translator.h"
 
 AdvancedForm::AdvancedForm()
@@ -34,15 +40,33 @@ AdvancedForm::AdvancedForm()
     // block all child signals during initialization
     const RecursiveSignalBlocker signalBlocker(this);
 
+    Settings &s = Settings::getInstance();
+    bodyUI->cbEnableIPv6->setChecked(s.getEnableIPv6());
     bodyUI->cbMakeToxPortable->setChecked(Settings::getInstance().getMakeToxPortable());
+    bodyUI->cbEnableUDP->setChecked(!s.getForceTCP());
+    bodyUI->proxyAddr->setText(s.getProxyAddr());
+    int port = s.getProxyPort();
+    if (port != -1)
+        bodyUI->proxyPort->setValue(port);
 
+    bodyUI->proxyType->setCurrentIndex(static_cast<int>(s.getProxyType()));
+    onUseProxyUpdated();
+
+    // portable
     connect(bodyUI->cbMakeToxPortable, &QCheckBox::stateChanged, this, &AdvancedForm::onMakeToxPortableUpdated);
-    connect(bodyUI->resetButton, SIGNAL(clicked()), this, SLOT(resetToDefault()));
+    connect(bodyUI->resetButton, &QPushButton::clicked, this, &AdvancedForm::resetToDefault);
+    //connection
+    void (QComboBox::* currentIndexChanged)(int) = &QComboBox::currentIndexChanged;
+    void (QSpinBox::* valueChanged)(int) = &QSpinBox::valueChanged;
+    connect(bodyUI->cbEnableIPv6, &QCheckBox::stateChanged, this, &AdvancedForm::onEnableIPv6Updated);
+    connect(bodyUI->cbEnableUDP, &QCheckBox::stateChanged, this, &AdvancedForm::onUDPUpdated);
+    connect(bodyUI->proxyType, currentIndexChanged, this, &AdvancedForm::onUseProxyUpdated);
+    connect(bodyUI->proxyAddr, &QLineEdit::editingFinished, this, &AdvancedForm::onProxyAddrEdited);
+    connect(bodyUI->proxyPort, valueChanged, this, &AdvancedForm::onProxyPortEdited);
+    connect(bodyUI->reconnectButton, &QPushButton::clicked, this, &AdvancedForm::onReconnectClicked);
 
     for (QCheckBox *cb : findChildren<QCheckBox*>()) // this one is to allow scrolling on checkboxes
-    {
         cb->installEventFilter(this);
-    }
 
     Translator::registerHandler(std::bind(&AdvancedForm::retranslateUi, this), this);
 }
@@ -62,18 +86,55 @@ void AdvancedForm::resetToDefault()
 {
 }
 
-bool AdvancedForm::eventFilter(QObject *o, QEvent *e)
+void AdvancedForm::onEnableIPv6Updated()
 {
-    if ((e->type() == QEvent::Wheel) &&
-         (qobject_cast<QAbstractSpinBox*>(o) || qobject_cast<QCheckBox*>(o)))
+    Settings::getInstance().setEnableIPv6(bodyUI->cbEnableIPv6->isChecked());
+}
+
+void AdvancedForm::onUDPUpdated()
+{
+    Settings::getInstance().setForceTCP(!bodyUI->cbEnableUDP->isChecked());
+}
+
+void AdvancedForm::onProxyAddrEdited()
+{
+    Settings::getInstance().setProxyAddr(bodyUI->proxyAddr->text());
+}
+
+void AdvancedForm::onProxyPortEdited(int port)
+{
+    if (port <= 0)
+        port = -1;
+
+    Settings::getInstance().setProxyPort(port);
+}
+
+void AdvancedForm::onUseProxyUpdated()
+{
+    Settings::ProxyType proxytype =
+            static_cast<Settings::ProxyType>(bodyUI->proxyType->currentIndex());
+
+    bodyUI->proxyAddr->setEnabled(proxytype != Settings::ProxyType::ptNone);
+    bodyUI->proxyPort->setEnabled(proxytype != Settings::ProxyType::ptNone);
+    Settings::getInstance().setProxyType(proxytype);
+}
+
+void AdvancedForm::onReconnectClicked()
+{
+    if (Core::getInstance()->getAv()->anyActiveCalls())
     {
-        e->ignore();
-        return true;
+        QMessageBox::warning(this, tr("Call active", "popup title"),
+                        tr("You can't disconnect while a call is active!", "popup text"));
+        return;
     }
-    return QWidget::eventFilter(o, e);
+
+    emit Core::getInstance()->statusSet(Status::Offline);
+    Nexus::getProfile()->restartCore();
 }
 
 void AdvancedForm::retranslateUi()
 {
+    int proxyType = bodyUI->proxyType->currentIndex();
     bodyUI->retranslateUi(this);
+    bodyUI->proxyType->setCurrentIndex(proxyType);
 }

--- a/src/widget/form/settings/advancedform.cpp
+++ b/src/widget/form/settings/advancedform.cpp
@@ -20,7 +20,10 @@
 #include "advancedform.h"
 #include "ui_advancedsettings.h"
 
+#include <QDir>
 #include <QMessageBox>
+#include <QProcess>
+#include <QApplication>
 
 #include "src/core/core.h"
 #include "src/core/coreav.h"
@@ -29,6 +32,7 @@
 #include "src/persistence/settings.h"
 #include "src/persistence/db/plaindb.h"
 #include "src/persistence/profile.h"
+#include "src/widget/gui.h"
 #include "src/widget/translator.h"
 
 AdvancedForm::AdvancedForm()
@@ -65,9 +69,7 @@ AdvancedForm::AdvancedForm()
     connect(bodyUI->proxyPort, valueChanged, this, &AdvancedForm::onProxyPortEdited);
     connect(bodyUI->reconnectButton, &QPushButton::clicked, this, &AdvancedForm::onReconnectClicked);
 
-    for (QCheckBox *cb : findChildren<QCheckBox*>()) // this one is to allow scrolling on checkboxes
-        cb->installEventFilter(this);
-
+    eventsInit();
     Translator::registerHandler(std::bind(&AdvancedForm::retranslateUi, this), this);
 }
 
@@ -84,6 +86,16 @@ void AdvancedForm::onMakeToxPortableUpdated()
 
 void AdvancedForm::resetToDefault()
 {
+    const QString titile = tr("Reset settings");
+    bool result = GUI::askQuestion(titile,
+                                   tr("All settings will be reset to default. Are you sure?"),
+                                   tr("Yes"), tr("No"));
+
+    if (!result)
+        return;
+
+    Settings::getInstance().resetToDefault();
+    GUI::showInfo(titile, "Changes will take effect after restart");
 }
 
 void AdvancedForm::onEnableIPv6Updated()

--- a/src/widget/form/settings/advancedform.h
+++ b/src/widget/form/settings/advancedform.h
@@ -41,15 +41,15 @@ public:
 
 private slots:
     // Portable
-    void onMakeToxPortableUpdated();
-    void resetToDefault();
+    void on_cbMakeToxPortable_stateChanged();
+    void on_resetButton_clicked();
     // Connection
-    void onEnableIPv6Updated();
-    void onUDPUpdated();
-    void onProxyAddrEdited();
-    void onProxyPortEdited(int port);
-    void onUseProxyUpdated();
-    void onReconnectClicked();
+    void on_cbEnableIPv6_stateChanged();
+    void on_cbEnableUDP_stateChanged();
+    void on_proxyAddr_editingFinished();
+    void on_proxyPort_valueChanged(int port);
+    void on_proxyType_currentIndexChanged(int index);
+    void on_reconnectButton_clicked();
 
 private:
     void retranslateUi();

--- a/src/widget/form/settings/advancedform.h
+++ b/src/widget/form/settings/advancedform.h
@@ -39,12 +39,17 @@ public:
         return tr("Advanced");
     }
 
-protected:
-    bool eventFilter(QObject *o, QEvent *e) final override;
-
 private slots:
+    // Portable
     void onMakeToxPortableUpdated();
     void resetToDefault();
+    // Connection
+    void onEnableIPv6Updated();
+    void onUDPUpdated();
+    void onProxyAddrEdited();
+    void onProxyPortEdited(int port);
+    void onUseProxyUpdated();
+    void onReconnectClicked();
 
 private:
     void retranslateUi();

--- a/src/widget/form/settings/advancedsettings.ui
+++ b/src/widget/form/settings/advancedsettings.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>418</width>
-    <height>476</height>
+    <width>505</width>
+    <height>565</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -24,21 +24,11 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>398</width>
-        <height>456</height>
+        <width>489</width>
+        <height>549</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2">
-       <item>
-        <widget class="QCheckBox" name="cbMakeToxPortable">
-         <property name="toolTip">
-          <string extracomment="describes makeToxPortable checkbox">Save settings to the working directory instead of the usual conf dir</string>
-         </property>
-         <property name="text">
-          <string>Make Tox portable</string>
-         </property>
-        </widget>
-       </item>
        <item>
         <widget class="QLabel" name="warningLabel">
          <property name="text">
@@ -55,7 +45,149 @@
          </property>
         </widget>
        </item>
-       <item alignment="Qt::AlignTop">
+       <item>
+        <widget class="QGroupBox" name="ProtableGroup">
+         <property name="title">
+          <string>Portable</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_3">
+          <item>
+           <widget class="QCheckBox" name="cbMakeToxPortable">
+            <property name="toolTip">
+             <string extracomment="describes makeToxPortable checkbox">Save settings to the working directory instead of the usual conf dir</string>
+            </property>
+            <property name="text">
+             <string>Make Tox portable</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="connectionGroup">
+         <property name="title">
+          <string>Connection Settings</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayoutProxy">
+          <property name="topMargin">
+           <number>9</number>
+          </property>
+          <item>
+           <layout class="QVBoxLayout" name="verticalLayout_5">
+            <item>
+             <widget class="QCheckBox" name="cbEnableIPv6">
+              <property name="text">
+               <string extracomment="Text on a checkbox to enable IPv6">Enable IPv6 (recommended)</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="cbEnableUDP">
+              <property name="toolTip">
+               <string extracomment="force tcp checkbox tooltip">Disabling this allows, e.g., toxing over Tor. It adds load to the Tox network however, so uncheck only when necessary.</string>
+              </property>
+              <property name="text">
+               <string extracomment="Text on checkbox to disable UDP">Enable UDP (recommended)</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QGridLayout" name="proxyLayout">
+            <item row="1" column="0">
+             <widget class="QLabel" name="proxyTypeLabel">
+              <property name="text">
+               <string>Proxy type:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="3">
+             <widget class="QSpinBox" name="proxyPort">
+              <property name="minimum">
+               <number>0</number>
+              </property>
+              <property name="maximum">
+               <number>65535</number>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="proxyAddrLabel">
+              <property name="text">
+               <string extracomment="Text on proxy addr label">Address:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QLineEdit" name="proxyAddr"/>
+            </item>
+            <item row="2" column="2">
+             <widget class="QLabel" name="proxyPortLabel">
+              <property name="text">
+               <string extracomment="Text on proxy port label">Port:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1" colspan="3">
+             <widget class="QComboBox" name="proxyType">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <item>
+               <property name="text">
+                <string>None</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>SOCKS5</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>HTTP</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_4">
+            <item>
+             <spacer name="horizontalSpacer_4">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QPushButton" name="reconnectButton">
+              <property name="text">
+               <string comment="reconnect button">Reconnect</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <widget class="QPushButton" name="resetButton">
          <property name="text">
           <string>Reset to default settings</string>

--- a/src/widget/form/settings/advancedsettings.ui
+++ b/src/widget/form/settings/advancedsettings.ui
@@ -32,7 +32,7 @@
        <item>
         <widget class="QLabel" name="warningLabel">
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; color:#ff0000;&quot;&gt;IMPORTANT NOTE&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;Unless you &lt;/span&gt;&lt;span style=&quot; font-weight:600; color:#ff0000;&quot;&gt;really&lt;/span&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt; know what you are doing, please do &lt;/span&gt;&lt;span style=&quot; font-weight:600; color:#ff0000;&quot;&gt;not&lt;/span&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt; change anything here. Changes made here may lead to problems with qTox, and even to loss of your data, e.g. history.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string notr="true">{IMPORTANT NOTE HERE}</string>
          </property>
          <property name="textFormat">
           <enum>Qt::RichText</enum>

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -78,11 +78,7 @@ AVForm::AVForm()
     microphoneSlider->setTracking(false);
     microphoneSlider->installEventFilter(this);
 
-    for (QComboBox* cb : findChildren<QComboBox*>())
-    {
-        cb->installEventFilter(this);
-        cb->setFocusPolicy(Qt::StrongFocus);
-    }
+    eventsInit();
 
     QDesktopWidget *desktop = QApplication::desktop();
     connect(desktop, &QDesktopWidget::resized, this, &AVForm::rescanDevices);
@@ -565,18 +561,6 @@ void AVForm::killVideoSurface()
     camVideoSurface->close();
     delete camVideoSurface;
     camVideoSurface = nullptr;
-}
-
-bool AVForm::eventFilter(QObject *o, QEvent *e)
-{
-    if ((e->type() == QEvent::Wheel) &&
-         (qobject_cast<QComboBox*>(o) || qobject_cast<QAbstractSpinBox*>(o) ||
-          qobject_cast<QSlider*>(o)))
-    {
-        e->ignore();
-        return true;
-    }
-    return QWidget::eventFilter(o, e);
 }
 
 void AVForm::retranslateUi()

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -19,24 +19,24 @@
 
 #include "avform.h"
 
+#include <map>
+#include <cassert>
+
+#include <QDebug>
+#include <QDesktopWidget>
+#include <QScreen>
+#include <QShowEvent>
+
 #include "src/audio/audio.h"
-#include "src/persistence/settings.h"
-#include "src/video/camerasource.h"
-#include "src/video/cameradevice.h"
-#include "src/video/videosurface.h"
-#include "src/widget/translator.h"
-#include "src/widget/tool/screenshotgrabber.h"
 #include "src/core/core.h"
 #include "src/core/coreav.h"
 #include "src/core/recursivesignalblocker.h"
-
-#include <QDesktopWidget>
-#include <QDebug>
-#include <QScreen>
-#include <QShowEvent>
-#include <cassert>
-#include <map>
-
+#include "src/persistence/settings.h"
+#include "src/video/cameradevice.h"
+#include "src/video/camerasource.h"
+#include "src/video/videosurface.h"
+#include "src/widget/tool/screenshotgrabber.h"
+#include "src/widget/translator.h"
 
 #ifndef ALC_ALL_DEVICES_SPECIFIER
 #define ALC_ALL_DEVICES_SPECIFIER ALC_DEVICE_SPECIFIER

--- a/src/widget/form/settings/avform.h
+++ b/src/widget/form/settings/avform.h
@@ -74,7 +74,6 @@ protected:
     void updateVideoModes(int curIndex);
 
 private:
-    bool eventFilter(QObject *o, QEvent *e) final override;
     void hideEvent(QHideEvent* event) final override;
     void showEvent(QShowEvent*event) final override;
     void open(const QString &devName, const VideoMode &mode);

--- a/src/widget/form/settings/generalform.cpp
+++ b/src/widget/form/settings/generalform.cpp
@@ -20,26 +20,20 @@
 #include "generalform.h"
 #include "ui_generalsettings.h"
 
-#include <src/core/recursivesignalblocker.h>
-#include "src/widget/form/settingswidget.h"
-#include "src/widget/widget.h"
-#include "src/persistence/settings.h"
-#include "src/persistence/smileypack.h"
+#include <QFileDialog>
+
 #include "src/core/core.h"
 #include "src/core/coreav.h"
-#include "src/widget/style.h"
+#include "src/core/recursivesignalblocker.h"
+#include "src/net/autoupdate.h"
 #include "src/nexus.h"
 #include "src/persistence/profile.h"
+#include "src/persistence/settings.h"
+#include "src/persistence/smileypack.h"
+#include "src/widget/form/settingswidget.h"
+#include "src/widget/style.h"
 #include "src/widget/translator.h"
-#include "src/net/autoupdate.h"
-#include <QDesktopWidget>
-#include <QMessageBox>
-#include <QStyleFactory>
-#include <QTime>
-#include <QFileDialog>
-#include <QFont>
-#include <QStandardPaths>
-#include <QDebug>
+#include "src/widget/widget.h"
 
 static QStringList locales = {"ar",
                               "be",
@@ -104,10 +98,6 @@ static QStringList langs = {"Arabic",
                             "Українська",
                             "简体中文"};
 
-static QStringList timeFormats = {"hh:mm AP", "hh:mm", "hh:mm:ss AP", "hh:mm:ss"};
-// http://doc.qt.io/qt-4.8/qdate.html#fromString
-static QStringList dateFormats = {"yyyy-MM-dd", "dd-MM-yyyy", "d-MM-yyyy", "dddd d-MM-yyyy", "dddd d-MM", "dddd dd MMMM"};
-
 GeneralForm::GeneralForm(SettingsWidget *myParent)
     : GenericForm(QPixmap(":/img/settings/general.png"))
     , bodyUI(new Ui::GeneralSettings)
@@ -124,148 +114,55 @@ GeneralForm::GeneralForm(SettingsWidget *myParent)
     bodyUI->checkUpdates->setVisible(AUTOUPDATE_ENABLED);
     bodyUI->checkUpdates->setChecked(s.getCheckUpdates());
 
-    bodyUI->cbEnableIPv6->setChecked(s.getEnableIPv6());
     for (int i = 0; i < langs.size(); i++)
         bodyUI->transComboBox->insertItem(i, langs[i]);
 
     bodyUI->transComboBox->setCurrentIndex(locales.indexOf(s.getTranslation()));
 
-    const QFont chatBaseFont = s.getChatMessageFont();
-    bodyUI->txtChatFontSize->setValue(QFontInfo(chatBaseFont).pixelSize());
-    bodyUI->txtChatFont->setCurrentFont(chatBaseFont);
-    bodyUI->textStyleComboBox->setCurrentIndex(static_cast<int>(s.getStylePreference()));
     bodyUI->cbAutorun->setChecked(s.getAutorun());
 
+    bodyUI->lightTrayIcon->setChecked(s.getLightTrayIcon());
     bool showSystemTray = s.getShowSystemTray();
 
     bodyUI->showSystemTray->setChecked(showSystemTray);
     bodyUI->startInTray->setChecked(s.getAutostartInTray());
     bodyUI->startInTray->setEnabled(showSystemTray);
-    bodyUI->closeToTray->setChecked(s.getCloseToTray());
-    bodyUI->closeToTray->setEnabled(showSystemTray);
     bodyUI->minimizeToTray->setChecked(s.getMinimizeToTray());
     bodyUI->minimizeToTray->setEnabled(showSystemTray);
-    bodyUI->lightTrayIcon->setChecked(s.getLightTrayIcon());
+    bodyUI->closeToTray->setChecked(s.getCloseToTray());
+    bodyUI->closeToTray->setEnabled(showSystemTray);
+
+    bodyUI->notifySound->setChecked(s.getNotifySound());
+    bodyUI->busySound->setChecked(s.getBusySound());
+    bodyUI->busySound->setEnabled(s.getNotifySound());
 
     bodyUI->statusChanges->setChecked(s.getStatusChangeNotificationEnabled());
-    bodyUI->useEmoticons->setChecked(s.getUseEmoticons());
-    bodyUI->autoacceptFiles->setChecked(s.getAutoSaveEnabled());
-    bodyUI->autoSaveFilesDir->setText(s.getGlobalAutoAcceptDir());
-
-    bool showWindow = s.getShowWindow();
-
-    bodyUI->showWindow->setChecked(showWindow);
-    bodyUI->showInFront->setChecked(s.getShowInFront());
-    bodyUI->showInFront->setEnabled(showWindow);
-
-    bool notifySound = s.getNotifySound();
-
-    bodyUI->notifySound->setChecked(notifySound);
-    bodyUI->busySound->setChecked(s.getBusySound());
-    bodyUI->busySound->setEnabled(notifySound);
-    bodyUI->groupAlwaysNotify->setChecked(s.getGroupAlwaysNotify());
     bodyUI->cbFauxOfflineMessaging->setChecked(s.getFauxOfflineMessaging());
-    bodyUI->cbCompactLayout->setChecked(s.getCompactLayout());
-    bodyUI->cbSeparateWindow->setChecked(s.getSeparateWindow());
-    bodyUI->cbDontGroupWindows->setChecked(s.getDontGroupWindows());
-    bodyUI->cbDontGroupWindows->setEnabled(bodyUI->cbSeparateWindow->isChecked());
-    bodyUI->cbGroupchatPosition->setChecked(s.getGroupchatPosition());
-
-    for (auto entry : SmileyPack::listSmileyPacks())
-        bodyUI->smileyPackBrowser->addItem(entry.first, entry.second);
-
-    bodyUI->smileyPackBrowser->setCurrentIndex(bodyUI->smileyPackBrowser->findData(s.getSmileyPack()));
-    reloadSmiles();
-    bodyUI->smileyPackBrowser->setEnabled(bodyUI->useEmoticons->isChecked());
-
-    bodyUI->styleBrowser->addItem(tr("None"));
-    bodyUI->styleBrowser->addItems(QStyleFactory::keys());
-    if (QStyleFactory::keys().contains(s.getStyle()))
-        bodyUI->styleBrowser->setCurrentText(s.getStyle());
-    else
-        bodyUI->styleBrowser->setCurrentText(tr("None"));
-
-    for (QString color : Style::getThemeColorNames())
-        bodyUI->themeColorCBox->addItem(color);
-
-    bodyUI->themeColorCBox->setCurrentIndex(s.getThemeColor());
-
-    bodyUI->emoticonSize->setValue(s.getEmojiFontPointSize());
-
-    QStringList timestamps;
-    for (QString timestamp : timeFormats)
-        timestamps << QString("%1 - %2").arg(timestamp, QTime::currentTime().toString(timestamp));
-
-    bodyUI->timestamp->addItems(timestamps);
-
-    QLocale ql;
-    QStringList datestamps;
-    dateFormats.append(ql.dateFormat());
-    dateFormats.append(ql.dateFormat(QLocale::LongFormat));
-    dateFormats.removeDuplicates();
-    timeFormats.append(ql.timeFormat());
-    timeFormats.append(ql.timeFormat(QLocale::LongFormat));
-    timeFormats.removeDuplicates();
-
-    for (QString datestamp : dateFormats)
-        datestamps << QString("%1 - %2").arg(datestamp, QDate::currentDate().toString(datestamp));
-
-    bodyUI->dateFormats->addItems(datestamps);
-
-    bodyUI->timestamp->setCurrentText(QString("%1 - %2").arg(s.getTimestampFormat(), QTime::currentTime().toString(s.getTimestampFormat())));
-
-    bodyUI->dateFormats->setCurrentText(QString("%1 - %2").arg(s.getDateFormat(), QDate::currentDate().toString(s.getDateFormat())));
 
     bodyUI->autoAwaySpinBox->setValue(s.getAutoAwayTime());
+    bodyUI->autoSaveFilesDir->setText(s.getGlobalAutoAcceptDir());
+    bodyUI->autoacceptFiles->setChecked(s.getAutoSaveEnabled());
 
-    bodyUI->cbEnableUDP->setChecked(!s.getForceTCP());
-    bodyUI->proxyAddr->setText(s.getProxyAddr());
-    int port = s.getProxyPort();
-    if (port != -1)
-        bodyUI->proxyPort->setValue(port);
-
-    bodyUI->proxyType->setCurrentIndex(static_cast<int>(s.getProxyType()));
-    onUseProxyUpdated();
-
-    //general
+    // General
+    void (QComboBox::* currentIndexChanged)(int index) = &QComboBox::currentIndexChanged;
+    connect(bodyUI->transComboBox, currentIndexChanged, this, &GeneralForm::onTranslationUpdated);
     connect(bodyUI->checkUpdates, &QCheckBox::stateChanged, this, &GeneralForm::onCheckUpdateChanged);
-    connect(bodyUI->transComboBox, SIGNAL(currentIndexChanged(int)), this, SLOT(onTranslationUpdated()));
     connect(bodyUI->cbAutorun, &QCheckBox::stateChanged, this, &GeneralForm::onAutorunUpdated);
     connect(bodyUI->lightTrayIcon, &QCheckBox::stateChanged, this, &GeneralForm::onSetLightTrayIcon);
+
     connect(bodyUI->showSystemTray, &QCheckBox::stateChanged, this, &GeneralForm::onSetShowSystemTray);
     connect(bodyUI->startInTray, &QCheckBox::stateChanged, this, &GeneralForm::onSetAutostartInTray);
-    connect(bodyUI->closeToTray, &QCheckBox::stateChanged, this, &GeneralForm::onSetCloseToTray);
     connect(bodyUI->minimizeToTray, &QCheckBox::stateChanged, this, &GeneralForm::onSetMinimizeToTray);
-    connect(bodyUI->statusChanges, &QCheckBox::stateChanged, this, &GeneralForm::onSetStatusChange);
-    connect(bodyUI->autoAwaySpinBox, SIGNAL(editingFinished()), this, SLOT(onAutoAwayChanged()));
-    connect(bodyUI->showWindow, &QCheckBox::stateChanged, this, &GeneralForm::onShowWindowChanged);
-    connect(bodyUI->showInFront, &QCheckBox::stateChanged, this, &GeneralForm::onSetShowInFront);
+    connect(bodyUI->closeToTray, &QCheckBox::stateChanged, this, &GeneralForm::onSetCloseToTray);
+
     connect(bodyUI->notifySound, &QCheckBox::stateChanged, this, &GeneralForm::onSetNotifySound);
     connect(bodyUI->busySound, &QCheckBox::stateChanged, this, &GeneralForm::onSetBusySound);
-    connect(bodyUI->textStyleComboBox, &QComboBox::currentTextChanged, this, &GeneralForm::onStyleUpdated);
-    connect(bodyUI->groupAlwaysNotify, &QCheckBox::stateChanged, this, &GeneralForm::onSetGroupAlwaysNotify);
-    connect(bodyUI->autoacceptFiles, &QCheckBox::stateChanged, this, &GeneralForm::onAutoAcceptFileChange);
-    connect(bodyUI->autoSaveFilesDir, SIGNAL(clicked()), this, SLOT(onAutoSaveDirChange()));
-    //theme
-    connect(bodyUI->useEmoticons, &QCheckBox::stateChanged, this, &GeneralForm::onUseEmoticonsChange);
-    connect(bodyUI->smileyPackBrowser, SIGNAL(currentIndexChanged(int)), this, SLOT(onSmileyBrowserIndexChanged(int)));
-    connect(bodyUI->styleBrowser, SIGNAL(currentTextChanged(QString)), this, SLOT(onStyleSelected(QString)));
-    connect(bodyUI->themeColorCBox, SIGNAL(currentIndexChanged(int)), this, SLOT(onThemeColorChanged(int)));
-    connect(bodyUI->emoticonSize, SIGNAL(editingFinished()), this, SLOT(onEmoticonSizeChanged()));
-    connect(bodyUI->timestamp, SIGNAL(currentIndexChanged(int)), this, SLOT(onTimestampSelected(int)));
-    connect(bodyUI->dateFormats, SIGNAL(currentIndexChanged(int)), this, SLOT(onDateFormatSelected(int)));
-    //connection
-    connect(bodyUI->cbEnableIPv6, &QCheckBox::stateChanged, this, &GeneralForm::onEnableIPv6Updated);
-    connect(bodyUI->cbEnableUDP, &QCheckBox::stateChanged, this, &GeneralForm::onUDPUpdated);
-    connect(bodyUI->proxyType, SIGNAL(currentIndexChanged(int)), this, SLOT(onUseProxyUpdated()));
-    connect(bodyUI->proxyAddr, &QLineEdit::editingFinished, this, &GeneralForm::onProxyAddrEdited);
-    connect(bodyUI->proxyPort, SIGNAL(valueChanged(int)), this, SLOT(onProxyPortEdited(int)));
-    connect(bodyUI->reconnectButton, &QPushButton::clicked, this, &GeneralForm::onReconnectClicked);
+    connect(bodyUI->statusChanges, &QCheckBox::stateChanged, this, &GeneralForm::onSetStatusChange);
     connect(bodyUI->cbFauxOfflineMessaging, &QCheckBox::stateChanged, this, &GeneralForm::onFauxOfflineMessaging);
-    connect(bodyUI->cbCompactLayout, &QCheckBox::stateChanged, this, &GeneralForm::onCompactLayout);
-    connect(bodyUI->cbSeparateWindow, &QCheckBox::stateChanged, this, &GeneralForm::onSeparateWindowChanged);
-    connect(bodyUI->cbDontGroupWindows, &QCheckBox::stateChanged, this, &GeneralForm::onDontGroupWindowsChanged);
-    connect(bodyUI->cbGroupchatPosition, &QCheckBox::stateChanged, this, &GeneralForm::onGroupchatPositionChanged);
+
+    connect(bodyUI->autoAwaySpinBox, &QSpinBox::editingFinished, this, &GeneralForm::onAutoAwayChanged);
+    connect(bodyUI->autoSaveFilesDir, &QPushButton::clicked, this, &GeneralForm::onAutoSaveDirChange);
+    connect(bodyUI->autoacceptFiles, &QCheckBox::stateChanged, this, &GeneralForm::onAutoAcceptFileChange);
 
     // prevent stealing mouse wheel scroll
     // scrolling event won't be transmitted to comboboxes or qspinboxes when scrolling
@@ -284,9 +181,7 @@ GeneralForm::GeneralForm(SettingsWidget *myParent)
     }
 
     for (QCheckBox *cb : findChildren<QCheckBox*>()) // this one is to allow scrolling on checkboxes
-    {
         cb->installEventFilter(this);
-    }
 
 #ifndef QTOX_PLATFORM_EXT
     bodyUI->autoAwayLabel->setEnabled(false);   // these don't seem to change the appearance of the widgets,
@@ -300,11 +195,6 @@ GeneralForm::~GeneralForm()
 {
     Translator::unregister(this);
     delete bodyUI;
-}
-
-void GeneralForm::onEnableIPv6Updated()
-{
-    Settings::getInstance().setEnableIPv6(bodyUI->cbEnableIPv6->isChecked());
 }
 
 void GeneralForm::onTranslationUpdated()
@@ -345,32 +235,26 @@ void GeneralForm::onSetMinimizeToTray()
     Settings::getInstance().setMinimizeToTray(bodyUI->minimizeToTray->isChecked());
 }
 
-void GeneralForm::onStyleSelected(QString style)
+void GeneralForm::onSetNotifySound()
 {
-    if (bodyUI->styleBrowser->currentIndex() == 0)
-        Settings::getInstance().setStyle("None");
-    else
-        Settings::getInstance().setStyle(style);
-
-    this->setStyle(QStyleFactory::create(style));
-    parent->setBodyHeadStyle(style);
+    bool notify = bodyUI->notifySound->isChecked();
+    Settings::getInstance().setNotifySound(notify);
+    bodyUI->busySound->setEnabled(notify);
 }
 
-void GeneralForm::onEmoticonSizeChanged()
+void GeneralForm::onSetBusySound()
 {
-    Settings::getInstance().setEmojiFontPointSize(bodyUI->emoticonSize->value());
+    Settings::getInstance().setBusySound(bodyUI->busySound->isChecked());
 }
 
-void GeneralForm::onTimestampSelected(int index)
+void GeneralForm::onSetStatusChange()
 {
-    Settings::getInstance().setTimestampFormat(timeFormats.at(index));
-    Translator::translate();
+    Settings::getInstance().setStatusChangeNotificationEnabled(bodyUI->statusChanges->isChecked());
 }
 
-void GeneralForm::onDateFormatSelected(int index)
+void GeneralForm::onFauxOfflineMessaging()
 {
-    Settings::getInstance().setDateFormat(dateFormats.at(index));
-    Translator::translate();
+    Settings::getInstance().setFauxOfflineMessaging(bodyUI->cbFauxOfflineMessaging->isChecked());
 }
 
 void GeneralForm::onAutoAwayChanged()
@@ -398,165 +282,9 @@ void GeneralForm::onAutoSaveDirChange()
     bodyUI->autoSaveFilesDir->setText(directory);
 }
 
-void GeneralForm::onUseEmoticonsChange()
-{
-    Settings::getInstance().setUseEmoticons(bodyUI->useEmoticons->isChecked());
-    bodyUI->smileyPackBrowser->setEnabled(bodyUI->useEmoticons->isChecked());
-}
-
-void GeneralForm::onStyleUpdated()
-{
-    Settings::StyleType styleType =
-            static_cast<Settings::StyleType>(bodyUI->textStyleComboBox->currentIndex());
-    Settings::getInstance().setStylePreference(styleType);
-}
-
-void GeneralForm::onSetStatusChange()
-{
-    Settings::getInstance().setStatusChangeNotificationEnabled(bodyUI->statusChanges->isChecked());
-}
-
-void GeneralForm::onSmileyBrowserIndexChanged(int index)
-{
-    QString filename = bodyUI->smileyPackBrowser->itemData(index).toString();
-    Settings::getInstance().setSmileyPack(filename);
-    reloadSmiles();
-}
-
-void GeneralForm::onUDPUpdated()
-{
-    Settings::getInstance().setForceTCP(!bodyUI->cbEnableUDP->isChecked());
-}
-
-void GeneralForm::onProxyAddrEdited()
-{
-    Settings::getInstance().setProxyAddr(bodyUI->proxyAddr->text());
-}
-
-void GeneralForm::onProxyPortEdited(int port)
-{
-    Settings::getInstance().setProxyPort(static_cast<quint16>(port));
-}
-
-void GeneralForm::onUseProxyUpdated()
-{
-    Settings::ProxyType proxytype =
-            static_cast<Settings::ProxyType>(bodyUI->proxyType->currentIndex());
-
-    bodyUI->proxyAddr->setEnabled(proxytype != Settings::ProxyType::ptNone);
-    bodyUI->proxyPort->setEnabled(proxytype != Settings::ProxyType::ptNone);
-    Settings::getInstance().setProxyType(proxytype);
-}
-
-void GeneralForm::onReconnectClicked()
-{
-    if (Core::getInstance()->getAv()->anyActiveCalls())
-    {
-        QMessageBox::warning(this, tr("Call active", "popup title"),
-                        tr("You can't disconnect while a call is active!", "popup text"));
-    }
-    else
-    {
-        emit Core::getInstance()->statusSet(Status::Offline);
-        Nexus::getProfile()->restartCore();
-    }
-}
-
-void GeneralForm::reloadSmiles()
-{
-    QList<QStringList> emoticons = SmileyPack::getInstance().getEmoticons();
-    if (emoticons.isEmpty())
-    { // sometimes there are no emoticons available, don't crash in this case
-        qDebug() << "reloadSmilies: No emoticons found";
-        return;
-    }
-
-    QStringList smiles;
-    for (int i = 0; i < emoticons.size(); i++)
-        smiles.push_front(emoticons.at(i).first());
-
-    const QSize size(18,18);
-    bodyUI->smile1->setPixmap(SmileyPack::getInstance().getAsIcon(smiles[0]).pixmap(size));
-    bodyUI->smile2->setPixmap(SmileyPack::getInstance().getAsIcon(smiles[1]).pixmap(size));
-    bodyUI->smile3->setPixmap(SmileyPack::getInstance().getAsIcon(smiles[2]).pixmap(size));
-    bodyUI->smile4->setPixmap(SmileyPack::getInstance().getAsIcon(smiles[3]).pixmap(size));
-    bodyUI->smile5->setPixmap(SmileyPack::getInstance().getAsIcon(smiles[4]).pixmap(size));
-
-    bodyUI->smile1->setToolTip(smiles[0]);
-    bodyUI->smile2->setToolTip(smiles[1]);
-    bodyUI->smile3->setToolTip(smiles[2]);
-    bodyUI->smile4->setToolTip(smiles[3]);
-    bodyUI->smile5->setToolTip(smiles[4]);
-
-    //set maximum size of emoji
-    QDesktopWidget desktop;
-    int maxSize = qMin(desktop.geometry().height()/8,
-                       desktop.geometry().width()/8); // 8 is the count of row and column in emoji's in widget
-    bodyUI->emoticonSize->setMaximum(SmileyPack::getInstance().getAsIcon(smiles[0]).actualSize(QSize(maxSize,maxSize)).width());
-}
-
 void GeneralForm::onCheckUpdateChanged()
 {
     Settings::getInstance().setCheckUpdates(bodyUI->checkUpdates->isChecked());
-}
-
-void GeneralForm::onShowWindowChanged()
-{
-    Settings::getInstance().setShowWindow(bodyUI->showWindow->isChecked());
-}
-
-void GeneralForm::onSetShowInFront()
-{
-    Settings::getInstance().setShowInFront(bodyUI->showInFront->isChecked());
-}
-
-void GeneralForm::onSetNotifySound()
-{
-    Settings::getInstance().setNotifySound(bodyUI->notifySound->isChecked());
-}
-
-void GeneralForm::onSetBusySound()
-{
-    Settings::getInstance().setBusySound(bodyUI->busySound->isChecked());
-}
-
-void GeneralForm::onSetGroupAlwaysNotify()
-{
-    Settings::getInstance().setGroupAlwaysNotify(bodyUI->groupAlwaysNotify->isChecked());
-}
-
-void GeneralForm::onFauxOfflineMessaging()
-{
-    Settings::getInstance().setFauxOfflineMessaging(bodyUI->cbFauxOfflineMessaging->isChecked());
-}
-
-void GeneralForm::onCompactLayout()
-{
-    Settings::getInstance().setCompactLayout(bodyUI->cbCompactLayout->isChecked());
-}
-
-void GeneralForm::onSeparateWindowChanged()
-{
-    bodyUI->cbDontGroupWindows->setEnabled(bodyUI->cbSeparateWindow->isChecked());
-    Settings::getInstance().setSeparateWindow(bodyUI->cbSeparateWindow->isChecked());
-}
-
-void GeneralForm::onDontGroupWindowsChanged()
-{
-    Settings::getInstance().setDontGroupWindows(bodyUI->cbDontGroupWindows->isChecked());
-}
-
-void GeneralForm::onGroupchatPositionChanged()
-{
-    Settings::getInstance().setGroupchatPosition(bodyUI->cbGroupchatPosition->isChecked());
-}
-
-void GeneralForm::onThemeColorChanged(int)
-{
-    int index = bodyUI->themeColorCBox->currentIndex();
-    Settings::getInstance().setThemeColor(index);
-    Style::setThemeColor(index);
-    Style::applyTheme();
 }
 
 bool GeneralForm::eventFilter(QObject *o, QEvent *e)
@@ -572,39 +300,5 @@ bool GeneralForm::eventFilter(QObject *o, QEvent *e)
 
 void GeneralForm::retranslateUi()
 {
-    int proxyType = bodyUI->proxyType->currentIndex();
     bodyUI->retranslateUi(this);
-    bodyUI->proxyType->setCurrentIndex(proxyType);
-
-    QStringList colorThemes(Style::getThemeColorNames());
-    for (int i = 0; i != colorThemes.size(); ++i)
-    {
-        bodyUI->themeColorCBox->setItemText(i, colorThemes[i]);
-    }
-
-    bodyUI->styleBrowser->setItemText(0, tr("None"));
-}
-
-void GeneralForm::on_txtChatFont_currentFontChanged(const QFont& f)
-{
-    QFont tmpFont = f;
-    const int px = bodyUI->txtChatFontSize->value();
-
-    if (QFontInfo(tmpFont).pixelSize() != px)
-        tmpFont.setPixelSize(px);
-
-    Settings::getInstance().setChatMessageFont(tmpFont);
-}
-
-void GeneralForm::on_txtChatFontSize_valueChanged(int px)
-{
-    Settings& s = Settings::getInstance();
-    QFont tmpFont = s.getChatMessageFont();
-    const int fontSize = QFontInfo(tmpFont).pixelSize();
-
-    if (px != fontSize)
-    {
-        tmpFont.setPixelSize(px);
-        s.setChatMessageFont(tmpFont);
-    }
 }

--- a/src/widget/form/settings/generalform.cpp
+++ b/src/widget/form/settings/generalform.cpp
@@ -98,6 +98,11 @@ static QStringList langs = {"Arabic",
                             "Українська",
                             "简体中文"};
 
+/**
+ * @class GeneralForm
+ *
+ * This form contains all settings that are not suited to other forms
+ */
 GeneralForm::GeneralForm(SettingsWidget *myParent)
     : GenericForm(QPixmap(":/img/settings/general.png"))
     , bodyUI(new Ui::GeneralSettings)
@@ -248,6 +253,9 @@ void GeneralForm::on_checkUpdates_stateChanged()
     Settings::getInstance().setCheckUpdates(bodyUI->checkUpdates->isChecked());
 }
 
+/**
+ * @brief Retranslate all elements in the form.
+ */
 void GeneralForm::retranslateUi()
 {
     bodyUI->retranslateUi(this);

--- a/src/widget/form/settings/generalform.cpp
+++ b/src/widget/form/settings/generalform.cpp
@@ -143,27 +143,6 @@ GeneralForm::GeneralForm(SettingsWidget *myParent)
     bodyUI->autoSaveFilesDir->setText(s.getGlobalAutoAcceptDir());
     bodyUI->autoacceptFiles->setChecked(s.getAutoSaveEnabled());
 
-    // General
-    void (QComboBox::* currentIndexChanged)(int index) = &QComboBox::currentIndexChanged;
-    connect(bodyUI->transComboBox, currentIndexChanged, this, &GeneralForm::onTranslationUpdated);
-    connect(bodyUI->checkUpdates, &QCheckBox::stateChanged, this, &GeneralForm::onCheckUpdateChanged);
-    connect(bodyUI->cbAutorun, &QCheckBox::stateChanged, this, &GeneralForm::onAutorunUpdated);
-    connect(bodyUI->lightTrayIcon, &QCheckBox::stateChanged, this, &GeneralForm::onSetLightTrayIcon);
-
-    connect(bodyUI->showSystemTray, &QCheckBox::stateChanged, this, &GeneralForm::onSetShowSystemTray);
-    connect(bodyUI->startInTray, &QCheckBox::stateChanged, this, &GeneralForm::onSetAutostartInTray);
-    connect(bodyUI->minimizeToTray, &QCheckBox::stateChanged, this, &GeneralForm::onSetMinimizeToTray);
-    connect(bodyUI->closeToTray, &QCheckBox::stateChanged, this, &GeneralForm::onSetCloseToTray);
-
-    connect(bodyUI->notifySound, &QCheckBox::stateChanged, this, &GeneralForm::onSetNotifySound);
-    connect(bodyUI->busySound, &QCheckBox::stateChanged, this, &GeneralForm::onSetBusySound);
-    connect(bodyUI->statusChanges, &QCheckBox::stateChanged, this, &GeneralForm::onSetStatusChange);
-    connect(bodyUI->cbFauxOfflineMessaging, &QCheckBox::stateChanged, this, &GeneralForm::onFauxOfflineMessaging);
-
-    connect(bodyUI->autoAwaySpinBox, &QSpinBox::editingFinished, this, &GeneralForm::onAutoAwayChanged);
-    connect(bodyUI->autoSaveFilesDir, &QPushButton::clicked, this, &GeneralForm::onAutoSaveDirChange);
-    connect(bodyUI->autoacceptFiles, &QCheckBox::stateChanged, this, &GeneralForm::onAutoAcceptFileChange);
-
 #ifndef QTOX_PLATFORM_EXT
     bodyUI->autoAwayLabel->setEnabled(false);   // these don't seem to change the appearance of the widgets,
     bodyUI->autoAwaySpinBox->setEnabled(false); // though they are unusable
@@ -179,78 +158,78 @@ GeneralForm::~GeneralForm()
     delete bodyUI;
 }
 
-void GeneralForm::onTranslationUpdated()
+void GeneralForm::on_transComboBox_currentIndexChanged(int index)
 {
-    Settings::getInstance().setTranslation(locales[bodyUI->transComboBox->currentIndex()]);
+    Settings::getInstance().setTranslation(locales[index]);
     Translator::translate();
 }
 
-void GeneralForm::onAutorunUpdated()
+void GeneralForm::on_cbAutorun_stateChanged()
 {
     Settings::getInstance().setAutorun(bodyUI->cbAutorun->isChecked());
 }
 
-void GeneralForm::onSetShowSystemTray()
+void GeneralForm::on_showSystemTray_stateChanged()
 {
     Settings::getInstance().setShowSystemTray(bodyUI->showSystemTray->isChecked());
     Settings::getInstance().saveGlobal();
 }
 
-void GeneralForm::onSetAutostartInTray()
+void GeneralForm::on_startInTray_stateChanged()
 {
     Settings::getInstance().setAutostartInTray(bodyUI->startInTray->isChecked());
 }
 
-void GeneralForm::onSetCloseToTray()
+void GeneralForm::on_closeToTray_stateChanged()
 {
     Settings::getInstance().setCloseToTray(bodyUI->closeToTray->isChecked());
 }
 
-void GeneralForm::onSetLightTrayIcon()
+void GeneralForm::on_lightTrayIcon_stateChanged()
 {
     Settings::getInstance().setLightTrayIcon(bodyUI->lightTrayIcon->isChecked());
     Widget::getInstance()->updateIcons();
 }
 
-void GeneralForm::onSetMinimizeToTray()
+void GeneralForm::on_minimizeToTray_stateChanged()
 {
     Settings::getInstance().setMinimizeToTray(bodyUI->minimizeToTray->isChecked());
 }
 
-void GeneralForm::onSetNotifySound()
+void GeneralForm::on_notifySound_stateChanged()
 {
     bool notify = bodyUI->notifySound->isChecked();
     Settings::getInstance().setNotifySound(notify);
     bodyUI->busySound->setEnabled(notify);
 }
 
-void GeneralForm::onSetBusySound()
+void GeneralForm::on_busySound_stateChanged()
 {
     Settings::getInstance().setBusySound(bodyUI->busySound->isChecked());
 }
 
-void GeneralForm::onSetStatusChange()
+void GeneralForm::on_statusChanges_stateChanged()
 {
     Settings::getInstance().setStatusChangeNotificationEnabled(bodyUI->statusChanges->isChecked());
 }
 
-void GeneralForm::onFauxOfflineMessaging()
+void GeneralForm::on_cbFauxOfflineMessaging_stateChanged()
 {
     Settings::getInstance().setFauxOfflineMessaging(bodyUI->cbFauxOfflineMessaging->isChecked());
 }
 
-void GeneralForm::onAutoAwayChanged()
+void GeneralForm::on_autoAwaySpinBox_editingFinished()
 {
     int minutes = bodyUI->autoAwaySpinBox->value();
     Settings::getInstance().setAutoAwayTime(minutes);
 }
 
-void GeneralForm::onAutoAcceptFileChange()
+void GeneralForm::on_autoacceptFiles_stateChanged()
 {
     Settings::getInstance().setAutoSaveEnabled(bodyUI->autoacceptFiles->isChecked());
 }
 
-void GeneralForm::onAutoSaveDirChange()
+void GeneralForm::on_autoSaveFilesDir_clicked()
 {
     QString previousDir = Settings::getInstance().getGlobalAutoAcceptDir();
     QString directory = QFileDialog::getExistingDirectory(0,
@@ -264,7 +243,7 @@ void GeneralForm::onAutoSaveDirChange()
     bodyUI->autoSaveFilesDir->setText(directory);
 }
 
-void GeneralForm::onCheckUpdateChanged()
+void GeneralForm::on_checkUpdates_stateChanged()
 {
     Settings::getInstance().setCheckUpdates(bodyUI->checkUpdates->isChecked());
 }

--- a/src/widget/form/settings/generalform.cpp
+++ b/src/widget/form/settings/generalform.cpp
@@ -164,30 +164,12 @@ GeneralForm::GeneralForm(SettingsWidget *myParent)
     connect(bodyUI->autoSaveFilesDir, &QPushButton::clicked, this, &GeneralForm::onAutoSaveDirChange);
     connect(bodyUI->autoacceptFiles, &QCheckBox::stateChanged, this, &GeneralForm::onAutoAcceptFileChange);
 
-    // prevent stealing mouse wheel scroll
-    // scrolling event won't be transmitted to comboboxes or qspinboxes when scrolling
-    // you can scroll through general settings without accidentially changing theme/skin/icons etc.
-    // @see GeneralForm::eventFilter(QObject *o, QEvent *e) at the bottom of this file for more
-    for (QComboBox *cb : findChildren<QComboBox*>())
-    {
-        cb->installEventFilter(this);
-        cb->setFocusPolicy(Qt::StrongFocus);
-    }
-
-    for (QSpinBox *sp : findChildren<QSpinBox*>())
-    {
-        sp->installEventFilter(this);
-        sp->setFocusPolicy(Qt::WheelFocus);
-    }
-
-    for (QCheckBox *cb : findChildren<QCheckBox*>()) // this one is to allow scrolling on checkboxes
-        cb->installEventFilter(this);
-
 #ifndef QTOX_PLATFORM_EXT
     bodyUI->autoAwayLabel->setEnabled(false);   // these don't seem to change the appearance of the widgets,
     bodyUI->autoAwaySpinBox->setEnabled(false); // though they are unusable
 #endif
 
+    eventsInit();
     Translator::registerHandler(std::bind(&GeneralForm::retranslateUi, this), this);
 }
 
@@ -285,17 +267,6 @@ void GeneralForm::onAutoSaveDirChange()
 void GeneralForm::onCheckUpdateChanged()
 {
     Settings::getInstance().setCheckUpdates(bodyUI->checkUpdates->isChecked());
-}
-
-bool GeneralForm::eventFilter(QObject *o, QEvent *e)
-{
-    if ((e->type() == QEvent::Wheel) &&
-         (qobject_cast<QComboBox*>(o) || qobject_cast<QAbstractSpinBox*>(o) || qobject_cast<QCheckBox*>(o)))
-    {
-        e->ignore();
-        return true;
-    }
-    return QWidget::eventFilter(o, e);
 }
 
 void GeneralForm::retranslateUi()

--- a/src/widget/form/settings/generalform.h
+++ b/src/widget/form/settings/generalform.h
@@ -40,52 +40,28 @@ public:
     }
 
 private slots:
-    void onEnableIPv6Updated();
     void onTranslationUpdated();
     void onAutorunUpdated();
     void onSetShowSystemTray();
     void onSetAutostartInTray();
     void onSetCloseToTray();
     void onSetLightTrayIcon();
-    void onSmileyBrowserIndexChanged(int index);
-    void onUDPUpdated();
-    void onProxyAddrEdited();
-    void onProxyPortEdited(int port);
-    void onUseProxyUpdated();
-    void onEmoticonSizeChanged();
-    void onStyleSelected(QString style);
-    void onTimestampSelected(int index);
-    void onDateFormatSelected(int index);
-    void onStyleUpdated();
-    void onSetStatusChange();
     void onAutoAwayChanged();
-    void onUseEmoticonsChange();
     void onSetMinimizeToTray();
-    void onReconnectClicked();
+    void onSetNotifySound();
+    void onSetBusySound();
+    void onSetStatusChange();
+    void onFauxOfflineMessaging();
+
     void onAutoAcceptFileChange();
     void onAutoSaveDirChange();
     void onCheckUpdateChanged();
-    void onShowWindowChanged();
-    void onSetShowInFront();
-    void onSetNotifySound();
-    void onSetBusySound();
-    void onSetGroupAlwaysNotify();
-    void onFauxOfflineMessaging();
-    void onCompactLayout();
-    void onSeparateWindowChanged();
-    void onDontGroupWindowsChanged();
-    void onGroupchatPositionChanged();
-    void onThemeColorChanged(int);
-
-    void on_txtChatFont_currentFontChanged(const QFont& f);
-    void on_txtChatFontSize_valueChanged(int px);
 
 private:
     void retranslateUi();
 
 private:
     Ui::GeneralSettings *bodyUI;
-    void reloadSmiles();
     SettingsWidget *parent;
 
 protected:

--- a/src/widget/form/settings/generalform.h
+++ b/src/widget/form/settings/generalform.h
@@ -40,22 +40,22 @@ public:
     }
 
 private slots:
-    void onTranslationUpdated();
-    void onAutorunUpdated();
-    void onSetShowSystemTray();
-    void onSetAutostartInTray();
-    void onSetCloseToTray();
-    void onSetLightTrayIcon();
-    void onAutoAwayChanged();
-    void onSetMinimizeToTray();
-    void onSetNotifySound();
-    void onSetBusySound();
-    void onSetStatusChange();
-    void onFauxOfflineMessaging();
+    void on_transComboBox_currentIndexChanged(int index);
+    void on_cbAutorun_stateChanged();
+    void on_showSystemTray_stateChanged();
+    void on_startInTray_stateChanged();
+    void on_closeToTray_stateChanged();
+    void on_lightTrayIcon_stateChanged();
+    void on_autoAwaySpinBox_editingFinished();
+    void on_minimizeToTray_stateChanged();
+    void on_notifySound_stateChanged();
+    void on_busySound_stateChanged();
+    void on_statusChanges_stateChanged();
+    void on_cbFauxOfflineMessaging_stateChanged();
 
-    void onAutoAcceptFileChange();
-    void onAutoSaveDirChange();
-    void onCheckUpdateChanged();
+    void on_autoacceptFiles_stateChanged();
+    void on_autoSaveFilesDir_clicked();
+    void on_checkUpdates_stateChanged();
 
 private:
     void retranslateUi();

--- a/src/widget/form/settings/generalform.h
+++ b/src/widget/form/settings/generalform.h
@@ -63,9 +63,6 @@ private:
 private:
     Ui::GeneralSettings *bodyUI;
     SettingsWidget *parent;
-
-protected:
-    bool eventFilter(QObject *o, QEvent *e) final override;
 };
 
 #endif

--- a/src/widget/form/settings/generalsettings.ui
+++ b/src/widget/form/settings/generalsettings.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1312</width>
-    <height>1098</height>
+    <height>580</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -39,11 +39,11 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>1278</width>
-        <height>1382</height>
+        <width>1270</width>
+        <height>587</height>
        </rect>
       </property>
-      <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,0,0,1">
+      <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,0">
        <property name="spacing">
         <number>32</number>
        </property>
@@ -208,6 +208,55 @@ instead of closing itself.</string>
               </item>
              </layout>
             </item>
+            <item>
+             <widget class="QLabel" name="newMessageLabel">
+              <property name="text">
+               <string>On new message:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <layout class="QVBoxLayout" name="verticalLayout_5">
+              <property name="leftMargin">
+               <number>40</number>
+              </property>
+              <item>
+               <widget class="QCheckBox" name="notifySound">
+                <property name="text">
+                 <string>Play sound</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <layout class="QVBoxLayout" name="verticalLayout">
+                <property name="leftMargin">
+                 <number>40</number>
+                </property>
+                <item>
+                 <widget class="QCheckBox" name="busySound">
+                  <property name="text">
+                   <string>Play sound while Busy</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="statusChanges">
+              <property name="text">
+               <string>Show contacts' status changes</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="cbFauxOfflineMessaging">
+              <property name="text">
+               <string>Faux offline messaging</string>
+              </property>
+             </widget>
+            </item>
            </layout>
           </item>
           <item>
@@ -299,635 +348,17 @@ instead of closing itself.</string>
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="chatGroupBox">
-         <property name="title">
-          <string>Chat</string>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_7">
-          <item>
-           <layout class="QGridLayout" name="gridLayout_2">
-            <item row="0" column="0">
-             <widget class="QLabel" name="label_2">
-              <property name="text">
-               <string>Base font:</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QFontComboBox" name="txtChatFont"/>
-            </item>
-            <item row="0" column="2">
-             <widget class="QSpinBox" name="txtChatFontSize">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="suffix">
-               <string>px</string>
-              </property>
-              <property name="prefix">
-               <string>Size: </string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="textStyleLabel">
-              <property name="toolTip">
-               <string>New text styling preference may not load until qTox restarts.</string>
-              </property>
-              <property name="text">
-               <string>Text Style format:</string>
-              </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="3">
-             <spacer name="horizontalSpacer">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item row="1" column="3">
-             <spacer name="generalSpacer_2">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item row="1" column="1" colspan="2">
-             <widget class="QComboBox" name="textStyleComboBox">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="toolTip">
-               <string>Select text styling preference.</string>
-              </property>
-              <property name="currentIndex">
-               <number>1</number>
-              </property>
-              <item>
-               <property name="text">
-                <string>Plaintext</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Show formatting characters</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>Don't show formatting characters</string>
-               </property>
-              </item>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <widget class="Line" name="line">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <layout class="QVBoxLayout" name="verticalLayout_9">
-            <item>
-             <widget class="QLabel" name="label_3">
-              <property name="text">
-               <string>On new message:</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <layout class="QVBoxLayout" name="verticalLayout_10">
-              <property name="leftMargin">
-               <number>40</number>
-              </property>
-              <item>
-               <widget class="QCheckBox" name="notifySound">
-                <property name="toolTip">
-                 <string comment="toolTip for Notify sound setting">Play a sound when you recieve message.</string>
-                </property>
-                <property name="text">
-                 <string>Play sound</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <layout class="QVBoxLayout" name="verticalLayout_13">
-                <property name="leftMargin">
-                 <number>40</number>
-                </property>
-                <item>
-                 <widget class="QCheckBox" name="busySound">
-                  <property name="text">
-                   <string>Play sound while Busy</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </item>
-              <item>
-               <widget class="QCheckBox" name="showWindow">
-                <property name="toolTip">
-                 <string comment="tooltip for Show window setting">Open qTox's window when you receive a new message and no window is open yet.</string>
-                </property>
-                <property name="text">
-                 <string>Open window</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <layout class="QVBoxLayout" name="verticalLayout_15">
-                <property name="leftMargin">
-                 <number>40</number>
-                </property>
-                <item>
-                 <widget class="QCheckBox" name="showInFront">
-                  <property name="toolTip">
-                   <string comment="toolTip for Focus window setting">Focus qTox when you receive message.</string>
-                  </property>
-                  <property name="text">
-                   <string>Focus window</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </item>
-             </layout>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <widget class="Line" name="line_2">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="statusChanges">
-            <property name="text">
-             <string>Show contacts' status changes</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="groupAlwaysNotify">
-            <property name="toolTip">
-             <string comment="toolTip for Group chat always notify">Always notify about new messages in groupchats.</string>
-            </property>
-            <property name="text">
-             <string>Group chats always notify</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="cbGroupchatPosition">
-            <property name="toolTip">
-             <string comment="toolTip for groupchat positioning">If checked, groupchats will be placed at the top of the friends list, otherwise, they'll be placed below online friends.</string>
-            </property>
-            <property name="text">
-             <string>Place groupchats at top of friend list</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="cbFauxOfflineMessaging">
-            <property name="toolTip">
-             <string comment="toolTip for Faux offline messaging setting">Messages you are trying to send to your friends when they are not online
-will be sent to them when they appear online to you.</string>
-            </property>
-            <property name="text">
-             <string>Faux offline messaging</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="cbCompactLayout">
-            <property name="toolTip">
-             <string comment="toolTip for compact layout setting">Your contact list will be shown in compact mode.</string>
-            </property>
-            <property name="text">
-             <string>Compact contact list</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="Line" name="line_3">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <layout class="QVBoxLayout" name="verticalLayout_11">
-            <item>
-             <widget class="QCheckBox" name="cbSeparateWindow">
-              <property name="text">
-               <string>Multiple windows mode</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <layout class="QVBoxLayout" name="verticalLayout_12">
-              <property name="leftMargin">
-               <number>40</number>
-              </property>
-              <item>
-               <widget class="QCheckBox" name="cbDontGroupWindows">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string>Open each chat in an individual window</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="themeGroup">
-         <property name="title">
-          <string>Theme</string>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout">
-          <item>
-           <widget class="QCheckBox" name="useEmoticons">
-            <property name="text">
-             <string>Use emoticons</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <layout class="QFormLayout" name="formLayout">
-            <property name="fieldGrowthPolicy">
-             <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-            </property>
-            <property name="topMargin">
-             <number>0</number>
-            </property>
-            <property name="bottomMargin">
-             <number>0</number>
-            </property>
-            <item row="0" column="0">
-             <widget class="QLabel" name="smileyPackLabel">
-              <property name="text">
-               <string extracomment="Text on smiley pack label">Smiley Pack:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QComboBox" name="smileyPackBrowser">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <spacer name="horizontalSpacer_2">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>80</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item row="1" column="1">
-             <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0,0,0">
-              <property name="sizeConstraint">
-               <enum>QLayout::SetDefaultConstraint</enum>
-              </property>
-              <item alignment="Qt::AlignTop">
-               <widget class="QLabel" name="smile1">
-                <property name="toolTip">
-                 <string notr="true">:)</string>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item alignment="Qt::AlignTop">
-               <widget class="QLabel" name="smile2">
-                <property name="toolTip">
-                 <string notr="true">;)</string>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item alignment="Qt::AlignTop">
-               <widget class="QLabel" name="smile3">
-                <property name="toolTip">
-                 <string notr="true">:p</string>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item alignment="Qt::AlignTop">
-               <widget class="QLabel" name="smile4">
-                <property name="toolTip">
-                 <string notr="true">:O</string>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item alignment="Qt::AlignTop">
-               <widget class="QLabel" name="smile5">
-                <property name="toolTip">
-                 <string notr="true">:'(</string>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="emoticonSizeLabel">
-              <property name="text">
-               <string>Emoticon size:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1">
-             <widget class="QSpinBox" name="emoticonSize">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="specialValueText">
-               <string/>
-              </property>
-              <property name="suffix">
-               <string> px</string>
-              </property>
-              <property name="minimum">
-               <number>1</number>
-              </property>
-              <property name="maximum">
-               <number>2147483647</number>
-              </property>
-              <property name="value">
-               <number>25</number>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="0">
-             <widget class="QLabel" name="styleLabel">
-              <property name="text">
-               <string>Style:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="1">
-             <widget class="QComboBox" name="styleBrowser">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-             </widget>
-            </item>
-            <item row="4" column="0">
-             <widget class="QLabel" name="themeColorLabel">
-              <property name="text">
-               <string>Theme color:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="4" column="1">
-             <widget class="QComboBox" name="themeColorCBox">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-             </widget>
-            </item>
-            <item row="5" column="0">
-             <widget class="QLabel" name="timestampLabel">
-              <property name="text">
-               <string>Timestamp format:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="5" column="1">
-             <widget class="QComboBox" name="timestamp">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-             </widget>
-            </item>
-            <item row="6" column="0">
-             <widget class="QLabel" name="dateformatLabel">
-              <property name="text">
-               <string>Date format:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="6" column="1">
-             <widget class="QComboBox" name="dateFormats"/>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="connectionGroup">
-         <property name="title">
-          <string>Connection Settings</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayoutProxy">
-          <property name="topMargin">
-           <number>9</number>
-          </property>
-          <item>
-           <layout class="QVBoxLayout" name="verticalLayout_5">
-            <item>
-             <widget class="QCheckBox" name="cbEnableIPv6">
-              <property name="text">
-               <string extracomment="Text on a checkbox to enable IPv6">Enable IPv6 (recommended)</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QCheckBox" name="cbEnableUDP">
-              <property name="toolTip">
-               <string extracomment="force tcp checkbox tooltip">Disabling this allows, e.g., toxing over Tor. It adds load to the Tox network however, so uncheck only when necessary.</string>
-              </property>
-              <property name="text">
-               <string extracomment="Text on checkbox to disable UDP">Enable UDP (recommended)</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QGridLayout" name="proxyLayout">
-            <item row="1" column="0">
-             <widget class="QLabel" name="proxyTypeLabel">
-              <property name="text">
-               <string>Proxy type:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="3">
-             <widget class="QSpinBox" name="proxyPort">
-              <property name="minimum">
-               <number>0</number>
-              </property>
-              <property name="maximum">
-               <number>65535</number>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="proxyAddrLabel">
-              <property name="text">
-               <string extracomment="Text on proxy addr label">Address:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1">
-             <widget class="QLineEdit" name="proxyAddr"/>
-            </item>
-            <item row="2" column="2">
-             <widget class="QLabel" name="proxyPortLabel">
-              <property name="text">
-               <string extracomment="Text on proxy port label">Port:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1" colspan="3">
-             <widget class="QComboBox" name="proxyType">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <item>
-               <property name="text">
-                <string>None</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>SOCKS5</string>
-               </property>
-              </item>
-              <item>
-               <property name="text">
-                <string>HTTP</string>
-               </property>
-              </item>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_4">
-            <item>
-             <spacer name="horizontalSpacer_4">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QPushButton" name="reconnectButton">
-              <property name="text">
-               <string comment="reconnect button">Reconnect</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
+        </spacer>
        </item>
       </layout>
      </widget>
@@ -952,44 +383,9 @@ will be sent to them when they appear online to you.</string>
   <tabstop>cbAutorun</tabstop>
   <tabstop>checkUpdates</tabstop>
   <tabstop>autoSaveFilesDir</tabstop>
-  <tabstop>statusChanges</tabstop>
-  <tabstop>groupAlwaysNotify</tabstop>
-  <tabstop>cbGroupchatPosition</tabstop>
-  <tabstop>cbFauxOfflineMessaging</tabstop>
-  <tabstop>cbCompactLayout</tabstop>
-  <tabstop>cbSeparateWindow</tabstop>
-  <tabstop>useEmoticons</tabstop>
-  <tabstop>smileyPackBrowser</tabstop>
-  <tabstop>emoticonSize</tabstop>
-  <tabstop>styleBrowser</tabstop>
-  <tabstop>themeColorCBox</tabstop>
-  <tabstop>timestamp</tabstop>
-  <tabstop>dateFormats</tabstop>
-  <tabstop>cbEnableIPv6</tabstop>
-  <tabstop>cbEnableUDP</tabstop>
-  <tabstop>proxyType</tabstop>
-  <tabstop>proxyAddr</tabstop>
-  <tabstop>proxyPort</tabstop>
-  <tabstop>reconnectButton</tabstop>
  </tabstops>
  <resources/>
  <connections>
-  <connection>
-   <sender>showWindow</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>showInFront</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>329</x>
-     <y>349</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>451</x>
-     <y>349</y>
-    </hint>
-   </hints>
-  </connection>
   <connection>
    <sender>showSystemTray</sender>
    <signal>toggled(bool)</signal>
@@ -1035,22 +431,6 @@ will be sent to them when they appear online to you.</string>
     <hint type="destinationlabel">
      <x>119</x>
      <y>177</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>notifySound</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>busySound</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>665</x>
-     <y>522</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>684</x>
-     <y>551</y>
     </hint>
    </hints>
   </connection>

--- a/src/widget/form/settings/genericsettings.cpp
+++ b/src/widget/form/settings/genericsettings.cpp
@@ -1,8 +1,8 @@
 #include "genericsettings.h"
 
-#include <QEvent>
 #include <QCheckBox>
 #include <QComboBox>
+#include <QEvent>
 #include <QSpinBox>
 
 GenericForm::GenericForm(const QPixmap &icon)

--- a/src/widget/form/settings/genericsettings.cpp
+++ b/src/widget/form/settings/genericsettings.cpp
@@ -5,6 +5,13 @@
 #include <QEvent>
 #include <QSpinBox>
 
+/**
+ * @class GenericForm
+ *
+ * This is abstract class used as superclass for all settings forms.
+ * It provides correct behaviour of controls for settings forms.
+ */
+
 GenericForm::GenericForm(const QPixmap &icon)
     : formIcon(icon)
 {
@@ -15,12 +22,16 @@ QPixmap GenericForm::getFormIcon()
     return formIcon;
 }
 
+/**
+ * @brief Prevent stealing mouse wheel scroll.
+ *
+ * Scrolling event won't be transmitted to comboboxes or spinboxes.
+ * You can scroll through general settings without accidentially changing
+ * theme / skin / icons etc.
+ * @see GenericForm::eventFilter(QObject *o, QEvent *e) at the bottom of this file for more
+ */
 void GenericForm::eventsInit()
 {
-    // prevent stealing mouse wheel scroll
-    // scrolling event won't be transmitted to comboboxes or qspinboxes when scrolling
-    // you can scroll through general settings without accidentially changing theme/skin/icons etc.
-    // @see GenericForm::eventFilter(QObject *o, QEvent *e) at the bottom of this file for more
     for (QComboBox *cb : findChildren<QComboBox*>())
     {
         cb->installEventFilter(this);
@@ -37,6 +48,12 @@ void GenericForm::eventsInit()
         cb->installEventFilter(this);
 }
 
+/**
+ * @brief Ignore scroll on different controls.
+ * @param o Object which has been installed for the watched object.
+ * @param e Event object.
+ * @return True to stop it being handled further, false otherwise.
+ */
 bool GenericForm::eventFilter(QObject *o, QEvent *e)
 {
     if ((e->type() == QEvent::Wheel) &&
@@ -47,5 +64,6 @@ bool GenericForm::eventFilter(QObject *o, QEvent *e)
         e->ignore();
         return true;
     }
+
     return QWidget::eventFilter(o, e);
 }

--- a/src/widget/form/settings/genericsettings.cpp
+++ b/src/widget/form/settings/genericsettings.cpp
@@ -1,0 +1,51 @@
+#include "genericsettings.h"
+
+#include <QEvent>
+#include <QCheckBox>
+#include <QComboBox>
+#include <QSpinBox>
+
+GenericForm::GenericForm(const QPixmap &icon)
+    : formIcon(icon)
+{
+}
+
+QPixmap GenericForm::getFormIcon()
+{
+    return formIcon;
+}
+
+void GenericForm::eventsInit()
+{
+    // prevent stealing mouse wheel scroll
+    // scrolling event won't be transmitted to comboboxes or qspinboxes when scrolling
+    // you can scroll through general settings without accidentially changing theme/skin/icons etc.
+    // @see GenericForm::eventFilter(QObject *o, QEvent *e) at the bottom of this file for more
+    for (QComboBox *cb : findChildren<QComboBox*>())
+    {
+        cb->installEventFilter(this);
+        cb->setFocusPolicy(Qt::StrongFocus);
+    }
+
+    for (QSpinBox *sp : findChildren<QSpinBox*>())
+    {
+        sp->installEventFilter(this);
+        sp->setFocusPolicy(Qt::WheelFocus);
+    }
+
+    for (QCheckBox *cb : findChildren<QCheckBox*>()) // this one is to allow scrolling on checkboxes
+        cb->installEventFilter(this);
+}
+
+bool GenericForm::eventFilter(QObject *o, QEvent *e)
+{
+    if ((e->type() == QEvent::Wheel) &&
+         (qobject_cast<QComboBox*>(o) ||
+          qobject_cast<QAbstractSpinBox*>(o) ||
+          qobject_cast<QCheckBox*>(o)))
+    {
+        e->ignore();
+        return true;
+    }
+    return QWidget::eventFilter(o, e);
+}

--- a/src/widget/form/settings/genericsettings.h
+++ b/src/widget/form/settings/genericsettings.h
@@ -24,14 +24,15 @@ class GenericForm : public QWidget
 {
     Q_OBJECT
 public:
-    explicit GenericForm(const QPixmap &icon) : formIcon(icon) {;}
+    explicit GenericForm(const QPixmap &icon);
     virtual ~GenericForm() {}
 
     virtual QString getFormName() = 0;
-    QPixmap getFormIcon()
-    {
-        return formIcon;
-    }
+    QPixmap getFormIcon();
+
+protected:
+    bool eventFilter(QObject *o, QEvent *e) final override;
+    void eventsInit();
 
 protected:
     QPixmap formIcon;

--- a/src/widget/form/settings/privacyform.cpp
+++ b/src/widget/form/settings/privacyform.cpp
@@ -51,6 +51,7 @@ PrivacyForm::PrivacyForm()
     connect(bodyUI->randomNosapamButton, SIGNAL(clicked()), this, SLOT(generateRandomNospam()));
     connect(bodyUI->nospamLineEdit, SIGNAL(textChanged(QString)), this, SLOT(onNospamEdit()));
 
+    eventsInit();
     Translator::registerHandler(std::bind(&PrivacyForm::retranslateUi, this), this);
 }
 

--- a/src/widget/form/settings/privacyform.cpp
+++ b/src/widget/form/settings/privacyform.cpp
@@ -20,8 +20,12 @@
 #include "privacyform.h"
 #include "ui_privacysettings.h"
 
+#include <QDebug>
+#include <QFile>
+#include <QMessageBox>
+
 #include "src/core/core.h"
-#include <src/core/recursivesignalblocker.h>
+#include "src/core/recursivesignalblocker.h"
 #include "src/nexus.h"
 #include "src/persistence/history.h"
 #include "src/persistence/profile.h"
@@ -32,10 +36,6 @@
 #include "src/widget/translator.h"
 #include "src/widget/widget.h"
 
-#include <QMessageBox>
-#include <QFile>
-#include <QDebug>
-
 PrivacyForm::PrivacyForm()
     : GenericForm(QPixmap(":/img/settings/privacy.png"))
     , bodyUI(new Ui::PrivacySettings)
@@ -44,12 +44,6 @@ PrivacyForm::PrivacyForm()
 
     // block all child signals during initialization
     const RecursiveSignalBlocker signalBlocker(this);
-
-    connect(bodyUI->cbTypingNotification, SIGNAL(stateChanged(int)), this, SLOT(onTypingNotificationEnabledUpdated()));
-    connect(bodyUI->cbKeepHistory, SIGNAL(stateChanged(int)), this, SLOT(onEnableLoggingUpdated()));
-    connect(bodyUI->nospamLineEdit, SIGNAL(editingFinished()), this, SLOT(setNospam()));
-    connect(bodyUI->randomNosapamButton, SIGNAL(clicked()), this, SLOT(generateRandomNospam()));
-    connect(bodyUI->nospamLineEdit, SIGNAL(textChanged(QString)), this, SLOT(onNospamEdit()));
 
     eventsInit();
     Translator::registerHandler(std::bind(&PrivacyForm::retranslateUi, this), this);
@@ -61,7 +55,7 @@ PrivacyForm::~PrivacyForm()
     delete bodyUI;
 }
 
-void PrivacyForm::onEnableLoggingUpdated()
+void PrivacyForm::on_cbKeepHistory_stateChanged()
 {
     Settings::getInstance().setEnableLogging(bodyUI->cbKeepHistory->isChecked());
     Widget::getInstance()->clearAllReceipts();
@@ -77,12 +71,12 @@ void PrivacyForm::onEnableLoggingUpdated()
     }
 }
 
-void PrivacyForm::onTypingNotificationEnabledUpdated()
+void PrivacyForm::on_cbTypingNotification_stateChanged()
 {
     Settings::getInstance().setTypingNotification(bodyUI->cbTypingNotification->isChecked());
 }
 
-void PrivacyForm::setNospam()
+void PrivacyForm::on_nospamLineEdit_editingFinished()
 {
     QString newNospam = bodyUI->nospamLineEdit->text();
 
@@ -100,7 +94,7 @@ void PrivacyForm::showEvent(QShowEvent*)
     bodyUI->cbKeepHistory->setChecked(Settings::getInstance().getEnableLogging());
 }
 
-void PrivacyForm::generateRandomNospam()
+void PrivacyForm::on_randomNosapamButton_clicked()
 {
     QTime time = QTime::currentTime();
     qsrand((uint)time.msec());
@@ -113,7 +107,7 @@ void PrivacyForm::generateRandomNospam()
     bodyUI->nospamLineEdit->setText(Core::getInstance()->getSelfId().noSpam);
 }
 
-void PrivacyForm::onNospamEdit()
+void PrivacyForm::on_nospamLineEdit_textChanged()
 {
     QString str = bodyUI->nospamLineEdit->text();
     int curs = bodyUI->nospamLineEdit->cursorPosition();

--- a/src/widget/form/settings/privacyform.h
+++ b/src/widget/form/settings/privacyform.h
@@ -38,11 +38,11 @@ public:
     }
 
 private slots:
-    void onEnableLoggingUpdated();
-    void onTypingNotificationEnabledUpdated();
-    void setNospam();
-    void generateRandomNospam();
-    void onNospamEdit();
+    void on_cbKeepHistory_stateChanged();
+    void on_cbTypingNotification_stateChanged();
+    void on_nospamLineEdit_editingFinished();
+    void on_randomNosapamButton_clicked();
+    void on_nospamLineEdit_textChanged();
     virtual void showEvent(QShowEvent*) final override;
 
 private:

--- a/src/widget/form/settings/privacysettings.ui
+++ b/src/widget/form/settings/privacysettings.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>300</height>
+    <height>359</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -36,30 +36,39 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>380</width>
-        <height>280</height>
+        <width>378</width>
+        <height>337</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_3">
        <item>
-        <widget class="QCheckBox" name="cbTypingNotification">
-         <property name="toolTip">
-          <string comment="tooltip for typing notifications setting">Your friends will be able to see when you are typing.</string>
+        <widget class="QGroupBox" name="verticalGroupBox">
+         <property name="title">
+          <string>Privacy</string>
          </property>
-         <property name="text">
-          <string>Send typing notifications</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="cbKeepHistory">
-         <property name="toolTip">
-          <string comment="toolTip for Keep History setting">Chat history keeping is still in development.
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <item>
+           <widget class="QCheckBox" name="cbTypingNotification">
+            <property name="toolTip">
+             <string comment="tooltip for typing notifications setting">Your friends will be able to see when you are typing.</string>
+            </property>
+            <property name="text">
+             <string>Send typing notifications</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="cbKeepHistory">
+            <property name="toolTip">
+             <string comment="toolTip for Keep History setting">Chat history keeping is still in development.
 Save format changes are possible, which may result in data loss.</string>
-         </property>
-         <property name="text">
-          <string>Keep chat history</string>
-         </property>
+            </property>
+            <property name="text">
+             <string>Keep chat history</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
        <item alignment="Qt::AlignTop">

--- a/src/widget/form/settings/userinterfaceform.cpp
+++ b/src/widget/form/settings/userinterfaceform.cpp
@@ -1,0 +1,381 @@
+/*
+    Copyright © 2014-2015 by The qTox Project
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "userinterfaceform.h"
+#include "ui_userinterfacesettings.h"
+
+#include <QDebug>
+#include <QDesktopWidget>
+#include <QFileDialog>
+#include <QFont>
+#include <QMessageBox>
+#include <QStandardPaths>
+#include <QStyleFactory>
+#include <QTime>
+#include <QVector>
+
+#include "src/core/core.h"
+#include "src/core/coreav.h"
+#include "src/core/recursivesignalblocker.h"
+#include "src/net/autoupdate.h"
+#include "src/nexus.h"
+#include "src/persistence/profile.h"
+#include "src/persistence/settings.h"
+#include "src/persistence/smileypack.h"
+#include "src/widget/form/settingswidget.h"
+#include "src/widget/style.h"
+#include "src/widget/translator.h"
+#include "src/widget/widget.h"
+
+/**
+ * @class UserInterfaceForm
+ *
+ * This form contains all settings which change the UI appearance or behaviour.
+ * It also contains the smiley configuration.
+ */
+
+static QStringList timeFormats = {"hh:mm AP", "hh:mm", "hh:mm:ss AP", "hh:mm:ss"};
+
+// http://doc.qt.io/qt-4.8/qdate.html#fromString
+static QStringList dateFormats = {"yyyy-MM-dd", "dd-MM-yyyy", "d-MM-yyyy", "dddd d-MM-yyyy", "dddd d-MM", "dddd dd MMMM"};
+
+/**
+ * @brief UserInterfaceForm::UserInterfaceForm
+ * @param myParent Setting widget which will contain this form as tab.
+ *
+ * Constructor of UserInterfaceForm. Restores all controls from the settings.
+ */
+UserInterfaceForm::UserInterfaceForm(SettingsWidget* myParent) :
+    GenericForm(QPixmap(":/img/settings/general.png"))
+{
+    parent = myParent;
+
+    bodyUI = new Ui::UserInterfaceSettings;
+    bodyUI->setupUi(this);
+
+    // block all child signals during initialization
+    const RecursiveSignalBlocker signalBlocker(this);
+
+    Settings &s = Settings::getInstance();
+    const QFont chatBaseFont = s.getChatMessageFont();
+    bodyUI->txtChatFontSize->setValue(QFontInfo(chatBaseFont).pixelSize());
+    bodyUI->txtChatFont->setCurrentFont(chatBaseFont);
+    int index = static_cast<int>(s.getStylePreference());
+    bodyUI->textStyleComboBox->setCurrentIndex(index);
+
+    bool showWindow = s.getShowWindow();
+
+    bodyUI->showWindow->setChecked(showWindow);
+    bodyUI->showInFront->setChecked(s.getShowInFront());
+    bodyUI->showInFront->setEnabled(showWindow);
+
+    bodyUI->groupAlwaysNotify->setChecked(s.getGroupAlwaysNotify());
+    bodyUI->cbGroupchatPosition->setChecked(s.getGroupchatPosition());
+    bodyUI->cbCompactLayout->setChecked(s.getCompactLayout());
+    bodyUI->cbSeparateWindow->setChecked(s.getSeparateWindow());
+    bodyUI->cbDontGroupWindows->setChecked(s.getDontGroupWindows());
+    bodyUI->cbDontGroupWindows->setEnabled(s.getSeparateWindow());
+
+    bodyUI->useEmoticons->setChecked(s.getUseEmoticons());
+    for (auto entry : SmileyPack::listSmileyPacks())
+        bodyUI->smileyPackBrowser->addItem(entry.first, entry.second);
+
+    smileLabels = {bodyUI->smile1, bodyUI->smile2, bodyUI->smile3,
+                   bodyUI->smile4, bodyUI->smile5};
+
+    int currentPack = bodyUI->smileyPackBrowser->findData(s.getSmileyPack());
+    bodyUI->smileyPackBrowser->setCurrentIndex(currentPack);
+    reloadSmiles();
+    bodyUI->smileyPackBrowser->setEnabled(bodyUI->useEmoticons->isChecked());
+
+    bodyUI->styleBrowser->addItem(tr("None"));
+    bodyUI->styleBrowser->addItems(QStyleFactory::keys());
+
+    QString style;
+    if (QStyleFactory::keys().contains(s.getStyle()))
+        style = s.getStyle();
+    else
+        style = tr("None");
+
+    bodyUI->styleBrowser->setCurrentText(style);
+
+    for (QString color : Style::getThemeColorNames())
+        bodyUI->themeColorCBox->addItem(color);
+
+    bodyUI->themeColorCBox->setCurrentIndex(s.getThemeColor());
+    bodyUI->emoticonSize->setValue(s.getEmojiFontPointSize());
+
+    QStringList timestamps;
+    for (QString timestamp : timeFormats)
+        timestamps << QString("%1 - %2").arg(timestamp, QTime::currentTime().toString(timestamp));
+
+    bodyUI->timestamp->addItems(timestamps);
+
+    QLocale ql;
+    QStringList datestamps;
+    dateFormats.append(ql.dateFormat());
+    dateFormats.append(ql.dateFormat(QLocale::LongFormat));
+    dateFormats.removeDuplicates();
+    timeFormats.append(ql.timeFormat());
+    timeFormats.append(ql.timeFormat(QLocale::LongFormat));
+    timeFormats.removeDuplicates();
+
+    for (QString datestamp : dateFormats)
+        datestamps << QString("%1 - %2").arg(datestamp, QDate::currentDate().toString(datestamp));
+
+    bodyUI->dateFormats->addItems(datestamps);
+    bodyUI->timestamp->setCurrentText(QString("%1 - %2").arg(s.getTimestampFormat(), QTime::currentTime().toString(s.getTimestampFormat())));
+    bodyUI->dateFormats->setCurrentText(QString("%1 - %2").arg(s.getDateFormat(), QDate::currentDate().toString(s.getDateFormat())));
+
+    // Chat
+    connect(bodyUI->textStyleComboBox, &QComboBox::currentTextChanged, this, &UserInterfaceForm::onStyleUpdated);
+
+    connect(bodyUI->showWindow, &QCheckBox::stateChanged, this, &UserInterfaceForm::onShowWindowChanged);
+    connect(bodyUI->showInFront, &QCheckBox::stateChanged, this, &UserInterfaceForm::onSetShowInFront);
+
+    connect(bodyUI->groupAlwaysNotify, &QCheckBox::stateChanged, this, &UserInterfaceForm::onSetGroupAlwaysNotify);
+    connect(bodyUI->cbGroupchatPosition, &QCheckBox::stateChanged, this, &UserInterfaceForm::onGroupchatPositionChanged);
+    connect(bodyUI->cbCompactLayout, &QCheckBox::stateChanged, this, &UserInterfaceForm::onCompactLayout);
+
+    connect(bodyUI->cbDontGroupWindows, &QCheckBox::stateChanged, this, &UserInterfaceForm::onDontGroupWindowsChanged);
+    connect(bodyUI->cbSeparateWindow, &QCheckBox::stateChanged, this, &UserInterfaceForm::onSeparateWindowChanged);
+
+    // Theme
+    void (QComboBox::* currentIndexChanged)(int) = &QComboBox::currentIndexChanged;
+    connect(bodyUI->useEmoticons, &QCheckBox::stateChanged, this, &UserInterfaceForm::onUseEmoticonsChange);
+    connect(bodyUI->smileyPackBrowser, currentIndexChanged, this, &UserInterfaceForm::onSmileyBrowserIndexChanged);
+    connect(bodyUI->styleBrowser, &QComboBox::currentTextChanged, this, &UserInterfaceForm::onStyleSelected);
+    connect(bodyUI->themeColorCBox, currentIndexChanged, this, &UserInterfaceForm::onThemeColorChanged);
+    connect(bodyUI->emoticonSize, &QSpinBox::editingFinished, this, &UserInterfaceForm::onEmoticonSizeChanged);
+    connect(bodyUI->timestamp, currentIndexChanged, this, &UserInterfaceForm::onTimestampSelected);
+    connect(bodyUI->dateFormats, currentIndexChanged, this, &UserInterfaceForm::onDateFormatSelected);
+
+
+    // prevent stealing mouse wheel scroll
+    // scrolling event won't be transmitted to comboboxes or qspinboxes when scrolling
+    // you can scroll through general settings without accidentially changing theme/skin/icons etc.
+    // @see UserInterfaceForm::eventFilter(QObject *o, QEvent *e) at the bottom of this file for more
+    for (QComboBox *cb : findChildren<QComboBox*>())
+    {
+        cb->installEventFilter(this);
+        cb->setFocusPolicy(Qt::StrongFocus);
+    }
+
+    for (QSpinBox *sp : findChildren<QSpinBox*>())
+    {
+        sp->installEventFilter(this);
+        sp->setFocusPolicy(Qt::WheelFocus);
+    }
+
+    for (QCheckBox *cb : findChildren<QCheckBox*>()) // this one is to allow scrolling on checkboxes
+    {
+        cb->installEventFilter(this);
+    }
+
+    Translator::registerHandler(std::bind(&UserInterfaceForm::retranslateUi, this), this);
+}
+
+UserInterfaceForm::~UserInterfaceForm()
+{
+    Translator::unregister(this);
+    delete bodyUI;
+}
+
+void UserInterfaceForm::onStyleSelected(QString style)
+{
+    if (bodyUI->styleBrowser->currentIndex() == 0)
+        Settings::getInstance().setStyle("None");
+    else
+        Settings::getInstance().setStyle(style);
+
+    this->setStyle(QStyleFactory::create(style));
+    parent->setBodyHeadStyle(style);
+}
+
+void UserInterfaceForm::onEmoticonSizeChanged()
+{
+    Settings::getInstance().setEmojiFontPointSize(bodyUI->emoticonSize->value());
+}
+
+void UserInterfaceForm::onTimestampSelected(int index)
+{
+    Settings::getInstance().setTimestampFormat(timeFormats.at(index));
+    Translator::translate();
+}
+
+void UserInterfaceForm::onDateFormatSelected(int index)
+{
+    Settings::getInstance().setDateFormat(dateFormats.at(index));
+    Translator::translate();
+}
+
+void UserInterfaceForm::onUseEmoticonsChange()
+{
+    Settings::getInstance().setUseEmoticons(bodyUI->useEmoticons->isChecked());
+    bodyUI->smileyPackBrowser->setEnabled(bodyUI->useEmoticons->isChecked());
+}
+
+void UserInterfaceForm::onStyleUpdated()
+{
+    Settings::StyleType styleType =
+            static_cast<Settings::StyleType>(bodyUI->textStyleComboBox->currentIndex());
+    Settings::getInstance().setStylePreference(styleType);
+}
+
+void UserInterfaceForm::onSmileyBrowserIndexChanged(int index)
+{
+    QString filename = bodyUI->smileyPackBrowser->itemData(index).toString();
+    Settings::getInstance().setSmileyPack(filename);
+    reloadSmiles();
+}
+
+/**
+ * @brief Reload smiles and size information.
+ */
+void UserInterfaceForm::reloadSmiles()
+{
+    QList<QStringList> emoticons = SmileyPack::getInstance().getEmoticons();
+
+    // sometimes there are no emoticons available, don't crash in this case
+    if (emoticons.isEmpty())
+    {
+        qDebug() << "reloadSmilies: No emoticons found";
+        return;
+    }
+
+    QStringList smiles;
+    for (int i = 0; i < emoticons.size(); i++)
+        smiles.push_front(emoticons.at(i).first());
+
+    const QSize size(18,18);
+    for (int i = 0; i < smileLabels.size(); i++)
+    {
+        QIcon icon = SmileyPack::getInstance().getAsIcon(smiles[i]);
+        smileLabels[i]->setPixmap(icon.pixmap(size));
+        smileLabels[i]->setToolTip(smiles[i]);
+    }
+
+    //set maximum size of emoji
+    QDesktopWidget desktop;
+    // 8 is the count of row and column in emoji's in widget
+    const int sideSize = 8;
+    int maxSide = qMin(desktop.geometry().height() / sideSize,
+                       desktop.geometry().width() / sideSize);
+    QSize maxSize(maxSide, maxSide);
+
+    QIcon icon = SmileyPack::getInstance().getAsIcon(smiles[0]);
+    QSize actualSize = icon.actualSize(maxSize);
+    bodyUI->emoticonSize->setMaximum(actualSize.width());
+}
+
+void UserInterfaceForm::onShowWindowChanged()
+{
+    Settings::getInstance().setShowWindow(bodyUI->showWindow->isChecked());
+}
+
+void UserInterfaceForm::onSetShowInFront()
+{
+    Settings::getInstance().setShowInFront(bodyUI->showInFront->isChecked());
+}
+
+void UserInterfaceForm::onSetGroupAlwaysNotify()
+{
+    Settings::getInstance().setGroupAlwaysNotify(bodyUI->groupAlwaysNotify->isChecked());
+}
+
+void UserInterfaceForm::onCompactLayout()
+{
+    Settings::getInstance().setCompactLayout(bodyUI->cbCompactLayout->isChecked());
+}
+
+void UserInterfaceForm::onSeparateWindowChanged()
+{
+    bool checked = bodyUI->cbSeparateWindow->isChecked();
+    bodyUI->cbDontGroupWindows->setEnabled(checked);
+    Settings::getInstance().setSeparateWindow(checked);
+}
+
+void UserInterfaceForm::onDontGroupWindowsChanged()
+{
+    Settings::getInstance().setDontGroupWindows(bodyUI->cbDontGroupWindows->isChecked());
+}
+
+void UserInterfaceForm::onGroupchatPositionChanged()
+{
+    Settings::getInstance().setGroupchatPosition(bodyUI->cbGroupchatPosition->isChecked());
+}
+
+void UserInterfaceForm::onThemeColorChanged(int)
+{
+    int index = bodyUI->themeColorCBox->currentIndex();
+    Settings::getInstance().setThemeColor(index);
+    Style::setThemeColor(index);
+    Style::applyTheme();
+}
+
+/**
+ * @brief Retranslate all elements on the form.
+ */
+void UserInterfaceForm::retranslateUi()
+{
+    bodyUI->retranslateUi(this);
+
+    QStringList colorThemes(Style::getThemeColorNames());
+    for (int i = 0; i < colorThemes.size(); ++i)
+    {
+        bodyUI->themeColorCBox->setItemText(i, colorThemes[i]);
+    }
+
+    bodyUI->styleBrowser->setItemText(0, tr("None"));
+}
+
+void UserInterfaceForm::on_txtChatFont_currentFontChanged(const QFont& f)
+{
+    QFont tmpFont = f;
+    const int px = bodyUI->txtChatFontSize->value();
+
+    if (QFontInfo(tmpFont).pixelSize() != px)
+        tmpFont.setPixelSize(px);
+
+    Settings::getInstance().setChatMessageFont(tmpFont);
+}
+
+void UserInterfaceForm::on_txtChatFontSize_valueChanged(int px)
+{
+    Settings& s = Settings::getInstance();
+    QFont tmpFont = s.getChatMessageFont();
+    const int fontSize = QFontInfo(tmpFont).pixelSize();
+
+    if (px != fontSize)
+    {
+        tmpFont.setPixelSize(px);
+        s.setChatMessageFont(tmpFont);
+    }
+}
+
+bool UserInterfaceForm::eventFilter(QObject *o, QEvent *e)
+{
+    if ((e->type() == QEvent::Wheel) &&
+         (qobject_cast<QComboBox*>(o) || qobject_cast<QAbstractSpinBox*>(o) || qobject_cast<QCheckBox*>(o)))
+    {
+        e->ignore();
+        return true;
+    }
+    return QWidget::eventFilter(o, e);
+}

--- a/src/widget/form/settings/userinterfaceform.cpp
+++ b/src/widget/form/settings/userinterfaceform.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2014-2015 by The qTox Project
+    Copyright © 2014-2016 by The qTox Project
 
     This file is part of qTox, a Qt-based graphical interface for Tox.
 
@@ -56,10 +56,10 @@ static QStringList timeFormats = {"hh:mm AP", "hh:mm", "hh:mm:ss AP", "hh:mm:ss"
 static QStringList dateFormats = {"yyyy-MM-dd", "dd-MM-yyyy", "d-MM-yyyy", "dddd d-MM-yyyy", "dddd d-MM", "dddd dd MMMM"};
 
 /**
- * @brief UserInterfaceForm::UserInterfaceForm
+ * @brief Constructor of UserInterfaceForm.
  * @param myParent Setting widget which will contain this form as tab.
  *
- * Constructor of UserInterfaceForm. Restores all controls from the settings.
+ * Restores all controls from the settings.
  */
 UserInterfaceForm::UserInterfaceForm(SettingsWidget* myParent) :
     GenericForm(QPixmap(":/img/settings/general.png"))
@@ -288,7 +288,7 @@ void UserInterfaceForm::on_themeColorCBox_currentIndexChanged(int)
 }
 
 /**
- * @brief Retranslate all elements on the form.
+ * @brief Retranslate all elements in the form.
  */
 void UserInterfaceForm::retranslateUi()
 {

--- a/src/widget/form/settings/userinterfaceform.cpp
+++ b/src/widget/form/settings/userinterfaceform.cpp
@@ -143,30 +143,6 @@ UserInterfaceForm::UserInterfaceForm(SettingsWidget* myParent) :
     bodyUI->timestamp->setCurrentText(QString("%1 - %2").arg(s.getTimestampFormat(), QTime::currentTime().toString(s.getTimestampFormat())));
     bodyUI->dateFormats->setCurrentText(QString("%1 - %2").arg(s.getDateFormat(), QDate::currentDate().toString(s.getDateFormat())));
 
-    // Chat
-    connect(bodyUI->textStyleComboBox, &QComboBox::currentTextChanged, this, &UserInterfaceForm::onStyleUpdated);
-
-    connect(bodyUI->showWindow, &QCheckBox::stateChanged, this, &UserInterfaceForm::onShowWindowChanged);
-    connect(bodyUI->showInFront, &QCheckBox::stateChanged, this, &UserInterfaceForm::onSetShowInFront);
-
-    connect(bodyUI->groupAlwaysNotify, &QCheckBox::stateChanged, this, &UserInterfaceForm::onSetGroupAlwaysNotify);
-    connect(bodyUI->cbGroupchatPosition, &QCheckBox::stateChanged, this, &UserInterfaceForm::onGroupchatPositionChanged);
-    connect(bodyUI->cbCompactLayout, &QCheckBox::stateChanged, this, &UserInterfaceForm::onCompactLayout);
-
-    connect(bodyUI->cbDontGroupWindows, &QCheckBox::stateChanged, this, &UserInterfaceForm::onDontGroupWindowsChanged);
-    connect(bodyUI->cbSeparateWindow, &QCheckBox::stateChanged, this, &UserInterfaceForm::onSeparateWindowChanged);
-
-    // Theme
-    void (QComboBox::* currentIndexChanged)(int) = &QComboBox::currentIndexChanged;
-    connect(bodyUI->useEmoticons, &QCheckBox::stateChanged, this, &UserInterfaceForm::onUseEmoticonsChange);
-    connect(bodyUI->smileyPackBrowser, currentIndexChanged, this, &UserInterfaceForm::onSmileyBrowserIndexChanged);
-    connect(bodyUI->styleBrowser, &QComboBox::currentTextChanged, this, &UserInterfaceForm::onStyleSelected);
-    connect(bodyUI->themeColorCBox, currentIndexChanged, this, &UserInterfaceForm::onThemeColorChanged);
-    connect(bodyUI->emoticonSize, &QSpinBox::editingFinished, this, &UserInterfaceForm::onEmoticonSizeChanged);
-    connect(bodyUI->timestamp, currentIndexChanged, this, &UserInterfaceForm::onTimestampSelected);
-    connect(bodyUI->dateFormats, currentIndexChanged, this, &UserInterfaceForm::onDateFormatSelected);
-
-
     eventsInit();
     Translator::registerHandler(std::bind(&UserInterfaceForm::retranslateUi, this), this);
 }
@@ -177,7 +153,7 @@ UserInterfaceForm::~UserInterfaceForm()
     delete bodyUI;
 }
 
-void UserInterfaceForm::onStyleSelected(QString style)
+void UserInterfaceForm::on_styleBrowser_currentIndexChanged(QString style)
 {
     if (bodyUI->styleBrowser->currentIndex() == 0)
         Settings::getInstance().setStyle("None");
@@ -188,37 +164,37 @@ void UserInterfaceForm::onStyleSelected(QString style)
     parent->setBodyHeadStyle(style);
 }
 
-void UserInterfaceForm::onEmoticonSizeChanged()
+void UserInterfaceForm::on_emoticonSize_editingFinished()
 {
     Settings::getInstance().setEmojiFontPointSize(bodyUI->emoticonSize->value());
 }
 
-void UserInterfaceForm::onTimestampSelected(int index)
+void UserInterfaceForm::on_timestamp_currentIndexChanged(int index)
 {
     Settings::getInstance().setTimestampFormat(timeFormats.at(index));
     Translator::translate();
 }
 
-void UserInterfaceForm::onDateFormatSelected(int index)
+void UserInterfaceForm::on_dateFormats_currentIndexChanged(int index)
 {
     Settings::getInstance().setDateFormat(dateFormats.at(index));
     Translator::translate();
 }
 
-void UserInterfaceForm::onUseEmoticonsChange()
+void UserInterfaceForm::on_useEmoticons_stateChanged()
 {
     Settings::getInstance().setUseEmoticons(bodyUI->useEmoticons->isChecked());
     bodyUI->smileyPackBrowser->setEnabled(bodyUI->useEmoticons->isChecked());
 }
 
-void UserInterfaceForm::onStyleUpdated()
+void UserInterfaceForm::on_textStyleComboBox_currentTextChanged()
 {
     Settings::StyleType styleType =
             static_cast<Settings::StyleType>(bodyUI->textStyleComboBox->currentIndex());
     Settings::getInstance().setStylePreference(styleType);
 }
 
-void UserInterfaceForm::onSmileyBrowserIndexChanged(int index)
+void UserInterfaceForm::on_smileyPackBrowser_currentIndexChanged(int index)
 {
     QString filename = bodyUI->smileyPackBrowser->itemData(index).toString();
     Settings::getInstance().setSmileyPack(filename);
@@ -264,44 +240,46 @@ void UserInterfaceForm::reloadSmiles()
     bodyUI->emoticonSize->setMaximum(actualSize.width());
 }
 
-void UserInterfaceForm::onShowWindowChanged()
+void UserInterfaceForm::on_showWindow_stateChanged()
 {
-    Settings::getInstance().setShowWindow(bodyUI->showWindow->isChecked());
+    bool isChecked = bodyUI->showWindow->isChecked();
+    Settings::getInstance().setShowWindow(isChecked);
+    bodyUI->showInFront->setEnabled(isChecked);
 }
 
-void UserInterfaceForm::onSetShowInFront()
+void UserInterfaceForm::on_showInFront_stateChanged()
 {
     Settings::getInstance().setShowInFront(bodyUI->showInFront->isChecked());
 }
 
-void UserInterfaceForm::onSetGroupAlwaysNotify()
+void UserInterfaceForm::on_groupAlwaysNotify_stateChanged()
 {
     Settings::getInstance().setGroupAlwaysNotify(bodyUI->groupAlwaysNotify->isChecked());
 }
 
-void UserInterfaceForm::onCompactLayout()
+void UserInterfaceForm::on_cbCompactLayout_stateChanged()
 {
     Settings::getInstance().setCompactLayout(bodyUI->cbCompactLayout->isChecked());
 }
 
-void UserInterfaceForm::onSeparateWindowChanged()
+void UserInterfaceForm::on_cbSeparateWindow_stateChanged()
 {
     bool checked = bodyUI->cbSeparateWindow->isChecked();
     bodyUI->cbDontGroupWindows->setEnabled(checked);
     Settings::getInstance().setSeparateWindow(checked);
 }
 
-void UserInterfaceForm::onDontGroupWindowsChanged()
+void UserInterfaceForm::on_cbDontGroupWindows_stateChanged()
 {
     Settings::getInstance().setDontGroupWindows(bodyUI->cbDontGroupWindows->isChecked());
 }
 
-void UserInterfaceForm::onGroupchatPositionChanged()
+void UserInterfaceForm::on_cbGroupchatPosition_stateChanged()
 {
     Settings::getInstance().setGroupchatPosition(bodyUI->cbGroupchatPosition->isChecked());
 }
 
-void UserInterfaceForm::onThemeColorChanged(int)
+void UserInterfaceForm::on_themeColorCBox_currentIndexChanged(int)
 {
     int index = bodyUI->themeColorCBox->currentIndex();
     Settings::getInstance().setThemeColor(index);

--- a/src/widget/form/settings/userinterfaceform.cpp
+++ b/src/widget/form/settings/userinterfaceform.cpp
@@ -101,7 +101,7 @@ UserInterfaceForm::UserInterfaceForm(SettingsWidget* myParent) :
 
     int currentPack = bodyUI->smileyPackBrowser->findData(s.getSmileyPack());
     bodyUI->smileyPackBrowser->setCurrentIndex(currentPack);
-    reloadSmiles();
+    reloadSmileys();
     bodyUI->smileyPackBrowser->setEnabled(bodyUI->useEmoticons->isChecked());
 
     bodyUI->styleBrowser->addItem(tr("None"));
@@ -198,13 +198,13 @@ void UserInterfaceForm::on_smileyPackBrowser_currentIndexChanged(int index)
 {
     QString filename = bodyUI->smileyPackBrowser->itemData(index).toString();
     Settings::getInstance().setSmileyPack(filename);
-    reloadSmiles();
+    reloadSmileys();
 }
 
 /**
- * @brief Reload smiles and size information.
+ * @brief Reload smileys and size information.
  */
-void UserInterfaceForm::reloadSmiles()
+void UserInterfaceForm::reloadSmileys()
 {
     QList<QStringList> emoticons = SmileyPack::getInstance().getEmoticons();
 
@@ -215,16 +215,16 @@ void UserInterfaceForm::reloadSmiles()
         return;
     }
 
-    QStringList smiles;
+    QStringList smileys;
     for (int i = 0; i < emoticons.size(); i++)
-        smiles.push_front(emoticons.at(i).first());
+        smileys.push_front(emoticons.at(i).first());
 
     const QSize size(18,18);
     for (int i = 0; i < smileLabels.size(); i++)
     {
-        QIcon icon = SmileyPack::getInstance().getAsIcon(smiles[i]);
+        QIcon icon = SmileyPack::getInstance().getAsIcon(smileys[i]);
         smileLabels[i]->setPixmap(icon.pixmap(size));
-        smileLabels[i]->setToolTip(smiles[i]);
+        smileLabels[i]->setToolTip(smileys[i]);
     }
 
     //set maximum size of emoji
@@ -235,7 +235,7 @@ void UserInterfaceForm::reloadSmiles()
                        desktop.geometry().width() / sideSize);
     QSize maxSize(maxSide, maxSide);
 
-    QIcon icon = SmileyPack::getInstance().getAsIcon(smiles[0]);
+    QIcon icon = SmileyPack::getInstance().getAsIcon(smileys[0]);
     QSize actualSize = icon.actualSize(maxSize);
     bodyUI->emoticonSize->setMaximum(actualSize.width());
 }

--- a/src/widget/form/settings/userinterfaceform.cpp
+++ b/src/widget/form/settings/userinterfaceform.cpp
@@ -167,27 +167,7 @@ UserInterfaceForm::UserInterfaceForm(SettingsWidget* myParent) :
     connect(bodyUI->dateFormats, currentIndexChanged, this, &UserInterfaceForm::onDateFormatSelected);
 
 
-    // prevent stealing mouse wheel scroll
-    // scrolling event won't be transmitted to comboboxes or qspinboxes when scrolling
-    // you can scroll through general settings without accidentially changing theme/skin/icons etc.
-    // @see UserInterfaceForm::eventFilter(QObject *o, QEvent *e) at the bottom of this file for more
-    for (QComboBox *cb : findChildren<QComboBox*>())
-    {
-        cb->installEventFilter(this);
-        cb->setFocusPolicy(Qt::StrongFocus);
-    }
-
-    for (QSpinBox *sp : findChildren<QSpinBox*>())
-    {
-        sp->installEventFilter(this);
-        sp->setFocusPolicy(Qt::WheelFocus);
-    }
-
-    for (QCheckBox *cb : findChildren<QCheckBox*>()) // this one is to allow scrolling on checkboxes
-    {
-        cb->installEventFilter(this);
-    }
-
+    eventsInit();
     Translator::registerHandler(std::bind(&UserInterfaceForm::retranslateUi, this), this);
 }
 
@@ -367,15 +347,4 @@ void UserInterfaceForm::on_txtChatFontSize_valueChanged(int px)
         tmpFont.setPixelSize(px);
         s.setChatMessageFont(tmpFont);
     }
-}
-
-bool UserInterfaceForm::eventFilter(QObject *o, QEvent *e)
-{
-    if ((e->type() == QEvent::Wheel) &&
-         (qobject_cast<QComboBox*>(o) || qobject_cast<QAbstractSpinBox*>(o) || qobject_cast<QCheckBox*>(o)))
-    {
-        e->ignore();
-        return true;
-    }
-    return QWidget::eventFilter(o, e);
 }

--- a/src/widget/form/settings/userinterfaceform.h
+++ b/src/widget/form/settings/userinterfaceform.h
@@ -63,9 +63,6 @@ private:
     QList<QLabel*> smileLabels;
     SettingsWidget* parent;
     Ui::UserInterfaceSettings *bodyUI;
-
-protected:
-    bool eventFilter(QObject *o, QEvent *e) final override;
 };
 
 #endif

--- a/src/widget/form/settings/userinterfaceform.h
+++ b/src/widget/form/settings/userinterfaceform.h
@@ -36,24 +36,25 @@ public:
     virtual QString getFormName() final override {return tr("User Interface");}
 
 private slots:
-    void onSmileyBrowserIndexChanged(int index);
-    void onEmoticonSizeChanged();
-    void onStyleSelected(QString style);
-    void onTimestampSelected(int index);
-    void onDateFormatSelected(int index);
-    void onStyleUpdated();
-    void onUseEmoticonsChange();
-    void onShowWindowChanged();
-    void onSetShowInFront();
-    void onSetGroupAlwaysNotify();
-    void onCompactLayout();
-    void onSeparateWindowChanged();
-    void onDontGroupWindowsChanged();
-    void onGroupchatPositionChanged();
-    void onThemeColorChanged(int);
+    void on_smileyPackBrowser_currentIndexChanged(int index);
+    void on_emoticonSize_editingFinished();
+    void on_styleBrowser_currentIndexChanged(QString style);
+    void on_timestamp_currentIndexChanged(int index);
+    void on_dateFormats_currentIndexChanged(int index);
+    void on_textStyleComboBox_currentTextChanged();
+    void on_useEmoticons_stateChanged();
+    void on_showWindow_stateChanged();
+    void on_showInFront_stateChanged();
+    void on_groupAlwaysNotify_stateChanged();
+    void on_cbCompactLayout_stateChanged();
+    void on_cbSeparateWindow_stateChanged();
+    void on_cbDontGroupWindows_stateChanged();
+    void on_cbGroupchatPosition_stateChanged();
+    void on_themeColorCBox_currentIndexChanged(int);
 
     void on_txtChatFont_currentFontChanged(const QFont& f);
     void on_txtChatFontSize_valueChanged(int arg1);
+
 
 private:
     void retranslateUi();

--- a/src/widget/form/settings/userinterfaceform.h
+++ b/src/widget/form/settings/userinterfaceform.h
@@ -58,7 +58,7 @@ private slots:
 
 private:
     void retranslateUi();
-    void reloadSmiles();
+    void reloadSmileys();
 
 private:
     QList<QLabel*> smileLabels;

--- a/src/widget/form/settings/userinterfaceform.h
+++ b/src/widget/form/settings/userinterfaceform.h
@@ -1,0 +1,71 @@
+/*
+    Copyright © 2014-2015 by The qTox Project
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef USERINTERFACEFORM_H
+#define USERINTERFACEFORM_H
+
+#include "genericsettings.h"
+#include "src/widget/form/settingswidget.h"
+
+namespace Ui {
+class UserInterfaceSettings;
+}
+
+class UserInterfaceForm : public GenericForm
+{
+    Q_OBJECT
+public:
+    explicit UserInterfaceForm(SettingsWidget* myParent);
+    ~UserInterfaceForm();
+    virtual QString getFormName() final override {return tr("User Interface");}
+
+private slots:
+    void onSmileyBrowserIndexChanged(int index);
+    void onEmoticonSizeChanged();
+    void onStyleSelected(QString style);
+    void onTimestampSelected(int index);
+    void onDateFormatSelected(int index);
+    void onStyleUpdated();
+    void onUseEmoticonsChange();
+    void onShowWindowChanged();
+    void onSetShowInFront();
+    void onSetGroupAlwaysNotify();
+    void onCompactLayout();
+    void onSeparateWindowChanged();
+    void onDontGroupWindowsChanged();
+    void onGroupchatPositionChanged();
+    void onThemeColorChanged(int);
+
+    void on_txtChatFont_currentFontChanged(const QFont& f);
+    void on_txtChatFontSize_valueChanged(int arg1);
+
+private:
+    void retranslateUi();
+    void reloadSmiles();
+
+private:
+    QList<QLabel*> smileLabels;
+    SettingsWidget* parent;
+    Ui::UserInterfaceSettings *bodyUI;
+
+protected:
+    bool eventFilter(QObject *o, QEvent *e) final override;
+};
+
+#endif

--- a/src/widget/form/settings/userinterfacesettings.ui
+++ b/src/widget/form/settings/userinterfacesettings.ui
@@ -1,0 +1,518 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>UserInterfaceSettings</class>
+ <widget class="QWidget" name="UserInterfaceSettings">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>1312</width>
+    <height>1025</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string notr="true">Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <property name="leftMargin">
+    <number>9</number>
+   </property>
+   <property name="topMargin">
+    <number>9</number>
+   </property>
+   <property name="rightMargin">
+    <number>9</number>
+   </property>
+   <property name="bottomMargin">
+    <number>9</number>
+   </property>
+   <item>
+    <widget class="VerticalOnlyScroller" name="scrollArea">
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>1290</width>
+        <height>1003</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,0,0,0,0">
+       <property name="spacing">
+        <number>32</number>
+       </property>
+       <property name="topMargin">
+        <number>9</number>
+       </property>
+       <item>
+        <widget class="QGroupBox" name="formGroupBox_2">
+         <property name="title">
+          <string>Chat</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_2">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string>Base font:</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QFontComboBox" name="txtChatFont"/>
+          </item>
+          <item row="0" column="2">
+           <widget class="QSpinBox" name="txtChatFontSize">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="suffix">
+             <string>px</string>
+            </property>
+            <property name="prefix">
+             <string>Size: </string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="textStyleLabel">
+            <property name="toolTip">
+             <string>New text styling preference may not load until qTox restarts.</string>
+            </property>
+            <property name="text">
+             <string>Text Style format:</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="3">
+           <spacer name="horizontalSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="1" column="3">
+           <spacer name="generalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="1" column="1" colspan="2">
+           <widget class="QComboBox" name="textStyleComboBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="toolTip">
+             <string>Select text styling preference.</string>
+            </property>
+            <property name="currentIndex">
+             <number>1</number>
+            </property>
+            <item>
+             <property name="text">
+              <string>Plaintext</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Show formatting characters</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Don't show formatting characters</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="newMessageGroup">
+         <property name="title">
+          <string>New message</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_10">
+          <item>
+           <widget class="QCheckBox" name="showWindow">
+            <property name="toolTip">
+             <string comment="tooltip for Show window setting">Open qTox's window when you receive a new message and no window is open yet.</string>
+            </property>
+            <property name="text">
+             <string>Open window</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QVBoxLayout" name="verticalLayout_15">
+            <property name="leftMargin">
+             <number>40</number>
+            </property>
+            <item>
+             <widget class="QCheckBox" name="showInFront">
+              <property name="toolTip">
+               <string comment="toolTip for Focus window setting">Focus qTox when you receive message.</string>
+              </property>
+              <property name="text">
+               <string>Focus window</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="contactListGroup">
+         <property name="title">
+          <string>Contact list</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_5">
+          <item>
+           <widget class="QCheckBox" name="groupAlwaysNotify">
+            <property name="toolTip">
+             <string comment="toolTip for Group chat always notify">Always notify about new messages in groupchats.</string>
+            </property>
+            <property name="text">
+             <string>Group chats always notify</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="cbGroupchatPosition">
+            <property name="toolTip">
+             <string comment="toolTip for groupchat positioning">If checked, groupchats will be placed at the top of the friends list, otherwise, they'll be placed below online friends.</string>
+            </property>
+            <property name="text">
+             <string>Place groupchats at top of friend list</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="cbCompactLayout">
+            <property name="toolTip">
+             <string comment="toolTip for compact layout setting">Your contact list will be shown in compact mode.</string>
+            </property>
+            <property name="text">
+             <string>Compact contact list</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="cbSeparateWindow">
+            <property name="text">
+             <string>Multiple windows mode</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QVBoxLayout" name="verticalLayout_12">
+            <property name="leftMargin">
+             <number>40</number>
+            </property>
+            <item>
+             <widget class="QCheckBox" name="cbDontGroupWindows">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Open each chat in an individual window</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="formGroupBox">
+         <property name="title">
+          <string>Emoticons</string>
+         </property>
+         <layout class="QFormLayout" name="formLayout_4">
+          <item row="0" column="0">
+           <widget class="QCheckBox" name="useEmoticons">
+            <property name="text">
+             <string>Use emoticons</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="smileyPackLabel">
+            <property name="text">
+             <string extracomment="Text on smiley pack label">Smiley Pack:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QComboBox" name="smileyPackBrowser">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <spacer name="horizontalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>80</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="2" column="1">
+           <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0,0,0">
+            <property name="sizeConstraint">
+             <enum>QLayout::SetDefaultConstraint</enum>
+            </property>
+            <item>
+             <widget class="QLabel" name="smile1">
+              <property name="toolTip">
+               <string notr="true">:)</string>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="smile2">
+              <property name="toolTip">
+               <string notr="true">;)</string>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="smile3">
+              <property name="toolTip">
+               <string notr="true">:p</string>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="smile4">
+              <property name="toolTip">
+               <string notr="true">:O</string>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item alignment="Qt::AlignTop">
+             <widget class="QLabel" name="smile5">
+              <property name="toolTip">
+               <string notr="true">:'(</string>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignCenter</set>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="emoticonSizeLabel">
+            <property name="text">
+             <string>Emoticon size:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QSpinBox" name="emoticonSize">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="specialValueText">
+             <string/>
+            </property>
+            <property name="suffix">
+             <string> px</string>
+            </property>
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>2147483647</number>
+            </property>
+            <property name="value">
+             <number>25</number>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBox">
+         <property name="title">
+          <string>Theme</string>
+         </property>
+         <layout class="QFormLayout" name="formLayout">
+          <property name="fieldGrowthPolicy">
+           <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+          </property>
+          <property name="topMargin">
+           <number>1</number>
+          </property>
+          <property name="bottomMargin">
+           <number>1</number>
+          </property>
+          <item row="3" column="0">
+           <widget class="QLabel" name="styleLabel">
+            <property name="text">
+             <string>Style:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QComboBox" name="styleBrowser">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="themeColorLabel">
+            <property name="text">
+             <string>Theme color:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QComboBox" name="themeColorCBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="timestampLabel">
+            <property name="text">
+             <string>Timestamp format:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QComboBox" name="timestamp">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0">
+           <widget class="QLabel" name="dateformatLabel">
+            <property name="text">
+             <string>Date format:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="1">
+           <widget class="QComboBox" name="dateFormats"/>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>VerticalOnlyScroller</class>
+   <extends>QScrollArea</extends>
+   <header>src/widget/form/settings/verticalonlyscroller.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>scrollArea</tabstop>
+  <tabstop>styleBrowser</tabstop>
+  <tabstop>themeColorCBox</tabstop>
+  <tabstop>timestamp</tabstop>
+  <tabstop>dateFormats</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/widget/form/settingswidget.cpp
+++ b/src/widget/form/settingswidget.cpp
@@ -18,18 +18,21 @@
 */
 
 #include "settingswidget.h"
-#include "src/widget/widget.h"
+
+#include <QTabWidget>
+#include <QLabel>
+#include <QWindow>
+
 #include "src/video/camerasource.h"
+#include "src/widget/widget.h"
 #include "src/widget/form/settings/generalform.h"
+#include "src/widget/form/settings/userinterfaceform.h"
 #include "src/widget/form/settings/privacyform.h"
 #include "src/widget/form/settings/avform.h"
 #include "src/widget/form/settings/advancedform.h"
 #include "src/widget/form/settings/aboutform.h"
 #include "src/widget/translator.h"
 #include "src/widget/contentlayout.h"
-#include <QTabWidget>
-#include <QLabel>
-#include <QWindow>
 
 SettingsWidget::SettingsWidget(QWidget* parent)
     : QWidget(parent, Qt::Window)
@@ -61,12 +64,13 @@ SettingsWidget::SettingsWidget(QWidget* parent)
     bodyLayout->addWidget(settingsWidgets);
 
     GeneralForm* gfrm = new GeneralForm(this);
-    PrivacyForm* pfrm = new PrivacyForm;
-    AVForm* avfrm = new AVForm;
-    AdvancedForm *expfrm = new AdvancedForm;
-    AboutForm *abtfrm = new AboutForm;
+    UserInterfaceForm* uifrm = new UserInterfaceForm(this);
+    PrivacyForm* pfrm = new PrivacyForm();
+    AVForm* avfrm = new AVForm();
+    AdvancedForm *expfrm = new AdvancedForm();
+    AboutForm *abtfrm = new AboutForm();
 
-    cfgForms = {{ gfrm, pfrm, avfrm, expfrm, abtfrm }};
+    cfgForms = {{ gfrm, uifrm, pfrm, avfrm, expfrm, abtfrm }};
     for (GenericForm* cfgForm : cfgForms)
         settingsWidgets->addTab(cfgForm, cfgForm->getFormIcon(), cfgForm->getFormName());
 

--- a/src/widget/form/settingswidget.cpp
+++ b/src/widget/form/settingswidget.cpp
@@ -40,27 +40,10 @@ SettingsWidget::SettingsWidget(QWidget* parent)
     // block all signals during initialization, including child widgets
     blockSignals(true);
 
-    body = new QWidget();
     QVBoxLayout* bodyLayout = new QVBoxLayout();
-    body->setLayout(bodyLayout);
-
-    head = new QWidget(this);
-    QHBoxLayout* headLayout = new QHBoxLayout();
-    head->setLayout(headLayout);
-
-    imgLabel = new QLabel();
-    headLayout->addWidget(imgLabel);
-
-    nameLabel = new QLabel();
-    QFont bold;
-    bold.setBold(true);
-    nameLabel->setFont(bold);
-    headLayout->addWidget(nameLabel);
-    headLayout->addStretch(1);
 
     settingsWidgets = new QTabWidget(this);
     settingsWidgets->setTabPosition(QTabWidget::North);
-
     bodyLayout->addWidget(settingsWidgets);
 
     GeneralForm* gfrm = new GeneralForm(this);
@@ -88,8 +71,7 @@ SettingsWidget::~SettingsWidget()
 
 void SettingsWidget::setBodyHeadStyle(QString style)
 {
-    head->setStyle(QStyleFactory::create(style));
-    body->setStyle(QStyleFactory::create(style));
+    settingsWidgets->setStyle(QStyleFactory::create(style));
 }
 
 void SettingsWidget::showAbout()
@@ -99,9 +81,9 @@ void SettingsWidget::showAbout()
 
 bool SettingsWidget::isShown() const
 {
-    if (body->isVisible())
+    if (settingsWidgets->isVisible())
     {
-        body->window()->windowHandle()->alert(0);
+        settingsWidgets->window()->windowHandle()->alert(0);
         return true;
     }
 
@@ -110,25 +92,18 @@ bool SettingsWidget::isShown() const
 
 void SettingsWidget::show(ContentLayout* contentLayout)
 {
-    contentLayout->mainContent->layout()->addWidget(body);
-    contentLayout->mainHead->layout()->addWidget(head);
-    body->show();
-    head->show();
+    contentLayout->mainContent->layout()->addWidget(settingsWidgets);
+    settingsWidgets->show();
     onTabChanged(settingsWidgets->currentIndex());
 }
 
 void SettingsWidget::onTabChanged(int index)
 {
-    this->settingsWidgets->setCurrentIndex(index);
-    GenericForm* currentWidget = static_cast<GenericForm*>(this->settingsWidgets->widget(index));
-    nameLabel->setText(currentWidget->getFormName());
-    imgLabel->setPixmap(currentWidget->getFormIcon().scaledToHeight(40, Qt::SmoothTransformation));
+    settingsWidgets->setCurrentIndex(index);
 }
 
 void SettingsWidget::retranslateUi()
 {
-    GenericForm* currentWidget = static_cast<GenericForm*>(settingsWidgets->currentWidget());
-    nameLabel->setText(currentWidget->getFormName());
-    for (size_t i=0; i<cfgForms.size(); i++)
+    for (size_t i = 0; i < cfgForms.size(); i++)
         settingsWidgets->setTabText(i, cfgForms[i]->getFormName());
 }

--- a/src/widget/form/settingswidget.h
+++ b/src/widget/form/settingswidget.h
@@ -57,7 +57,7 @@ private:
     QWidget *head, *body;
     QTabWidget *settingsWidgets;
     QLabel *nameLabel, *imgLabel;
-    std::array<GenericForm*, 5> cfgForms;
+    std::array<GenericForm*, 6> cfgForms;
     int currentIndex;
 };
 

--- a/src/widget/form/settingswidget.h
+++ b/src/widget/form/settingswidget.h
@@ -54,9 +54,7 @@ private:
     void retranslateUi();
 
 private:
-    QWidget *head, *body;
     QTabWidget *settingsWidgets;
-    QLabel *nameLabel, *imgLabel;
     std::array<GenericForm*, 6> cfgForms;
     int currentIndex;
 };


### PR DESCRIPTION
Fix #1069.

Tasks:
- [x] Remove `Reset to default settings` from `Porable`
- [X] Add implemenation `Reset to default settings` // provided that user will be asked whether they want to restart in order to reset settings
- [X] Move `Show contacts`, `Faux Offline Messaging`, `Play sound` and `Play sound while Busy` in `General`

**General tab**
![spectacle i11800](https://cloud.githubusercontent.com/assets/6306608/16710228/60f94202-4638-11e6-93cf-26fe46c96b91.png)

**UI tab**
![spectacle w11800](https://cloud.githubusercontent.com/assets/6306608/16710230/708a4b26-4638-11e6-96c2-c35bf7180b77.png)

**Advanced tab**
![spectacle e11800](https://cloud.githubusercontent.com/assets/6306608/16710232/86ff294e-4638-11e6-8b52-688df3c774a7.png)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tux3/qtox/3457)

<!-- Reviewable:end -->
