### PR TITLE
[WIP] create forms in the requested context

### DIFF
--- a/qtox.pro
+++ b/qtox.pro
@@ -273,6 +273,7 @@ HEADERS  += \
     src/core/cstring.h \
     src/core/toxid.h \
     src/core/indexedlist.h \
+    src/core/recursivesignalblocker.h \
     src/core/toxcall.h \
     src/net/toxuri.h \
     src/net/toxdns.h \
@@ -378,6 +379,7 @@ SOURCES += \
     src/core/coreencryption.cpp \
     src/core/corefile.cpp \
     src/core/corestructs.cpp \
+    src/core/recursivesignalblocker.cpp \
     src/core/toxid.cpp \
     src/core/toxcall.cpp \
     src/chatlog/chatlog.cpp \

--- a/qtox.pro
+++ b/qtox.pro
@@ -304,6 +304,7 @@ HEADERS  += \
     src/video/videomode.h \
     src/video/genericnetcamview.h \
     src/video/groupnetcamview.h \
+    src/widget/contentwidget.h \
     src/widget/emoticonswidget.h \
     src/widget/style.h \
     src/widget/tool/croppinglabel.h \
@@ -423,6 +424,7 @@ SOURCES += \
     src/video/groupnetcamview.cpp \
     src/video/netcamview.cpp \
     src/video/videosurface.cpp \
+    src/widget/contentwidget.cpp \
     src/widget/form/addfriendform.cpp \
     src/widget/form/settingswidget.cpp \
     src/widget/form/settings/generalform.cpp \

--- a/src/core/recursivesignalblocker.cpp
+++ b/src/core/recursivesignalblocker.cpp
@@ -1,0 +1,64 @@
+/*
+    Copyright © 2016 by The qTox Project
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "recursivesignalblocker.h"
+
+#include <QObject>
+#include <QSignalBlocker>
+
+namespace qTox {
+
+/**
+@class  RecursiveSignalBlocker
+@brief  Recursively blocks all signals from an object and its children.
+@note   All children must be created before the blocker is used.
+
+Wraps a QSignalBlocker on each object. Signals will be unblocked when the
+blocker gets destroyed. According to QSignalBlocker, we are also exception safe.
+*/
+
+/**
+@brief      Creates a QSignalBlocker recursively on the object and child objects.
+@param[in]  object  the object, which signals should be blocked
+*/
+RecursiveSignalBlocker::RecursiveSignalBlocker(QObject* object)
+{
+    recursiveBlock(object);
+}
+
+RecursiveSignalBlocker::~RecursiveSignalBlocker()
+{
+    qDeleteAll(mBlockers);
+}
+
+/**
+@brief      Recursively blocks all signals of the object.
+@param[in]  object  the object to block
+*/
+void RecursiveSignalBlocker::recursiveBlock(QObject* object)
+{
+    mBlockers << new QSignalBlocker(object);
+
+    for (QObject* child : object->children())
+    {
+        recursiveBlock(child);
+    }
+}
+
+}

