### PR TITLE
add settings change notification

### DIFF
--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -364,7 +364,7 @@ bool Audio::initInput(const QString& deviceName)
         return false;
     }
 
-    d->setInputGain(Settings::getInstance().getAudioInGain());
+    d->setInputGain(Settings::getInstance().getAudioInGainDecibel());
 
     qDebug() << "Opened audio input" << deviceName;
     alcCaptureStart(alInDev);

--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -52,7 +52,6 @@ public:
     void setTypingNotificationVisible(bool visible);
     void scrollToLine(ChatLine::Ptr line);
     void selectAll();
-    void forceRelayout();
 
     QString getSelectedText() const;
 
@@ -66,6 +65,13 @@ public:
 
 signals:
     void selectionChanged();
+
+public slots:
+    void forceRelayout();
+
+private slots:
+    void onSelectionTimerTimeout();
+    void onWorkerTimeout();
 
 protected:
     QRectF calculateSceneRect() const;
@@ -99,10 +105,6 @@ protected:
     void updateBusyNotification();
 
     ChatLine::Ptr findLineByPosY(qreal yPos) const;
-
-private slots:
-    void onSelectionTimerTimeout();
-    void onWorkerTimeout();
 
 private:
     void retranslateUi();

--- a/src/chatlog/chatmessage.cpp
+++ b/src/chatlog/chatmessage.cpp
@@ -56,7 +56,7 @@ ChatMessage::Ptr ChatMessage::createChatMessage(const QString &sender, const QSt
     text = detectQuotes(detectAnchors(text), type);
 
     //text styling
-    if (Settings::getInstance().getStylePreference() != NONE)
+    if (Settings::getInstance().getStylePreference() != Settings::StyleType::NONE)
         text = detectStyle(text);
 
     switch(type)
@@ -229,7 +229,7 @@ QString ChatMessage::detectStyle(const QString &str)
         {
             int mul = 0; // Determines how many characters to strip from text
             // Set mul depending on styleownPreference
-            if (Settings::getInstance().getStylePreference() == WITHOUT_CHARS)
+            if (Settings::getInstance().getStylePreference() == Settings::StyleType::WITHOUT_CHARS)
                 mul = 2;
 
             // Match captured string to corresponding style format

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -122,8 +122,8 @@ void Core::makeTox(QByteArray savedata)
     // IPv6 needed for LAN discovery, but can crash some weird routers. On by default, can be disabled in options.
     bool enableIPv6 = Settings::getInstance().getEnableIPv6();
     bool forceTCP = Settings::getInstance().getForceTCP();
-    ProxyType proxyType = Settings::getInstance().getProxyType();
-    int proxyPort = Settings::getInstance().getProxyPort();
+    Settings::ProxyType proxyType = Settings::getInstance().getProxyType();
+    quint16 proxyPort = Settings::getInstance().getProxyPort();
     QString proxyAddr = Settings::getInstance().getProxyAddr();
     QByteArray proxyAddrData = proxyAddr.toUtf8();
 
@@ -147,7 +147,7 @@ void Core::makeTox(QByteArray savedata)
     toxOptions.savedata_data = (uint8_t*)savedata.data();
     toxOptions.savedata_length = savedata.size();
 
-    if (proxyType != ProxyType::ptNone)
+    if (proxyType != Settings::ProxyType::ptNone)
     {
         if (proxyAddr.length() > 255)
         {
@@ -157,9 +157,9 @@ void Core::makeTox(QByteArray savedata)
         {
             qDebug() << "using proxy" << proxyAddr << ":" << proxyPort;
             // protection against changings in TOX_PROXY_TYPE enum
-            if (proxyType == ProxyType::ptSOCKS5)
+            if (proxyType == Settings::ProxyType::ptSOCKS5)
                 toxOptions.proxy_type = TOX_PROXY_TYPE_SOCKS5;
-            else if (proxyType == ProxyType::ptHTTP)
+            else if (proxyType == Settings::ProxyType::ptHTTP)
                 toxOptions.proxy_type = TOX_PROXY_TYPE_HTTP;
 
             toxOptions.proxy_host = proxyAddrData.data();
@@ -592,7 +592,7 @@ void Core::requestFriendship(const QString& friendAddress, const QString& messag
         {
             qDebug() << "Requested friendship of "<<friendId;
             // Update our friendAddresses
-            Settings::getInstance().updateFriendAdress(friendAddress);
+            Settings::getInstance().updateFriendAddress(friendAddress);
             QString inviteStr = tr("/me offers friendship.");
             if (message.length())
                 inviteStr = tr("/me offers friendship, \"%1\"").arg(message);
@@ -1166,7 +1166,7 @@ bool Core::hasFriendWithPublicKey(const QString &pubkey) const
 QString Core::getFriendAddress(uint32_t friendNumber) const
 {
     QString id = getFriendPublicKey(friendNumber);
-    QString addr = Settings::getInstance().getFriendAdress(id);
+    QString addr = Settings::getInstance().getFriendAddress(id);
     if (addr.size() > id.size())
         return addr;
 

--- a/src/core/corestructs.cpp
+++ b/src/core/corestructs.cpp
@@ -7,17 +7,40 @@
 #define TOX_HEX_ID_LENGTH 2*TOX_ADDRESS_SIZE
 
 /**
-@file corestructs.h
-@brief Some headers use Core structs but don't need to include all of core.h
-
-They should include this file directly instead to reduce compilation times
-*/
+ * @file corestructs.h
+ * @brief Some headers use Core structs but don't need to include all of core.h
+ *
+ * They should include this file directly instead to reduce compilation times
+ *
+ *
+ * @var ToxFile::fileKind   Data file (default) or avatar
+ */
 
 /**
-@var uint8_t ToxFile::fileKind
-@brief Data file (default) or avatar
-*/
+ * @brief   Compare equal operator
+ * @param   other   the compared instance
+ * @return  true, if equal; false otherwise
+ */
+bool DhtServer::operator==(const DhtServer& other) const
+{
+    return this == &other ||
+            (port == other.port && address == other.address &&
+             userId == other.userId && name == other.name);
+}
 
+/**
+ * @brief   Compare not equal operator
+ * @param   other   the compared instance
+ * @return  true, if not equal; false otherwise
+ */
+bool DhtServer::operator!=(const DhtServer& other) const
+{
+    return !(*this == other);
+}
+
+/**
+ * @brief ToxFile constructor
+ */
 ToxFile::ToxFile(uint32_t fileNum, uint32_t friendId, QByteArray filename, QString filePath, FileDirection Direction)
     : fileKind{TOX_FILE_KIND_DATA}, fileNum(fileNum), friendId(friendId), fileName{filename},
       filePath{filePath}, file{new QFile(filePath)}, bytesSent{0}, filesize{0},

--- a/src/core/corestructs.h
+++ b/src/core/corestructs.h
@@ -15,6 +15,9 @@ struct DhtServer
     QString userId;
     QString address;
     quint16 port;
+
+    bool operator==(const DhtServer& other) const;
+    bool operator!=(const DhtServer& other) const;
 };
 
 struct ToxFile

--- a/src/persistence/db/plaindb.h
+++ b/src/persistence/db/plaindb.h
@@ -25,7 +25,7 @@
 #include <QSqlDatabase>
 
 namespace Db {
-    enum class syncType : int {stOff = 0, stNormal = 1, stFull = 2};
+    enum class syncType {stOff = 0, stNormal = 1, stFull = 2};
 }
 
 class PlainDb : public GenericDdInterface

--- a/src/persistence/historykeeper.h
+++ b/src/persistence/historykeeper.h
@@ -29,7 +29,10 @@
 
 class Profile;
 class GenericDdInterface;
-namespace Db { enum class syncType; }
+
+namespace Db {
+enum class syncType;
+}
 
 class HistoryKeeper
 {

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -171,7 +171,7 @@ void Settings::loadGlobal()
         autostartInTray = s.value("autostartInTray", false).toBool();
         closeToTray = s.value("closeToTray", false).toBool();
         forceTCP = s.value("forceTCP", false).toBool();
-        setProxyType(s.value("proxyType", static_cast<int>(ProxyType::ptNone)).toInt());
+        proxyType = static_cast<ProxyType>(s.value("proxyType", 0).toInt());
         proxyAddr = s.value("proxyAddr", "").toString();
         proxyPort = static_cast<quint16>(s.value("proxyPort", 0).toUInt());
         if (currentProfile.isEmpty())
@@ -198,7 +198,7 @@ void Settings::loadGlobal()
     s.endGroup();
 
     s.beginGroup("Advanced");
-        int sType = s.value("dbSyncType", static_cast<int>(Db::syncType::stFull)).toInt();
+        Db::syncType sType = static_cast<Db::syncType>(s.value("dbSyncType", 2).toInt());
         setDbSyncType(sType);
     s.endGroup();
 
@@ -701,8 +701,12 @@ const QList<DhtServer>& Settings::getDhtServerList() const
 void Settings::setDhtServerList(const QList<DhtServer>& newDhtServerList)
 {
     QMutexLocker locker{&bigLock};
-    dhtServerList = newDhtServerList;
-    emit dhtServerListChanged();
+
+    if (newDhtServerList != dhtServerList)
+    {
+        dhtServerList = newDhtServerList;
+        emit dhtServerListChanged(dhtServerList);
+    }
 }
 
 bool Settings::getEnableIPv6() const
@@ -714,7 +718,12 @@ bool Settings::getEnableIPv6() const
 void Settings::setEnableIPv6(bool newValue)
 {
     QMutexLocker locker{&bigLock};
-    enableIPv6 = newValue;
+
+    if (newValue != enableIPv6)
+    {
+        enableIPv6 = newValue;
+        emit enableIPv6Changed(enableIPv6);
+    }
 }
 
 bool Settings::getMakeToxPortable() const
@@ -726,15 +735,22 @@ bool Settings::getMakeToxPortable() const
 void Settings::setMakeToxPortable(bool newValue)
 {
     QMutexLocker locker{&bigLock};
-    QFile(getSettingsDirPath()+globalSettingsFile).remove();
-    makeToxPortable = newValue;
-    saveGlobal();
+
+    if (newValue != makeToxPortable)
+    {
+        QFile(getSettingsDirPath() + globalSettingsFile).remove();
+        makeToxPortable = newValue;
+        saveGlobal();
+
+        emit makeToxPortableChanged(makeToxPortable);
+    }
 }
 
 bool Settings::getAutorun() const
 {
-#ifdef QTOX_PLATFORM_EXT
     QMutexLocker locker{&bigLock};
+
+#ifdef QTOX_PLATFORM_EXT
     return Platform::getAutorun();
 #else
     return false;
@@ -745,7 +761,14 @@ void Settings::setAutorun(bool newValue)
 {
 #ifdef QTOX_PLATFORM_EXT
     QMutexLocker locker{&bigLock};
-    Platform::setAutorun(newValue);
+
+    bool autorun = Platform::getAutorun();
+
+    if (newValue != autorun)
+    {
+        Platform::setAutorun(newValue);
+        emit autorunChanged(autorun);
+    }
 #else
     Q_UNUSED(newValue);
 #endif
@@ -766,7 +789,12 @@ QString Settings::getStyle() const
 void Settings::setStyle(const QString& newStyle)
 {
     QMutexLocker locker{&bigLock};
-    style = newStyle;
+
+    if (newStyle != style)
+    {
+        style = newStyle;
+        emit styleChanged(style);
+    }
 }
 
 bool Settings::getShowSystemTray() const
@@ -775,16 +803,26 @@ bool Settings::getShowSystemTray() const
     return showSystemTray;
 }
 
-void Settings::setShowSystemTray(const bool& newValue)
+void Settings::setShowSystemTray(bool newValue)
 {
     QMutexLocker locker{&bigLock};
-    showSystemTray = newValue;
+
+    if (newValue != showSystemTray)
+    {
+        showSystemTray = newValue;
+        emit showSystemTrayChanged(newValue);
+    }
 }
 
 void Settings::setUseEmoticons(bool newValue)
 {
     QMutexLocker locker{&bigLock};
-    useEmoticons = newValue;
+
+    if (newValue != useEmoticons)
+    {
+        useEmoticons = newValue;
+        emit useEmoticonsChanged(useEmoticons);
+    }
 }
 
 bool Settings::getUseEmoticons() const
@@ -796,7 +834,12 @@ bool Settings::getUseEmoticons() const
 void Settings::setAutoSaveEnabled(bool newValue)
 {
     QMutexLocker locker{&bigLock};
-    autoSaveEnabled = newValue;
+
+    if (newValue != autoSaveEnabled)
+    {
+        autoSaveEnabled = newValue;
+        emit autoSaveEnabledChanged(autoSaveEnabled);
+    }
 }
 
 bool Settings::getAutoSaveEnabled() const
@@ -808,7 +851,12 @@ bool Settings::getAutoSaveEnabled() const
 void Settings::setAutostartInTray(bool newValue)
 {
     QMutexLocker locker{&bigLock};
-    autostartInTray = newValue;
+
+    if (newValue != autostartInTray)
+    {
+        autostartInTray = newValue;
+        emit autostartInTrayChanged(autostartInTray);
+    }
 }
 
 bool Settings::getCloseToTray() const
@@ -820,7 +868,12 @@ bool Settings::getCloseToTray() const
 void Settings::setCloseToTray(bool newValue)
 {
     QMutexLocker locker{&bigLock};
-    closeToTray = newValue;
+
+    if (newValue != closeToTray)
+    {
+        closeToTray = newValue;
+        emit closeToTrayChanged(newValue);
+    }
 }
 
 bool Settings::getMinimizeToTray() const
@@ -832,7 +885,12 @@ bool Settings::getMinimizeToTray() const
 void Settings::setMinimizeToTray(bool newValue)
 {
     QMutexLocker locker{&bigLock};
-    minimizeToTray = newValue;
+
+    if (newValue != minimizeToTray)
+    {
+        minimizeToTray = newValue;
+        emit minimizeToTrayChanged(minimizeToTray);
+    }
 }
 
 bool Settings::getLightTrayIcon() const
@@ -844,7 +902,12 @@ bool Settings::getLightTrayIcon() const
 void Settings::setLightTrayIcon(bool newValue)
 {
     QMutexLocker locker{&bigLock};
-    lightTrayIcon = newValue;
+
+    if (newValue != lightTrayIcon)
+    {
+        lightTrayIcon = newValue;
+        emit lightTrayIconChanged(lightTrayIcon);
+    }
 }
 
 bool Settings::getStatusChangeNotificationEnabled() const
@@ -856,7 +919,12 @@ bool Settings::getStatusChangeNotificationEnabled() const
 void Settings::setStatusChangeNotificationEnabled(bool newValue)
 {
     QMutexLocker locker{&bigLock};
-    statusChangeNotificationEnabled = newValue;
+
+    if (newValue != statusChangeNotificationEnabled)
+    {
+        statusChangeNotificationEnabled = newValue;
+        emit statusChangeNotificationEnabledChanged(statusChangeNotificationEnabled);
+    }
 }
 
 bool Settings::getShowInFront() const
@@ -868,7 +936,12 @@ bool Settings::getShowInFront() const
 void Settings::setShowInFront(bool newValue)
 {
     QMutexLocker locker{&bigLock};
-    showInFront = newValue;
+
+    if (newValue != showInFront)
+    {
+        showInFront = newValue;
+        emit showInFrontChanged(showInFront);
+    }
 }
 
 bool Settings::getNotifySound() const
@@ -880,7 +953,12 @@ bool Settings::getNotifySound() const
 void Settings::setNotifySound(bool newValue)
 {
     QMutexLocker locker{&bigLock};
-    notifySound = newValue;
+
+    if (newValue != notifySound)
+    {
+        notifySound = newValue;
+        emit notifySoundChanged(notifySound);
+    }
 }
 
 bool Settings::getBusySound() const
@@ -892,7 +970,12 @@ bool Settings::getBusySound() const
 void Settings::setBusySound(bool newValue)
 {
     QMutexLocker locker{&bigLock};
-    busySound = newValue;
+
+    if (newValue != busySound)
+    {
+        busySound = newValue;
+        emit busySoundChanged(busySound);
+    }
 }
 
 bool Settings::getGroupAlwaysNotify() const
@@ -904,7 +987,12 @@ bool Settings::getGroupAlwaysNotify() const
 void Settings::setGroupAlwaysNotify(bool newValue)
 {
     QMutexLocker locker{&bigLock};
-    groupAlwaysNotify = newValue;
+
+    if (newValue != groupAlwaysNotify)
+    {
+        groupAlwaysNotify = newValue;
+        emit groupAlwaysNotifyChanged(groupAlwaysNotify);
+    }
 }
 
 QString Settings::getTranslation() const
@@ -913,10 +1001,15 @@ QString Settings::getTranslation() const
     return translation;
 }
 
-void Settings::setTranslation(QString newValue)
+void Settings::setTranslation(const QString& newValue)
 {
     QMutexLocker locker{&bigLock};
-    translation = newValue;
+
+    if (newValue != translation)
+    {
+        translation = newValue;
+        emit translationChanged(translation);
+    }
 }
 
 void Settings::deleteToxme()
@@ -942,11 +1035,22 @@ QString Settings::getToxmeInfo() const
     return toxmeInfo;
 }
 
-void Settings::setToxmeInfo(QString info)
+void Settings::setToxmeInfo(const QString& info)
 {
     QMutexLocker locker{&bigLock};
-    if (info.split("@").size() == 2)
-        toxmeInfo = info;
+
+    if (info != toxmeInfo)
+    {
+        if (info.split("@").size() == 2)
+        {
+            toxmeInfo = info;
+            emit toxmeInfoChanged(toxmeInfo);
+        }
+        else
+        {
+            qWarning() << info << "is not a valid toxme string -> value ignored.";
+        }
+    }
 }
 
 QString Settings::getToxmeBio() const
@@ -955,10 +1059,15 @@ QString Settings::getToxmeBio() const
     return toxmeBio;
 }
 
-void Settings::setToxmeBio(QString bio)
+void Settings::setToxmeBio(const QString& bio)
 {
     QMutexLocker locker{&bigLock};
-    toxmeBio = bio;
+
+    if (bio != toxmeBio)
+    {
+        toxmeBio = bio;
+        emit toxmeBioChanged(toxmeBio);
+    }
 }
 
 bool Settings::getToxmePriv() const
@@ -970,7 +1079,12 @@ bool Settings::getToxmePriv() const
 void Settings::setToxmePriv(bool priv)
 {
     QMutexLocker locker{&bigLock};
-    toxmePriv = priv;
+
+    if (priv != toxmePriv)
+    {
+        toxmePriv = priv;
+        emit toxmePrivChanged(toxmePriv);
+    }
 }
 
 QString Settings::getToxmePass() const
@@ -979,10 +1093,17 @@ QString Settings::getToxmePass() const
     return toxmePass;
 }
 
-void Settings::setToxmePass(const QString &pass)
+void Settings::setToxmePass(const QString& pass)
 {
     QMutexLocker locker{&bigLock};
-    toxmePass = pass;
+
+    if (pass != toxmePass)
+    {
+        toxmePass = pass;
+
+        // password is not exposed for security reasons
+        emit toxmePassChanged();
+    }
 }
 
 bool Settings::getForceTCP() const
@@ -994,7 +1115,12 @@ bool Settings::getForceTCP() const
 void Settings::setForceTCP(bool newValue)
 {
     QMutexLocker locker{&bigLock};
-    forceTCP = newValue;
+
+    if (newValue != forceTCP)
+    {
+        forceTCP = newValue;
+        emit forceTCPChanged(forceTCP);
+    }
 }
 
 QNetworkProxy Settings::getProxy() const
@@ -1022,19 +1148,21 @@ QNetworkProxy Settings::getProxy() const
     return proxy;
 }
 
-ProxyType Settings::getProxyType() const
+Settings::ProxyType Settings::getProxyType() const
 {
     QMutexLocker locker{&bigLock};
     return proxyType;
 }
 
-void Settings::setProxyType(int newValue)
+void Settings::setProxyType(ProxyType newValue)
 {
     QMutexLocker locker{&bigLock};
-    if (newValue >= 0 && newValue <= 2)
-        proxyType = static_cast<ProxyType>(newValue);
-    else
-        proxyType = ProxyType::ptNone;
+
+    if (newValue != proxyType)
+    {
+        proxyType = newValue;
+        emit proxyTypeChanged(proxyType);
+    }
 }
 
 QString Settings::getProxyAddr() const
@@ -1046,7 +1174,12 @@ QString Settings::getProxyAddr() const
 void Settings::setProxyAddr(const QString& newValue)
 {
     QMutexLocker locker{&bigLock};
-    proxyAddr = newValue;
+
+    if (newValue != proxyAddr)
+    {
+        proxyAddr = newValue;
+        emit proxyAddressChanged(proxyAddr);
+    }
 }
 
 quint16 Settings::getProxyPort() const
@@ -1058,7 +1191,12 @@ quint16 Settings::getProxyPort() const
 void Settings::setProxyPort(quint16 newValue)
 {
     QMutexLocker locker{&bigLock};
-    proxyPort = newValue;
+
+    if (newValue != proxyPort)
+    {
+        proxyPort = newValue;
+        emit proxyPortChanged(proxyPort);
+    }
 }
 
 QString Settings::getCurrentProfile() const
@@ -1073,11 +1211,17 @@ uint32_t Settings::getCurrentProfileId() const
     return currentProfileId;
 }
 
-void Settings::setCurrentProfile(QString profile)
+void Settings::setCurrentProfile(const QString& profile)
 {
     QMutexLocker locker{&bigLock};
-    currentProfile = profile;
-    currentProfileId = makeProfileId(currentProfile);
+
+    if (profile != currentProfile)
+    {
+        currentProfile = profile;
+        currentProfileId = makeProfileId(currentProfile);
+        emit currentProfileChanged(currentProfile);
+        emit currentProfileIdChanged(currentProfileId);
+    }
 }
 
 bool Settings::getEnableLogging() const
@@ -1089,7 +1233,12 @@ bool Settings::getEnableLogging() const
 void Settings::setEnableLogging(bool newValue)
 {
     QMutexLocker locker{&bigLock};
-    enableLogging = newValue;
+
+    if (newValue != enableLogging)
+    {
+        enableLogging = newValue;
+        emit enableLoggingChanged(enableLogging);
+    }
 }
 
 Db::syncType Settings::getDbSyncType() const
@@ -1098,13 +1247,15 @@ Db::syncType Settings::getDbSyncType() const
     return dbSyncType;
 }
 
-void Settings::setDbSyncType(int newValue)
+void Settings::setDbSyncType(Db::syncType newValue)
 {
     QMutexLocker locker{&bigLock};
-    if (newValue >= 0 && newValue <= 2)
-        dbSyncType = static_cast<Db::syncType>(newValue);
-    else
-        dbSyncType = Db::syncType::stFull;
+
+    if (newValue != dbSyncType)
+    {
+        dbSyncType = newValue;
+        emit dbSyncTypeChanged(dbSyncType);
+    }
 }
 
 int Settings::getAutoAwayTime() const
@@ -1113,13 +1264,23 @@ int Settings::getAutoAwayTime() const
     return autoAwayTime;
 }
 
+/**
+ * @brief Sets how long the user may stay idle, before online status is set to "away".
+ * @param[in] newValue  the user idle duration in minutes
+ * @note Values < 0 default to 10 minutes.
+ */
 void Settings::setAutoAwayTime(int newValue)
 {
     QMutexLocker locker{&bigLock};
+
     if (newValue < 0)
         newValue = 10;
 
-    autoAwayTime = newValue;
+    if (newValue != autoAwayTime)
+    {
+        autoAwayTime = newValue;
+        emit autoAwayTimeChanged(autoAwayTime);
+    }
 }
 
 QString Settings::getAutoAcceptDir(const ToxId& id) const
@@ -1146,7 +1307,7 @@ void Settings::setAutoAcceptDir(const ToxId &id, const QString& dir)
     }
     else
     {
-        updateFriendAdress(id.toString());
+        updateFriendAddress(id.toString());
         setAutoAcceptDir(id, dir);
     }
 }
