### PR TITLE
refactor: Make aboutuser's placeholderText optional.

### DIFF
--- a/src/widget/about/aboutuser.cpp
+++ b/src/widget/about/aboutuser.cpp
@@ -16,6 +16,10 @@ AboutUser::AboutUser(ToxId &toxId, QWidget *parent) :
     ui->label_4->hide();
     ui->aliases->hide();
 
+#if QT_MAJOR_VERSION > 5 || QT_MAJOR_VERSION == 5 && QT_MINOR_VERSION >= 3
+    ui->note->setPlaceholderText(tr("You can save comment about this contact here."));
+#endif
+
     connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &AboutUser::onAcceptedClicked);
     connect(ui->autoaccept, &QCheckBox::clicked, this, &AboutUser::onAutoAcceptClicked);
     connect(ui->selectSaveDir, &QPushButton::clicked, this,  &AboutUser::onSelectDirClicked);

--- a/src/widget/about/aboutuser.ui
+++ b/src/widget/about/aboutuser.ui
@@ -205,9 +205,6 @@
         <property name="plainText">
          <string/>
         </property>
-        <property name="placeholderText">
-         <string>You can save comment about this contact here.</string>
-        </property>
        </widget>
       </item>
      </layout>


### PR DESCRIPTION
This is one step towards making qTox compatible with Qt 5.2 again.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3673)

<!-- Reviewable:end -->
