### PR TITLE
feat(chatform): Disable call buttons if friend is offline

### DIFF
--- a/src/widget/form/chatform.h
+++ b/src/widget/form/chatform.h
@@ -77,6 +77,7 @@ private slots:
     void onMicMuteToggle();
     void onVolMuteToggle();
     void onFileSendFailed(uint32_t FriendId, const QString &fname);
+    void onFriendStatusChanged(uint32_t friendId, Status status);
     void onLoadHistory();
     void onUpdateTime();
     void onEnableCallButtons();


### PR DESCRIPTION
Call buttons would be enabled but non-functional if you were looking at a friend who was offline. We now check if the friend is offline and disable the call buttons if so. 

Closes #556
