### PR TITLE
add a recursive signal blocker for safe widget initialization 

### DIFF
--- a/qtox.pro
+++ b/qtox.pro
@@ -273,6 +273,7 @@ HEADERS  += \
     src/core/cstring.h \
     src/core/toxid.h \
     src/core/indexedlist.h \
+    src/core/recursivesignalblocker.h \
     src/core/toxcall.h \
     src/net/toxuri.h \
     src/net/toxdns.h \
@@ -378,6 +379,7 @@ SOURCES += \
     src/core/coreencryption.cpp \
     src/core/corefile.cpp \
     src/core/corestructs.cpp \
+    src/core/recursivesignalblocker.cpp \
     src/core/toxid.cpp \
     src/core/toxcall.cpp \
     src/chatlog/chatlog.cpp \

--- a/src/core/recursivesignalblocker.cpp
+++ b/src/core/recursivesignalblocker.cpp
@@ -1,0 +1,60 @@
+/*
+    Copyright © 2016 by The qTox Project
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "recursivesignalblocker.h"
+
+#include <QObject>
+#include <QSignalBlocker>
+
+/**
+@class  RecursiveSignalBlocker
+@brief  Recursively blocks all signals from an object and its children.
+@note   All children must be created before the blocker is used.
+
+Wraps a QSignalBlocker on each object. Signals will be unblocked when the
+blocker gets destroyed. According to QSignalBlocker, we are also exception safe.
+*/
+
+/**
+@brief      Creates a QSignalBlocker recursively on the object and child objects.
+@param[in]  object  the object, which signals should be blocked
+*/
+RecursiveSignalBlocker::RecursiveSignalBlocker(QObject* object)
+{
+    recursiveBlock(object);
+}
+
+RecursiveSignalBlocker::~RecursiveSignalBlocker()
+{
+    qDeleteAll(mBlockers);
+}
+
+/**
+@brief      Recursively blocks all signals of the object.
+@param[in]  object  the object to block
+*/
+void RecursiveSignalBlocker::recursiveBlock(QObject* object)
+{
+    mBlockers << new QSignalBlocker(object);
+
+    for (QObject* child : object->children())
+    {
+        recursiveBlock(child);
+    }
+}