--- a/src/core/recursivesignalblocker.h
+++ b/src/core/recursivesignalblocker.h
@@ -1,0 +1,44 @@
+/*
+    Copyright © 2016 by The qTox Project
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef QTOX_RECURSIVESIGNALBLOCKER_H
+#define QTOX_RECURSIVESIGNALBLOCKER_H
+
+#include <QVector>
+
+class QObject;
+class QSignalBlocker;
+
+namespace qTox {
+
+class RecursiveSignalBlocker
+{
+public:
+    explicit RecursiveSignalBlocker(QObject* object);
+    ~RecursiveSignalBlocker();
+
+    void recursiveBlock(QObject* object);
+
+private:
+    QVector<const QSignalBlocker*> mBlockers;
+};
+
+}
+
+#endif

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -778,7 +778,12 @@ bool Settings::getShowSystemTray() const
 void Settings::setShowSystemTray(const bool& newValue)
 {
     QMutexLocker locker{&bigLock};
-    showSystemTray = newValue;
+
+    if (newValue != showSystemTray)
+    {
+        showSystemTray = newValue;
+        emit showSystemTrayChanged(newValue);
+    }
 }
 
 void Settings::setUseEmoticons(bool newValue)
@@ -1702,7 +1707,12 @@ bool Settings::getCompactLayout() const
 void Settings::setCompactLayout(bool value)
 {
     QMutexLocker locker{&bigLock};
-    compactLayout = value;
+
+    if (value != compactLayout)
+    {
+        compactLayout = value;
+        emit compactLayoutChanged(value);
+    }
 }
 
 bool Settings::getSeparateWindow() const
@@ -1714,7 +1724,11 @@ bool Settings::getSeparateWindow() const
 void Settings::setSeparateWindow(bool value)
 {
     QMutexLocker locker{&bigLock};
-    separateWindow = value;
+    if (value != separateWindow)
+    {
+        separateWindow = value;
+        emit separateWindowChanged(value);
+    }
 }
 
 bool Settings::getDontGroupWindows() const
@@ -1738,7 +1752,12 @@ bool Settings::getGroupchatPosition() const
 void Settings::setGroupchatPosition(bool value)
 {
     QMutexLocker locker{&bigLock};
-    groupchatPosition = value;
+
+    if (value != groupchatPosition)
+    {
+        groupchatPosition = value;
+        emit groupchatPositionChanged(value);
+    }
 }
 
 int Settings::getCircleCount() const

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -41,6 +41,21 @@ enum StyleType {NONE, WITH_CHARS, WITHOUT_CHARS};
 class Settings : public QObject
 {
     Q_OBJECT
+
+    // general
+    Q_PROPERTY(bool compactLayout READ getCompactLayout WRITE setCompactLayout
+               NOTIFY compactLayoutChanged FINAL)
+    Q_PROPERTY(bool showSystemTray READ getShowSystemTray
+               WRITE setShowSystemTray NOTIFY showSystemTrayChanged FINAL)
+
+    // gui
+    Q_PROPERTY(bool separateWindow READ getSeparateWindow
+               WRITE setSeparateWindow NOTIFY separateWindowChanged FINAL)
+
+    // chat
+    Q_PROPERTY(bool groupchatPosition READ getGroupchatPosition
+               WRITE setGroupchatPosition NOTIFY groupchatPositionChanged FINAL)
+
 public:
     static Settings& getInstance();
     static void destroyInstance();
@@ -71,9 +86,20 @@ public slots:
     void sync();
 
 signals:
+    // general
     void dhtServerListChanged();
+
+    // gui
+    void separateWindowChanged(bool enabled);
+    void showSystemTrayChanged(bool enabled);
+
+    // friends
+    void compactLayoutChanged(bool enabled);
+
+    // chat
     void smileyPackChanged();
     void emojiFontChanged();
+    void groupchatPositionChanged(bool enabled);
 
 public:
     const QList<DhtServer>& getDhtServerList() const;

--- a/src/widget/contentdialog.h
+++ b/src/widget/contentdialog.h
@@ -22,6 +22,8 @@
 
 #include <tuple>
 
+#include <QPointer>
+
 #include "src/core/corestructs.h"
 #include "src/widget/genericchatitemlayout.h"
 #include "src/widget/tool/activatedialog.h"
@@ -42,7 +44,7 @@ class ContentDialog : public ActivateDialog
 {
     Q_OBJECT
 public:
-    ContentDialog(SettingsWidget* settingsWidget, QWidget* parent = 0);
+    explicit ContentDialog(QWidget* parent = nullptr);
     ~ContentDialog();
 
     FriendWidget* addFriend(int friendId, QString id);
@@ -113,11 +115,10 @@ private:
     ContentLayout* contentLayout;
     GenericChatroomWidget* activeChatroomWidget;
     GenericChatroomWidget* displayWidget = nullptr;
-    SettingsWidget* settingsWidget;
     QSize videoSurfaceSize;
     int videoCount;
 
-    static ContentDialog* currentDialog;
+    static QPointer<ContentDialog> currentDialog;
     static QHash<int, std::tuple<ContentDialog*, GenericChatroomWidget*>> friendList;
     static QHash<int, std::tuple<ContentDialog*, GenericChatroomWidget*>> groupList;
 };

--- a/src/widget/contentlayout.cpp
+++ b/src/widget/contentlayout.cpp
@@ -71,15 +71,11 @@ void ContentLayout::clear()
     QLayoutItem* item;
     while ((item = mainHead->layout()->takeAt(0)) != 0)
     {
-        item->widget()->hide();
-        item->widget()->setParent(nullptr);
         delete item;
     }
 
     while ((item = mainContent->layout()->takeAt(0)) != 0)
     {
-        item->widget()->hide();
-        item->widget()->setParent(nullptr);
         delete item;
     }
 }

--- a/src/widget/contentwidget.cpp
+++ b/src/widget/contentwidget.cpp
@@ -1,0 +1,121 @@
+/*
+    Copyright © 2016 by The qTox Project
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "contentwidget.h"
+
+#include "src/widget/style.h"
+
+#include <QFrame>
+#include <QPalette>
+#include <QVBoxLayout>
+
+/**
+ * @class   ContentWidget
+ * @brief   Provides a widget with a fixed 2-row (header, body) layout.
+ *
+ * The widget defines a header widget and a body widget, which can be used
+ * or replaced by the inheriting class. Header and body are separated by a thin
+ * horizontal line to visually separate them.
+ */
+
+/**
+ * @brief       ContentWidget constructor
+ * @param[in]   parent  the parent widget (may be nullptr)
+ * @param[in]   f       optional window flags; defaults to Qt::Window
+ */
+ContentWidget::ContentWidget(QWidget *parent, Qt::WindowFlags f)
+    : QWidget(parent, f)
+    , contentLayout(new QVBoxLayout(this))
+{
+    setAttribute(Qt::WA_DeleteOnClose);
+
+    setContentsMargins(0,0,0,0);
+    contentLayout->setMargin(0);
+
+    // TODO: the palette has to be set by the style implementation instead
+    //       of using a fixed one.
+    QPalette pal = palette();
+
+    pal.setBrush(QPalette::WindowText, QColor(0, 0, 0));
+    pal.setBrush(QPalette::Button, QColor(255, 255, 255));
+    pal.setBrush(QPalette::Light, QColor(255, 255, 255));
+    pal.setBrush(QPalette::Midlight, QColor(255, 255, 255));
+    pal.setBrush(QPalette::Dark, QColor(127, 127, 127));
+    pal.setBrush(QPalette::Mid, QColor(170, 170, 170));
+    pal.setBrush(QPalette::Text, QColor(0, 0, 0));
+    pal.setBrush(QPalette::BrightText, QColor(255, 255, 255));
+    pal.setBrush(QPalette::ButtonText, QColor(0, 0, 0));
+    pal.setBrush(QPalette::Base, QColor(255, 255, 255));
+    pal.setBrush(QPalette::Window, QColor(255, 255, 255));
+    pal.setBrush(QPalette::Shadow, QColor(0, 0, 0));
+    pal.setBrush(QPalette::AlternateBase, QColor(255, 255, 255));
+    pal.setBrush(QPalette::ToolTipBase, QColor(255, 255, 220));
+    pal.setBrush(QPalette::ToolTipText, QColor(0, 0, 0));
+
+    pal.setBrush(QPalette::Disabled, QPalette::WindowText, QColor(127, 127, 127));
+    pal.setBrush(QPalette::Disabled, QPalette::Text, QColor(127, 127, 127));
+    pal.setBrush(QPalette::Disabled, QPalette::ButtonText, QColor(127, 127, 127));
+
+    setPalette(pal);
+
+    // horizontal line
+    mainHLine.setFrameShape(QFrame::HLine);
+    mainHLine.setFrameShadow(QFrame::Plain);
+    mainHLine.setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed);
+
+    // TODO: the palette has to be set by the style implementation instead
+    //       of using a fixed one.
+    QPalette palette = mainHLine.palette();
+    palette.setBrush(QPalette::WindowText, QBrush(QColor(193, 193, 193)));
+    mainHLine.setPalette(palette);
+}
+
+void ContentWidget::setupLayout(QWidget* head, QWidget* body)
+{
+    QLayoutItem* item = nullptr;
+    while ((item = contentLayout->takeAt(0)) != nullptr)
+    {
+        delete item;
+    }
+
+    head->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed);
+
+    contentLayout->addWidget(head);
+    contentLayout->addWidget(&mainHLine);
+    contentLayout->addSpacing(5);
+    contentLayout->addWidget(body);
+}
+
+QWidget* ContentWidget::headerWidget() const
+{
+    QLayoutItem* item = contentLayout->itemAt(0);
+    return item ? item->widget() : nullptr;
+}
+
+QWidget* ContentWidget::bodyWidget() const
+{
+    QLayoutItem* item = contentLayout->itemAt(3);
+    return item ? item->widget() : nullptr;
+}
+
+
+QSize ContentWidget::minimumSizeHint() const
+{
+    return QSize(500, 500);
+}

