### PR TITLE
[WIP] qTox Audio API reimplementation based on RtAudio

### DIFF
--- a/.travis/build-ubuntu_14_04.sh
+++ b/.travis/build-ubuntu_14_04.sh
@@ -35,6 +35,7 @@ sudo apt-get install -y \
     libopenal-dev \
     libopus-dev \
     libqrencode-dev \
+    librtaudio-dev \
     libsqlcipher-dev \
     libtool \
     libvpx-dev \

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -38,18 +38,19 @@
 <a name="dependencies" />
 ## Dependencies
 
-| Name          | Version     | Modules                                           |
-|---------------|-------------|-------------------------------------------------- |
-| Qt            | >= 5.3.0    | core, gui, network, opengl, sql, svg, widget, xml |
-| GCC/MinGW     | >= 4.8      | C++11 enabled                                     |
-| toxcore       | most recent | core, av                                          |
-| FFmpeg        | >= 2.6.0    | avformat, avdevice, avcodec, avutil, swscale      |
-| OpenAL Soft   | >= 1.16.0   |                                                   |
-| qrencode      | >= 3.0.3    |                                                   |
-| sqlcipher     | >= 3.2.0    |                                                   |
-| libXScrnSaver | >= 1.2      |                                                   |
-| pkg-config    | >= 0.28     |                                                   |
-| libX11        | >= 1.6.0    |                                                   |
+Name          | Version     | Modules
+--------------|-------------|--------
+Qt            | >= 5.3.0    | core, gui, network, opengl, sql, svg, widget, xml
+GCC/MinGW     | >= 4.8      | C++11 enabled
+toxcore       | most recent | core, av
+FFmpeg        | >= 2.6.0    | avformat, avdevice, avcodec, avutil, swscale
+OpenAL Soft   | >= 1.16.0   |
+[RtAudio]     | >= 4.0.11   |
+qrencode      | >= 3.0.3    |
+sqlcipher     | >= 3.2.0    |
+libXScrnSaver | >= 1.2      |
+pkg-config    | >= 0.28     |
+libX11        | >= 1.6.0    |
 
 
 <a name="linux" />
@@ -199,7 +200,7 @@ and others. Instructions here: http://backports.debian.org/Instructions/
 sudo apt-get install build-essential qt5-qmake qt5-default qttools5-dev-tools \
 libqt5opengl5-dev libqt5svg5-dev libopenal-dev libxss-dev qrencode \
 libqrencode-dev libglib2.0-dev libgdk-pixbuf2.0-dev libgtk2.0-dev ffmpeg \
