### PR TITLE
fix(gui): don't quit application before last event

### DIFF
--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -583,8 +583,8 @@ void Widget::closeEvent(QCloseEvent *event)
         }
         saveWindowGeometry();
         saveSplitterGeometry();
-        qApp->exit(0);
         QWidget::closeEvent(event);
+        qApp->quit();
     }
 }
 


### PR DESCRIPTION
Quitting the application kills the event loop. So any event past that will not be handled. ~~Probably causes the "BAD!" entries in log.~~

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3587)

<!-- Reviewable:end -->