--- a/src/widget/contentwidget.h
+++ b/src/widget/contentwidget.h
@@ -1,0 +1,53 @@
+/*
+    Copyright © 2016 by The qTox Project
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef CONTENTWIDGET_H
+#define CONTENTWIDGET_H
+
+#include <QFrame>
+#include <QPointer>
+
+class QVBoxLayout;
+
+class ContentWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit ContentWidget(QWidget *parent = nullptr,
+                           Qt::WindowFlags f = Qt::Window);
+
+    void setLayout(QLayout* layout) = delete;
+
+    QSize minimumSizeHint() const override;
+
+protected:
+    void setupLayout(QWidget* head, QWidget* body);
+
+    QWidget* headerWidget() const;
+    QWidget* bodyWidget() const;
+
+private:
+    QVBoxLayout*        contentLayout;
+    QFrame              mainHLine;
+    QPointer<QWidget>   head;
+    QPointer<QWidget>   body;
+};
+
+#endif

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -28,6 +28,7 @@
 #include "src/widget/tool/screenshotgrabber.h"
 #include "src/core/core.h"
 #include "src/core/coreav.h"
+#include "src/core/recursivesignalblocker.h"
 
 #include <QDebug>
 #include <QShowEvent>
@@ -45,6 +46,9 @@ AVForm::AVForm()
     , camera(CameraSource::getInstance())
 {
     setupUi(this);
+
+    // block all child signals during initialization
+    const qTox::RecursiveSignalBlocker signalBlocker(this);
 
     const Audio& audio = Audio::getInstance();
     const Settings& s = Settings::getInstance();

--- a/src/widget/form/settings/generalform.cpp
+++ b/src/widget/form/settings/generalform.cpp
@@ -314,7 +314,6 @@ void GeneralForm::onAutorunUpdated()
 void GeneralForm::onSetShowSystemTray()
 {
     Settings::getInstance().setShowSystemTray(bodyUI->showSystemTray->isChecked());
-    emit parent->setShowSystemTray(bodyUI->showSystemTray->isChecked());
     Settings::getInstance().saveGlobal();
 }
 

--- a/src/widget/form/settingswidget.cpp
+++ b/src/widget/form/settingswidget.cpp
@@ -34,8 +34,7 @@
 SettingsWidget::SettingsWidget(QWidget* parent)
     : QWidget(parent, Qt::Window)
 {
-    // block all signals during initialization, including child widgets
-    blockSignals(true);
+    setAttribute(Qt::WA_DeleteOnClose);
 
     body = new QWidget();
     QVBoxLayout* bodyLayout = new QVBoxLayout();
@@ -73,8 +72,6 @@ SettingsWidget::SettingsWidget(QWidget* parent)
     connect(settingsWidgets, &QTabWidget::currentChanged, this, &SettingsWidget::onTabChanged);
 
     Translator::registerHandler(std::bind(&SettingsWidget::retranslateUi, this), this);
-
-    blockSignals(false);
 }
 
 SettingsWidget::~SettingsWidget()

--- a/src/widget/genericchatroomwidget.cpp
+++ b/src/widget/genericchatroomwidget.cpp
@@ -47,7 +47,7 @@ GenericChatroomWidget::GenericChatroomWidget(QWidget *parent)
     setAutoFillBackground(true);
     reloadTheme();
 
-    compactChange(isCompact());
+    compactLayoutChanged(isCompact());
 }
 
 bool GenericChatroomWidget::eventFilter(QObject *, QEvent *)
@@ -55,7 +55,7 @@ bool GenericChatroomWidget::eventFilter(QObject *, QEvent *)
     return true; // Disable all events.
 }
 
-void GenericChatroomWidget::compactChange(bool _compact)
+void GenericChatroomWidget::compactLayoutChanged(bool _compact)
 {
     if (!isCompact())
         delete textLayout; // has to be first, deleted by layout

--- a/src/widget/genericchatroomwidget.h
+++ b/src/widget/genericchatroomwidget.h
@@ -59,7 +59,7 @@ public:
 	void reloadTheme();
 
 public slots:
-	void compactChange(bool compact);
+    void compactLayoutChanged(bool compact);
 
 signals:
     void chatroomWidgetClicked(GenericChatroomWidget* widget, bool group = false);

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -235,7 +235,6 @@ void Widget::init()
     addFriendForm = new AddFriendForm;
     groupInviteForm = new GroupInviteForm;
     profileForm = new ProfileForm();
-    settingsWidget = new SettingsWidget();
 
     //connect logout tray menu action
     connect(actionLogout, &QAction::triggered, profileForm, &ProfileForm::onLogoutClicked);
@@ -243,12 +242,11 @@ void Widget::init()
     Core* core = Nexus::getCore();
     connect(core, &Core::fileDownloadFinished, filesForm, &FilesForm::onFileDownloadComplete);
     connect(core, &Core::fileUploadFinished, filesForm, &FilesForm::onFileUploadComplete);
-    connect(settingsWidget, &SettingsWidget::setShowSystemTray, this, &Widget::onSetShowSystemTray);
     connect(core, &Core::selfAvatarChanged, profileForm, &ProfileForm::onSelfAvatarLoaded);
     connect(ui->addButton, &QPushButton::clicked, this, &Widget::onAddClicked);
     connect(ui->groupButton, &QPushButton::clicked, this, &Widget::onGroupClicked);
     connect(ui->transferButton, &QPushButton::clicked, this, &Widget::onTransferClicked);
-    connect(ui->settingsButton, &QPushButton::clicked, this, &Widget::onSettingsClicked);
+    connect(ui->settingsButton, &QPushButton::clicked, this, &Widget::onShowSettings);
     connect(profilePicture, &MaskablePixmapWidget::clicked, this, &Widget::showProfile);
     connect(ui->nameLabel, &CroppingLabel::clicked, this, &Widget::showProfile);
     connect(ui->statusLabel, &CroppingLabel::editFinished, this, &Widget::onStatusMessageChanged);
@@ -380,9 +378,6 @@ void Widget::init()
         ui->mainSplitter->setSizes(sizes);
     }
 
-    connect(settingsWidget, &SettingsWidget::compactToggled, contactListWidget, &FriendListWidget::onCompactChanged);
-    connect(settingsWidget, &SettingsWidget::groupchatPositionToggled, contactListWidget, &FriendListWidget::onGroupchatPositionChanged);
-    connect(settingsWidget, &SettingsWidget::separateWindowToggled, this, &Widget::onSeparateWindowClicked);
 #if (AUTOUPDATE_ENABLED)
     if (Settings::getInstance().getCheckUpdates())
         AutoUpdater::checkUpdatesAsyncInteractive();
@@ -397,6 +392,17 @@ void Widget::init()
     connect(addFriendForm, &AddFriendForm::friendRequestAccepted, this, &Widget::friendRequestAccepted);
     connect(groupInviteForm, &GroupInviteForm::groupInvitesSeen, this, &Widget::groupInvitesClear);
     connect(groupInviteForm, &GroupInviteForm::groupInviteAccepted, this, &Widget::onGroupInviteAccepted);
+
+    // settings
+    const Settings& s = Settings::getInstance();
+    connect(&s, &Settings::showSystemTrayChanged,
+            this, &Widget::onSetShowSystemTray);
+    connect(&s, &Settings::separateWindowChanged,
+            this, &Widget::onSeparateWindowClicked);
+    connect(&s, &Settings::compactLayoutChanged,
+            contactListWidget, &FriendListWidget::onCompactChanged);
+    connect(&s, &Settings::groupchatPositionChanged,
+            contactListWidget, &FriendListWidget::onGroupchatPositionChanged);
 
     retranslateUi();
     Translator::registerHandler(std::bind(&Widget::retranslateUi, this), this);
@@ -522,7 +528,6 @@ Widget::~Widget()
 
     delete icon;
     delete profileForm;
-    delete settingsWidget;
     delete addFriendForm;
     delete groupInviteForm;
     delete filesForm;
@@ -553,8 +558,8 @@ Widget* Widget::getInstance()
 */
 void Widget::showUpdateDownloadProgress()
 {
+    onShowSettings();
     settingsWidget->showAbout();
-    onSettingsClicked();
 }
 
 void Widget::moveEvent(QMoveEvent *event)
