### PR TITLE
fix: use `qAbs()` instead of `abs()` for better platform compatibility

### DIFF
--- a/src/video/videomode.cpp
+++ b/src/video/videomode.cpp
@@ -63,7 +63,7 @@ bool VideoMode::operator==(const VideoMode &other) const
 
 uint32_t VideoMode::norm(const VideoMode &other) const
 {
-    return abs(this->width-other.width) + abs(this->height-other.height);
+    return qAbs(this->width-other.width) + qAbs(this->height-other.height);
 }
 
 /**

--- a/src/widget/tool/screengrabberchooserrectitem.cpp
+++ b/src/widget/tool/screengrabberchooserrectitem.cpp
@@ -19,8 +19,6 @@
 
 #include "screengrabberchooserrectitem.h"
 
-#include <cstdlib>
-
 #include <QGraphicsSceneMouseEvent>
 #include <QGraphicsScene>
 #include <QPainter>
@@ -213,8 +211,8 @@ void ScreenGrabberChooserRectItem::mouseMoveHandle(int x, int y, QGraphicsSceneM
         return;
 
     QPointF delta = event->scenePos() - event->lastScenePos();
-    delta.rx() *= qreal(std::abs(x));
-    delta.ry() *= qreal(std::abs(y));
+    delta.rx() *= qAbs(x);
+    delta.ry() *= qAbs(y);
 
     // We increase if the multiplier and the delta have the same sign
     bool increaseX = ((x < 0) == (delta.x() < 0));

--- a/src/widget/tool/screenshotgrabber.cpp
+++ b/src/widget/tool/screenshotgrabber.cpp
@@ -200,8 +200,8 @@ void ScreenshotGrabber::adjustTooltipPosition()
     QRect recGL = QGuiApplication::primaryScreen()->virtualGeometry();
     QRect rec = qApp->desktop()->screenGeometry(QCursor::pos());
     const QRectF ttRect = this->helperToolbox->childrenBoundingRect();
-    int x = abs(recGL.x()) + rec.x() + ((rec.width() - ttRect.width()) / 2);
-    int y = abs(recGL.y()) + rec.y();
+    int x = qAbs(recGL.x()) + rec.x() + ((rec.width() - ttRect.width()) / 2);
+    int y = qAbs(recGL.y()) + rec.y();
 
     // Multiply by devicePixelRatio to get centered positions under scaling
     helperToolbox->setX(x * pixRatio);


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3623)

<!-- Reviewable:end -->
