### PR TITLE
fix: hide option to `Load automatically` for encrypted profiles

### DIFF
--- a/src/widget/loginscreen.cpp
+++ b/src/widget/loginscreen.cpp
@@ -191,16 +191,15 @@ void LoginScreen::onLoginUsernameSelected(const QString &name)
         ui->loginPassword->show();
         // there is no way to do autologin if profile is encrypted, and
         // visible option confuses users into thinking that it is possible,
-        // thus disable it (and hope that users won't think that it's a bug)
-        ui->autoLoginCB->setEnabled(false);
-        ui->autoLoginCB->setToolTip(tr("Password protected profiles can't be automatically loaded."));
+        // thus hide it
+        ui->autoLoginCB->hide();
     }
     else
     {
         ui->loginPasswordLabel->hide();
         ui->loginPassword->hide();
-        ui->autoLoginCB->setEnabled(true);
-        ui->autoLoginCB->setToolTip("");
+        ui->autoLoginCB->show();
+        ui->autoLoginCB->setToolTip(tr("Password protected profiles can't be automatically loaded."));
     }
 }
 


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3642)

<!-- Reviewable:end -->