--- a/src/core/recursivesignalblocker.h
+++ b/src/core/recursivesignalblocker.h
@@ -1,0 +1,40 @@
+/*
+    Copyright © 2016 by The qTox Project
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef QTOX_RECURSIVESIGNALBLOCKER_H
+#define QTOX_RECURSIVESIGNALBLOCKER_H
+
+#include <QVector>
+
+class QObject;
+class QSignalBlocker;
+
+class RecursiveSignalBlocker
+{
+public:
+    explicit RecursiveSignalBlocker(QObject* object);
+    ~RecursiveSignalBlocker();
+
+    void recursiveBlock(QObject* object);
+
+private:
+    QVector<const QSignalBlocker*> mBlockers;
+};
+
+#endif

--- a/src/widget/form/settings/aboutform.cpp
+++ b/src/widget/form/settings/aboutform.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2014-2015 by The qTox Project
+    Copyright © 2014-2016 by The qTox Project
 
     This file is part of qTox, a Qt-based graphical interface for Tox.
 
@@ -17,27 +17,32 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "aboutform.h"
 #include "ui_aboutsettings.h"
 
-#include "aboutform.h"
+#include <src/core/recursivesignalblocker.h>
 #include "src/widget/translator.h"
 #include "tox/tox.h"
 #include "src/net/autoupdate.h"
 #include <QTimer>
 #include <QDebug>
 
-AboutForm::AboutForm() :
-    GenericForm(QPixmap(":/img/settings/general.png"))
+AboutForm::AboutForm()
+    : GenericForm(QPixmap(":/img/settings/general.png"))
+    , bodyUI(new Ui::AboutSettings)
+    , progressTimer(new QTimer(this))
 {
-    bodyUI = new Ui::AboutSettings;
     bodyUI->setupUi(this);
+
+    // block all child signals during initialization
+    const RecursiveSignalBlocker signalBlocker(this);
+
     replaceVersions();
 
     if (QString(GIT_VERSION).indexOf(" ") > -1)
         bodyUI->gitVersion->setOpenExternalLinks(false);
 
     showUpdateProgress();
-    progressTimer = new QTimer();
     progressTimer->setInterval(500);
     progressTimer->setSingleShot(false);
     connect(progressTimer, &QTimer::timeout, this, &AboutForm::showUpdateProgress);
@@ -107,7 +112,6 @@ void AboutForm::replaceVersions()
 AboutForm::~AboutForm()
 {
     Translator::unregister(this);
-    delete progressTimer;
     delete bodyUI;
 }
 

--- a/src/widget/form/settings/advancedform.cpp
+++ b/src/widget/form/settings/advancedform.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2014-2015 by The qTox Project
+    Copyright © 2014-2016 by The qTox Project
 
     This file is part of qTox, a Qt-based graphical interface for Tox.
 
@@ -17,18 +17,22 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "advancedform.h"
 #include "ui_advancedsettings.h"
 
-#include "advancedform.h"
+#include <src/core/recursivesignalblocker.h>
 #include "src/persistence/settings.h"
 #include "src/persistence/db/plaindb.h"
 #include "src/widget/translator.h"
 
-AdvancedForm::AdvancedForm() :
-    GenericForm(QPixmap(":/img/settings/general.png"))
+AdvancedForm::AdvancedForm()
+  : GenericForm(QPixmap(":/img/settings/general.png"))
+  , bodyUI (new Ui::AdvancedSettings)
 {
-    bodyUI = new Ui::AdvancedSettings;
     bodyUI->setupUi(this);
+
+    // block all child signals during initialization
+    const RecursiveSignalBlocker signalBlocker(this);
 
     bodyUI->cbMakeToxPortable->setChecked(Settings::getInstance().getMakeToxPortable());
 

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2014-2015 by The qTox Project
+    Copyright © 2014-2016 by The qTox Project
 
     This file is part of qTox, a Qt-based graphical interface for Tox.
 
@@ -28,6 +28,7 @@
 #include "src/widget/tool/screenshotgrabber.h"
 #include "src/core/core.h"
 #include "src/core/coreav.h"
+#include "src/core/recursivesignalblocker.h"
 
 #include <QDebug>
 #include <QShowEvent>
@@ -45,6 +46,9 @@ AVForm::AVForm()
     , camera(CameraSource::getInstance())
 {
     setupUi(this);
+
+    // block all child signals during initialization
+    const RecursiveSignalBlocker signalBlocker(this);
 
     const Audio& audio = Audio::getInstance();
     const Settings& s = Settings::getInstance();

--- a/src/widget/form/settings/generalform.cpp
+++ b/src/widget/form/settings/generalform.cpp
@@ -17,8 +17,10 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "ui_generalsettings.h"
 #include "generalform.h"
+#include "ui_generalsettings.h"
+
+#include <src/core/recursivesignalblocker.h>
 #include "src/widget/form/settingswidget.h"
 #include "src/widget/widget.h"
 #include "src/persistence/settings.h"
@@ -104,13 +106,16 @@ static QStringList timeFormats = {"hh:mm AP", "hh:mm", "hh:mm:ss AP", "hh:mm:ss"
 // http://doc.qt.io/qt-4.8/qdate.html#fromString
 static QStringList dateFormats = {"yyyy-MM-dd", "dd-MM-yyyy", "d-MM-yyyy", "dddd d-MM-yyyy", "dddd d-MM", "dddd dd MMMM"};
 
-GeneralForm::GeneralForm(SettingsWidget *myParent) :
-    GenericForm(QPixmap(":/img/settings/general.png"))
+GeneralForm::GeneralForm(SettingsWidget *myParent)
+    : GenericForm(QPixmap(":/img/settings/general.png"))
+    , bodyUI(new Ui::GeneralSettings)
 {
     parent = myParent;
 
-    bodyUI = new Ui::GeneralSettings;
     bodyUI->setupUi(this);
+
+    // block all child signals during initialization
+    const RecursiveSignalBlocker signalBlocker(this);
 
     Settings& s = Settings::getInstance();
 

--- a/src/widget/form/settings/privacyform.cpp
+++ b/src/widget/form/settings/privacyform.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2014-2015 by The qTox Project
+    Copyright © 2014-2016 by The qTox Project
 
     This file is part of qTox, a Qt-based graphical interface for Tox.
 
@@ -19,25 +19,31 @@
 
 #include "privacyform.h"
 #include "ui_privacysettings.h"
-#include "src/widget/form/settingswidget.h"
-#include "src/persistence/settings.h"
+
 #include "src/core/core.h"
-#include "src/widget/widget.h"
-#include "src/widget/gui.h"
-#include "src/widget/form/setpassworddialog.h"
-#include "src/widget/translator.h"
+#include <src/core/recursivesignalblocker.h>
 #include "src/nexus.h"
-#include "src/persistence/profile.h"
 #include "src/persistence/history.h"
+#include "src/persistence/profile.h"
+#include "src/persistence/settings.h"
+#include "src/widget/form/setpassworddialog.h"
+#include "src/widget/form/settingswidget.h"
+#include "src/widget/gui.h"
+#include "src/widget/translator.h"
+#include "src/widget/widget.h"
+
 #include <QMessageBox>
 #include <QFile>
 #include <QDebug>
 
-PrivacyForm::PrivacyForm() :
-    GenericForm(QPixmap(":/img/settings/privacy.png"))
+PrivacyForm::PrivacyForm()
+    : GenericForm(QPixmap(":/img/settings/privacy.png"))
+    , bodyUI(new Ui::PrivacySettings)
 {
-    bodyUI = new Ui::PrivacySettings;
     bodyUI->setupUi(this);
+
+    // block all child signals during initialization
+    const RecursiveSignalBlocker signalBlocker(this);
 
     connect(bodyUI->cbTypingNotification, SIGNAL(stateChanged(int)), this, SLOT(onTypingNotificationEnabledUpdated()));
     connect(bodyUI->cbKeepHistory, SIGNAL(stateChanged(int)), this, SLOT(onEnableLoggingUpdated()));


### PR DESCRIPTION
The `RecursiveSignalBlocker` has to be applied in a settings page's constructor and widgets must be created **before** the blocker is created. 

**How does it work?** 
The blocker itself creates a `QSignalBlocker` on a QObject and recursively on every child. All signals of those objects are being blocked, until the blocker is destroyed. In this case it unlocks. This is not restricted to widgets, but can be used on any QObject.

**Note** Through the recent PR #3590 this might not be required any longer. Anyway such blocker can come in handy in other use cases as well.

@Diadlo FYI

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3591)

<!-- Reviewable:end -->
