### PR TITLE
refactor: Disable RecursiveSignalBlocker if not available.

### DIFF
--- a/src/core/recursivesignalblocker.cpp
+++ b/src/core/recursivesignalblocker.cpp
@@ -20,7 +20,9 @@
 #include "recursivesignalblocker.h"
 
 #include <QObject>
+#if HAVE_QSIGNAL_BLOCKER
 #include <QSignalBlocker>
+#endif
 
 /**
 @class  RecursiveSignalBlocker
@@ -37,14 +39,19 @@ blocker gets destroyed. According to QSignalBlocker, we are also exception safe.
 */
 RecursiveSignalBlocker::RecursiveSignalBlocker(QObject* object)
 {
+#if HAVE_QSIGNAL_BLOCKER
     recursiveBlock(object);
+#endif
 }
 
 RecursiveSignalBlocker::~RecursiveSignalBlocker()
 {
+#if HAVE_QSIGNAL_BLOCKER
     qDeleteAll(mBlockers);
+#endif
 }
 
+#if HAVE_QSIGNAL_BLOCKER
 /**
 @brief      Recursively blocks all signals of the object.
 @param[in]  object  the object to block
@@ -58,3 +65,4 @@ void RecursiveSignalBlocker::recursiveBlock(QObject* object)
         recursiveBlock(child);
     }
 }
+#endif

--- a/src/core/recursivesignalblocker.h
+++ b/src/core/recursivesignalblocker.h
@@ -22,6 +22,9 @@
 
 #include <QVector>
 
+#define HAVE_QSIGNAL_BLOCKER (QT_MAJOR_VERSION > 5 \
+                              || QT_MAJOR_VERSION == 5 && QT_MINOR_VERSION >= 3)
+
 class QObject;
 class QSignalBlocker;
 
@@ -31,10 +34,12 @@ public:
     explicit RecursiveSignalBlocker(QObject* object);
     ~RecursiveSignalBlocker();
 
+#if HAVE_QSIGNAL_BLOCKER
     void recursiveBlock(QObject* object);
 
 private:
     QVector<const QSignalBlocker*> mBlockers;
+#endif
 };
 
 #endif


### PR DESCRIPTION
This is the second step to ensuring Qt 5.2 compatibility.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3674)

<!-- Reviewable:end -->
