### PR TITLE
Fix automatic travis documentation deployment

### DIFF
--- a/.travis/deploy-docs.sh
+++ b/.travis/deploy-docs.sh
@@ -38,7 +38,7 @@ GIT_CHASH=$(git rev-parse HEAD)
 # Push generated doxygen to GitHub pages
 cd "$DOCS_DIR"
 
-git --quiet init
+git init --quiet
 git config user.name "Travis CI"
 git config user.email "qTox@users.noreply.github.com"
 


### PR DESCRIPTION
An invalid git command was being used in the documentation deployment script causing travis to not auto-deploy the doxygen documentation. This PR fixes this command to allow proper doc deployment to GH pages.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3619)

<!-- Reviewable:end -->