@@ -1174,7 +1335,7 @@ void Settings::setContactNote(const ToxId &id, const QString& note)
     }
     else
     {
-        updateFriendAdress(id.toString());
+        updateFriendAddress(id.toString());
         setContactNote(id, note);
     }
 }
@@ -1188,7 +1349,12 @@ QString Settings::getGlobalAutoAcceptDir() const
 void Settings::setGlobalAutoAcceptDir(const QString& newValue)
 {
     QMutexLocker locker{&bigLock};
-    globalAutoAcceptDir = newValue;
+
+    if (newValue != globalAutoAcceptDir)
+    {
+        globalAutoAcceptDir = newValue;
+        emit globalAutoAcceptDirChanged(globalAutoAcceptDir);
+    }
 }
 
 const QFont& Settings::getChatMessageFont() const
@@ -1200,13 +1366,24 @@ const QFont& Settings::getChatMessageFont() const
 void Settings::setChatMessageFont(const QFont& font)
 {
     QMutexLocker locker(&bigLock);
-    chatMessageFont = font;
+
+    if (font != chatMessageFont)
+    {
+        chatMessageFont = font;
+        emit chatMessageFontChanged(chatMessageFont);
+    }
 }
 
 void Settings::setWidgetData(const QString& uniqueName, const QByteArray& data)
 {
     QMutexLocker locker{&bigLock};
-    widgetSettings[uniqueName] = data;
+
+    if (!widgetSettings.contains(uniqueName) ||
+        widgetSettings[uniqueName] != data)
+    {
+        widgetSettings[uniqueName] = data;
+        emit widgetDataChanged(uniqueName);
+    }
 }
 
 QByteArray Settings::getWidgetData(const QString& uniqueName) const
