### PR TITLE
Allow creation of OSX dmg binary for travis deployment

### DIFF
--- a/.travis/travis.sh
+++ b/.travis/travis.sh
@@ -16,6 +16,7 @@ then
     bash ./osx/qTox-Mac-Deployer-ULTIMATE.sh -i
     bash ./osx/qTox-Mac-Deployer-ULTIMATE.sh -b
     bash ./osx/qTox-Mac-Deployer-ULTIMATE.sh -d
-    # Disabled due to error: hdiutil: create failed - Resource busy
-    #bash ./osx/qTox-Mac-Deployer-ULTIMATE.sh -dmg
+    # The following line can randomly fail due to travis emitting the error:
+    # "hdiutil: create failed - Resource busy"
+    bash ./osx/qTox-Mac-Deployer-ULTIMATE.sh -dmg
 fi


### PR DESCRIPTION
This PR uncomments a previously removed line that creates OSX binaries. Travis cannot automatically deploy OSX releases if the DMG binaries are not being built.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3608)

<!-- Reviewable:end -->
