### PR TITLE
Fixes scaling issues under HiDPI displays with desktop video

### DIFF
--- a/src/video/cameradevice.cpp
+++ b/src/video/cameradevice.cpp
@@ -438,7 +438,13 @@ QVector<VideoMode> CameraDevice::getScreenModes()
         QRect rect = s->geometry();
         QPoint p = rect.topLeft();
 
-        VideoMode mode(rect.width(), rect.height(), p.x(), p.y());
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 5, 0))
+        qreal pixRatio = s->devicePixelRatio();
+#else
+        qreal pixRatio = 1.0;
+#endif
+
+        VideoMode mode(rect.width() * pixRatio, rect.height() * pixRatio, p.x() * pixRatio, p.y() * pixRatio);
         result.push_back(mode);
     });
 

--- a/src/widget/tool/screenshotgrabber.cpp
+++ b/src/widget/tool/screenshotgrabber.cpp
@@ -53,9 +53,6 @@ ScreenshotGrabber::ScreenshotGrabber()
     pixRatio = QApplication::primaryScreen()->devicePixelRatio();
 #endif
 
-    // Scale window down by devicePixelRatio to show full screen region
-    window->scale(1 / pixRatio, 1 / pixRatio);
-
     setupScene();
 }
 
@@ -131,6 +128,9 @@ void ScreenshotGrabber::acceptRegion()
     if (rect.width() < 1 || rect.height() < 1)
         return;
 
+    // Scale the accepted region from DIPs to actual pixels
+    rect.setRect(rect.x() * pixRatio, rect.y() * pixRatio, rect.width() * pixRatio, rect.height() * pixRatio);
+
     emit regionChosen(rect);
     qDebug() << "Screenshot accepted, chosen region" << rect;
     QPixmap pixmap = this->screenGrab.copy(rect);
@@ -151,10 +151,6 @@ void ScreenshotGrabber::setupScene()
 
     this->screenGrabDisplay = scene->addPixmap(this->screenGrab);
     this->helperTooltip = scene->addText(QString());
-
-    // Scale UI elements up by devicePixelRatio to compensate for window downscaling
-    this->helperToolbox->setScale(pixRatio);
-    this->helperTooltip->setScale(pixRatio);
 
     scene->addItem(this->overlay);
     this->chooserRect = new ScreenGrabberChooserRectItem(scene);
@@ -203,9 +199,8 @@ void ScreenshotGrabber::adjustTooltipPosition()
     int x = qAbs(recGL.x()) + rec.x() + ((rec.width() - ttRect.width()) / 2);
     int y = qAbs(recGL.y()) + rec.y();
 
-    // Multiply by devicePixelRatio to get centered positions under scaling
-    helperToolbox->setX(x * pixRatio);
-    helperToolbox->setY(y * pixRatio);
+    helperToolbox->setX(x);
+    helperToolbox->setY(y);
 }
 
 void ScreenshotGrabber::reject()


### PR DESCRIPTION
Changes introduced in PR #3392 caused the existing HiDPI scaling code to no longer work, this PR fixes desktop screen scaling for HiDPI displays again (without proper scaling multipliers, HiDPI users would be restricted to streaming only a certain ratio of their screen, limited to the upper left corner).

Given that the screen region selection code uses the screenshot grabber, this also fixes the screenshot grabber when used with HiDPI code (the reason for this breakage seems to stem from internal Qt changes across versions).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3628)

<!-- Reviewable:end -->
