### PR TITLE
Fixes missing first video mode from video mode selection

### DIFF
--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -247,12 +247,22 @@ void AVForm::selectBestModes(QVector<VideoMode> &allVideoModes)
     for (auto it = bestModeInds.rbegin(); it != bestModeInds.rend(); ++it)
     {
         VideoMode mode = allVideoModes[it->second];
-        int size = getModeSize(mode);
-        auto result = std::find_if(newVideoModes.cbegin(), newVideoModes.cend(),
-                                   [size](VideoMode mode) { return getModeSize(mode) == size; });
 
-        if (result == newVideoModes.end())
+        if(newVideoModes.empty())
+        {
             newVideoModes.push_back(mode);
+        }
+        else
+        {
+            int size = getModeSize(mode);
+            auto result = std::find_if(newVideoModes.cbegin(), newVideoModes.cend(),
+                                       [size](VideoMode mode) { return getModeSize(mode) == size; });
+
+            if(result == newVideoModes.end())
+            {
+                newVideoModes.push_back(mode);
+            }
+        }
     }
     allVideoModes = newVideoModes;
 }

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -248,7 +248,7 @@ void AVForm::selectBestModes(QVector<VideoMode> &allVideoModes)
     {
         VideoMode mode = allVideoModes[it->second];
 
-        if(newVideoModes.empty())
+        if (newVideoModes.empty())
         {
             newVideoModes.push_back(mode);
         }
@@ -258,10 +258,8 @@ void AVForm::selectBestModes(QVector<VideoMode> &allVideoModes)
             auto result = std::find_if(newVideoModes.cbegin(), newVideoModes.cend(),
                                        [size](VideoMode mode) { return getModeSize(mode) == size; });
 
-            if(result == newVideoModes.end())
-            {
+            if (result == newVideoModes.end())
                 newVideoModes.push_back(mode);
-            }
         }
     }
     allVideoModes = newVideoModes;
@@ -281,7 +279,7 @@ void AVForm::fillCameraModesComboBox()
         qDebug("width: %d, height: %d, FPS: %f, pixel format: %s\n", mode.width, mode.height, mode.FPS, pixelFormat.toStdString().c_str());
 
         if (mode.height && mode.width)
-            str += QString("%1p").arg(getModeSize(mode));
+            str += QString("%1p").arg(mode.height);
         else
             str += tr("Default resolution");
 


### PR DESCRIPTION
The `selectBestModes()` function in `avform.cpp` strips off the first video mode (when the vector `newVideoModes` is empty). This PR resolves the issue by adding the first video mode to the list if the `newVideoModes` vector is empty.

This PR also resolves the issue where video modes aren't truthfully displayed to the user (instead they're rounded to the closest multiple of 120).

This PR fixes issue #3588.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3589)

<!-- Reviewable:end -->
