### PR TITLE
fix: send offline message history once

### DIFF
--- a/src/persistence/offlinemsgengine.h
+++ b/src/persistence/offlinemsgengine.h
@@ -39,25 +39,22 @@ public:
     static QMutex globalMutex;
 
     void dischargeReceipt(int receipt);
-    void registerReceipt(int receipt, int64_t messageID, ChatMessage::Ptr msg, const QDateTime &timestamp = QDateTime::currentDateTime());
+    void registerReceipt(int receipt, int64_t messageID, ChatMessage::Ptr msg,
+                         const QDateTime &ts = QDateTime::currentDateTime());
 
 public slots:
     void deliverOfflineMsgs();
     void removeAllReceipts();
 
 private:
+    class Private;
+    Private* d;
+
     struct MsgPtr {
         ChatMessage::Ptr msg;
         QDateTime timestamp;
         int receipt;
     };
-
-    QMutex mutex;
-    Friend* f;
-    QHash<int, int64_t> receipts;
-    QMap<int64_t, MsgPtr> undeliveredMsgs;
-
-    static const int offlineTimeout;
 };
 
 #endif // OFFLINEMSGENGINE_H

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -974,7 +974,7 @@ void ChatForm::SendMessageStr(QString msg)
 
     bool isAction = msg.startsWith("/me ", Qt::CaseInsensitive);
     if (isAction)
-        msg = msg = msg.right(msg.length() - 4);
+        msg = msg.right(msg.length() - 4);
 
     QList<CString> splittedMsg = Core::splitMessage(msg, TOX_MAX_MESSAGE_LENGTH);
     QDateTime timestamp = QDateTime::currentDateTime();
@@ -996,14 +996,18 @@ void ChatForm::SendMessageStr(QString msg)
         else
             rec = Core::getInstance()->sendMessage(f->getFriendID(), qt_msg);
 
-
         Profile* profile = Nexus::getProfile();
         if (profile->isHistoryEnabled())
         {
-            auto* offMsgEngine = getOfflineMsgEngine();
-            profile->getHistory()->addNewMessage(f->getToxId().publicKey, qt_msg_hist,
-                        Core::getInstance()->getSelfId().publicKey, timestamp, status, Core::getInstance()->getUsername(),
-                                        [offMsgEngine,rec,ma](int64_t id)
+            Core* core = Core::getInstance();
+            auto* offMsgEngine = offlineEngine;
+            profile->getHistory()->addNewMessage(f->getToxId().publicKey,
+                                                 qt_msg_hist,
+                                                 core->getSelfId().publicKey,
+                                                 timestamp, status,
+                                                 core->getUsername(),
+                                                 [offMsgEngine,rec,ma]
+                                                 (int64_t id)
             {
                 offMsgEngine->registerReceipt(rec, id, ma);
             });


### PR DESCRIPTION
~~closes 2726~~

@GrayHatter Would you review this? Moving the "deliverOfflineMsgs" call to the "non-ui classes" - where it belongs - is not possible in master yet. Unfortunately UI and data are highly bound and by far not separated, which is WIP in the "ui/redesign" branch). IOW: This cannot be completely solved/fixed yet.

Have a look at current implementation in `widget.cpp`:

``` c++
// This slot is called from "Core" when a friend's connection status changed (same trigger as for "corefile.cpp#L472").
void Widget::onFriendStatusChanged(/*…*/) {
  //… some code above

  // f = instance of Friend
  // i removed that distracting bullshit code around, checking if a status really changed, firing a singleshot timer etc.
  f->getChatForm()->getOfflineMsgEngine()->deliverOfflineMsgs();
}
```

In #3639 this completely vanished and is triggered only by the status change (from "Core"). So both changes are pointing in the same direction.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3734)

<!-- Reviewable:end -->