@@ -1221,11 +1398,15 @@ QString Settings::getSmileyPack() const
     return smileyPack;
 }
 
-void Settings::setSmileyPack(const QString &value)
+void Settings::setSmileyPack(const QString& value)
 {
     QMutexLocker locker{&bigLock};
-    smileyPack = value;
-    emit smileyPackChanged();
+
+    if (value != smileyPack)
+    {
+        smileyPack = value;
+        emit smileyPackChanged(smileyPack);
+    }
 }
 
 int Settings::getEmojiFontPointSize() const
@@ -1237,32 +1418,12 @@ int Settings::getEmojiFontPointSize() const
 void Settings::setEmojiFontPointSize(int value)
 {
     QMutexLocker locker{&bigLock};
-    emojiFontPointSize = value;
-    emit emojiFontChanged();
-}
 
-int Settings::getFirstColumnHandlePos() const
-{
-    QMutexLocker locker{&bigLock};
-    return firstColumnHandlePos;
-}
-
-void Settings::setFirstColumnHandlePos(const int pos)
-{
-    QMutexLocker locker{&bigLock};
-    firstColumnHandlePos = pos;
-}
-
-int Settings::getSecondColumnHandlePosFromRight() const
-{
-    QMutexLocker locker{&bigLock};
-    return secondColumnHandlePosFromRight;
-}
-
-void Settings::setSecondColumnHandlePosFromRight(const int pos)
-{
-    QMutexLocker locker{&bigLock};
-    secondColumnHandlePosFromRight = pos;
+    if (value != emojiFontPointSize)
+    {
+        emojiFontPointSize = value;
+        emit emojiFontPointSizeChanged(emojiFontPointSize);
+    }
 }
 
 const QString& Settings::getTimestampFormat() const
@@ -1271,10 +1432,15 @@ const QString& Settings::getTimestampFormat() const
     return timestampFormat;
 }
 
-void Settings::setTimestampFormat(const QString &format)
+void Settings::setTimestampFormat(const QString& format)
 {
     QMutexLocker locker{&bigLock};
-    timestampFormat = format;
+
+    if (format != timestampFormat)
+    {
+        timestampFormat = format;
+        emit timestampFormatChanged(timestampFormat);
+    }
 }
 
 const QString& Settings::getDateFormat() const
@@ -1283,13 +1449,18 @@ const QString& Settings::getDateFormat() const
     return dateFormat;
 }
 
-void Settings::setDateFormat(const QString &format)
+void Settings::setDateFormat(const QString& format)
 {
     QMutexLocker locker{&bigLock};
-    dateFormat = format;
+
+    if (format != dateFormat)
+    {
+        dateFormat = format;
+        emit dateFormatChanged(dateFormat);
+    }
 }
 
-StyleType Settings::getStylePreference() const
+Settings::StyleType Settings::getStylePreference() const
 {
     QMutexLocker locker{&bigLock};
     return stylePreference;
@@ -1298,7 +1469,12 @@ StyleType Settings::getStylePreference() const
 void Settings::setStylePreference(StyleType newValue)
 {
     QMutexLocker locker{&bigLock};
-    stylePreference = newValue;
+
+    if (newValue != stylePreference)
+    {
+        stylePreference = newValue;
+        emit stylePreferenceChanged(stylePreference);
+    }
 }
 
 QByteArray Settings::getWindowGeometry() const
@@ -1307,10 +1483,15 @@ QByteArray Settings::getWindowGeometry() const
     return windowGeometry;
 }
 
-void Settings::setWindowGeometry(const QByteArray &value)
+void Settings::setWindowGeometry(const QByteArray& value)
 {
     QMutexLocker locker{&bigLock};
-    windowGeometry = value;
+
+    if (value != windowGeometry)
+    {
+        windowGeometry = value;
+        emit windowGeometryChanged(windowGeometry);
+    }
 }
 
 QByteArray Settings::getWindowState() const
@@ -1319,10 +1500,15 @@ QByteArray Settings::getWindowState() const
     return windowState;
 }
 
-void Settings::setWindowState(const QByteArray &value)
+void Settings::setWindowState(const QByteArray& value)
 {
     QMutexLocker locker{&bigLock};
-    windowState = value;
+
+    if (value != windowState)
+    {
+        windowState = value;
+        emit windowStateChanged(windowState);
+    }
 }
 
 bool Settings::getCheckUpdates() const
