### PR TITLE
chore: Shorten source file names in log messages.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -58,10 +58,20 @@ void logMessageHandler(QtMsgType type, const QMessageLogContext& ctxt, const QSt
             && msg == QString("QFSFileEngine::open: No file name specified"))
         return;
 
+    QString file = ctxt.file;
+    // We're not using QT_MESSAGELOG_FILE here, because that can be 0, NULL, or
+    // nullptr in release builds.
+    QString path = QString(__FILE__);
+    path = path.left(path.lastIndexOf('/') + 1);
+    if (file.startsWith(path))
+    {
+        file = file.mid(path.length());
+    }
+
     // Time should be in UTC to save user privacy on log sharing
     QTime time = QDateTime::currentDateTime().toUTC().time();
     QString LogMsg = QString("[%1 UTC] %2:%3 : ")
-                .arg(time.toString("HH:mm:ss.zzz")).arg(ctxt.file).arg(ctxt.line);
+                .arg(time.toString("HH:mm:ss.zzz")).arg(file).arg(ctxt.line);
     switch (type)
     {
         case QtDebugMsg:


### PR DESCRIPTION
In cmake builds, `__FILE__` is the absolute file path. In qmake, it's a
relative path. For in-tree qmake builds, it would be `"src/..."`, for
out of tree, it could be `"../src/..."` or `"../qTox/src/..."` or any
other relative path depending on how qTox was built. This change
normalises them to paths based in src.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3686)

<!-- Reviewable:end -->