@@ -646,7 +651,7 @@ void Widget::onBadProxyCore()
                "settings and restart.", "popup text"));
     critical.setIcon(QMessageBox::Critical);
     critical.exec();
-    onSettingsClicked();
+    onShowSettings();
 }
 
 void Widget::onStatusSet(Status status)
@@ -709,19 +714,19 @@ void Widget::onSeparateWindowChanged(bool separate, bool clicked)
         {
             showNormal();
             resize(width, height());
+
+            if (settingsWidget)
+            {
+                ContentLayout* contentLayout = createContentDialog((SettingDialog));
+                contentLayout->parentWidget()->resize(size);
+                contentLayout->parentWidget()->move(pos);
+                settingsWidget->show(contentLayout);
+                setActiveToolMenuButton(Widget::None);
+            }
         }
 
         setWindowTitle(QString());
         setActiveToolMenuButton(None);
-
-        if (clicked)
-        {
-            ContentLayout* contentLayout = createContentDialog((SettingDialog));
-            contentLayout->parentWidget()->resize(size);
-            contentLayout->parentWidget()->move(pos);
-            settingsWidget->show(contentLayout);
-            setActiveToolMenuButton(Widget::None);
-        }
     }
 }
 
@@ -846,8 +851,11 @@ void Widget::onIconClick(QSystemTrayIcon::ActivationReason reason)
     }
 }
 
-void Widget::onSettingsClicked()
+void Widget::onShowSettings()
 {
+    if (!settingsWidget)
+        settingsWidget = new SettingsWidget(this);
+
     if (Settings::getInstance().getSeparateWindow())
     {
         if (!settingsWidget->isShown())
@@ -944,6 +952,7 @@ void Widget::reloadHistory()
 
 void Widget::addFriend(int friendId, const QString &userId)
 {
+    Settings& s = Settings::getInstance();
     ToxId userToxId = ToxId(userId);
     Friend* newfriend = FriendList::addFriend(friendId, userToxId);
 
@@ -951,14 +960,15 @@ void Widget::addFriend(int friendId, const QString &userId)
     QDate chatDate = newfriend->getChatForm()->getLatestDate();
 
     if (chatDate > activityDate && chatDate.isValid())
-        Settings::getInstance().setFriendActivity(newfriend->getToxId(), chatDate);
+        s.setFriendActivity(newfriend->getToxId(), chatDate);
 
     contactListWidget->addFriendWidget(newfriend->getFriendWidget(), Status::Offline, Settings::getInstance().getFriendCircleID(newfriend->getToxId()));
 
     Core* core = Nexus::getCore();
     CoreAV* coreav = core->getAv();
     connect(newfriend, &Friend::displayedNameChanged, this, &Widget::onFriendDisplayChanged);
-    connect(settingsWidget, &SettingsWidget::compactToggled, newfriend->getFriendWidget(), &GenericChatroomWidget::compactChange);
+    connect(&s, &Settings::compactLayoutChanged, newfriend->getFriendWidget(),
+            &GenericChatroomWidget::compactChange);
     connect(newfriend->getFriendWidget(), SIGNAL(chatroomWidgetClicked(GenericChatroomWidget*, bool)), this, SLOT(onChatroomWidgetClicked(GenericChatroomWidget*, bool)));
     connect(newfriend->getFriendWidget(), SIGNAL(removeFriend(int)), this, SLOT(removeFriend(int)));
     connect(newfriend->getFriendWidget(), SIGNAL(copyFriendIdToClipboard(int)), this, SLOT(copyFriendIdToClipboard(int)));
@@ -1682,7 +1692,8 @@ Group *Widget::createGroup(int groupId)
     newgroup->getGroupWidget()->updateStatusLight();
     contactListWidget->activateWindow();
 
-    connect(settingsWidget, &SettingsWidget::compactToggled, newgroup->getGroupWidget(), &GenericChatroomWidget::compactChange);
+    connect(&Settings::getInstance(), &Settings::compactLayoutChanged,
+            newgroup->getGroupWidget(), &GenericChatroomWidget::compactChange);
     connect(newgroup->getGroupWidget(), SIGNAL(chatroomWidgetClicked(GenericChatroomWidget*,bool)), this, SLOT(onChatroomWidgetClicked(GenericChatroomWidget*,bool)));
     connect(newgroup->getGroupWidget(), SIGNAL(removeGroup(int)), this, SLOT(removeGroup(int)));
     connect(newgroup->getGroupWidget(), SIGNAL(chatroomWidgetClicked(GenericChatroomWidget*)), newgroup->getChatForm(), SLOT(focusInput()));

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -353,7 +353,6 @@ void Widget::init()
     connect(this, &Widget::windowStateChanged, &Nexus::getInstance(), &Nexus::onWindowStateChanged);
 #endif
 
-    contentLayout = nullptr;
     onSeparateWindowChanged(Settings::getInstance().getSeparateWindow(), false);
 
     ui->addButton->setCheckable(true);
@@ -533,7 +532,6 @@ Widget::~Widget()
     delete filesForm;
     delete timer;
     delete offlineMsgTimer;
-    delete contentLayout;
 
     FriendList::clear();
     GroupList::clear();
@@ -705,7 +703,6 @@ void Widget::onSeparateWindowChanged(bool separate, bool clicked)
             contentLayout->parentWidget()->hide();
             contentLayout->parentWidget()->deleteLater();
             contentLayout->deleteLater();
-            contentLayout = nullptr;
         }
 
         setMinimumWidth(ui->tooliconsZone->sizeHint().width());

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -991,7 +991,7 @@ void Widget::addFriend(int friendId, const QString &userId)
         newfriend->getFriendWidget()->onAvatarChange(friendId, avatar);
     }
 
-    int filter = getFilterCriteria();
+    FilterCriteria filter = getFilterCriteria();
     newfriend->getFriendWidget()->search(ui->searchContactText->text(), filterOffline(filter));
 
 }