@@ -1334,7 +1520,12 @@ bool Settings::getCheckUpdates() const
 void Settings::setCheckUpdates(bool newValue)
 {
     QMutexLocker locker{&bigLock};
-    checkUpdates = newValue;
+
+    if (newValue != checkUpdates)
+    {
+        checkUpdates = newValue;
+        emit checkUpdatesChanged(checkUpdates);
+    }
 }
 
 bool Settings::getShowWindow() const
@@ -1346,7 +1537,12 @@ bool Settings::getShowWindow() const
 void Settings::setShowWindow(bool newValue)
 {
     QMutexLocker locker{&bigLock};
-    showWindow = newValue;
+
+    if (newValue != showWindow)
+    {
+        showWindow = newValue;
+        emit showWindowChanged(showWindow);
+    }
 }
 
 QByteArray Settings::getSplitterState() const
@@ -1355,10 +1551,15 @@ QByteArray Settings::getSplitterState() const
     return splitterState;
 }
 
-void Settings::setSplitterState(const QByteArray &value)
+void Settings::setSplitterState(const QByteArray& value)
 {
     QMutexLocker locker{&bigLock};
-    splitterState = value;
+
+    if(value != splitterState)
+    {
+        splitterState = value;
+        emit splitterStateChanged(splitterState);
+    }
 }
 
 QByteArray Settings::getDialogGeometry() const
@@ -1367,10 +1568,15 @@ QByteArray Settings::getDialogGeometry() const
     return dialogGeometry;
 }
 
-void Settings::setDialogGeometry(const QByteArray &value)
+void Settings::setDialogGeometry(const QByteArray& value)
 {
     QMutexLocker locker{&bigLock};
-    dialogGeometry = value;
+
+    if (value != dialogGeometry)
+    {
+        dialogGeometry = value;
+        emit dialogGeometryChanged(dialogGeometry);
+    }
 }
 
 QByteArray Settings::getDialogSplitterState() const
@@ -1379,10 +1585,15 @@ QByteArray Settings::getDialogSplitterState() const
     return dialogSplitterState;
 }
 
-void Settings::setDialogSplitterState(const QByteArray &value)
+void Settings::setDialogSplitterState(const QByteArray& value)
 {
     QMutexLocker locker{&bigLock};
-    dialogSplitterState = value;
+
+    if (value != dialogSplitterState)
+    {
+        dialogSplitterState = value;
+        emit dialogSplitterStateChanged(dialogSplitterState);
+    }
 }
 
 QByteArray Settings::getDialogSettingsGeometry() const
@@ -1391,13 +1602,18 @@ QByteArray Settings::getDialogSettingsGeometry() const
     return dialogSettingsGeometry;
 }
 
-void Settings::setDialogSettingsGeometry(const QByteArray &value)
+void Settings::setDialogSettingsGeometry(const QByteArray& value)
 {
     QMutexLocker locker{&bigLock};
-    dialogSettingsGeometry = value;
+
+    if (value != dialogSettingsGeometry)
+    {
+        dialogSettingsGeometry = value;
+        emit dialogSettingsGeometryChanged(dialogSettingsGeometry);
+    }
 }
 
-bool Settings::isMinimizeOnCloseEnabled() const
+bool Settings::getMinimizeOnClose() const
 {
     QMutexLocker locker{&bigLock};
     return minimizeOnClose;
@@ -1406,10 +1622,15 @@ bool Settings::isMinimizeOnCloseEnabled() const
 void Settings::setMinimizeOnClose(bool newValue)
 {
     QMutexLocker locker{&bigLock};
-    minimizeOnClose = newValue;
+
+    if (newValue != minimizeOnClose)
+    {
+        minimizeOnClose = newValue;
+        emit minimizeOnCloseChanged(minimizeOnClose);
+    }
 }
 
-bool Settings::isTypingNotificationEnabled() const
+bool Settings::getTypingNotification() const
 {
     QMutexLocker locker{&bigLock};
     return typingNotification;
@@ -1418,7 +1639,12 @@ bool Settings::isTypingNotificationEnabled() const
 void Settings::setTypingNotification(bool enabled)
 {
     QMutexLocker locker{&bigLock};
-    typingNotification = enabled;
+
+    if (enabled != typingNotification)
+    {
+        typingNotification = enabled;
+        emit typingNotificationChanged(typingNotification);
+    }
 }
 
 QString Settings::getInDev() const
@@ -1430,7 +1656,12 @@ QString Settings::getInDev() const
 void Settings::setInDev(const QString& deviceSpecifier)
 {
     QMutexLocker locker{&bigLock};
-    inDev = deviceSpecifier;
+
+    if (deviceSpecifier != inDev)
+    {
+        inDev = deviceSpecifier;
+        emit inDevChanged(inDev);
+    }
 }
 
 bool Settings::getAudioInDevEnabled() const
@@ -1442,19 +1673,29 @@ bool Settings::getAudioInDevEnabled() const
 void Settings::setAudioInDevEnabled(bool enabled)
 {
     QMutexLocker locker(&bigLock);
-    audioInDevEnabled = enabled;
+
+    if (enabled != audioInDevEnabled)
+    {
+        audioInDevEnabled = enabled;
+        emit audioInDevEnabledChanged(enabled);
+    }
 }
 
-qreal Settings::getAudioInGain() const
+qreal Settings::getAudioInGainDecibel() const
 {
     QMutexLocker locker{&bigLock};
     return audioInGainDecibel;
 }
 
-void Settings::setAudioInGain(qreal dB)
+void Settings::setAudioInGainDecibel(qreal dB)
 {
     QMutexLocker locker{&bigLock};
-    audioInGainDecibel = dB;
+
+    if (dB < audioInGainDecibel || dB > audioInGainDecibel)
+    {
+        audioInGainDecibel = dB;
+        emit audioInGainDecibelChanged(audioInGainDecibel);
+    }
 }
 
 QString Settings::getVideoDev() const
@@ -1466,7 +1707,12 @@ QString Settings::getVideoDev() const
 void Settings::setVideoDev(const QString& deviceSpecifier)
 {
     QMutexLocker locker{&bigLock};
-    videoDev = deviceSpecifier;
+
+    if(deviceSpecifier != videoDev)
+    {
+        videoDev = deviceSpecifier;
+        emit videoDevChanged(videoDev);
+    }
 }
 
 QString Settings::getOutDev() const
@@ -1478,7 +1724,12 @@ QString Settings::getOutDev() const
 void Settings::setOutDev(const QString& deviceSpecifier)
 {
     QMutexLocker locker{&bigLock};
-    outDev = deviceSpecifier;
+
+    if (deviceSpecifier != outDev)
+    {
+        outDev = deviceSpecifier;
+        emit outDevChanged(outDev);
+    }
 }
 
 bool Settings::getAudioOutDevEnabled() const
@@ -1490,7 +1741,12 @@ bool Settings::getAudioOutDevEnabled() const
 void Settings::setAudioOutDevEnabled(bool enabled)
 {
     QMutexLocker locker(&bigLock);
-    audioOutDevEnabled = enabled;
+
+    if(enabled != audioOutDevEnabled)
+    {
+        audioOutDevEnabled = enabled;
+        emit audioOutDevEnabledChanged(audioOutDevEnabled);
+    }
 }
 
 int Settings::getOutVolume() const
@@ -1502,29 +1758,46 @@ int Settings::getOutVolume() const
 void Settings::setOutVolume(int volume)
 {
     QMutexLocker locker{&bigLock};
-    outVolume = volume;
+
+    if (volume != outVolume)
+    {
+        outVolume = volume;
+        emit outVolumeChanged(outVolume);
+    }
 }
 
 QRect Settings::getScreenRegion() const
 {
+    QMutexLocker locker (&bigLock);
     return screenRegion;
 }
 
-void Settings::setScreenRegion(const QRect &value)
+void Settings::setScreenRegion(const QRect& value)
 {
     QMutexLocker locker{&bigLock};
-    screenRegion = value;
+
+    if (value != screenRegion)
+    {
+        screenRegion = value;
+        emit screenRegionChanged(screenRegion);
+    }
 }
 
 bool Settings::getScreenGrabbed() const
 {
+    QMutexLocker locker(&bigLock);
     return screenGrabbed;
 }
 
 void Settings::setScreenGrabbed(bool value)
 {
     QMutexLocker locker{&bigLock};
-    screenGrabbed = value;
+
+    if (value != screenGrabbed)
+    {
+        screenGrabbed = value;
+        emit screenGrabbedChanged(screenGrabbed);
+    }
 }
 
 QRect Settings::getCamVideoRes() const
@@ -1536,7 +1809,12 @@ QRect Settings::getCamVideoRes() const
 void Settings::setCamVideoRes(QRect newValue)
 {
     QMutexLocker locker{&bigLock};
-    camVideoRes = newValue;
+
+    if (newValue != camVideoRes)
+    {
+        camVideoRes = newValue;
+        emit camVideoResChanged(camVideoRes);
+    }
 }
 
 unsigned short Settings::getCamVideoFPS() const
@@ -1548,10 +1826,15 @@ unsigned short Settings::getCamVideoFPS() const
 void Settings::setCamVideoFPS(unsigned short newValue)
 {
     QMutexLocker locker{&bigLock};
-    camVideoFPS = newValue;
+
+    if (newValue != camVideoFPS)
+    {
+        camVideoFPS = newValue;
+        emit camVideoFPSChanged(camVideoFPS);
+    }
 }
 
-QString Settings::getFriendAdress(const QString &publicKey) const
+QString Settings::getFriendAddress(const QString& publicKey) const
 {
     QMutexLocker locker{&bigLock};
     QString key = ToxId(publicKey).publicKey;
@@ -1562,7 +1845,7 @@ QString Settings::getFriendAdress(const QString &publicKey) const
     return QString();
 }
 
-void Settings::updateFriendAdress(const QString &newAddr)
+void Settings::updateFriendAddress(const QString& newAddr)
 {
     QMutexLocker locker{&bigLock};
     QString key = ToxId(newAddr).publicKey;
@@ -1582,7 +1865,7 @@ void Settings::updateFriendAdress(const QString &newAddr)
     }
 }
 
-QString Settings::getFriendAlias(const ToxId &id) const
+QString Settings::getFriendAlias(const ToxId& id) const
 {
     QMutexLocker locker{&bigLock};
     QString key = id.publicKey;
@@ -1593,7 +1876,7 @@ QString Settings::getFriendAlias(const ToxId &id) const
     return QString();
 }
 
-void Settings::setFriendAlias(const ToxId &id, const QString &alias)
+void Settings::setFriendAlias(const ToxId& id, const QString& alias)
 {
     QMutexLocker locker{&bigLock};
     QString key = id.publicKey;
@@ -1613,7 +1896,7 @@ void Settings::setFriendAlias(const ToxId &id, const QString &alias)
     }
 }
 
