### PR TITLE
fix(settings): On change language title (#3708)

### DIFF
--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -2274,7 +2274,7 @@ void Widget::retranslateUi()
     actionShow->setText(tr("Show", "Tray action menu to show qTox window"));
 
     if (!Settings::getInstance().getSeparateWindow())
-        setWindowTitle(fromDialogType(AddDialog));
+        setWindowTitle(fromDialogType(SettingDialog));
 
     friendRequestsUpdate();
     groupInvitesUpdate();


### PR DESCRIPTION
Changes UI behavior.  Before changing the language would set title to
"Add Friend" when in one window mode.  This code change fixes that
behaviour.

This was because the wrong value was hard coded.  This fix corrects the
value.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3731)

<!-- Reviewable:end -->
