### PR TITLE
Update OSX build image to Xcode 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
     - os: linux
       env: JOB=build-ubuntu-14-04
     - os: osx
+      osx_image: xcode7.3
       env: JOB=build-osx
 
 script: "./.travis/$JOB.sh"

--- a/.travis/build-osx.sh
+++ b/.travis/build-osx.sh
@@ -23,6 +23,4 @@ set -e -o pipefail
 bash ./osx/qTox-Mac-Deployer-ULTIMATE.sh -i
 bash ./osx/qTox-Mac-Deployer-ULTIMATE.sh -b
 bash ./osx/qTox-Mac-Deployer-ULTIMATE.sh -d
-# The following line can randomly fail due to travis emitting the error:
-# "hdiutil: create failed - Resource busy"
 bash ./osx/qTox-Mac-Deployer-ULTIMATE.sh -dmg


### PR DESCRIPTION
OSX build were occastionally failing due to an error from `hdiutil` during dmg creation. According to travis support, this may be a result of the default (older) OSX build images not having enough free space and recommended us using a newer OSX image.

As such, I've applied this PR to my personal fork and ran travis 18 times on it, all without failure. Though this is not conclusive evidence, I believe it's stable enough for usage on qTox PRs and non-release master. I'll be monitoring travis failures just in case it crops up again, in which I'll report back to travis support.

In the meanwhile, whilst I don't think this will affect OSX builds otherwise, it would be nice for someone who fully understands the implications of this change to try it out/comment about it.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3627)

<!-- Reviewable:end -->
