### PR TITLE
feat(reconnect): Made `Reconnect` button wider

### DIFF
--- a/src/widget/form/settings/advancedsettings.ui
+++ b/src/widget/form/settings/advancedsettings.ui
@@ -163,19 +163,6 @@
           <item>
            <layout class="QHBoxLayout" name="horizontalLayout_4">
             <item>
-             <spacer name="horizontalSpacer_4">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
              <widget class="QPushButton" name="reconnectButton">
               <property name="text">
                <string comment="reconnect button">Reconnect</string>


### PR DESCRIPTION
After #3457 `Reconnect` button was moved on `Advanced` tab. It can be
harder to find it (#3662). So it made wider.

![spectacle j18092](https://cloud.githubusercontent.com/assets/6306608/18032191/c408b9b6-6d0e-11e6-9c0f-aea1645fde4a.png)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3663)

<!-- Reviewable:end -->
