### PR TITLE
fix(widget): do not block logout on Linux desktop environments v2

### DIFF
--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -568,11 +568,11 @@ void Widget::moveEvent(QMoveEvent *event)
     QWidget::moveEvent(event);
 }
 
-void Widget::hideEvent(QHideEvent *event)
+void Widget::closeEvent(QCloseEvent *event)
 {
     if (Settings::getInstance().getShowSystemTray() && Settings::getInstance().getCloseToTray())
     {
-        QWidget::hideEvent(event);
+        QWidget::closeEvent(event);
     }
     else
     {
@@ -583,7 +583,7 @@ void Widget::hideEvent(QHideEvent *event)
         }
         saveWindowGeometry();
         saveSplitterGeometry();
-        QWidget::hideEvent(event);
+        QWidget::closeEvent(event);
         qApp->quit();
     }
 }

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -161,7 +161,7 @@ signals:
 protected:
     virtual bool eventFilter(QObject *obj, QEvent *event) final override;
     virtual bool event(QEvent * e) final override;
-    virtual void hideEvent(QHideEvent *event) final override;
+    virtual void closeEvent(QCloseEvent *event) final override;
     virtual void changeEvent(QEvent *event) final override;
     virtual void resizeEvent(QResizeEvent *event) final override;
     virtual void moveEvent(QMoveEvent *event) final override;


### PR DESCRIPTION
Revert commit 191fc15 to use closeEvent() but without QEvent::ignore() which blocked logout on various Linux desktops, and without redundant hide(). Previous fix with hideEvent() produced regressions because hide() is used in various places, which produced closing behavior.

Since qApp->setQuitOnLastWindowClosed(false) is used, and Qt::WA_DeleteOnClose is _NOT_ used, default closeEvent() handling is enough for implementing close-to-systray feature.

Improves fix for #1485 and closes #3699.

Tested only on various Linux distributions.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3702)

<!-- Reviewable:end -->