-int Settings::getFriendCircleID(const ToxId &id) const
+int Settings::getFriendCircleID(const ToxId& id) const
 {
     QString key = id.publicKey;
     auto it = friendLst.find(key);
@@ -1623,7 +1906,7 @@ int Settings::getFriendCircleID(const ToxId &id) const
     return -1;
 }
 
-void Settings::setFriendCircleID(const ToxId &id, int circleID)
+void Settings::setFriendCircleID(const ToxId& id, int circleID)
 {
     QString key = id.publicKey;
     auto it = friendLst.find(key);
@@ -1643,7 +1926,7 @@ void Settings::setFriendCircleID(const ToxId &id, int circleID)
     }
 }
 
-QDate Settings::getFriendActivity(const ToxId &id) const
+QDate Settings::getFriendActivity(const ToxId& id) const
 {
     QString key = id.publicKey;
     auto it = friendLst.find(key);
@@ -1653,7 +1936,7 @@ QDate Settings::getFriendActivity(const ToxId &id) const
     return QDate();
 }
 
-void Settings::setFriendActivity(const ToxId &id, const QDate &activity)
+void Settings::setFriendActivity(const ToxId& id, const QDate& activity)
 {
     QString key = id.publicKey;
     auto it = friendLst.find(key);
@@ -1674,7 +1957,7 @@ void Settings::setFriendActivity(const ToxId &id, const QDate &activity)
     }
 }
 
-void Settings::removeFriendSettings(const ToxId &id)
+void Settings::removeFriendSettings(const ToxId& id)
 {
     QMutexLocker locker{&bigLock};
     QString key = id.publicKey;
@@ -1690,7 +1973,12 @@ bool Settings::getFauxOfflineMessaging() const
 void Settings::setFauxOfflineMessaging(bool value)
 {
     QMutexLocker locker{&bigLock};
-    fauxOfflineMessaging = value;
+
+    if (value != fauxOfflineMessaging)
+    {
+        fauxOfflineMessaging = value;
+        emit fauxOfflineMessagingChanged(fauxOfflineMessaging);
+    }
 }
 
 bool Settings::getCompactLayout() const
@@ -1702,7 +1990,12 @@ bool Settings::getCompactLayout() const
 void Settings::setCompactLayout(bool value)
 {
     QMutexLocker locker{&bigLock};
-    compactLayout = value;
+
+    if (value != compactLayout)
+    {
+        compactLayout = value;
+        emit compactLayoutChanged(value);
+    }
 }
 
 bool Settings::getSeparateWindow() const
@@ -1714,7 +2007,12 @@ bool Settings::getSeparateWindow() const
 void Settings::setSeparateWindow(bool value)
 {
     QMutexLocker locker{&bigLock};
-    separateWindow = value;
+
+    if (value != separateWindow)
+    {
+        separateWindow = value;
+        emit separateWindowChanged(value);
+    }
 }
 
 bool Settings::getDontGroupWindows() const
@@ -1726,7 +2024,12 @@ bool Settings::getDontGroupWindows() const
 void Settings::setDontGroupWindows(bool value)
 {
     QMutexLocker locker{&bigLock};
-    dontGroupWindows = value;
+
+    if (value != dontGroupWindows)
+    {
+        dontGroupWindows = value;
+        emit dontGroupWindowsChanged(dontGroupWindows);
+    }
 }
 
 bool Settings::getGroupchatPosition() const
@@ -1738,7 +2041,12 @@ bool Settings::getGroupchatPosition() const
 void Settings::setGroupchatPosition(bool value)
 {
     QMutexLocker locker{&bigLock};
-    groupchatPosition = value;
+
+    if (value != groupchatPosition)
+    {
+        groupchatPosition = value;
+        emit groupchatPositionChanged(value);
+    }
 }
 
 int Settings::getCircleCount() const
@@ -1751,13 +2059,13 @@ QString Settings::getCircleName(int id) const
     return circleLst[id].name;
 }
 
-void Settings::setCircleName(int id, const QString &name)
+void Settings::setCircleName(int id, const QString& name)
 {
     circleLst[id].name = name;
     savePersonal();
 }
 
-int Settings::addCircle(const QString &name)
+int Settings::addCircle(const QString& name)
 {
     circleProp cp;
     cp.expanded = false;
@@ -1782,7 +2090,7 @@ void Settings::setCircleExpanded(int id, bool expanded)
     circleLst[id].expanded = expanded;
 }
 
-bool Settings::addFriendRequest(const QString &friendAddress, const QString &message)
+bool Settings::addFriendRequest(const QString& friendAddress, const QString& message)
 {
     QMutexLocker locker{&bigLock};
 
@@ -1864,10 +2172,15 @@ int Settings::getThemeColor() const
     return themeColor;
 }
 
-void Settings::setThemeColor(const int &value)
+void Settings::setThemeColor(int value)
 {
     QMutexLocker locker{&bigLock};
-    themeColor = value;
+
+    if (value != themeColor)
+    {
+        themeColor = value;
+        emit themeColorChanged(themeColor);
+    }
 }
 
 bool Settings::getAutoLogin() const
@@ -1879,7 +2192,12 @@ bool Settings::getAutoLogin() const
 void Settings::setAutoLogin(bool state)
 {
     QMutexLocker locker{&bigLock};
-    autoLogin = state;
+
+    if (state != autoLogin)
+    {
+        autoLogin = state;
+        emit autoLoginChanged(autoLogin);
+    }
 }
 
 /**

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -626,7 +626,7 @@ uint32_t Settings::makeProfileId(const QString& profile)
 @brief Get path to directory, where the settings files are stored.
 @return Path to settings directory, ends with a directory separator.
 */
