### PR TITLE
fix(build): fix OpenAL build on Windows

### DIFF
--- a/windows/bootstrap.sh
+++ b/windows/bootstrap.sh
@@ -62,7 +62,7 @@ fi
 
 if [ ! -f "bin/OpenAL32.dll" ]; then
     pushd openal-soft-1.16.0/build
-    cmake -G "MSYS Makefiles" -DQT_QMAKE_EXECUTABLE=NOTFOUND -DCMAKE_BUILD_TYPE=Release -DALSOFT_REQUIRE_DSOUND=NO -DCMAKE_INSTALL_PREFIX=$QTOX_DIR/libs ..
+    CFLAGS="-D_TIMESPEC_DEFINED" cmake -G "MSYS Makefiles" -DQT_QMAKE_EXECUTABLE=NOTFOUND -DCMAKE_BUILD_TYPE=Release -DALSOFT_REQUIRE_DSOUND=NO -DCMAKE_INSTALL_PREFIX=$QTOX_DIR/libs ..
     make
     make install
     popd


### PR DESCRIPTION
Add OpenAL-specific define to fix `error: redefinition of 'struct timespec'` when compiling with MinGW. `timespec` is already defined within MinGW, but probably detection does not work correctly.

Partially fixes #3372

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3604)

<!-- Reviewable:end -->
