### PR TITLE
fix(systemtrayicon): #3419, don't activate qTox widget on tray icon click in Unity backend

### DIFF
--- a/src/widget/systemtrayicon.cpp
+++ b/src/widget/systemtrayicon.cpp
@@ -356,3 +356,8 @@ void SystemTrayIcon::setIcon(QIcon &icon)
         qtIcon->setIcon(icon);
     }
 }
+
+SystrayBackendType SystemTrayIcon::backend() const
+{
+    return backendType;
+}

--- a/src/widget/systemtrayicon.h
+++ b/src/widget/systemtrayicon.h
@@ -38,6 +38,7 @@ public:
     void hide();
     void setVisible(bool);
     void setIcon(QIcon &icon);
+    SystrayBackendType backend() const;
 
 signals:
     void activated(QSystemTrayIcon::ActivationReason);

--- a/src/widget/systemtrayicon_private.h
+++ b/src/widget/systemtrayicon_private.h
@@ -63,15 +63,9 @@ extern "C" {
 enum class SystrayBackendType
 {
     Qt,
-#ifdef ENABLE_SYSTRAY_UNITY_BACKEND
     Unity,
-#endif
-#ifdef ENABLE_SYSTRAY_STATUSNOTIFIER_BACKEND
     StatusNotifier,
-#endif
-#ifdef ENABLE_SYSTRAY_GTK_BACKEND
-    GTK,
-#endif
+    GTK
 };
 
 #endif // SYSTEMTRAYICON_PRIVATE_H

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1815,7 +1815,9 @@ void Widget::onTryCreateTrayIcon()
             trayMenu->addAction(actionQuit);
             icon->setContextMenu(trayMenu);
 
-            connect(icon, &SystemTrayIcon::activated, this, &Widget::onIconClick);
+            // don't activate qTox widget on tray icon click in Unity backend (see #3419)
+            if (icon->backend() != SystrayBackendType::Unity)
+                connect(icon, &SystemTrayIcon::activated, this, &Widget::onIconClick);
 
             if (Settings::getInstance().getShowSystemTray())
             {


### PR DESCRIPTION
based on #3423 by @abbat

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tux3/qtox/3580)

<!-- Reviewable:end -->
