### PR TITLE
fix(build): enable backports repository for Debian Jessie

### DIFF
--- a/simple_make.sh
+++ b/simple_make.sh
@@ -28,6 +28,16 @@ apt_install() {
         qt5-qmake
         qttools5-dev-tools
     )
+
+    local codename=$(lsb_release -c -s)
+
+    # Enable Debian Jessie backports repository for libsqlcipher-dev (if not yet enabled)
+    if [ ${codename} == jessie ] && [ $(apt-cache policy | fgrep jessie-backports -c) == 0 ]
+    then
+        echo "deb http://httpredir.debian.org/debian jessie-backports main" | sudo tee /etc/apt/sources.list.d/qtox-backports.list
+        sudo apt-get update
+    fi
+
     sudo apt-get install "${apt_packages[@]}"
 }
 


### PR DESCRIPTION
Enable jessie-backports repository for libsqlcipher-dev package
in Debian Jessie by creating qtox-backports.list file if
repository is not enabled yet.

Closes #3679

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3683)

<!-- Reviewable:end -->