-QString Settings::getSettingsDirPath()
+QString Settings::getSettingsDirPath() const
 {
     QMutexLocker locker{&bigLock};
     if (makeToxPortable)
@@ -649,7 +649,7 @@ QString Settings::getSettingsDirPath()
 @brief Get path to directory, where the application data are stored.
 @return Path to application data, ends with a directory separator.
 */
-QString Settings::getAppDataDirPath()
+QString Settings::getAppDataDirPath() const
 {
     QMutexLocker locker{&bigLock};
     if (makeToxPortable)
@@ -674,7 +674,7 @@ QString Settings::getAppDataDirPath()
 @brief Get path to directory, where the application cache are stored.
 @return Path to application cache, ends with a directory separator.
 */
-QString Settings::getAppCacheDirPath()
+QString Settings::getAppCacheDirPath() const
 {
     QMutexLocker locker{&bigLock};
     if (makeToxPortable)

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -32,15 +32,106 @@
 
 class ToxId;
 class Profile;
-namespace Db { enum class syncType; }
 
-enum ProxyType {ptNone, ptSOCKS5, ptHTTP};
-
-enum StyleType {NONE, WITH_CHARS, WITHOUT_CHARS};
+namespace Db {
+enum class syncType;
+}
 
 class Settings : public QObject
 {
     Q_OBJECT
+
+    Q_ENUMS(ProxyType)
+    Q_ENUMS(StyleType)
+
+    // general
+    Q_PROPERTY(bool compactLayout READ getCompactLayout WRITE setCompactLayout
+               NOTIFY compactLayoutChanged FINAL)
+    Q_PROPERTY(bool autorun READ getAutorun WRITE setAutorun
+               NOTIFY autorunChanged FINAL)
+
+    // GUI
+    Q_PROPERTY(bool separateWindow READ getSeparateWindow
+               WRITE setSeparateWindow NOTIFY separateWindowChanged FINAL)
+    Q_PROPERTY(QString smileyPack READ getSmileyPack WRITE setSmileyPack
+               NOTIFY smileyPackChanged FINAL)
+    Q_PROPERTY(int emojiFontPointSize READ getEmojiFontPointSize
+               WRITE setEmojiFontPointSize NOTIFY emojiFontPointSizeChanged
+               FINAL)
+    Q_PROPERTY(bool minimizeOnClose READ getMinimizeOnClose
+               WRITE setMinimizeOnClose NOTIFY minimizeOnCloseChanged FINAL)
+    Q_PROPERTY(QByteArray windowGeometry READ getWindowGeometry
+               WRITE setWindowGeometry NOTIFY windowGeometryChanged FINAL)
+    Q_PROPERTY(QByteArray windowState READ getWindowState WRITE setWindowState
+               NOTIFY windowStateChanged FINAL)
+    Q_PROPERTY(QByteArray splitterState READ getSplitterState
+               WRITE setSplitterState NOTIFY splitterStateChanged FINAL)
+    Q_PROPERTY(QByteArray dialogGeometry READ getDialogGeometry
+               WRITE setDialogGeometry NOTIFY dialogGeometryChanged FINAL)
+    Q_PROPERTY(QByteArray dialogSplitterState READ getDialogSplitterState
+               WRITE setDialogSplitterState NOTIFY dialogSplitterStateChanged
+               FINAL)
+    Q_PROPERTY(QByteArray dialogSettingsGeometry READ getDialogSettingsGeometry
+               WRITE setDialogSettingsGeometry
+               NOTIFY dialogSettingsGeometryChanged FINAL)
+    Q_PROPERTY(QString style READ getStyle WRITE setStyle NOTIFY styleChanged
+               FINAL)
+    Q_PROPERTY(bool showSystemTray READ getShowSystemTray
+               WRITE setShowSystemTray NOTIFY showSystemTrayChanged FINAL)
+
+    // ChatView
+    Q_PROPERTY(bool groupchatPosition READ getGroupchatPosition
+               WRITE setGroupchatPosition NOTIFY groupchatPositionChanged FINAL)
+    Q_PROPERTY(QFont chatMessageFont READ getChatMessageFont
+               WRITE setChatMessageFont NOTIFY chatMessageFontChanged FINAL)
+    Q_PROPERTY(StyleType stylePreference READ getStylePreference
+               WRITE setStylePreference NOTIFY stylePreferenceChanged FINAL)
+    Q_PROPERTY(QString timestampFormat READ getTimestampFormat
+               WRITE setTimestampFormat NOTIFY timestampFormatChanged FINAL)
+    Q_PROPERTY(QString dateFormat READ getDateFormat WRITE setDateFormat
+               NOTIFY dateFormatChanged FINAL)
+    Q_PROPERTY(bool statusChangeNotificationEnabled
+               READ getStatusChangeNotificationEnabled
+               WRITE setStatusChangeNotificationEnabled
+               NOTIFY statusChangeNotificationEnabledChanged FINAL)
+
+    // Privacy
+    Q_PROPERTY(bool typingNotification READ getTypingNotification
+               WRITE setTypingNotification NOTIFY typingNotificationChanged
+               FINAL)
+
+    // Audio
+    Q_PROPERTY(QString inDev READ getInDev WRITE setInDev
+               NOTIFY inDevChanged FINAL)
+    Q_PROPERTY(bool audioInDevEnabled READ getAudioInDevEnabled
+               WRITE setAudioInDevEnabled NOTIFY audioInDevEnabledChanged FINAL)
+    Q_PROPERTY(qreal audioInGainDecibel READ getAudioInGainDecibel
+               WRITE setAudioInGainDecibel NOTIFY audioInGainDecibelChanged
+               FINAL)
+    Q_PROPERTY(QString outDev READ getOutDev WRITE setOutDev
+               NOTIFY outDevChanged FINAL)
+    Q_PROPERTY(bool audioOutDevEnabled READ getAudioOutDevEnabled
+               WRITE setAudioOutDevEnabled NOTIFY audioOutDevEnabledChanged
+               FINAL)
+    Q_PROPERTY(int outVolume READ getOutVolume WRITE setOutVolume
+               NOTIFY outVolumeChanged FINAL)
+
+    // Video
+    Q_PROPERTY(QString videoDev READ getVideoDev WRITE setVideoDev
+               NOTIFY videoDevChanged FINAL)
+    Q_PROPERTY(QRect camVideoRes READ getCamVideoRes WRITE setCamVideoRes
+               NOTIFY camVideoResChanged FINAL)
+    Q_PROPERTY(QRect screenRegion READ getScreenRegion WRITE setScreenRegion
+               NOTIFY screenRegionChanged FINAL)
+    Q_PROPERTY(bool screenGrabbed READ getScreenGrabbed WRITE setScreenGrabbed
+               NOTIFY screenGrabbedChanged FINAL)
+    Q_PROPERTY(quint16 camVideoFPS READ getCamVideoFPS
+               WRITE setCamVideoFPS NOTIFY camVideoFPSChanged FINAL)
+
+public:
+    enum class ProxyType {ptNone = 0, ptSOCKS5 = 1, ptHTTP = 2};
+    enum class StyleType {NONE = 0, WITH_CHARS = 1, WITHOUT_CHARS = 2};
+
 public:
     static Settings& getInstance();
     static void destroyInstance();
@@ -65,15 +156,89 @@ public:
         bool read;
     };
 
-
 public slots:
     void saveGlobal();
     void sync();
 
 signals:
-    void dhtServerListChanged();
-    void smileyPackChanged();
-    void emojiFontChanged();
+    // General
+    void enableIPv6Changed(bool enabled);
+    void forceTCPChanged(bool enabled);
+    void proxyTypeChanged(ProxyType type);
+    void proxyAddressChanged(const QString& address);
+    void proxyPortChanged(quint16 port);
+    void dhtServerListChanged(const QList<DhtServer>& servers);
+    void autorunChanged(bool enabled);
+    void autoSaveEnabledChanged(bool enabled);
+    void autostartInTrayChanged(bool enabled);
+    void showInFrontChanged(bool enabled);
+    void closeToTrayChanged(bool enabled);
+    void lightTrayIconChanged(bool enabled);
+    void minimizeToTrayChanged(bool enabled);
+    void showWindowChanged(bool enabled);
+    void makeToxPortableChanged(bool enabled);
+    void busySoundChanged(bool enabled);
+    void notifySoundChanged(bool enabled);
+    void groupAlwaysNotifyChanged(bool enabled);
+    void translationChanged(const QString& translation);
+    void toxmeInfoChanged(const QString& info);
+    void toxmeBioChanged(const QString& bio);
+    void toxmePrivChanged(bool priv);
+    void toxmePassChanged();
+    void currentProfileChanged(const QString& profile);
+    void currentProfileIdChanged(quint32 id);
+    void enableLoggingChanged(bool enabled);
+    void autoAwayTimeChanged(int minutes);
+    void globalAutoAcceptDirChanged(const QString& path);
+    void checkUpdatesChanged(bool enabled);
+    void widgetDataChanged(const QString& key);
+
+    // GUI
+    void autoLoginChanged(bool enabled);
+    void separateWindowChanged(bool enabled);
+    void showSystemTrayChanged(bool enabled);
+    bool minimizeOnCloseChanged(bool enabled);
+    void windowGeometryChanged(const QByteArray& rect);
+    void windowStateChanged(const QByteArray& state);
+    void splitterStateChanged(const QByteArray& state);
+    void dialogGeometryChanged(const QByteArray& rect);
+    void dialogSplitterStateChanged(const QByteArray& state);
+    void dialogSettingsGeometryChanged(const QByteArray& rect);
+    void styleChanged(const QString& style);
+    void themeColorChanged(int color);
+    void compactLayoutChanged(bool enabled);
+
+    // ChatView
+    void useEmoticonsChanged(bool enabled);
+    void smileyPackChanged(const QString& name);
+    void emojiFontPointSizeChanged(int size);
+    void dontGroupWindowsChanged(bool enabled);
+    void groupchatPositionChanged(bool enabled);
+    void chatMessageFontChanged(const QFont& font);
+    void stylePreferenceChanged(StyleType type);
+    void timestampFormatChanged(const QString& format);
+    void dateFormatChanged(const QString& format);
+    void statusChangeNotificationEnabledChanged(bool enabled);
+    void fauxOfflineMessagingChanged(bool enabled);
+
+    // Privacy
+    void typingNotificationChanged(bool enabled);
+    void dbSyncTypeChanged(Db::syncType type);
+
+    // Audio
+    void inDevChanged(const QString& name);
+    void audioInDevEnabledChanged(bool enabled);
+    void audioInGainDecibelChanged(qreal gain);
+    void outDevChanged(const QString& name);
+    void audioOutDevEnabledChanged(bool enabled);
+    void outVolumeChanged(int volume);
+
+    // Video
+    void videoDevChanged(const QString& name);
+    void camVideoResChanged(const QRect& resolution);
+    void screenRegionChanged(const QRect& region);
+    void screenGrabbedChanged(bool enabled);
+    void camVideoFPSChanged(quint16 fps);
 
 public:
     const QList<DhtServer>& getDhtServerList() const;
@@ -104,32 +269,32 @@ public:
     void setStyle(const QString& newValue);
 
     bool getShowSystemTray() const;
-    void setShowSystemTray(const bool& newValue);
+    void setShowSystemTray(bool newValue);
 
     bool getUseEmoticons() const;
     void setUseEmoticons(bool newValue);
 
     QString getCurrentProfile() const;
     uint32_t getCurrentProfileId() const;
-    void setCurrentProfile(QString profile);
+    void setCurrentProfile(const QString& profile);
 
     QString getTranslation() const;
-    void setTranslation(QString newValue);
+    void setTranslation(const QString& newValue);
 
     // Toxme
     void deleteToxme();
     void setToxme(QString name, QString server, QString bio, bool priv, QString pass = "");
     QString getToxmeInfo() const;
-    void setToxmeInfo(QString info);
+    void setToxmeInfo(const QString& info);
 
     QString getToxmeBio() const;
-    void setToxmeBio(QString bio);
+    void setToxmeBio(const QString& bio);
     
     bool getToxmePriv() const;
     void setToxmePriv(bool priv);
     
     QString getToxmePass() const;
-    void setToxmePass(const QString &pass);
+    void setToxmePass(const QString& pass);
     
     void setAutoSaveEnabled(bool newValue);
     bool getAutoSaveEnabled() const;
@@ -143,7 +308,7 @@ public:
     void setProxyAddr(const QString& newValue);
 
     ProxyType getProxyType() const;
-    void setProxyType(int newValue);
+    void setProxyType(ProxyType newValue);
 
     quint16 getProxyPort() const;
     void setProxyPort(quint16 newValue);
@@ -152,7 +317,7 @@ public:
     void setEnableLogging(bool newValue);
 
     Db::syncType getDbSyncType() const;
-    void setDbSyncType(int newValue);
+    void setDbSyncType(Db::syncType newValue);
 
     int getAutoAwayTime() const;
     void setAutoAwayTime(int newValue);
@@ -187,8 +352,8 @@ public:
     bool getAudioOutDevEnabled() const;
     void setAudioOutDevEnabled(bool enabled);
 
-    qreal getAudioInGain() const;
-    void setAudioInGain(qreal dB);
+    qreal getAudioInGainDecibel() const;
+    void setAudioInGainDecibel(qreal dB);
 
     int getOutVolume() const;
     void setOutVolume(int volume);
@@ -197,7 +362,7 @@ public:
     void setVideoDev(const QString& deviceSpecifier);
 
     QRect getScreenRegion() const;
-    void setScreenRegion(const QRect &value);
+    void setScreenRegion(const QRect& value);
 
     bool getScreenGrabbed() const;
     void setScreenGrabbed(bool value);
@@ -212,10 +377,10 @@ public:
     void setAnimationEnabled(bool newValue);
 
     QString getSmileyPack() const;
-    void setSmileyPack(const QString &value);
+    void setSmileyPack(const QString& value);
 
     int getThemeColor() const;
-    void setThemeColor(const int& value);
+    void setThemeColor(int value);
 
     StyleType getStylePreference() const;
     void setStylePreference(StyleType newValue);
@@ -239,60 +404,54 @@ public:
     const QFont& getChatMessageFont() const;
     void setChatMessageFont(const QFont& font);
 
-    int getFirstColumnHandlePos() const;
-    void setFirstColumnHandlePos(const int pos);
-
-    int getSecondColumnHandlePosFromRight() const;
-    void setSecondColumnHandlePosFromRight(const int pos);
-
     const QString& getTimestampFormat() const;
     void setTimestampFormat(const QString& format);
 
     const QString& getDateFormat() const;
     void setDateFormat(const QString& format);
 
-    bool isMinimizeOnCloseEnabled() const;
+    bool getMinimizeOnClose() const;
     void setMinimizeOnClose(bool newValue);
 
     bool getStatusChangeNotificationEnabled() const;
     void setStatusChangeNotificationEnabled(bool newValue);
 
     // Privacy
-    bool isTypingNotificationEnabled() const;
+    bool getTypingNotification() const;
     void setTypingNotification(bool enabled);
 
     // State
     QByteArray getWindowGeometry() const;
-    void setWindowGeometry(const QByteArray &value);
+    void setWindowGeometry(const QByteArray& value);
 
     QByteArray getWindowState() const;
-    void setWindowState(const QByteArray &value);
+    void setWindowState(const QByteArray& value);
 
     QByteArray getSplitterState() const;
-    void setSplitterState(const QByteArray &value);
+    void setSplitterState(const QByteArray& value);
 
     QByteArray getDialogGeometry() const;
     void setDialogGeometry(const QByteArray& value);
 
     QByteArray getDialogSplitterState() const;
-    void setDialogSplitterState(const QByteArray &value);
+    void setDialogSplitterState(const QByteArray& value);
 
     QByteArray getDialogSettingsGeometry() const;
     void setDialogSettingsGeometry(const QByteArray& value);
 
-    QString getFriendAdress(const QString &publicKey) const;
-    void updateFriendAdress(const QString &newAddr);
+    QString getFriendAddress(const QString& publicKey) const;
+    void updateFriendAddress(const QString& newAddr);
 
-    QString getFriendAlias(const ToxId &id) const;
-    void setFriendAlias(const ToxId &id, const QString &alias);
+    QString getFriendAlias(const ToxId& id) const;
+    void setFriendAlias(const ToxId& id, const QString& alias);
 
-    int getFriendCircleID(const ToxId &id) const;
-    void setFriendCircleID(const ToxId &id, int circleID);
+    int getFriendCircleID(const ToxId& id) const;
+    void setFriendCircleID(const ToxId& id, int circleID);
 
-    QDate getFriendActivity(const ToxId &id) const;
-    void setFriendActivity(const ToxId &id, const QDate &date);
+    QDate getFriendActivity(const ToxId& id) const;
+    void setFriendActivity(const ToxId& id, const QDate &date);
 
-    void removeFriendSettings(const ToxId &id);
+    void removeFriendSettings(const ToxId& id);
 
     bool getFauxOfflineMessaging() const;
     void setFauxOfflineMessaging(bool value);
@@ -313,14 +472,14 @@ public:
     void setAutoLogin(bool state);
 
     int getCircleCount() const;
-    int addCircle(const QString &name = QString());
+    int addCircle(const QString& name = QString());
     int removeCircle(int id);
     QString getCircleName(int id) const;
-    void setCircleName(int id, const QString &name);
+    void setCircleName(int id, const QString& name);
     bool getCircleExpanded(int id) const;
     void setCircleExpanded(int id, bool expanded);
 
-    bool addFriendRequest(const QString &friendAddress, const QString &message);
+    bool addFriendRequest(const QString& friendAddress, const QString& message);
     unsigned int getUnreadFriendRequests() const;
     Request getFriendRequest(int index) const;
     int getFriendRequestSize() const;

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -135,9 +135,9 @@ public:
 public:
     static Settings& getInstance();
     static void destroyInstance();
-    QString getSettingsDirPath();
-    QString getAppDataDirPath();
-    QString getAppCacheDirPath();
+    QString getSettingsDirPath() const;
+    QString getAppDataDirPath() const;
+    QString getAppCacheDirPath() const;
 
     void createSettingsDir();
     void createPersonal(QString basename);

--- a/src/widget/contentdialog.cpp
+++ b/src/widget/contentdialog.cpp
@@ -96,7 +96,8 @@ ContentDialog::ContentDialog(SettingsWidget* settingsWidget, QWidget* parent)
 
     connect(splitter, &QSplitter::splitterMoved, this, &ContentDialog::saveSplitterState);
 
-    connect(settingsWidget, &SettingsWidget::groupchatPositionToggled, this, &ContentDialog::onGroupchatPositionChanged);
+    const Settings& s = Settings::getInstance();
+    connect(&s, &Settings::groupchatPositionChanged, this, &ContentDialog::onGroupchatPositionChanged);
 
     setMinimumSize(500, 220);
     setAttribute(Qt::WA_DeleteOnClose);
@@ -167,9 +168,10 @@ FriendWidget* ContentDialog::addFriend(int friendId, QString id)
     friendLayout->addFriendWidget(friendWidget, FriendList::findFriend(friendId)->getStatus());
 
     Friend* frnd = friendWidget->getFriend();
+    const Settings& s = Settings::getInstance();
 
     connect(frnd, &Friend::displayedNameChanged, this, &ContentDialog::updateFriendWidget);
-    connect(settingsWidget, &SettingsWidget::compactToggled, friendWidget, &FriendWidget::compactChange);
+    connect(&s, &Settings::compactLayoutChanged, friendWidget, &FriendWidget::compactChange);
     connect(friendWidget, &FriendWidget::chatroomWidgetClicked, this, &ContentDialog::onChatroomWidgetClicked);
     connect(friendWidget, SIGNAL(chatroomWidgetClicked(GenericChatroomWidget*)), frnd->getChatForm(), SLOT(focusInput()));
     connect(Core::getInstance(), &Core::friendAvatarChanged, friendWidget, &FriendWidget::onAvatarChange);
@@ -191,10 +193,11 @@ GroupWidget* ContentDialog::addGroup(int groupId, const QString& name)
     GroupWidget* groupWidget = new GroupWidget(groupId, name);
     groupLayout.addSortedWidget(groupWidget);
 
+    const Settings& s = Settings::getInstance();
     Group* group = groupWidget->getGroup();
     connect(group, &Group::titleChanged, this, &ContentDialog::updateGroupWidget);
     connect(group, &Group::userListChanged, this, &ContentDialog::updateGroupWidget);
-    connect(settingsWidget, &SettingsWidget::compactToggled, groupWidget, &GroupWidget::compactChange);
+    connect(&s, &Settings::compactLayoutChanged, groupWidget, &GroupWidget::compactChange);
     connect(groupWidget, &GroupWidget::chatroomWidgetClicked, this, &ContentDialog::onChatroomWidgetClicked);
 
     ContentDialog* lastDialog = getGroupDialog(groupId);

--- a/src/widget/form/addfriendform.cpp
+++ b/src/widget/form/addfriendform.cpp
@@ -165,7 +165,7 @@ void AddFriendForm::onSendTriggered()
         if (toxId.toString().isEmpty())  // If it isn't supported
         {
             qDebug() << "Toxme didn't return a ToxID, trying ToxDNS";
-            if (Settings::getInstance().getProxyType() != ProxyType::ptNone)
+            if (Settings::getInstance().getProxyType() != Settings::ProxyType::ptNone)
             {
                 QMessageBox::StandardButton btn = QMessageBox::warning(main, "qTox", tr("qTox needs to use the Tox DNS, but can't do it through a proxy.\n\
     Ignore the proxy and connect to the Internet directly?"), QMessageBox::Yes|QMessageBox::No, QMessageBox::No);

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -163,7 +163,7 @@ void ChatForm::onSendTriggered()
 
 void ChatForm::onTextEditChanged()
 {
-    if (!Settings::getInstance().isTypingNotificationEnabled())
+    if (!Settings::getInstance().getTypingNotification())
     {
         if (isTyping)
             Core::getInstance()->sendTyping(f->getFriendID(), false);

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -76,8 +76,10 @@ GenericChatForm::GenericChatForm(QWidget *parent)
     chatWidget = new ChatLog(this);
     chatWidget->setBusyNotification(ChatMessage::createBusyNotification());
 
-    connect(&Settings::getInstance(), &Settings::emojiFontChanged,
-            this, [this]() { chatWidget->forceRelayout(); });
+    // settings
+    const Settings& s = Settings::getInstance();
+    connect(&s, &Settings::emojiFontPointSizeChanged,
+            chatWidget, &ChatLog::forceRelayout);
 
     msgEdit = new ChatTextEdit();
 

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -537,7 +537,7 @@ void AVForm::on_microphoneSlider_valueChanged(int value)
 {
     const qreal dB = value / 10.0;
 
-    Settings::getInstance().setAudioInGain(dB);
+    Settings::getInstance().setAudioInGainDecibel(dB);
     Audio::getInstance().setInputGain(dB);
 }
 

--- a/src/widget/form/settings/generalform.cpp
+++ b/src/widget/form/settings/generalform.cpp
@@ -321,7 +321,6 @@ void GeneralForm::onAutorunUpdated()
 void GeneralForm::onSetShowSystemTray()
 {
     Settings::getInstance().setShowSystemTray(bodyUI->showSystemTray->isChecked());
-    emit parent->setShowSystemTray(bodyUI->showSystemTray->isChecked());
     Settings::getInstance().saveGlobal();
 }
 
@@ -534,14 +533,12 @@ void GeneralForm::onFauxOfflineMessaging()
 void GeneralForm::onCompactLayout()
 {
     Settings::getInstance().setCompactLayout(bodyUI->cbCompactLayout->isChecked());
-    emit parent->compactToggled(bodyUI->cbCompactLayout->isChecked());
 }
 
 void GeneralForm::onSeparateWindowChanged()
 {
     bodyUI->cbDontGroupWindows->setEnabled(bodyUI->cbSeparateWindow->isChecked());
     Settings::getInstance().setSeparateWindow(bodyUI->cbSeparateWindow->isChecked());
-    emit parent->separateWindowToggled(bodyUI->cbSeparateWindow->isChecked());
 }
 
 void GeneralForm::onDontGroupWindowsChanged()
@@ -552,7 +549,6 @@ void GeneralForm::onDontGroupWindowsChanged()
 void GeneralForm::onGroupchatPositionChanged()
 {
     Settings::getInstance().setGroupchatPosition(bodyUI->cbGroupchatPosition->isChecked());
-    emit parent->groupchatPositionToggled(bodyUI->cbGroupchatPosition->isChecked());
 }
 
 void GeneralForm::onThemeColorChanged(int)

--- a/src/widget/form/settings/generalform.cpp
+++ b/src/widget/form/settings/generalform.cpp
@@ -133,7 +133,7 @@ GeneralForm::GeneralForm(SettingsWidget *myParent)
     const QFont chatBaseFont = s.getChatMessageFont();
     bodyUI->txtChatFontSize->setValue(QFontInfo(chatBaseFont).pixelSize());
     bodyUI->txtChatFont->setCurrentFont(chatBaseFont);
-    bodyUI->textStyleComboBox->setCurrentIndex(s.getStylePreference());
+    bodyUI->textStyleComboBox->setCurrentIndex(static_cast<int>(s.getStylePreference()));
     bodyUI->cbAutorun->setChecked(s.getAutorun());
 
     bool showSystemTray = s.getShowSystemTray();
@@ -407,7 +407,9 @@ void GeneralForm::onUseEmoticonsChange()
 
 void GeneralForm::onStyleUpdated()
 {
-    Settings::getInstance().setStylePreference(static_cast<StyleType>(bodyUI->textStyleComboBox->currentIndex()));
+    Settings::StyleType styleType =
+            static_cast<Settings::StyleType>(bodyUI->textStyleComboBox->currentIndex());
+    Settings::getInstance().setStylePreference(styleType);
 }
 
 void GeneralForm::onSetStatusChange()
@@ -434,18 +436,16 @@ void GeneralForm::onProxyAddrEdited()
 
 void GeneralForm::onProxyPortEdited(int port)
 {
-    if (port > 0)
-        Settings::getInstance().setProxyPort(port);
-    else
-        Settings::getInstance().setProxyPort(-1);
+    Settings::getInstance().setProxyPort(static_cast<quint16>(port));
 }
 
 void GeneralForm::onUseProxyUpdated()
 {
-    int proxytype = bodyUI->proxyType->currentIndex();
+    Settings::ProxyType proxytype =
+            static_cast<Settings::ProxyType>(bodyUI->proxyType->currentIndex());
 
-    bodyUI->proxyAddr->setEnabled(proxytype);
-    bodyUI->proxyPort->setEnabled(proxytype);
+    bodyUI->proxyAddr->setEnabled(proxytype != Settings::ProxyType::ptNone);
+    bodyUI->proxyPort->setEnabled(proxytype != Settings::ProxyType::ptNone);
     Settings::getInstance().setProxyType(proxytype);
 }
 

--- a/src/widget/form/settings/privacyform.cpp
+++ b/src/widget/form/settings/privacyform.cpp
@@ -93,8 +93,9 @@ void PrivacyForm::setNospam()
 
 void PrivacyForm::showEvent(QShowEvent*)
 {
+    const Settings& s = Settings::getInstance();
     bodyUI->nospamLineEdit->setText(Core::getInstance()->getSelfId().noSpam);
-    bodyUI->cbTypingNotification->setChecked(Settings::getInstance().isTypingNotificationEnabled());
+    bodyUI->cbTypingNotification->setChecked(s.getTypingNotification());
     bodyUI->cbKeepHistory->setChecked(Settings::getInstance().getEnableLogging());
 }
 

--- a/src/widget/form/settingswidget.h
+++ b/src/widget/form/settingswidget.h
@@ -47,12 +47,6 @@ public:
 
     void showAbout();
 
-signals:
-    void setShowSystemTray(bool newValue);
-    void compactToggled(bool compact);
-    void separateWindowToggled(bool separateWindow);
-    void groupchatPositionToggled(bool groupchatPosition);
-
 private slots:
     void onTabChanged(int);
 

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -240,10 +240,11 @@ void Widget::init()
     //connect logout tray menu action
     connect(actionLogout, &QAction::triggered, profileForm, &ProfileForm::onLogoutClicked);
 
+    const Settings& s = Settings::getInstance();
     Core* core = Nexus::getCore();
     connect(core, &Core::fileDownloadFinished, filesForm, &FilesForm::onFileDownloadComplete);
     connect(core, &Core::fileUploadFinished, filesForm, &FilesForm::onFileUploadComplete);
-    connect(settingsWidget, &SettingsWidget::setShowSystemTray, this, &Widget::onSetShowSystemTray);
+    connect(&s, &Settings::showSystemTrayChanged, this, &Widget::onSetShowSystemTray);
     connect(core, &Core::selfAvatarChanged, profileForm, &ProfileForm::onSelfAvatarLoaded);
     connect(ui->addButton, &QPushButton::clicked, this, &Widget::onAddClicked);
     connect(ui->groupButton, &QPushButton::clicked, this, &Widget::onGroupClicked);
@@ -380,9 +381,9 @@ void Widget::init()
         ui->mainSplitter->setSizes(sizes);
     }
 
-    connect(settingsWidget, &SettingsWidget::compactToggled, contactListWidget, &FriendListWidget::onCompactChanged);
-    connect(settingsWidget, &SettingsWidget::groupchatPositionToggled, contactListWidget, &FriendListWidget::onGroupchatPositionChanged);
-    connect(settingsWidget, &SettingsWidget::separateWindowToggled, this, &Widget::onSeparateWindowClicked);
+    connect(&s, &Settings::compactLayoutChanged, contactListWidget, &FriendListWidget::onCompactChanged);
+    connect(&s, &Settings::groupchatPositionChanged, contactListWidget, &FriendListWidget::onGroupchatPositionChanged);
+    connect(&s, &Settings::separateWindowChanged, this, &Widget::onSeparateWindowClicked);
 #if (AUTOUPDATE_ENABLED)
     if (Settings::getInstance().getCheckUpdates())
         AutoUpdater::checkUpdatesAsyncInteractive();
@@ -955,10 +956,11 @@ void Widget::addFriend(int friendId, const QString &userId)
 
     contactListWidget->addFriendWidget(newfriend->getFriendWidget(), Status::Offline, Settings::getInstance().getFriendCircleID(newfriend->getToxId()));
 
+    const Settings& s = Settings::getInstance();
     Core* core = Nexus::getCore();
     CoreAV* coreav = core->getAv();
     connect(newfriend, &Friend::displayedNameChanged, this, &Widget::onFriendDisplayChanged);
-    connect(settingsWidget, &SettingsWidget::compactToggled, newfriend->getFriendWidget(), &GenericChatroomWidget::compactChange);
+    connect(&s, &Settings::compactLayoutChanged, newfriend->getFriendWidget(), &GenericChatroomWidget::compactChange);
     connect(newfriend->getFriendWidget(), SIGNAL(chatroomWidgetClicked(GenericChatroomWidget*, bool)), this, SLOT(onChatroomWidgetClicked(GenericChatroomWidget*, bool)));
     connect(newfriend->getFriendWidget(), SIGNAL(removeFriend(int)), this, SLOT(removeFriend(int)));
     connect(newfriend->getFriendWidget(), SIGNAL(copyFriendIdToClipboard(int)), this, SLOT(copyFriendIdToClipboard(int)));
@@ -1682,7 +1684,8 @@ Group *Widget::createGroup(int groupId)
     newgroup->getGroupWidget()->updateStatusLight();
     contactListWidget->activateWindow();
 
-    connect(settingsWidget, &SettingsWidget::compactToggled, newgroup->getGroupWidget(), &GenericChatroomWidget::compactChange);
+    const Settings& s = Settings::getInstance();
+    connect(&s, &Settings::compactLayoutChanged, newgroup->getGroupWidget(), &GenericChatroomWidget::compactChange);
     connect(newgroup->getGroupWidget(), SIGNAL(chatroomWidgetClicked(GenericChatroomWidget*,bool)), this, SLOT(onChatroomWidgetClicked(GenericChatroomWidget*,bool)));
     connect(newgroup->getGroupWidget(), SIGNAL(removeGroup(int)), this, SLOT(removeGroup(int)));
     connect(newgroup->getGroupWidget(), SIGNAL(chatroomWidgetClicked(GenericChatroomWidget*)), newgroup->getChatForm(), SLOT(focusInput()));

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -640,7 +640,7 @@ void Widget::onFailedToStartCore()
 
 void Widget::onBadProxyCore()
 {
-    Settings::getInstance().setProxyType(0);
+    Settings::getInstance().setProxyType(Settings::ProxyType::ptNone);
     QMessageBox critical(this);
     critical.setText(tr("toxcore failed to start with your proxy settings. qTox cannot run; please modify your "
                "settings and restart.", "popup text"));


### PR DESCRIPTION
This PR turns our settings class into a "fully reflected" database. That means, we can now connect to it and get application wide notification signals, when a value changes. You can now stop to connect slots to a button or a checkbox within `SettingsWidget` and rely on `Settings` instead! ~~The PR itself does not change or correct any existing behaviour despite from few absolutely required changes.~~ **As some topics got corrected during the review process, it is just consequent to re-connect the corrected signals and get the values directly from settings changes.**

@initramfs Could you review please? I know it's huge, but we really need it - and it helps you as well with the video settings! :smile:

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3590)

<!-- Reviewable:end -->
