### PR TITLE
fix(settings): correct default value of dateformat

### DIFF
--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -249,7 +249,7 @@ void Settings::loadGlobal()
         firstColumnHandlePos = s.value("firstColumnHandlePos", 50).toInt();
         secondColumnHandlePosFromRight = s.value("secondColumnHandlePosFromRight", 50).toInt();
         timestampFormat = s.value("timestampFormat", "hh:mm:ss").toString();
-        dateFormat = s.value("dateFormat", "dddd, MMMM d, yyyy").toString();
+        dateFormat = s.value("dateFormat", "yyyy-MM-dd").toString();
         minimizeOnClose = s.value("minimizeOnClose", false).toBool();
         minimizeToTray = s.value("minimizeToTray", false).toBool();
         lightTrayIcon = s.value("lightTrayIcon", false).toBool();


### PR DESCRIPTION
incorrect values of a default date format field remains empty in form
fix #3707

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3713)

<!-- Reviewable:end -->
