### PR TITLE
fix(widget): do not block logout on Linux desktop environments

### DIFF
--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -568,12 +568,11 @@ void Widget::moveEvent(QMoveEvent *event)
     QWidget::moveEvent(event);
 }
 
-void Widget::closeEvent(QCloseEvent *event)
+void Widget::hideEvent(QHideEvent *event)
 {
     if (Settings::getInstance().getShowSystemTray() && Settings::getInstance().getCloseToTray())
     {
-        event->ignore();
-        this->hide();
+        QWidget::hideEvent(event);
     }
     else
     {
@@ -584,7 +583,7 @@ void Widget::closeEvent(QCloseEvent *event)
         }
         saveWindowGeometry();
         saveSplitterGeometry();
-        QWidget::closeEvent(event);
+        QWidget::hideEvent(event);
         qApp->quit();
     }
 }

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -161,7 +161,7 @@ signals:
 protected:
     virtual bool eventFilter(QObject *obj, QEvent *event) final override;
     virtual bool event(QEvent * e) final override;
-    virtual void closeEvent(QCloseEvent *event) final override;
+    virtual void hideEvent(QHideEvent *event) final override;
     virtual void changeEvent(QEvent *event) final override;
     virtual void resizeEvent(QResizeEvent *event) final override;
     virtual void moveEvent(QMoveEvent *event) final override;


### PR DESCRIPTION
Change closeEvent() to hideEvent() for handling main window closing.
Close event is no longer ignored, which prevented logging out from
various Linux desktop environments.

Tested with KDE, Gnome and XFCE.

Closes #1485

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3687)

<!-- Reviewable:end -->
