### PR TITLE
fix chat base-font settings

### DIFF
--- a/src/widget/form/settings/generalform.cpp
+++ b/src/widget/form/settings/generalform.cpp
@@ -121,8 +121,9 @@ GeneralForm::GeneralForm(SettingsWidget *myParent) :
 
     bodyUI->transComboBox->setCurrentIndex(locales.indexOf(s.getTranslation()));
 
-    bodyUI->txtChatFont->setCurrentFont(s.getChatMessageFont());
-    bodyUI->txtChatFontSize->setValue(s.getChatMessageFont().pixelSize());
+    const QFont chatBaseFont = s.getChatMessageFont();
+    bodyUI->txtChatFontSize->setValue(QFontInfo(chatBaseFont).pixelSize());
+    bodyUI->txtChatFont->setCurrentFont(chatBaseFont);
     bodyUI->markdownComboBox->setCurrentIndex(s.getMarkdownPreference());
     bodyUI->cbAutorun->setChecked(s.getAutorun());
 

--- a/src/widget/form/settings/generalform.cpp
+++ b/src/widget/form/settings/generalform.cpp
@@ -581,22 +581,23 @@ void GeneralForm::retranslateUi()
 void GeneralForm::on_txtChatFont_currentFontChanged(const QFont& f)
 {
     QFont tmpFont = f;
-    const int fontSize = bodyUI->txtChatFontSize->value();
+    const int px = bodyUI->txtChatFontSize->value();
 
-    if (tmpFont.pixelSize() != fontSize)
-        tmpFont.setPixelSize(fontSize);
+    if (QFontInfo(tmpFont).pixelSize() != px)
+        tmpFont.setPixelSize(px);
 
     Settings::getInstance().setChatMessageFont(tmpFont);
 }
 
-void GeneralForm::on_txtChatFontSize_valueChanged(int arg1)
+void GeneralForm::on_txtChatFontSize_valueChanged(int px)
 {
     Settings& s = Settings::getInstance();
     QFont tmpFont = s.getChatMessageFont();
+    const int fontSize = QFontInfo(tmpFont).pixelSize();
 
-    if (tmpFont.pixelSize() != arg1)
+    if (px != fontSize)
     {
-        tmpFont.setPixelSize(arg1);
+        tmpFont.setPixelSize(px);
         s.setChatMessageFont(tmpFont);
     }
 }

--- a/src/widget/form/settings/generalform.h
+++ b/src/widget/form/settings/generalform.h
@@ -75,7 +75,7 @@ private slots:
     void onThemeColorChanged(int);
 
     void on_txtChatFont_currentFontChanged(const QFont& f);
-    void on_txtChatFontSize_valueChanged(int arg1);
+    void on_txtChatFontSize_valueChanged(int px);
 
 private:
     void retranslateUi();


### PR DESCRIPTION
Fixes #3459 

This actually only fixes the situation (symptoms), but does not solve the actual problem behind it. Problem is: Initializing a QComboBox (or other child widgets) actually fires "changed" signals. This should probably be completely avoided on the topmost settings widget, by setting `QObject::blockSignals` while child widgets are being initialized - respectively guard their constructors. This has the advantage of order-independent initialization, but may raise some unwanted side effects.

Questions:
- Introduce a minimum pixel-size (e.g. 6px) for the chat base font?
- Does it make sense to completely block every child widget's signals during widget initialization?