@@ -1069,7 +1069,8 @@ void Widget::onFriendStatusMessageChanged(int friendId, const QString& message)
         return;
 
     QString str = message; str.replace('\n', ' ');
-    str.remove('\r'); str.remove(QChar((char)0)); // null terminator...
+    str.remove('\r');
+    str.remove(QChar()); // null terminator...
     f->setStatusMessage(str);
 
     ContentDialog::updateFriendStatusMessage(friendId, message);
@@ -1082,20 +1083,27 @@ void Widget::onFriendUsernameChanged(int friendId, const QString& username)
         return;
 
     QString str = username; str.replace('\n', ' ');
-    str.remove('\r'); str.remove(QChar((char)0)); // null terminator...
+    str.remove('\r');
+    str.remove(QChar()); // null terminator...
     f->setName(str);
 }
 
 void Widget::onFriendDisplayChanged(FriendWidget *friendWidget, Status s)
 {
     contactListWidget->moveWidget(friendWidget, s);
-    int filter = getFilterCriteria();
+    FilterCriteria filter = getFilterCriteria();
     switch (s)
     {
-        case Status::Offline:
-            friendWidget->searchName(ui->searchContactText->text(), filterOffline(filter));
-        default:
-            friendWidget->searchName(ui->searchContactText->text(), filterOnline(filter));
+    case Status::Offline:
+        friendWidget->searchName(ui->searchContactText->text(),
+                                 filterOffline(filter));
+        break;
+    case Status::Online:
+    case Status::Busy:
+    case Status::Away:
+        friendWidget->searchName(ui->searchContactText->text(),
+                                 filterOnline(filter));
+        break;
     }
 
 }
@@ -1499,7 +1507,6 @@ ContentLayout* Widget::createContentDialog(DialogType type)
     dialog->layout()->setMargin(0);
     dialog->layout()->setSpacing(0);
     dialog->setMinimumSize(720, 400);
-    dialog->setAttribute(Qt::WA_DeleteOnClose);
     dialog->show();
 
 #ifdef Q_OS_MAC
@@ -1615,7 +1622,7 @@ void Widget::onGroupTitleChanged(int groupnumber, const QString& author, const Q
 
     contactListWidget->renameGroupWidget(g->getGroupWidget(), title);
     g->setName(title);
-    int filter = getFilterCriteria();
+    FilterCriteria filter = getFilterCriteria();
     g->getGroupWidget()->searchName(ui->searchContactText->text(), filterGroups(filter));
 }
 
@@ -1698,7 +1705,7 @@ Group *Widget::createGroup(int groupId)
     connect(newgroup->getChatForm(), &GroupChatForm::sendAction, core, &Core::sendGroupAction);
     connect(newgroup->getChatForm(), &GroupChatForm::groupTitleChanged, core, &Core::changeGroupTitle);
 
-    int filter = getFilterCriteria();
+    FilterCriteria filter = getFilterCriteria();
     newgroup->getGroupWidget()->searchName(ui->searchContactText->text(), filterGroups(filter));
 
     return newgroup;
@@ -1937,40 +1944,55 @@ void Widget::cycleContacts(bool forward)
     contactListWidget->cycleContacts(activeChatroomWidget, forward);
 }
 
-bool Widget::filterGroups(int index)
+bool Widget::filterGroups(FilterCriteria filter)
 {
-    switch (index)
+    switch (filter)
     {
-        case FilterCriteria::Offline:
-        case FilterCriteria::Friends:
-            return true;
-        default:
-            return false;
+    case FilterCriteria::Offline:
+    case FilterCriteria::Friends:
+        return true;
+
+    case FilterCriteria::Online:
+    case FilterCriteria::Groups:
+    case FilterCriteria::All:
+        return false;
     }
+
+    return false;
 }
 
-bool Widget::filterOffline(int index)
+bool Widget::filterOffline(FilterCriteria filter)
 {
-    switch (index)
+    switch (filter)
     {
-        case FilterCriteria::Online:
-        case FilterCriteria::Groups:
-            return true;
-        default:
-            return false;
+    case FilterCriteria::Online:
+    case FilterCriteria::Groups:
+        return true;
+
+    case FilterCriteria::Offline:
+    case FilterCriteria::Friends:
+    case FilterCriteria::All:
+        return false;
     }
+
+    return false;
 }
 
-bool Widget::filterOnline(int index)
+bool Widget::filterOnline(FilterCriteria filter)
 {
-    switch (index)
+    switch (filter)
     {
         case FilterCriteria::Offline:
         case FilterCriteria::Groups:
             return true;
-        default:
+
+    case FilterCriteria::Online:
+    case FilterCriteria::Friends:
+    case FilterCriteria::All:
             return false;
     }
+
+    return false;
 }
 
 void Widget::processOfflineMsgs()
@@ -2101,7 +2123,7 @@ Status Widget::getStatusFromString(QString status)
 void Widget::searchContacts()
 {
     QString searchString = ui->searchContactText->text();
-    int filter = getFilterCriteria();
+    FilterCriteria filter = getFilterCriteria();
 
     contactListWidget->searchChatrooms(searchString, filterOnline(filter), filterOffline(filter), filterGroups(filter));
 
@@ -2130,39 +2152,41 @@ void Widget::updateFilterText()
      ui->searchContactFilterBox->setText(filterDisplayGroup->checkedAction()->text() + QStringLiteral(" | ") + filterGroup->checkedAction()->text());
 }
 
