### PR TITLE
docs(INSTALL.md): Fix minimal Qt version

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -40,7 +40,7 @@
 
 | Name          | Version     | Modules                                           |
 |---------------|-------------|-------------------------------------------------- |
-| Qt            | >= 5.3.0    | core, gui, network, opengl, sql, svg, widget, xml |
+| Qt            | >= 5.4.0    | core, gui, network, opengl, sql, svg, widget, xml |
 | GCC/MinGW     | >= 4.8      | C++11 enabled                                     |
 | toxcore       | most recent | core, av                                          |
 | FFmpeg        | >= 2.6.0    | avformat, avdevice, avcodec, avutil, swscale      |


### PR DESCRIPTION
Fix minimal Qt version in dependencies to 5.4.x, see #2407 for details.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3661)

<!-- Reviewable:end -->
