### PR TITLE
chore: Statically link the windows platform plugin.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -45,6 +45,11 @@
 #include "platform/install_osx.h"
 #endif
 
+#if defined(Q_OS_WIN32) && defined(QT_STATIC)
+#include <QtPlugin>
+Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin);
+#endif
+
 #ifdef LOG_TO_FILE
 static QAtomicPointer<FILE> logFileFile = nullptr;
 static QList<QByteArray>* logBuffer = new QList<QByteArray>();   //Store log messages until log file opened


### PR DESCRIPTION
When building statically linked versions of qTox, we need to link in all
plugins it uses. Linking the windows platform plugin will make linking
succeed, and the program will start. Some additional plugins may be
needed for e.g. image formats. These require some testing on windows and
are out of scope for this PR.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3685)

<!-- Reviewable:end -->