-int Widget::getFilterCriteria() const
+Widget::FilterCriteria Widget::getFilterCriteria() const
 {
     QAction* checked = filterGroup->checkedAction();
 
     if (checked == filterOnlineAction)
-        return Online;
+        return FilterCriteria::Online;
     else if (checked == filterOfflineAction)
-        return Offline;
+        return FilterCriteria::Offline;
     else if (checked == filterFriendsAction)
-        return Friends;
+        return FilterCriteria::Friends;
     else if (checked == filterGroupsAction)
-        return Groups;
+        return FilterCriteria::Groups;
 
-    return All;
+    return FilterCriteria::All;
 }
 
 void Widget::searchCircle(CircleWidget *circleWidget)
 {
-    int filter = getFilterCriteria();
+    FilterCriteria filter = getFilterCriteria();
     circleWidget->search(ui->searchContactText->text(), true, filterOnline(filter), filterOffline(filter));
 }
 
 void Widget::searchItem(GenericChatItemWidget *chatItem, GenericChatItemWidget::ItemType type)
 {
     bool hide;
-    int filter = getFilterCriteria();
+    FilterCriteria filter = getFilterCriteria();
     switch (type)
     {
-        case GenericChatItemWidget::GroupItem:
-            hide = filterGroups(filter);
-            break;
-        default:
-            hide = true;
+    case GenericChatItemWidget::GroupItem:
+        hide = filterGroups(filter);
+        break;
+    case GenericChatItemWidget::FriendOfflineItem:
+    case GenericChatItemWidget::FriendOnlineItem:
+        hide = true;
+        break;
     }
 
     chatItem->searchName(ui->searchContactText->text(), hide);
@@ -2170,7 +2194,7 @@ void Widget::searchItem(GenericChatItemWidget *chatItem, GenericChatItemWidget::
 
 bool Widget::groupsVisible() const
 {
-    int filter = getFilterCriteria();
+    FilterCriteria filter = getFilterCriteria();
     return !filterGroups(filter);
 }
 

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -909,7 +909,7 @@ void Widget::hideMainForms(GenericChatroomWidget* chatroomWidget)
     if (contentLayout != nullptr)
         contentLayout->clear();
 
-    if (activeChatroomWidget != nullptr)
+    if (activeChatroomWidget)
         activeChatroomWidget->setAsInactiveChatroom();
 
     activeChatroomWidget = chatroomWidget;
@@ -972,13 +972,14 @@ void Widget::addFriend(int friendId, const QString &userId)
     if (chatDate > activityDate && chatDate.isValid())
         s.setFriendActivity(newfriend->getToxId(), chatDate);
 
-    contactListWidget->addFriendWidget(newfriend->getFriendWidget(), Status::Offline, Settings::getInstance().getFriendCircleID(newfriend->getToxId()));
+    contactListWidget->addFriendWidget(newfriend->getFriendWidget(),
+                                       Status::Offline, s.getFriendCircleID(newfriend->getToxId()));
 
     Core* core = Nexus::getCore();
     CoreAV* coreav = core->getAv();
     connect(newfriend, &Friend::displayedNameChanged, this, &Widget::onFriendDisplayChanged);
     connect(&s, &Settings::compactLayoutChanged, newfriend->getFriendWidget(),
-            &GenericChatroomWidget::compactChange);
+            &GenericChatroomWidget::compactLayoutChanged);
     connect(newfriend->getFriendWidget(), SIGNAL(chatroomWidgetClicked(GenericChatroomWidget*, bool)), this, SLOT(onChatroomWidgetClicked(GenericChatroomWidget*, bool)));
     connect(newfriend->getFriendWidget(), SIGNAL(removeFriend(int)), this, SLOT(removeFriend(int)));
     connect(newfriend->getFriendWidget(), SIGNAL(copyFriendIdToClipboard(int)), this, SLOT(copyFriendIdToClipboard(int)));
@@ -1123,6 +1124,8 @@ void Widget::onFriendDisplayChanged(FriendWidget *friendWidget, Status s)
 
 void Widget::onChatroomWidgetClicked(GenericChatroomWidget *widget, bool group)
 {
+    const Settings& s = Settings::getInstance();
+
     widget->resetEventFlags();
     widget->updateStatusLight();
 
@@ -1453,9 +1456,9 @@ void Widget::updateScroll(GenericChatroomWidget *widget) {
 }
 
 
-ContentDialog* Widget::createContentDialog() const
+ContentDialog* Widget::createContentDialog()
 {
-    ContentDialog* contentDialog = new ContentDialog(settingsWidget);
+    ContentDialog* contentDialog = new ContentDialog(this);
 #ifdef Q_OS_MAC
     connect(contentDialog, &ContentDialog::destroyed, &Nexus::getInstance(), &Nexus::updateWindowsClosed);
     connect(contentDialog, &ContentDialog::windowStateChanged, &Nexus::getInstance(), &Nexus::onWindowStateChanged);
@@ -1471,12 +1474,12 @@ ContentLayout* Widget::createContentDialog(DialogType type)
     {
     public:
         explicit Dialog(DialogType type)
-            : ActivateDialog()
+            : ActivateDialog(this)
             , type(type)
         {
             restoreGeometry(Settings::getInstance().getDialogSettingsGeometry());
-            Translator::registerHandler(std::bind(&Dialog::retranslateUi, this), this);
             retranslateUi();
+            Translator::registerHandler(std::bind(&Dialog::retranslateUi, this), this);
 
             connect(Core::getInstance(), &Core::usernameSet, this, &Dialog::retranslateUi);
         }
@@ -1487,7 +1490,6 @@ ContentLayout* Widget::createContentDialog(DialogType type)
         }
 
     public slots:
-
         void retranslateUi()
         {
             setWindowTitle(Core::getInstance()->getUsername() + QStringLiteral(" - ") + Widget::fromDialogType(type));
@@ -1710,7 +1712,7 @@ Group *Widget::createGroup(int groupId)
     contactListWidget->activateWindow();
 
     connect(&Settings::getInstance(), &Settings::compactLayoutChanged,
-            newgroup->getGroupWidget(), &GenericChatroomWidget::compactChange);
+            newgroup->getGroupWidget(), &GenericChatroomWidget::compactLayoutChanged);
     connect(newgroup->getGroupWidget(), SIGNAL(chatroomWidgetClicked(GenericChatroomWidget*,bool)), this, SLOT(onChatroomWidgetClicked(GenericChatroomWidget*,bool)));
     connect(newgroup->getGroupWidget(), SIGNAL(removeGroup(int)), this, SLOT(removeGroup(int)));
     connect(newgroup->getGroupWidget(), SIGNAL(chatroomWidgetClicked(GenericChatroomWidget*)), newgroup->getChatForm(), SLOT(focusInput()));

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -75,6 +75,7 @@
 #include <QProcess>
 #include <QSvgRenderer>
 #include <QWindow>
+#include <QDesktopWidget>
 #include <tox/tox.h>
 
 #ifdef Q_OS_MAC
@@ -549,6 +550,18 @@ Widget* Widget::getInstance()
         instance = new Widget();
 
     return instance;
+}
+
+QSize Widget::minimumSizeHint() const
+{
+    QSize size(300, 480);
+
+    if (contentWidget)
+        size.rwidth() = ui->mainSplitter->minimumWidth();
+    else
+        size.rwidth() = ui->tooliconsZone->minimumSize().width();
+
+    return size;
 }
 
 /**
@@ -2054,6 +2067,8 @@ QString Widget::getStatusIconPath(Status status)
     case Status::Offline:
         return ":/img/status/dot_offline.svg";
     }
+
+    return QString();
 }
 
 inline QIcon Widget::prepareIcon(QString path, int w, int h)
@@ -2333,4 +2348,77 @@ void Widget::focusChatInput()
         else if (Group* g = activeChatroomWidget->getGroup())
             g->getChatForm()->focusInput();
     }
+}
+
+/**
+ * @brief       Shows a widget "detached" or as "embedded widget".
+ * @param[in]   contentWidget   the widget to show
+ * @param[in]   title           the title in "embedded" mode
+ * @param[in]   activeButton    the active tool button in "embedded" mode
+ *
+ * Depending on the mode, the widget is shown detached from the main window or
+ * embedded in the main window's splitter.
+ */
+void Widget::showContentWidget(QWidget* widget, const QString& title,
+                               Widget::ActiveToolMenuButton activeButton)
+{
+    Q_ASSERT(widget != this);
+
+    QWidget* prevWidget = contentWidget;
+
+    if (!widget)
+    {
+        setMinimumWidth(minimumSizeHint().width());
+        return;
+    }
+
+    const int dw = QApplication::desktop()->width();
+
+    if (Settings::getInstance().getSeparateWindow())
+    {
+        contentWidget = nullptr;
+        setWindowTitle(QString());
+
+        // detach the content widget
+        widget->setParent(nullptr);
+        widget->showNormal();
+        setMinimumWidth(minimumSizeHint().width());
+
+        resize(width() - widget->width(), height());
+
+        // move the content widget attached to top-right / top-left
+        QPoint newPos(0, geometry().top());
+        newPos.rx() = frameGeometry().right() + widget->width() > dw
+                   ? geometry().left() - widget->width()
+                   : geometry().right();
+
+        widget->setGeometry(newPos.x(), newPos.y(),
+                                   widget->width(), height());
+    }
+    else
+    {
+        contentWidget = widget;
+
+        if (prevWidget && prevWidget != contentWidget)
+            prevWidget->close();
+
+        setWindowTitle(title);
+        setActiveToolMenuButton(activeButton);
+
+        QList<int> sizes = ui->mainSplitter->sizes();
+
+        ui->mainSplitter->insertWidget(1, contentWidget);
+        sizes << contentWidget->minimumSizeHint().width();
+        setMinimumWidth(minimumSizeHint().width());
+
+        if (frameGeometry().right() >= dw)
+        {
+            // reverse splitter positions, depending on the desktop edge
+            ui->mainSplitter->insertWidget(0, contentWidget);
+            std::reverse(sizes.begin(), sizes.end());
+        }
+
+        // restore splitter pos
+        ui->mainSplitter->setSizes(sizes);
+   }
 }

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -363,7 +363,7 @@ void Widget::init()
     ui->transferButton->setCheckable(true);
     ui->settingsButton->setCheckable(true);
 
-    if (contentLayout != nullptr)
+    if (contentLayout)
         onAddClicked();
 
     //restore window state
@@ -693,7 +693,7 @@ void Widget::onSeparateWindowChanged(bool separate, bool clicked)
             size = ui->mainSplitter->widget(1)->size();
         }
 
-        if (contentLayout != nullptr)
+        if (contentLayout)
         {
             contentLayout->clear();
             contentLayout->parentWidget()->setParent(0); // Remove from splitter.
@@ -1396,7 +1396,7 @@ void Widget::removeFriend(Friend* f, bool fake)
     Nexus::getCore()->removeFriend(f->getFriendID(), fake);
 
     delete f;
-    if (contentLayout != nullptr && contentLayout->mainHead->layout()->isEmpty())
+    if (contentLayout && contentLayout->mainHead->layout()->isEmpty())
         onAddClicked();
 
     contactListWidget->reDraw();
@@ -1638,7 +1638,7 @@ void Widget::removeGroup(Group* g, bool fake)
 
     Nexus::getCore()->removeGroup(g->getGroupId(), fake);
     delete g;
-    if (contentLayout != nullptr && contentLayout->mainHead->layout()->isEmpty())
+    if (contentLayout && contentLayout->mainHead->layout()->isEmpty())
         onAddClicked();
 
     contactListWidget->reDraw();
@@ -2022,12 +2022,11 @@ QString Widget::getStatusIconPath(Status status)
     case Status::Busy:
         return ":/img/status/dot_busy.svg";
     case Status::Offline:
-    default:
         return ":/img/status/dot_offline.svg";
     }
 }
 