-libsqlcipher-dev
+librtaudio-dev libsqlcipher-dev
 ```
 
 
@@ -214,7 +215,7 @@ sudo dnf groupinstall "Development Tools" "C Development Tools and Libraries"
 # (can also use sudo dnf install @"Development Tools")
 sudo dnf install qt-devel qt-doc qt-creator qt5-qtsvg qt5-qtsvg-devel \
 openal-soft-devel libXScrnSaver-devel qrencode-devel ffmpeg-devel \
-qtsingleapplication qt5-linguist gtk2-devel libtool openssl-devel
+qtsingleapplication qt5-linguist gtk2-devel libtool openssl-devel rtaudio-devel
 ```
 
 **Go to [sqlcipher](#sqlcipher) section to compile it.**
@@ -245,13 +246,17 @@ libqt5opengl5-dev libqt5svg5-dev libopenal-dev libxss-dev qrencode \
 libqrencode-dev libavutil-ffmpeg-dev libswresample-ffmpeg-dev \
 libavcodec-ffmpeg-dev libswscale-ffmpeg-dev libavfilter-ffmpeg-dev \
 libavdevice-ffmpeg-dev libglib2.0-dev libgdk-pixbuf2.0-dev libgtk2.0-dev \
-libsqlcipher-dev
+librtaudio-dev libsqlcipher-dev
 ```
 
 <a name="ubuntu-other-1604-deps" />
 #### Ubuntu >=16.04:
 ```bash
-sudo apt-get install build-essential qt5-qmake qt5-default qttools5-dev-tools libqt5opengl5-dev libqt5svg5-dev libopenal-dev libxss-dev qrencode libqrencode-dev libavutil-dev libswresample-dev libavcodec-dev libswscale-dev libavfilter-dev libavdevice-dev libglib2.0-dev libgdk-pixbuf2.0-dev libgtk2.0-dev libsqlcipher-dev
+sudo apt-get install build-essential qt5-qmake qt5-default qttools5-dev-tools \
+libqt5opengl5-dev libqt5svg5-dev libopenal-dev libxss-dev qrencode \
+libqrencode-dev libavutil-dev libswresample-dev libavcodec-dev libswscale-dev \
+libavfilter-dev libavdevice-dev libglib2.0-dev libgdk-pixbuf2.0-dev \
+libgtk2.0-dev librtaudio-dev libsqlcipher-dev
 ```
 
 ### toxcore dependencies
@@ -560,4 +565,5 @@ dependencies compile them and put to appropriate directories.
 
 
 [OBS]: https://software.opensuse.org/download.html?project=home%3Aantonbatenev%3Atox&package=qtox
+[RtAudio]: http://www.music.mcgill.ca/~gary/rtaudio/
 [Ubuntu PPA]: https://launchpad.net/~abbat/+archive/ubuntu/tox

--- a/qtox.pro
+++ b/qtox.pro
@@ -95,7 +95,7 @@ contains(DEFINES, QTOX_PLATFORM_EXT) {
 win32 {
     RC_FILE = windows/qtox.rc
     LIBS += -L$$PWD/libs/lib -ltoxav -ltoxcore -ltoxencryptsave -ltoxdns -lsodium -lvpx -lpthread
-    LIBS += -L$$PWD/libs/lib -lavdevice -lavformat -lavcodec -lavutil -lswscale -lOpenAL32 -lopus
+    LIBS += -L$$PWD/libs/lib -lavdevice -lavformat -lavcodec -lavutil -lswscale -lOpenAL32 -lrtaudio -lopus
     LIBS += -lqrencode -lsqlcipher -lcrypto
     LIBS += -lopengl32 -lole32 -loleaut32 -lvfw32 -lws2_32 -liphlpapi -lgdi32 -lshlwapi -luuid
     LIBS += -lstrmiids # For DirectShow
@@ -105,7 +105,7 @@ win32 {
         ICON = img/icons/qtox.icns
         QMAKE_INFO_PLIST = osx/info.plist
         QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.7
-        LIBS += -L$$PWD/libs/lib/ -ltoxcore -ltoxav -ltoxencryptsave -ltoxdns -lsodium -lvpx -lopus -framework OpenAL -lavformat -lavdevice -lavcodec -lavutil -lswscale -mmacosx-version-min=10.7
+        LIBS += -L$$PWD/libs/lib/ -ltoxcore -ltoxav -ltoxencryptsave -ltoxdns -lsodium -lvpx -lopus -framework OpenAL -lrtaudio -lavformat -lavdevice -lavcodec -lavutil -lswscale -mmacosx-version-min=10.7
         LIBS += -framework AVFoundation -framework Foundation -framework CoreMedia -framework ApplicationServices
         LIBS += -lqrencode -lsqlcipher
         contains(DEFINES, QTOX_PLATFORM_EXT) { LIBS += -framework IOKit -framework CoreFoundation }
@@ -142,12 +142,12 @@ win32 {
 
         # If we're building a package, static link libtox[core,av] and libsodium, since they are not provided by any package
         contains(STATICPKG, YES) {
-            LIBS += -L$$PWD/libs/lib/ -lopus -lvpx -lopenal -Wl,-Bstatic -ltoxcore -ltoxav -ltoxencryptsave -ltoxdns -lsodium -lavformat -lavdevice -lavcodec -lavutil -lswscale -lz -Wl,-Bdynamic
+            LIBS += -L$$PWD/libs/lib/ -lopus -lvpx -lopenal -lrtaudio -Wl,-Bstatic -ltoxcore -ltoxav -ltoxencryptsave -ltoxdns -lsodium -lavformat -lavdevice -lavcodec -lavutil -lswscale -lz -Wl,-Bdynamic
             LIBS += -Wl,-Bstatic -ljpeg -ltiff -lpng -ljasper -lIlmImf -lIlmThread -lIex -ldc1394 -lraw1394 -lHalf -lz -llzma -ljbig
             LIBS += -Wl,-Bdynamic -lv4l1 -lv4l2 -lavformat -lavcodec -lavutil -lswscale -lusb-1.0
             LIBS += -lqrencode -lsqlcipher
         } else {
-            LIBS += -L$$PWD/libs/lib/ -ltoxcore -ltoxav -ltoxencryptsave -ltoxdns -lvpx -lsodium -lopenal -lavformat -lavdevice -lavcodec -lavutil -lswscale
+            LIBS += -L$$PWD/libs/lib/ -ltoxcore -ltoxav -ltoxencryptsave -ltoxdns -lvpx -lsodium -lopenal -lrtaudio -lavformat -lavdevice -lavcodec -lavutil -lswscale
             LIBS += -lqrencode -lsqlcipher
         }
 
@@ -156,7 +156,7 @@ win32 {
         }
 
         contains(JENKINS, YES) {
-            LIBS = ./libs/lib/libtoxav.a ./libs/lib/libvpx.a ./libs/lib/libopus.a ./libs/lib/libtoxdns.a ./libs/lib/libtoxencryptsave.a ./libs/lib/libtoxcore.a ./libs/lib/libopenal.a ./libs/lib/libsodium.a ./libs/lib/libavdevice.a ./libs/lib/libavformat.a ./libs/lib/libavcodec.a ./libs/lib/libavutil.a ./libs/lib/libswscale.a ./libs/lib/libqrencode.a -ldl -lX11 -lXss
+            LIBS = ./libs/lib/libtoxav.a ./libs/lib/libvpx.a ./libs/lib/libopus.a ./libs/lib/libtoxdns.a ./libs/lib/libtoxencryptsave.a ./libs/lib/libtoxcore.a ./libs/lib/libopenal.a ./libs/lib/librtaudio.a ./libs/lib/libsodium.a ./libs/lib/libavdevice.a ./libs/lib/libavformat.a ./libs/lib/libavcodec.a ./libs/lib/libavutil.a ./libs/lib/libswscale.a ./libs/lib/libqrencode.a -ldl -lX11 -lXss
             contains(ENABLE_SYSTRAY_UNITY_BACKEND, YES) {
                 LIBS += -lgobject-2.0 -lappindicator -lgtk-x11-2.0
             }

--- a/qtox.pro
+++ b/qtox.pro
@@ -249,6 +249,7 @@ HEADERS  += \
     src/ipc.h \
     src/nexus.h \
     src/audio/audio.h \
+    src/audio/devices.h \
     src/chatlog/chatlog.h \
     src/chatlog/chatline.h \
     src/chatlog/chatlinecontent.h \
@@ -371,6 +372,7 @@ SOURCES += \
     src/main.cpp \
     src/nexus.cpp \
     src/audio/audio.cpp \
+    src/audio/devices.cpp \
     src/core/cdata.cpp \
     src/core/cstring.cpp \
     src/core/core.cpp \

--- a/simple_make.sh
+++ b/simple_make.sh
@@ -18,6 +18,7 @@ apt_install() {
         libqrencode-dev
         libqt5opengl5-dev
         libqt5svg5-dev
+        librtaudio-dev
         libsodium-dev
         libsqlcipher-dev
         libtool
@@ -80,6 +81,7 @@ dnf_install() {
         qt-creator
         qt-devel
         qt-doc
+        rtaudio-devel
         sqlite
         sqlite-devel
     )

--- a/src/audio/devices.cpp
+++ b/src/audio/devices.cpp
@@ -101,6 +101,68 @@ QString Device::name() const
 }
 
 /**
+The maximum input channels the audio device supports.
+*/
+quint32 Device::inputChannels() const
+{
+    return d->info.inputChannels;
+}
+
+/**
+The maximum output channels the audio device supports.
+*/
+quint32 Device::outputChannels() const
+{
+    return d->info.outputChannels;
+}
+
+/**
+The maximum simultaneous input/output channels the audio device supports.
+*/
+quint32 Device::duplexChannels() const
+{
+    return d->info.duplexChannels;
+}
+
+/**
+Convenience method.
+
+@return true, if outputChannels() > 0
+*/
+bool Device::isOutput() const
+{
+    return d->info.outputChannels > 0;
+}
+
+/**
+@brief Returns, if this is the default audio output device.
+@return true, if this is the default output device
+*/
+bool Device::isDefaultOutput() const
+{
+    return d->info.isDefaultOutput;
+}
+
+/**
+Convenience method.
+
+@return true, if inputChannels() > 0
+*/
+bool Device::isInput() const
+{
+    return d->info.inputChannels > 0;
+}
+
+/**
+@brief Returns, if this is the default audio input device.
+@return true, if this is the default input device
+*/
+bool Device::isDefaultInput() const
+{
+    return d->info.isDefaultOutput;
+}
+
+/**
 Returns the singleton instance.
 */
 Devices& Devices::self()

--- a/src/audio/devices.cpp
+++ b/src/audio/devices.cpp
@@ -455,6 +455,59 @@ Audio::StreamContext& Audio::StreamContext::operator=(StreamContext&& other)
 }
 
 /**
+@brief  The current sample rate.
+@return the sample rate in Hz.
+*/
+quint32 Audio::StreamContext::sampleRate() const
+{
+    return d ? d->sampleRate : 0;
+}
+
+/**
+@brief Sets the sample rate for the stream context.
+
+@note An open stream will be closed by this method.
+*/
+void Audio::StreamContext::setSampleRate(quint32 hz)
+{
+    if (!d)
+        return;
+
+    if (hz != d->sampleRate)
+    {
+        d->close();
+        d->sampleRate = hz;
+    }
+}
+
+/**
+@brief Returns the current frame count.
+@return The StreamContext's (input) frame count.
+*/
+quint32 Audio::StreamContext::frameCount() const
+{
+    return d ? d->inFrames : 0;
+}
+
+/**
+@brief  Sets the frame count (for internal frame buffer) for input.
+@note   Can only be set for an input or playthrough (duplex) StreamContext.
+*/
+void Audio::StreamContext::setFrameCount(quint32 frames)
+{
+    if (!d || frames == d->inFrames)
+        return;
+
+    Q_ASSERT_X(d->inParams, __func__,
+               "Frame count can only be set within an input context.");
+
+    Q_ASSERT_X(!d->audio.isStreamRunning(), __func__,
+               "Frame count cannot be set on an active stream.");
+
+    d->inFrames = frames;
+}
+
+/**
 @brief Returns the StreamContext input device id.
 @return the input device id or -1, if no device was assigned
 */

--- a/src/audio/devices.cpp
+++ b/src/audio/devices.cpp
@@ -1,3 +1,22 @@
+/*
+    Copyright © 2014-2016 by The qTox Project
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 #include "devices.h"
 
 #include <QDebug>

--- a/src/audio/devices.cpp
+++ b/src/audio/devices.cpp
@@ -1,0 +1,82 @@
+#include "devices.h"
+
+#include <QDebug>
+#include <QVector>
+
+#include <RtAudio.h>
+
+#include <QTimer>
+
+namespace qTox {
+namespace Audio {
+
+class Device::Private : public QSharedData
+{
+public:
+    Private(const RtAudio::DeviceInfo& devInfo)
+        : info(devInfo)
+    {
+    }
+
+public:
+    RtAudio::DeviceInfo info;
+};
+
+class Devices::Private
+{
+public:
+    Private() = default;
+
+    int count()
+    {
+        return static_cast<int>(audio.getDeviceCount());
+    }
+
+public:
+    RtAudio audio;
+
+    QVector<Device::PrivatePtr> activeDevices;
+};
+
+Device::Device(Private* dev)
+    : d(dev)
+{
+}
+
+Device& Device::operator=(Device& other)
+{
+    d = other.d;
+    return *this;
+}
+
+bool Device::isValid() const
+{
+    return d->info.probed;
+}
+
+QString Device::name() const
+{
+    return QString::fromStdString(d->info.name);
+}
+
+/**
+Returns the singleton instance.
+*/
+Devices& Devices::self()
+{
+    static Devices instance;
+    return instance;
+}
+
+Devices::Devices()
+    : d(new Private)
+{
+}
+
+Devices::~Devices()
+{
+    delete d;
+}
+
+}
+}

--- a/src/audio/devices.cpp
+++ b/src/audio/devices.cpp
@@ -119,26 +119,26 @@ public:
         Q_UNUSED(streamTime);
         Q_UNUSED(status);
 
+        int ret = 1;
         const Private* p = static_cast<StreamContext::Private*>(userData);
 
-        if (inBuffer && p->inParams)
+        if (p->inParams && nFrames > 0)
         {
             if (p->evInput)
             {
                 quint8 channels = static_cast<quint8>((*p->inParams).nChannels);
-                size_t bytes = nFrames * channels * 2;
-                p->evInput(inBuffer, Format::SINT16, bytes,
-                           channels, p->sampleRate);
+                ret = p->evInput(inBuffer, Format::SINT16, nFrames,
+                                 channels, p->sampleRate);
             }
         }
 
-        if (outBuffer && p->outParams)
+        if (p->outParams)
         {
             if (p->playbackBuffer)
                 memcpy(outBuffer, p->playbackBuffer, nFrames);
         }
 
-        return 1;
+        return ret;
     }
 
 public:
@@ -231,7 +231,7 @@ public:
         if (audio.isStreamRunning())
             audio.abortStream();
 
-        delete playbackBuffer;
+        delete[] playbackBuffer;
         playbackBuffer = nullptr;
         inFrames = 0;
     }

--- a/src/audio/devices.cpp
+++ b/src/audio/devices.cpp
@@ -29,6 +29,24 @@
 namespace qTox {
 namespace Audio {
 
+/**
+@class Device
+@brief Representation of a physical audio device.
+*/
+
+/**
+@class Devices
+@brief Audio device manager.
+*/
+
+/**
+@internal
+
+@brief Private implementation of the Device class.
+
+Encapsulates RtAudio::DeviceInfo and provides access to the physical audio
+device.
+*/
 class Device::Private : public QSharedData
 {
 public:
@@ -73,6 +91,10 @@ bool Device::isValid() const
     return d->info.probed;
 }
 
+/**
+@brief Returns a QString representation of the audio device name.
+@return the device name
+*/
 QString Device::name() const
 {
     return QString::fromStdString(d->info.name);

--- a/src/audio/devices.cpp
+++ b/src/audio/devices.cpp
@@ -60,7 +60,7 @@ namespace qTox {
 @brief  Representation of a physical audio device.
 
 
-@class  Audio::StreamContext
+@class  Audio::Stream
 @brief  Defines the streaming context.
 
 Manages input and/or output audio resources in a streaming context. Input can
@@ -100,11 +100,11 @@ private:
 
 /**
 @internal
-@brief Private implementation of the StreamContext class.
+@brief Private implementation of the Stream class.
 */
-class Audio::StreamContext::Private : public QSharedData
+class Audio::Stream::Private : public QSharedData
 {
-    friend class StreamContext;
+    friend class Stream;
 
 public:
     /**
@@ -120,7 +120,7 @@ public:
         Q_UNUSED(status);
 
         int ret = 1;
-        const Private* p = static_cast<StreamContext::Private*>(userData);
+        const Private* p = static_cast<Stream::Private*>(userData);
 
         if (p->inParams && nFrames > 0)
         {
@@ -426,37 +426,37 @@ bool Audio::Device::isDefaultInput() const
 @brief Creates an audio stream context.
 @param[in] inputDevice      the input device index; -1 == no input
 @param[in] outputDevice     the output device index; -1 == no output
-@return the created StreamContext or a null object, if creation failed
+@return the created Stream or a null object, if creation failed
 
-The created StreamContext has a maximum of 2 (stereo) channels, depending on the
+The created Stream has a maximum of 2 (stereo) channels, depending on the
 devices' capabilities. A device in qTox cannot have more than two channels.
 */
-Audio::StreamContext::StreamContext()
+Audio::Stream::Stream()
     : d(new Private())
 {
 }
 
-Audio::StreamContext::StreamContext(const StreamContext& other)
+Audio::Stream::Stream(const Stream& other)
     : d(other.d)
 {
 }
 
-Audio::StreamContext::StreamContext(StreamContext&& other)
+Audio::Stream::Stream(Stream&& other)
     : d(std::move(other.d))
 {
 }
 
-Audio::StreamContext::~StreamContext()
+Audio::Stream::~Stream()
 {
 }
 
-Audio::StreamContext& Audio::StreamContext::operator=(const StreamContext& other)
+Audio::Stream& Audio::Stream::operator=(const Stream& other)
 {
     d = other.d;
     return *this;
 }
 
-Audio::StreamContext& Audio::StreamContext::operator=(StreamContext&& other)
+Audio::Stream& Audio::Stream::operator=(Stream&& other)
 {
     d = std::move(other.d);
     return *this;
@@ -466,7 +466,7 @@ Audio::StreamContext& Audio::StreamContext::operator=(StreamContext&& other)
 @brief  The current sample rate.
 @return the sample rate in Hz.
 */
-quint32 Audio::StreamContext::sampleRate() const
+quint32 Audio::Stream::sampleRate() const
 {
     return d ? d->sampleRate : 0;
 }
@@ -476,7 +476,7 @@ quint32 Audio::StreamContext::sampleRate() const
 
 @note An open stream will be closed by this method.
 */
-void Audio::StreamContext::setSampleRate(quint32 hz)
+void Audio::Stream::setSampleRate(quint32 hz)
 {
     if (!d)
         return;
@@ -490,18 +490,18 @@ void Audio::StreamContext::setSampleRate(quint32 hz)
 
 /**
 @brief Returns the current frame count.
-@return The StreamContext's (input) frame count.
+@return The Stream's (input) frame count.
 */
-quint32 Audio::StreamContext::frameCount() const
+quint32 Audio::Stream::frameCount() const
 {
     return d ? d->inFrames : 0;
 }
 
 /**
 @brief  Sets the frame count (for internal frame buffer) for input.
-@note   Can only be set for an input or playthrough (duplex) StreamContext.
+@note   Can only be set for an input or playthrough (duplex) Stream.
 */
-void Audio::StreamContext::setFrameCount(quint32 frames)
+void Audio::Stream::setFrameCount(quint32 frames)
 {
     if (!d || frames == d->inFrames)
         return;
@@ -516,19 +516,19 @@ void Audio::StreamContext::setFrameCount(quint32 frames)
 }
 
 /**
-@brief Returns the StreamContext input device id.
+@brief Returns the Stream input device id.
 @return the input device id or -1, if no device was assigned
 */
-int Audio::StreamContext::inputDeviceId() const
+int Audio::Stream::inputDeviceId() const
 {
     return (d && d->inParams) ? static_cast<int>((*d->inParams).deviceId) : -1;
 }
 
 /**
-@brief Returns the StreamContext input device.
+@brief Returns the Stream input device.
 @return the input @a Device or a null @a Device, if none was assigned
 */
-Audio::Device Audio::StreamContext::inputDevie() const
+Audio::Device Audio::Stream::inputDevie() const
 {
     return d && d->inParams
             ? new Device::Private(d->audio.getDeviceInfo((*d->inParams).deviceId))
@@ -536,10 +536,10 @@ Audio::Device Audio::StreamContext::inputDevie() const
 }
 
 /**
-@brief Initializes the input device for the StreamContext.
+@brief Initializes the input device for the Stream.
 @param[in] deviceId the input device id; -1 for default device
 */
-void Audio::StreamContext::setInputDevice(int deviceId)
+void Audio::Stream::setInputDevice(int deviceId)
 {
     if (!d)
         return;
@@ -565,11 +565,11 @@ void Audio::StreamContext::setInputDevice(int deviceId)
 }
 
 /**
-@brief  Removes the StreamContext input device.
+@brief  Removes the Stream input device.
 @note   The input device is destroyed and the stream is restored to it's
         previous open/running state.
 */
-void Audio::StreamContext::removeInputDevice()
+void Audio::Stream::removeInputDevice()
 {
     if (!d)
         return;
@@ -582,19 +582,19 @@ void Audio::StreamContext::removeInputDevice()
 }
 
 /**
-@brief Returns the StreamContext output device id.
+@brief Returns the Stream output device id.
 @return the input device id or -1, if no device was assigned
 */
-int Audio::StreamContext::outputDeviceId() const
+int Audio::Stream::outputDeviceId() const
 {
     return (d && d->outParams) ? static_cast<int>((*d->outParams).deviceId) : -1;
 }
 
 /**
-@brief Returns the StreamContext output device.
+@brief Returns the Stream output device.
 @return the output @a Device or a null @a Device, if none was assigned
 */
-Audio::Device Audio::StreamContext::outputDevice() const
+Audio::Device Audio::Stream::outputDevice() const
 {
 
     return d && d->outParams
@@ -603,10 +603,10 @@ Audio::Device Audio::StreamContext::outputDevice() const
 }
 
 /**
-@brief Sets the output device for the StreamContext.
+@brief Sets the output device for the Stream.
 @param[in] deviceId     the output device id
 */
-void Audio::StreamContext::setOutputDevice(int deviceId)
+void Audio::Stream::setOutputDevice(int deviceId)
 {
     if (!d)
         return;
@@ -632,11 +632,11 @@ void Audio::StreamContext::setOutputDevice(int deviceId)
 }
 
 /**
-@brief  Removes the StreamContext input device.
+@brief  Removes the Stream input device.
 @note   The input device is destroyed and the stream is restored to it's
         previous open/running state.
 */
-void Audio::StreamContext::removeOutputDevice()
+void Audio::Stream::removeOutputDevice()
 {
     if (!d)
         return;
@@ -652,7 +652,7 @@ void Audio::StreamContext::removeOutputDevice()
 @brief Opens the stream for reading and writing.
 @return
 */
-bool Audio::StreamContext::open()
+bool Audio::Stream::open()
 {
     return d ? d->open() : false;
 }
@@ -660,7 +660,7 @@ bool Audio::StreamContext::open()
 /**
 Closes the audio stream.
 */
-void Audio::StreamContext::close()
+void Audio::Stream::close()
 {
     if (d)
         d->close();
@@ -669,7 +669,7 @@ void Audio::StreamContext::close()
 /**
 Aborts a stream immediately.
 */
-bool Audio::StreamContext::abort()
+bool Audio::Stream::abort()
 {
     return d ? d->abort() : false;
 }
@@ -677,7 +677,7 @@ bool Audio::StreamContext::abort()
 /**
 Starts recording or playback on the stream.
 */
-bool Audio::StreamContext::start()
+bool Audio::Stream::start()
 {
     return d ? d->start() : false;
 }
@@ -685,12 +685,12 @@ bool Audio::StreamContext::start()
 /**
 Waits for the streamed buffers to drain and stops playback afterwards.
 */
-bool Audio::StreamContext::stop()
+bool Audio::Stream::stop()
 {
     return d ? d->stop() : false;
 }
 
-void Audio::StreamContext::playback(char* pcm, Format fmt, quint32 frames,
+void Audio::Stream::playback(char* pcm, Format fmt, quint32 frames,
                              quint8 channels, quint32 sampleRate)
 {
     // TODO: map the number of channels (currently assuming input == output)
@@ -716,7 +716,7 @@ void Audio::StreamContext::playback(char* pcm, Format fmt, quint32 frames,
     d->start();
 }
 
-void Audio::StreamContext::playback(const QString& fileName)
+void Audio::Stream::playback(const QString& fileName)
 {
     QFile f(fileName);
     if (f.open(QFile::ReadOnly))
@@ -734,17 +734,17 @@ void Audio::StreamContext::playback(const QString& fileName)
     }
 }
 
-bool Audio::StreamContext::isOpen() const
+bool Audio::Stream::isOpen() const
 {
     return d ? d->audio.isStreamOpen() : false;
 }
 
-bool Audio::StreamContext::isRunning() const
+bool Audio::Stream::isRunning() const
 {
     return d ? d->audio.isStreamRunning() : false;
 }
 
-void Audio::StreamContext::onRecorded(RecordFunc event)
+void Audio::Stream::onRecorded(RecordFunc event)
 {
     if (!d)
         return;

--- a/src/audio/devices.cpp
+++ b/src/audio/devices.cpp
@@ -135,7 +135,15 @@ public:
         if (p->outParams)
         {
             if (p->playbackBuffer)
+            {
                 memcpy(outBuffer, p->playbackBuffer, nFrames);
+            }
+            else if (p->playthrough)
+            {
+                quint8 channels = static_cast<quint8>((*p->inParams).nChannels);
+                size_t bytes = nFrames * channels * 2;
+                memcpy(outBuffer, inBuffer, bytes);
+            }
         }
 
         return ret;
@@ -549,7 +557,7 @@ void Audio::StreamContext::setInputDevice(int deviceId)
         RtAudio::DeviceInfo info = d->audio.getDeviceInfo(devId);
         d->inParams = new RtAudio::StreamParameters();
         (*d->inParams).deviceId = devId;
-        (*d->inParams).nChannels = 1; //qMin<unsigned int>(info.inputChannels, 2);
+        (*d->inParams).nChannels = qMin<unsigned int>(info.inputChannels, 2);
         (*d->inParams).firstChannel = 0;
     }
 
@@ -616,7 +624,7 @@ void Audio::StreamContext::setOutputDevice(int deviceId)
         RtAudio::DeviceInfo info = d->audio.getDeviceInfo(devId);
         d->outParams = new RtAudio::StreamParameters();
         (*d->outParams).deviceId = devId;
-        (*d->outParams).nChannels = 1; //qMin<unsigned int>(info.inputChannels, 2);
+        (*d->outParams).nChannels = qMin<unsigned int>(info.inputChannels, 2);
         (*d->outParams).firstChannel = 0;
     }
 

--- a/src/audio/devices.h
+++ b/src/audio/devices.h
@@ -1,3 +1,22 @@
+/*
+    Copyright © 2014-2016 by The qTox Project
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 #ifndef QTOX_AUDIO_H
 #define QTOX_AUDIO_H
 

--- a/src/audio/devices.h
+++ b/src/audio/devices.h
@@ -1,0 +1,53 @@
+#ifndef QTOX_AUDIO_H
+#define QTOX_AUDIO_H
+
+#include <QObject>
+#include <QSharedData>
+
+namespace qTox {
+namespace Audio {
+
+class Device
+{
+    class Private;
+
+public:
+    typedef QExplicitlySharedDataPointer<Private> PrivatePtr;
+
+public:
+    Device(Private* dev);
+    Device(Device&&) = default;
+
+    Device& operator=(Device& other);
+
+public:
+    bool isValid() const;
+    QString name() const;
+
+private:
+    PrivatePtr d;
+};
+
+class Devices : public QObject
+{
+    Q_OBJECT
+public:
+    static Devices& self();
+    inline static Devices& getInstance()
+    {
+        return self();
+    }
+
+private:
+    Devices();
+    ~Devices();
+
+private:
+    class Private;
+    Private* d;
+};
+
+}
+}
+
+#endif

--- a/src/audio/devices.h
+++ b/src/audio/devices.h
@@ -51,6 +51,9 @@ static inline quint8 formatSize(Format fmt)
     }
 }
 
+typedef std::function<int (const void* pcm, Format fmt, size_t size,
+                           quint8 channels, quint32 sampleRate)> RecordFunc;
+
 class Device
 {
     class Private;
@@ -131,6 +134,13 @@ public:
 
     bool isOpen() const;
     bool isRunning() const;
+
+    void playback(char* pcm, Format fmt, quint32 frames, quint8 channels,
+                  quint32 sampleRate);
+    void playback(const QString& fileName);
+
+public:
+    void onRecorded(RecordFunc event);
 
 private:
     QExplicitlySharedDataPointer<Private> d;

--- a/src/audio/devices.h
+++ b/src/audio/devices.h
@@ -26,127 +26,145 @@
 #include <QSharedData>
 
 namespace qTox {
-namespace Audio {
 
-enum class Format
+class Audio
 {
-    SINT8   = 0x01,
-    SINT16  = 0x02,
-    SINT24  = 0x04,
-    SINT32  = 0x08,
-    FLOAT32 = 0x10,
-    FLOAT64 = 0x20
-};
-
-static inline quint8 formatSize(Format fmt)
-{
-    switch (fmt)
+public:
+    enum class Format
     {
-    case Format::SINT8: return 1;
-    case Format::SINT16: return 2;
-    case Format::SINT24: return 3;
-    case Format::SINT32:
-    case Format::FLOAT32: return 4;
-    case Format::FLOAT64: return 8;
-    }
-}
+        SINT8   = 0x01,
+        SINT16  = 0x02,
+        SINT24  = 0x04,
+        SINT32  = 0x08,
+        FLOAT32 = 0x10,
+        FLOAT64 = 0x20
+    };
 
-typedef std::function<int (const void* pcm, Format fmt, size_t size,
-                           quint8 channels, quint32 sampleRate)> RecordFunc;
-
-class Device
-{
-    class Private;
-
-    friend class StreamContext;
-
-public:
-    typedef QVector<Device> List;
-
-public:
-    static List availableDevices();
-    static int find(const QString& name);
-
-public:
-    Device(Private* p = nullptr);
-    Device(const Device& other);
-    Device(Device&& other);
-    ~Device();
-
-    Device& operator=(const Device& other);
-    Device& operator=(Device&& other);
-
-public:
-    inline bool isNull() const
+    static inline quint8 formatSize(Format fmt)
     {
-        return !d;
+        switch (fmt)
+        {
+        case Format::SINT8: return 1;
+        case Format::SINT16: return 2;
+        case Format::SINT24: return 3;
+        case Format::SINT32:
+        case Format::FLOAT32: return 4;
+        case Format::FLOAT64: return 8;
+        }
+
+        return 0;
     }
 
-    bool isValid() const;
-    QString name() const;
-    quint32 inputChannels() const;
-    quint32 outputChannels() const;
-    quint32 duplexChannels() const;
-    bool isOutput() const;
-    bool isDefaultOutput() const;
-    bool isInput() const;
-    bool isDefaultInput() const;
+public:
+    typedef std::function<int (const void* pcm, Format fmt, size_t frames,
+                               quint8 channels, quint32 sampleRate)> RecordFunc;
+
+public:
+    class Device
+    {
+    public:
+        class Private;
+
+    public:
+        typedef QVector<Device> List;
+
+    public:
+        static int find(const QString& name);
+
+    public:
+        Device(Private* p = nullptr);
+        Device(const Device& other);
+        Device(Device&& other);
+        ~Device();
+
+        Device& operator=(const Device& other);
+        Device& operator=(Device&& other);
+
+    public:
+        inline bool isNull() const
+        {
+            return !d;
+        }
+
+        bool isValid() const;
+        QString name() const;
+        quint32 inputChannels() const;
+        quint32 outputChannels() const;
+        quint32 duplexChannels() const;
+        bool isOutput() const;
+        bool isDefaultOutput() const;
+        bool isInput() const;
+        bool isDefaultInput() const;
+
+    private:
+        QExplicitlySharedDataPointer<Private> d;
+    };
+
+    class StreamContext
+    {
+    public:
+        class Private;
+
+    public:
+        StreamContext();
+        StreamContext(const StreamContext& other);
+        StreamContext(StreamContext&& other);
+        ~StreamContext();
+
+        StreamContext& operator=(const StreamContext& other);
+        StreamContext& operator=(StreamContext&& other);
+
+        inline bool isNull() const
+        {
+            return !d;
+        }
+
+
+
+        int inputDeviceId() const;
+        Device inputDevie() const;
+        void setInputDevice(int deviceId = -1);
+        void removeInputDevice();
+
+        int outputDeviceId() const;
+        Device outputDevice() const;
+        void setOutputDevice(int deviceId = -1);
+        void removeOutputDevice();
+
+        bool open();
+        void close();
+
+        bool abort();
+        bool start();
+        bool stop();
+
+        bool isOpen() const;
+        bool isRunning() const;
+
+        void playback(char* pcm, Format fmt, quint32 frames, quint8 channels,
+                      quint32 sampleRate);
+        void playback(const QString& fileName);
+
+    public:
+        void onRecorded(RecordFunc event);
+
+    private:
+        QExplicitlySharedDataPointer<Private> d;
+    };
+
+public:
+    static Device::List availableDevices();
 
 private:
-    QExplicitlySharedDataPointer<Private> d;
+    Audio() = delete;
+    Audio(const Audio&) = delete;
+    Audio(Audio&&) = delete;
+    ~Audio() = delete;
+
+    Audio& operator=(const Audio&) = delete;
+    Audio& operator=(Audio&&) = delete;
 };
 
-class StreamContext
-{
-public:
-    class Private;
-
-public:
-    StreamContext();
-    StreamContext(const StreamContext& other);
-    StreamContext(StreamContext&& other);
-    ~StreamContext();
-
-    StreamContext& operator=(const StreamContext& other);
-    StreamContext& operator=(StreamContext&& other);
-
-    inline bool isNull() const
-    {
-        return !d;
-    }
-
-    int inputDeviceId() const;
-    Device inputDevie() const;
-    void setInputDevice(int deviceId = -1);
-    void removeInputDevice();
-
-    int outputDeviceId() const;
-    Device outputDevice() const;
-    void setOutputDevice(int deviceId = -1);
-    void removeOutputDevice();
-
-    bool open();
-    void close();
-
-    bool abort();
-    bool start();
-    bool stop();
-
-    bool isOpen() const;
-    bool isRunning() const;
-
-    void playback(char* pcm, Format fmt, quint32 frames, quint8 channels,
-                  quint32 sampleRate);
-    void playback(const QString& fileName);
-
-public:
-    void onRecorded(RecordFunc event);
-
-private:
-    QExplicitlySharedDataPointer<Private> d;
-};
-
-}
 }
 
 Q_DECLARE_METATYPE(qTox::Audio::Device)

--- a/src/audio/devices.h
+++ b/src/audio/devices.h
@@ -119,7 +119,11 @@ public:
             return !d;
         }
 
+        quint32 sampleRate() const;
+        void setSampleRate(quint32 hz);
 
+        quint32 frameCount() const;
+        void setFrameCount(quint32 frames);
 
         int inputDeviceId() const;
         Device inputDevie() const;

--- a/src/audio/devices.h
+++ b/src/audio/devices.h
@@ -42,21 +42,27 @@ class Device
 
 public:
     typedef QVector<Device> List;
-    typedef QExplicitlySharedDataPointer<Private> PrivatePtr;
 
 public:
     static List availableDevices();
     static int find(const QString& name);
 
 public:
-    Device(Private* p = nullptr);
-    Device(const Device&) = default;
-    Device(Device&&) = default;
+    Device();
+    Device(Private* p);
+    Device(const Device& other);
+    Device(Device&& other);
+    ~Device();
 
-    Device& operator=(const Device&) = default;
-    Device& operator=(Device&&) = default;
+    Device& operator=(const Device& other);
+    Device& operator=(Device&& other);
 
 public:
+    inline bool isNull() const
+    {
+        return !d;
+    }
+
     bool isValid() const;
     QString name() const;
     quint32 inputChannels() const;
@@ -68,29 +74,26 @@ public:
     bool isDefaultInput() const;
 
 private:
-    PrivatePtr d;
+    QExplicitlySharedDataPointer<Private> d;
 };
 
 class StreamContext
 {
-public:
     class Private;
 
-    typedef QExplicitlySharedDataPointer<Private> PrivatePtr;
-
 public:
-    static StreamContext create(int inputDevice = -1, int outputDevice = -1);
-
-public:
+    explicit StreamContext(int inputDevice = -1, int outputDevice = -1);
     StreamContext(Private* p);
-    StreamContext(StreamContext&&) = default;
+    StreamContext(const StreamContext& other);
+    StreamContext(StreamContext&& other);
+    ~StreamContext();
 
-    StreamContext& operator=(const StreamContext&) = default;
-    StreamContext& operator=(StreamContext&&) = default;
+    StreamContext& operator=(const StreamContext& other);
+    StreamContext& operator=(StreamContext&& other);
 
     inline bool isNull() const
     {
-        return d;
+        return !d;
     }
 
     bool open();
@@ -103,7 +106,7 @@ public:
     bool isRunning() const;
 
 private:
-    PrivatePtr d;
+    QExplicitlySharedDataPointer<Private> d;
 };
 
 }

--- a/src/audio/devices.h
+++ b/src/audio/devices.h
@@ -42,6 +42,13 @@ public:
 public:
     bool isValid() const;
     QString name() const;
+    quint32 inputChannels() const;
+    quint32 outputChannels() const;
+    quint32 duplexChannels() const;
+    bool isOutput() const;
+    bool isDefaultOutput() const;
+    bool isInput() const;
+    bool isDefaultInput() const;
 
 private:
     PrivatePtr d;

--- a/src/audio/devices.h
+++ b/src/audio/devices.h
@@ -26,18 +26,35 @@
 namespace qTox {
 namespace Audio {
 
+enum class Format
+{
+    SINT8   = 0x01,
+    SINT16  = 0x02,
+    SINT24  = 0x04,
+    SINT32  = 0x08,
+    FLOAT32 = 0x10,
+    FLOAT64 = 0x20
+};
+
 class Device
 {
     class Private;
 
 public:
+    typedef QVector<Device> List;
     typedef QExplicitlySharedDataPointer<Private> PrivatePtr;
 
 public:
-    Device(Private* dev);
+    static List availableDevices();
+    static int find(const QString& name);
+
+public:
+    Device(Private* p = nullptr);
+    Device(const Device&) = default;
     Device(Device&&) = default;
 
-    Device& operator=(Device& other);
+    Device& operator=(const Device&) = default;
+    Device& operator=(Device&&) = default;
 
 public:
     bool isValid() const;
@@ -54,26 +71,44 @@ private:
     PrivatePtr d;
 };
 
-class Devices : public QObject
+class StreamContext
 {
-    Q_OBJECT
 public:
-    static Devices& self();
-    inline static Devices& getInstance()
+    class Private;
+
+    typedef QExplicitlySharedDataPointer<Private> PrivatePtr;
+
+public:
+    static StreamContext create(int inputDevice = -1, int outputDevice = -1);
+
+public:
+    StreamContext(Private* p);
+    StreamContext(StreamContext&&) = default;
+
+    StreamContext& operator=(const StreamContext&) = default;
+    StreamContext& operator=(StreamContext&&) = default;
+
+    inline bool isNull() const
     {
-        return self();
+        return d;
     }
 
-private:
-    Devices();
-    ~Devices();
+    bool open();
+    void close();
+
+    void start();
+    void stop();
+
+    bool isOpen() const;
+    bool isRunning() const;
 
 private:
-    class Private;
-    Private* d;
+    PrivatePtr d;
 };
 
 }
 }
+
+Q_DECLARE_METATYPE(qTox::Audio::Device)
 
 #endif

--- a/src/audio/devices.h
+++ b/src/audio/devices.h
@@ -20,6 +20,8 @@
 #ifndef QTOX_AUDIO_H
 #define QTOX_AUDIO_H
 
+#include <functional>
+
 #include <QObject>
 #include <QSharedData>
 
@@ -36,9 +38,24 @@ enum class Format
     FLOAT64 = 0x20
 };
 
+static inline quint8 formatSize(Format fmt)
+{
+    switch (fmt)
+    {
+    case Format::SINT8: return 1;
+    case Format::SINT16: return 2;
+    case Format::SINT24: return 3;
+    case Format::SINT32:
+    case Format::FLOAT32: return 4;
+    case Format::FLOAT64: return 8;
+    }
+}
+
 class Device
 {
     class Private;
+
+    friend class StreamContext;
 
 public:
     typedef QVector<Device> List;
@@ -48,8 +65,7 @@ public:
     static int find(const QString& name);
 
 public:
-    Device();
-    Device(Private* p);
+    Device(Private* p = nullptr);
     Device(const Device& other);
     Device(Device&& other);
     ~Device();
@@ -79,11 +95,11 @@ private:
 
 class StreamContext
 {
+public:
     class Private;
 
 public:
-    explicit StreamContext(int inputDevice = -1, int outputDevice = -1);
-    StreamContext(Private* p);
+    StreamContext();
     StreamContext(const StreamContext& other);
     StreamContext(StreamContext&& other);
     ~StreamContext();
@@ -96,11 +112,22 @@ public:
         return !d;
     }
 
+    int inputDeviceId() const;
+    Device inputDevie() const;
+    void setInputDevice(int deviceId = -1);
+    void removeInputDevice();
+
+    int outputDeviceId() const;
+    Device outputDevice() const;
+    void setOutputDevice(int deviceId = -1);
+    void removeOutputDevice();
+
     bool open();
     void close();
 
-    void start();
-    void stop();
+    bool abort();
+    bool start();
+    bool stop();
 
     bool isOpen() const;
     bool isRunning() const;

--- a/src/audio/devices.h
+++ b/src/audio/devices.h
@@ -158,8 +158,11 @@ public:
 
 public:
     static Device::List availableDevices();
+    static int streamCount();
 
 private:
+    class Private;
+
     Audio() = delete;
     Audio(const Audio&) = delete;
     Audio(Audio&&) = delete;
@@ -167,6 +170,9 @@ private:
 
     Audio& operator=(const Audio&) = delete;
     Audio& operator=(Audio&&) = delete;
+
+private:
+    static QSet<const Stream::Private*> streams;
 };
 
 }

--- a/src/audio/devices.h
+++ b/src/audio/devices.h
@@ -100,19 +100,19 @@ public:
         QExplicitlySharedDataPointer<Private> d;
     };
 
-    class StreamContext
+    class Stream
     {
     public:
         class Private;
 
     public:
-        StreamContext();
-        StreamContext(const StreamContext& other);
-        StreamContext(StreamContext&& other);
-        ~StreamContext();
+        Stream();
+        Stream(const Stream& other);
+        Stream(Stream&& other);
+        ~Stream();
 
-        StreamContext& operator=(const StreamContext& other);
-        StreamContext& operator=(StreamContext&& other);
+        Stream& operator=(const Stream& other);
+        Stream& operator=(Stream&& other);
 
         inline bool isNull() const
         {

--- a/src/core/coreav.h
+++ b/src/core/coreav.h
@@ -113,7 +113,7 @@ private:
     static IndexedList<ToxGroupCall> groupCalls;
     std::atomic_flag threadSwitchLock;
 
-    qTox::Audio::StreamContext  audioTx;
+    qTox::Audio::Stream  audioTx;
 };
 
 #endif // COREAV_H

--- a/src/core/coreav.h
+++ b/src/core/coreav.h
@@ -113,7 +113,7 @@ private:
     static IndexedList<ToxGroupCall> groupCalls;
     std::atomic_flag threadSwitchLock;
 
-    friend class Audio;
+    qTox::Audio::StreamContext  audioTx;
 };
 
 #endif // COREAV_H

--- a/src/core/toxcall.h
+++ b/src/core/toxcall.h
@@ -51,7 +51,7 @@ public:
     bool muteVol;
 
 protected:
-    qTox::Audio::StreamContext audioRx;
+    qTox::Audio::Stream audioRx;
 };
 
 struct ToxFriendCall : public ToxCall

--- a/src/core/toxcall.h
+++ b/src/core/toxcall.h
@@ -34,8 +34,6 @@ public:
      inline void playbackAudio(const qint16* pcm, quint32 frames,
                                quint8 channels, quint32 sampleRate)
      {
-         qDebug() << "ToxCall: Playback of" <<frames<< "recieved frames…";
-
          qTox::Audio::Format fmt = qTox::Audio::Format::SINT16;
 
          size_t bytes = frames * channels * 2;

--- a/src/widget/form/settings/avform.h
+++ b/src/widget/form/settings/avform.h
@@ -81,7 +81,7 @@ private:
 
 private:
 
-    qTox::Audio::StreamContext audio;
+    qTox::Audio::Stream audio;
     //qTox::Audio::StreamContext audioCall;
     bool mPlayTestSound;
     bool mPlaythrough;

--- a/src/widget/form/settings/avform.h
+++ b/src/widget/form/settings/avform.h
@@ -26,6 +26,7 @@
 
 #include "genericsettings.h"
 #include "ui_avform.h"
+#include "src/audio/devices.h"
 #include "src/video/videomode.h"
 
 
@@ -79,8 +80,12 @@ private:
     void open(const QString &devName, const VideoMode &mode);
 
 private:
-    bool subscribedToAudioIn;
+
+    qTox::Audio::StreamContext audio;
+    //qTox::Audio::StreamContext audioCall;
     bool mPlayTestSound;
+    bool mPlaythrough;
+
     VideoSurface *camVideoSurface;
     CameraSource &camera;
     QVector<QPair<QString, QString>> videoDeviceList;


### PR DESCRIPTION
**Important note:** Library bindings are kept in parallel to OpenAL until it can be replaced completely.
- [x] add RtAudio library dependency
- [ ] update build scripts and maintenace
- [ ] update docs
- [ ] **(last step)** remove OpenAL code and dependency
# Concept

The goal of the qTox audio API is to create a flexible management mechanism for the use of audio resources within qTox. Access to audio resources is encapsulated in a special audio context, which defines the audio devices, that should be used to stream and/or monitor audio. Here are some examples for audio contexts:
- qTox call
- qTox group-call
- audio preview (aka monitor)

**qTox code won't be aware of the underlying API in use - namely RtAudio. Direct access to RtAudio from outside the API is strictly forbidden.**
## Namespaces & Classes

Each method, that belongs to the qTox audio API is wrapped by the `qTox::Audio` namespace. Within the namespace, there exist the following classes:
- Obsolete: ~~Devices -> Controls access to audio devices and manages the devices, which are in use.~~
- Device -> Represents an single input or output device, including an `RtAudio::DeviceInfo`, describing the device's capabilities.
- StreamContext -> A streaming context configures the required input and/or output device and parameters.
# TODO: Implementation
- [x] implement a ~~"context"~~ "stream" class, that is used as a binding object for each audio ~~context~~ stream. Streams are e.g. a "qTox call receiver", a "qTox call sender" or the "settings preview"), which connects the required input/output devices.
- [ ] Implement audio resource self-management.
- [ ] settings for volume and gain (gain algorithm can be probably used from OpenAL implementation), if there's no prepared one.
- [ ] Use `Opus` codec for audio filtering, compression and the like.
## Want to help?

This PR will get merged into `master`, if implementation of audio API is complete or at least in a state, that provides feature parity to the current implementation. If you want to help with implementation or have ideas, please contact me and I'll do my best to answer your questions (@antis81 --> Tox-ID: `C52DA9FE98B86AF01178CB605DA2585919B2BA72DF1968B97932DE7155EC354320A65105E357`).
# Solves issues

Closes #3625, #3626

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tux3/qtox/3524)

<!-- Reviewable:end -->
