### PR TITLE
chore: relax commit message verification rules for `Merge*` commits

### DIFF
--- a/verify-commit-messages.sh
+++ b/verify-commit-messages.sh
@@ -31,7 +31,7 @@ echo "" # ← formatting
 
 # Conform, /OR ELSE/.
 if git log --format=format:'%s' "$ARG" | \
-    grep -v -E '^((feat|fix|docs|style|refactor|perf|revert|test|chore)(\(.{,12}\))?:.{1,68})|(Merge pull request #[[:digit:]]{1,10})$'
+    grep -v -E '^((feat|fix|docs|style|refactor|perf|revert|test|chore)(\(.{,12}\))?:.{1,68})|(Merge(.+){,70})$'
 then
     echo ""
     echo "Above ↑ commits don't conform to commit message format:"


### PR DESCRIPTION
Now almost anything goes for `Merge` commits – the only requirement is
having at least one character after `Merge`, and up to 70 characters.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3615)

<!-- Reviewable:end -->