-inline QIcon Widget::prepareIcon(QString path, uint32_t w, uint32_t h)
+inline QIcon Widget::prepareIcon(QString path, int w, int h)
 {
 #ifdef Q_OS_LINUX
 

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -97,7 +97,7 @@ public:
 
     void reloadTheme();
     static QString getStatusIconPath(Status status);
-    static inline QIcon prepareIcon(QString path, uint32_t w=0, uint32_t h=0);
+    static inline QIcon prepareIcon(QString path, int w=0, int h=0);
     static QPixmap getStatusIconPixmap(QString path, uint32_t w, uint32_t h);
     static QString getStatusTitle(Status status);
     static Status getStatusFromString(QString status);

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -21,6 +21,7 @@
 #define WIDGET_H
 
 #include <QMainWindow>
+#include <QPointer>
 #include <QSystemTrayIcon>
 #include <QFileInfo>
 #include "src/core/corestructs.h"
@@ -109,7 +110,7 @@ public:
     void resetIcon();
 
 public slots:
-    void onSettingsClicked();
+    void onShowSettings();
     void onSeparateWindowClicked(bool separate);
     void onSeparateWindowChanged(bool separate, bool clicked);
     void setWindowTitle(const QString& title);
@@ -262,7 +263,7 @@ private:
     AddFriendForm *addFriendForm;
     GroupInviteForm* groupInviteForm;
     ProfileForm *profileForm;
-    SettingsWidget *settingsWidget;
+    QPointer<SettingsWidget> settingsWidget;
     FilesForm *filesForm;
     static Widget *instance;
     GenericChatroomWidget *activeChatroomWidget;

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -33,29 +33,29 @@ namespace Ui {
 class MainWindow;
 }
 
-class GenericChatroomWidget;
-class FriendWidget;
-class Group;
+class AddFriendForm;
+class ContentDialog;
+class ContentLayout;
+class CircleWidget;
+class FilesForm;
 class Friend;
-class QSplitter;
-class VideoSurface;
-class QMenu;
+class FriendListWidget;
+class FriendWidget;
+class GenericChatroomWidget;
+class Group;
+class GroupInviteForm;
 class Core;
 class Camera;
-class FriendListWidget;
 class MaskablePixmapWidget;
-class QTimer;
-class SystemTrayIcon;
-class FilesForm;
 class ProfileForm;
-class SettingsWidget;
-class AddFriendForm;
-class GroupInviteForm;
-class CircleWidget;
 class QActionGroup;
-class ContentLayout;
-class ContentDialog;
+class QMenu;
 class QPushButton;
+class QSplitter;
+class QTimer;
+class SettingsWidget;
+class SystemTrayIcon;
+class VideoSurface;
 
 class Widget final : public QMainWindow
 {
@@ -204,7 +204,7 @@ private:
         None,
     };
 
-    enum FilterCriteria
+    enum class FilterCriteria
     {
         All=0,
         Online,
@@ -226,14 +226,16 @@ private:
     void searchContacts();
     void changeDisplayMode();
     void updateFilterText();
-    int getFilterCriteria() const;
-    static bool filterGroups(int index);
-    static bool filterOnline(int index);
-    static bool filterOffline(int index);
+    FilterCriteria getFilterCriteria() const;
+    static bool filterGroups(FilterCriteria filter);
+    static bool filterOnline(FilterCriteria filter);
+    static bool filterOffline(FilterCriteria filter);
     void retranslateUi();
     void focusChatInput();
 
 private:
+    static Widget *instance;
+
     SystemTrayIcon *icon = nullptr;
     QMenu *trayMenu;
     QAction *statusOnline;
@@ -260,12 +262,11 @@ private:
     QSplitter *centralLayout;
     QPoint dragPosition;
     QPointer<ContentLayout> contentLayout;
-    AddFriendForm *addFriendForm;
-    GroupInviteForm* groupInviteForm;
-    ProfileForm *profileForm;
+    QPointer<AddFriendForm> addFriendForm;
+    QPointer<GroupInviteForm> groupInviteForm;
+    QPointer<ProfileForm> profileForm;
     QPointer<SettingsWidget> settingsWidget;
-    FilesForm *filesForm;
-    static Widget *instance;
+    QPointer<FilesForm> filesForm;
     GenericChatroomWidget *activeChatroomWidget;
     FriendListWidget *contactListWidget;
     MaskablePixmapWidget *profilePicture;

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -36,6 +36,7 @@ class MainWindow;
 class AddFriendForm;
 class ContentDialog;
 class ContentLayout;
+class ContentWidget;
 class CircleWidget;
 class FilesForm;
 class Friend;
@@ -61,13 +62,17 @@ class Widget final : public QMainWindow
 {
     Q_OBJECT
 public:
+    static Widget* getInstance();
+
+public:
     explicit Widget(QWidget *parent = 0);
     ~Widget();
+
     void init();
-    void setCentralWidget(QWidget *widget, const QString &widgetName);
+
     QString getUsername();
     Camera* getCamera();
-    static Widget* getInstance();
+
     void showUpdateDownloadProgress();
     void addFriendDialog(Friend* frnd, ContentDialog* dialog);
     void addGroupDialog(Group* group, ContentDialog* dialog);
@@ -108,6 +113,10 @@ public:
     bool groupsVisible() const;
 
     void resetIcon();
+
+public:
+    // QMainWindow overrides
+    QSize minimumSizeHint() const override final;
 
 public slots:
     void onShowSettings();
@@ -232,6 +241,8 @@ private:
     static bool filterOffline(FilterCriteria filter);
     void retranslateUi();
     void focusChatInput();
+    void showContentWidget(QWidget* widget, const QString& title = QString(),
+                  ActiveToolMenuButton activeButton = ActiveToolMenuButton::None);
 
 private:
     static Widget *instance;
@@ -261,6 +272,7 @@ private:
     Ui::MainWindow *ui;
     QSplitter *centralLayout;
     QPoint dragPosition;
+    QPointer<QWidget> contentWidget;
     QPointer<ContentLayout> contentLayout;
     QPointer<AddFriendForm> addFriendForm;
     QPointer<GroupInviteForm> groupInviteForm;

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -259,7 +259,7 @@ private:
     Ui::MainWindow *ui;
     QSplitter *centralLayout;
     QPoint dragPosition;
-    ContentLayout* contentLayout;
+    QPointer<ContentLayout> contentLayout;
     AddFriendForm *addFriendForm;
     GroupInviteForm* groupInviteForm;
     ProfileForm *profileForm;

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -93,7 +93,7 @@ public:
     };
 
     static QString fromDialogType(DialogType type);
-    ContentDialog* createContentDialog() const;
+    ContentDialog* createContentDialog();
     ContentLayout* createContentDialog(DialogType type);
 
     static void confirmExecutableOpen(const QFileInfo &file);


### PR DESCRIPTION
This PR improves general resource management within the UI. While not the main purpose, It also has a positive effect on qTox's memory footprint. The goal is to mainly improve resource management, where camera & audio resources are requested/free'd.

So, instead of creating all widgets at program start, they are now created within the context and free'd, when "closed". That means, a widget is not in memory until the user requests it. To make it complete for settings-ui however, we need to introduce a widget factory, that creates the widget for a specific "settings tab".

TODO:
- [ ] Destroy widgets in "embedded window" mode, when they are replaced. (**big change**, but totally worth it) 
- [ ] Implement a widget factory for "settings tab" widgets, so that only the "visible" widget is in memory.

@Diadlo, @initramfs, @sudden6 FYI

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tux3/qtox/3564)

<!-- Reviewable:end -->
