### PR TITLE
docs(INSTALL.md): add RtAudio to list of dependencies

### DIFF
--- a/.travis/build-ubuntu_14_04.sh
+++ b/.travis/build-ubuntu_14_04.sh
@@ -35,6 +35,7 @@ sudo apt-get install -y \
     libopenal-dev \
     libopus-dev \
     libqrencode-dev \
+    librtaudio-dev \
     libsqlcipher-dev \
     libtool \
     libvpx-dev \

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -38,18 +38,19 @@
 <a name="dependencies" />
 ## Dependencies
 
-| Name          | Version     | Modules                                           |
-|---------------|-------------|-------------------------------------------------- |
-| Qt            | >= 5.3.0    | core, gui, network, opengl, sql, svg, widget, xml |
-| GCC/MinGW     | >= 4.8      | C++11 enabled                                     |
-| toxcore       | most recent | core, av                                          |
-| FFmpeg        | >= 2.6.0    | avformat, avdevice, avcodec, avutil, swscale      |
-| OpenAL Soft   | >= 1.16.0   |                                                   |
-| qrencode      | >= 3.0.3    |                                                   |
-| sqlcipher     | >= 3.2.0    |                                                   |
-| libXScrnSaver | >= 1.2      |                                                   |
-| pkg-config    | >= 0.28     |                                                   |
-| libX11        | >= 1.6.0    |                                                   |
+Name          | Version     | Modules
+--------------|-------------|--------
+Qt            | >= 5.3.0    | core, gui, network, opengl, sql, svg, widget, xml
+GCC/MinGW     | >= 4.8      | C++11 enabled
+toxcore       | most recent | core, av
+FFmpeg        | >= 2.6.0    | avformat, avdevice, avcodec, avutil, swscale
+OpenAL Soft   | >= 1.16.0   |
+[RtAudio]     | >= 4.0.11   |
+qrencode      | >= 3.0.3    |
+sqlcipher     | >= 3.2.0    |
+libXScrnSaver | >= 1.2      |
+pkg-config    | >= 0.28     |
+libX11        | >= 1.6.0    |
 
 
 <a name="linux" />
@@ -199,7 +200,7 @@ and others. Instructions here: http://backports.debian.org/Instructions/
 sudo apt-get install build-essential qt5-qmake qt5-default qttools5-dev-tools \
 libqt5opengl5-dev libqt5svg5-dev libopenal-dev libxss-dev qrencode \
 libqrencode-dev libglib2.0-dev libgdk-pixbuf2.0-dev libgtk2.0-dev ffmpeg \
-libsqlcipher-dev
+librtaudio-dev libsqlcipher-dev
 ```
 
 
@@ -214,7 +215,7 @@ sudo dnf groupinstall "Development Tools" "C Development Tools and Libraries"
 # (can also use sudo dnf install @"Development Tools")
 sudo dnf install qt-devel qt-doc qt-creator qt5-qtsvg qt5-qtsvg-devel \
 openal-soft-devel libXScrnSaver-devel qrencode-devel ffmpeg-devel \
-qtsingleapplication qt5-linguist gtk2-devel libtool openssl-devel
+qtsingleapplication qt5-linguist gtk2-devel libtool openssl-devel rtaudio-devel
 ```
 
 **Go to [sqlcipher](#sqlcipher) section to compile it.**
@@ -245,13 +246,17 @@ libqt5opengl5-dev libqt5svg5-dev libopenal-dev libxss-dev qrencode \
 libqrencode-dev libavutil-ffmpeg-dev libswresample-ffmpeg-dev \
 libavcodec-ffmpeg-dev libswscale-ffmpeg-dev libavfilter-ffmpeg-dev \
 libavdevice-ffmpeg-dev libglib2.0-dev libgdk-pixbuf2.0-dev libgtk2.0-dev \
-libsqlcipher-dev
+librtaudio-dev libsqlcipher-dev
 ```
 
 <a name="ubuntu-other-1604-deps" />
 #### Ubuntu >=16.04:
 ```bash
-sudo apt-get install build-essential qt5-qmake qt5-default qttools5-dev-tools libqt5opengl5-dev libqt5svg5-dev libopenal-dev libxss-dev qrencode libqrencode-dev libavutil-dev libswresample-dev libavcodec-dev libswscale-dev libavfilter-dev libavdevice-dev libglib2.0-dev libgdk-pixbuf2.0-dev libgtk2.0-dev libsqlcipher-dev
+sudo apt-get install build-essential qt5-qmake qt5-default qttools5-dev-tools \
+libqt5opengl5-dev libqt5svg5-dev libopenal-dev libxss-dev qrencode \
+libqrencode-dev libavutil-dev libswresample-dev libavcodec-dev libswscale-dev \
+libavfilter-dev libavdevice-dev libglib2.0-dev libgdk-pixbuf2.0-dev \
+libgtk2.0-dev librtaudio-dev libsqlcipher-dev
 ```
 
 ### toxcore dependencies
@@ -560,4 +565,5 @@ dependencies compile them and put to appropriate directories.
 
 
 [OBS]: https://software.opensuse.org/download.html?project=home%3Aantonbatenev%3Atox&package=qtox
+[RtAudio]: http://www.music.mcgill.ca/~gary/rtaudio/
 [Ubuntu PPA]: https://launchpad.net/~abbat/+archive/ubuntu/tox

--- a/simple_make.sh
+++ b/simple_make.sh
@@ -18,6 +18,7 @@ apt_install() {
         libqrencode-dev
         libqt5opengl5-dev
         libqt5svg5-dev
+        librtaudio-dev
         libsodium-dev
         libsqlcipher-dev
         libtool
@@ -80,6 +81,7 @@ dnf_install() {
         qt-creator
         qt-devel
         qt-doc
+        rtaudio-devel
         sqlite
         sqlite-devel
     )


### PR DESCRIPTION
Added only for Debian, Ubuntu and Fedora, since Arch and openSUSE don't
have it in repos.

Also add dependency to Linux travis and `simple_make.sh`.

Minimal required version might be wrong – that's the lowest version that
is available on distro (Fedora) that is new enough to compile qTox.

Someone else will have to figure out osx travis.

cc @RowenStipe ?
