### PR TITLE
Remove Qt 4 major version check in qtox.pro

### DIFF
--- a/qtox.pro
+++ b/qtox.pro
@@ -17,8 +17,7 @@
 #    See the COPYING file for more details.
 
 
-QT       += core gui network xml opengl sql svg
-greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
+QT       += core gui network xml opengl sql svg widgets
 
 TARGET    = qtox
 TEMPLATE  = app


### PR DESCRIPTION
This PR removes a version check for Qt > 4 in the `qtox.pro` file since the minimum required Qt version for qTox is >= 5.x, meaning that such a check is unnecessary.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3586)

<!-- Reviewable:end -->
