### PR TITLE
refactor: Avoid RTTI by using qobject_cast.

### DIFF
--- a/src/chatlog/chatlinecontent.h
+++ b/src/chatlog/chatlinecontent.h
@@ -24,8 +24,11 @@
 
 class ChatLine;
 
-class ChatLineContent : public QGraphicsItem
+class ChatLineContent : public QObject, public QGraphicsItem
 {
+    Q_OBJECT
+    Q_INTERFACES(QGraphicsItem)
+
 public:
     enum GraphicsItemType
     {

--- a/src/chatlog/chatlinecontentproxy.h
+++ b/src/chatlog/chatlinecontentproxy.h
@@ -27,6 +27,8 @@ class FileTransferWidget;
 
 class ChatLineContentProxy : public ChatLineContent
 {
+    Q_OBJECT
+
 public:
     enum ChatLineContentProxyType
     {

--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -868,12 +868,12 @@ bool ChatLog::isActiveFileTransfer(ChatLine::Ptr l)
     for (int i = 0; i < count; i++)
     {
         ChatLineContent *content = l->getContent(i);
-        ChatLineContentProxy *proxy = dynamic_cast<ChatLineContentProxy*>(content);
+        ChatLineContentProxy *proxy = qobject_cast<ChatLineContentProxy*>(content);
         if (!proxy)
             continue;
 
         QWidget *widget = proxy->getWidget();
-        FileTransferWidget *transferWidget = dynamic_cast<FileTransferWidget*>(widget);
+        FileTransferWidget *transferWidget = qobject_cast<FileTransferWidget*>(widget);
         if (transferWidget && transferWidget->isActive())
             return true;
     }

--- a/src/chatlog/content/notificationicon.h
+++ b/src/chatlog/content/notificationicon.h
@@ -27,7 +27,7 @@
 
 class QTimer;
 
-class NotificationIcon : public QObject,  public ChatLineContent
+class NotificationIcon : public ChatLineContent
 {
     Q_OBJECT
 public:

--- a/src/chatlog/content/spinner.h
+++ b/src/chatlog/content/spinner.h
@@ -28,7 +28,7 @@
 
 class QVariantAnimation;
 
-class Spinner : public QObject, public ChatLineContent
+class Spinner : public ChatLineContent
 {
     Q_OBJECT
 public:

--- a/src/chatlog/content/timestamp.h
+++ b/src/chatlog/content/timestamp.h
@@ -25,6 +25,7 @@
 
 class Timestamp : public Text
 {
+    Q_OBJECT
 public:
     Timestamp(const QDateTime& time, const QString& format, const QFont& font);
     QDateTime getTime();

--- a/src/widget/categorywidget.cpp
+++ b/src/widget/categorywidget.cpp
@@ -30,7 +30,7 @@
 
 void CategoryWidget::emitChatroomWidget(QLayout* layout, int index)
 {
-    GenericChatroomWidget* chatWidget = dynamic_cast<GenericChatroomWidget*>(layout->itemAt(index)->widget());
+    GenericChatroomWidget* chatWidget = qobject_cast<GenericChatroomWidget*>(layout->itemAt(index)->widget());
     if (chatWidget != nullptr)
         emit chatWidget->chatroomWidgetClicked(chatWidget);
 }
@@ -199,7 +199,7 @@ bool CategoryWidget::cycleContacts(FriendWidget* activeChatroomWidget, bool forw
     int index = -1;
     QLayout* currentLayout = nullptr;
 
-    FriendWidget* friendWidget = dynamic_cast<FriendWidget*>(activeChatroomWidget);
+    FriendWidget* friendWidget = qobject_cast<FriendWidget*>(activeChatroomWidget);
     if (friendWidget == nullptr)
         return false;
 
@@ -236,7 +236,7 @@ bool CategoryWidget::cycleContacts(FriendWidget* activeChatroomWidget, bool forw
             continue;
         }
 
-        GenericChatroomWidget* chatWidget = dynamic_cast<GenericChatroomWidget*>(currentLayout->itemAt(index)->widget());
+        GenericChatroomWidget* chatWidget = qobject_cast<GenericChatroomWidget*>(currentLayout->itemAt(index)->widget());
         if (chatWidget != nullptr)
             emit chatWidget->chatroomWidgetClicked(chatWidget);
         return true;

--- a/src/widget/circlewidget.cpp
+++ b/src/widget/circlewidget.cpp
@@ -121,7 +121,7 @@ void CircleWidget::contextMenuEvent(QContextMenuEvent* event)
 
             for (int i = 0; i < friendOnlineLayout()->count(); ++i)
             {
-                FriendWidget* friendWidget = dynamic_cast<FriendWidget*>(friendOnlineLayout()->itemAt(i)->widget());
+                FriendWidget* friendWidget = qobject_cast<FriendWidget*>(friendOnlineLayout()->itemAt(i)->widget());
 
                 if (friendWidget != nullptr)
                 {
@@ -131,7 +131,7 @@ void CircleWidget::contextMenuEvent(QContextMenuEvent* event)
             }
             for (int i = 0; i < friendOfflineLayout()->count(); ++i)
             {
-                FriendWidget* friendWidget = dynamic_cast<FriendWidget*>(friendOfflineLayout()->itemAt(i)->widget());
+                FriendWidget* friendWidget = qobject_cast<FriendWidget*>(friendOfflineLayout()->itemAt(i)->widget());
 
                 if (friendWidget != nullptr)
                 {
@@ -219,14 +219,14 @@ void CircleWidget::updateID(int index)
 
     for (int i = 0; i < friendOnlineLayout()->count(); ++i)
     {
-        FriendWidget* friendWidget = dynamic_cast<FriendWidget*>(friendOnlineLayout()->itemAt(i)->widget());
+        FriendWidget* friendWidget = qobject_cast<FriendWidget*>(friendOnlineLayout()->itemAt(i)->widget());
 
         if (friendWidget != nullptr)
             Settings::getInstance().setFriendCircleID(FriendList::findFriend(friendWidget->friendId)->getToxId(), id);
     }
     for (int i = 0; i < friendOfflineLayout()->count(); ++i)
     {
-        FriendWidget* friendWidget = dynamic_cast<FriendWidget*>(friendOfflineLayout()->itemAt(i)->widget());
+        FriendWidget* friendWidget = qobject_cast<FriendWidget*>(friendOfflineLayout()->itemAt(i)->widget());
 
         if (friendWidget != nullptr)
             Settings::getInstance().setFriendCircleID(FriendList::findFriend(friendWidget->friendId)->getToxId(), id);

--- a/src/widget/contentdialog.cpp
+++ b/src/widget/contentdialog.cpp
@@ -358,7 +358,7 @@ void ContentDialog::cycleContacts(bool forward, bool loop)
             continue;
         }
 
-        GenericChatroomWidget* chatWidget = dynamic_cast<GenericChatroomWidget*>(currentLayout->itemAt(index)->widget());
+        GenericChatroomWidget* chatWidget = qobject_cast<GenericChatroomWidget*>(currentLayout->itemAt(index)->widget());
 
         if (chatWidget != nullptr && chatWidget != activeChatroomWidget)
             onChatroomWidgetClicked(chatWidget, false);

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -265,7 +265,7 @@ QDate GenericChatForm::getLatestDate() const
 
     if (chatLine)
     {
-        Timestamp* timestamp = dynamic_cast<Timestamp*>(chatLine->getContent(2));
+        Timestamp* timestamp = qobject_cast<Timestamp*>(chatLine->getContent(2));
 
         if (timestamp)
             return timestamp->getTime().date();
@@ -409,7 +409,7 @@ void GenericChatForm::onSaveLogClicked()
     auto lines = chatWidget->getLines();
     for (ChatLine::Ptr l : lines)
     {
-        Timestamp* rightCol = dynamic_cast<Timestamp*>(l->getContent(2));
+        Timestamp* rightCol = qobject_cast<Timestamp*>(l->getContent(2));
 
         if (!rightCol)
             return;

--- a/src/widget/friendlistlayout.cpp
+++ b/src/widget/friendlistlayout.cpp
@@ -81,14 +81,14 @@ void FriendListLayout::moveFriendWidgets(FriendListWidget* listWidget)
     {
         QWidget* getWidget = friendOnlineLayout.getLayout()->takeAt(0)->widget();
 
-        FriendWidget* friendWidget = dynamic_cast<FriendWidget*>(getWidget);
+        FriendWidget* friendWidget = qobject_cast<FriendWidget*>(getWidget);
         listWidget->moveWidget(friendWidget, FriendList::findFriend(friendWidget->friendId)->getStatus(), true);
     }
     while (friendOfflineLayout.getLayout()->count() != 0)
     {
         QWidget* getWidget = friendOfflineLayout.getLayout()->takeAt(0)->widget();
 
-        FriendWidget* friendWidget = dynamic_cast<FriendWidget*>(getWidget);
+        FriendWidget* friendWidget = qobject_cast<FriendWidget*>(getWidget);
         listWidget->moveWidget(friendWidget, FriendList::findFriend(friendWidget->friendId)->getStatus(), true);
     }
 }

--- a/src/widget/friendlistwidget.cpp
+++ b/src/widget/friendlistwidget.cpp
@@ -296,13 +296,13 @@ void FriendListWidget::setMode(Mode mode)
         {
             QDate activityDate = getDateFriend(contact);
             Time time = getTime(activityDate);
-            CategoryWidget* categoryWidget = dynamic_cast<CategoryWidget*>(activityLayout->itemAt(time)->widget());
+            CategoryWidget* categoryWidget = qobject_cast<CategoryWidget*>(activityLayout->itemAt(time)->widget());
             categoryWidget->addFriendWidget(contact->getFriendWidget(), contact->getStatus());
         }
 
         for (int i = 0; i < activityLayout->count(); ++i)
         {
-            CategoryWidget* categoryWidget = dynamic_cast<CategoryWidget*>(activityLayout->itemAt(i)->widget());
+            CategoryWidget* categoryWidget = qobject_cast<CategoryWidget*>(activityLayout->itemAt(i)->widget());
             categoryWidget->setVisible(categoryWidget->hasChatrooms());
         }
 
@@ -354,7 +354,7 @@ void FriendListWidget::removeFriendWidget(FriendWidget* w)
     {
         QDate activityDate = getDateFriend(contact);
         Time time = getTime(activityDate);
-        CategoryWidget* categoryWidget = dynamic_cast<CategoryWidget*>(activityLayout->itemAt(time)->widget());
+        CategoryWidget* categoryWidget = qobject_cast<CategoryWidget*>(activityLayout->itemAt(time)->widget());
         categoryWidget->removeFriendWidget(w, contact->getStatus());
         categoryWidget->setVisible(categoryWidget->hasChatrooms());
     }
@@ -467,7 +467,7 @@ void FriendListWidget::cycleContacts(GenericChatroomWidget* activeChatroomWidget
         return;
 
     int index = -1;
-    FriendWidget* friendWidget = dynamic_cast<FriendWidget*>(activeChatroomWidget);
+    FriendWidget* friendWidget = qobject_cast<FriendWidget*>(activeChatroomWidget);
 
     if (mode == Activity)
     {
@@ -476,7 +476,7 @@ void FriendListWidget::cycleContacts(GenericChatroomWidget* activeChatroomWidget
 
         QDate activityDate = getDateFriend(FriendList::findFriend(friendWidget->friendId));
         index = getTime(activityDate);
-        CategoryWidget* categoryWidget = dynamic_cast<CategoryWidget*>(activityLayout->itemAt(index)->widget());
+        CategoryWidget* categoryWidget = qobject_cast<CategoryWidget*>(activityLayout->itemAt(index)->widget());
 
         if (categoryWidget == nullptr || categoryWidget->cycleContacts(friendWidget, forward))
             return;
@@ -497,7 +497,7 @@ void FriendListWidget::cycleContacts(GenericChatroomWidget* activeChatroomWidget
                 continue;
             }
 
-            CategoryWidget* categoryWidget = dynamic_cast<CategoryWidget*>(activityLayout->itemAt(index)->widget());
+            CategoryWidget* categoryWidget = qobject_cast<CategoryWidget*>(activityLayout->itemAt(index)->widget());
 
             if (categoryWidget != nullptr)
             {
@@ -542,7 +542,7 @@ void FriendListWidget::cycleContacts(GenericChatroomWidget* activeChatroomWidget
     }
     else
     {
-        GroupWidget* groupWidget = dynamic_cast<GroupWidget*>(activeChatroomWidget);
+        GroupWidget* groupWidget = qobject_cast<GroupWidget*>(activeChatroomWidget);
         if (groupWidget != nullptr)
         {
             currentLayout = groupLayout.getLayout();
@@ -575,7 +575,7 @@ void FriendListWidget::cycleContacts(GenericChatroomWidget* activeChatroomWidget
         // Go to the actual next index.
         if (currentLayout == listLayout->getLayoutOnline() || currentLayout == listLayout->getLayoutOffline() || currentLayout == groupLayout.getLayout())
         {
-            GenericChatroomWidget* chatWidget = dynamic_cast<GenericChatroomWidget*>(currentLayout->itemAt(index)->widget());
+            GenericChatroomWidget* chatWidget = qobject_cast<GenericChatroomWidget*>(currentLayout->itemAt(index)->widget());
 
             if (chatWidget != nullptr)
                 emit chatWidget->chatroomWidgetClicked(chatWidget);
@@ -584,7 +584,7 @@ void FriendListWidget::cycleContacts(GenericChatroomWidget* activeChatroomWidget
         }
         else if (currentLayout == circleLayout->getLayout())
         {
-            circleWidget = dynamic_cast<CircleWidget*>(currentLayout->itemAt(index)->widget());
+            circleWidget = qobject_cast<CircleWidget*>(currentLayout->itemAt(index)->widget());
             if (circleWidget != nullptr)
             {
                 if (!circleWidget->cycleContacts(forward))
@@ -664,7 +664,7 @@ void FriendListWidget::moveWidget(FriendWidget* w, Status s, bool add)
         Friend* contact = FriendList::findFriend(w->friendId);
         QDate activityDate = getDateFriend(contact);
         Time time = getTime(activityDate);
-        CategoryWidget* categoryWidget = dynamic_cast<CategoryWidget*>(activityLayout->itemAt(time)->widget());
+        CategoryWidget* categoryWidget = qobject_cast<CategoryWidget*>(activityLayout->itemAt(time)->widget());
         categoryWidget->addFriendWidget(contact->getFriendWidget(), contact->getStatus());
         categoryWidget->show();
     }

--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -110,9 +110,9 @@ void FriendWidget::contextMenuEvent(QContextMenuEvent * event)
     FriendListWidget *friendList;
 
     if (circleWidget == nullptr)
-        friendList = dynamic_cast<FriendListWidget*>(FriendList::findFriend(friendId)->getFriendWidget()->parentWidget());
+        friendList = qobject_cast<FriendListWidget*>(FriendList::findFriend(friendId)->getFriendWidget()->parentWidget());
     else
-        friendList = dynamic_cast<FriendListWidget*>(circleWidget->parentWidget());
+        friendList = qobject_cast<FriendListWidget*>(circleWidget->parentWidget());
 
     circleMenu = menu.addMenu(tr("Move to circle...", "Menu to move a friend into a different circle"));
 

--- a/src/widget/genericchatitemlayout.cpp
+++ b/src/widget/genericchatitemlayout.cpp
@@ -49,7 +49,7 @@ int GenericChatItemLayout::indexOfSortedWidget(GenericChatItemWidget* widget) co
     if (index >= layout->count())
         return -1;
 
-    GenericChatItemWidget* atMid = dynamic_cast<GenericChatItemWidget*>(layout->itemAt(index)->widget());
+    GenericChatItemWidget* atMid = qobject_cast<GenericChatItemWidget*>(layout->itemAt(index)->widget());
     assert(atMid != nullptr);
 
     if (atMid == widget)
@@ -73,7 +73,7 @@ void GenericChatItemLayout::removeSortedWidget(GenericChatItemWidget* widget)
     if (layout->itemAt(index) == nullptr)
         return;
 
-    GenericChatItemWidget* atMid = dynamic_cast<GenericChatItemWidget*>(layout->itemAt(index)->widget());
+    GenericChatItemWidget* atMid = qobject_cast<GenericChatItemWidget*>(layout->itemAt(index)->widget());
     assert(atMid != nullptr);
 
     if (atMid == widget)
@@ -84,7 +84,7 @@ void GenericChatItemLayout::search(const QString &searchString, bool hideAll)
 {
     for (int index = 0; index < layout->count(); ++index)
     {
-        GenericChatItemWidget* widgetAt = dynamic_cast<GenericChatItemWidget*>(layout->itemAt(index)->widget());
+        GenericChatItemWidget* widgetAt = qobject_cast<GenericChatItemWidget*>(layout->itemAt(index)->widget());
         assert(widgetAt != nullptr);
 
         widgetAt->searchName(searchString, hideAll);
@@ -103,7 +103,7 @@ int GenericChatItemLayout::indexOfClosestSortedWidget(GenericChatItemWidget* wid
     while (min < max)
     {
         int mid = (max - min) / 2 + min;
-        GenericChatItemWidget* atMid = dynamic_cast<GenericChatItemWidget*>(layout->itemAt(mid)->widget());
+        GenericChatItemWidget* atMid = qobject_cast<GenericChatItemWidget*>(layout->itemAt(mid)->widget());
         assert(atMid != nullptr);
 
         bool lessThan = false;


### PR DESCRIPTION
This allows us to save some memory and executable size (5-6%) by removing the
need to generate and compile C++ RTTI.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3738)

<!-- Reviewable:end -->
