### PR TITLE
fix(UI): bump default emoticon size, since otherwise it can be too small

### DIFF
--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -248,7 +248,7 @@ void Settings::loadGlobal()
         if (!SmileyPack::isValid(smileyPack))
             smileyPack = DEFAULT_SMILEYS;
 
-        emojiFontPointSize = s.value("emojiFontPointSize", 16).toInt();
+        emojiFontPointSize = s.value("emojiFontPointSize", 24).toInt();
         firstColumnHandlePos = s.value("firstColumnHandlePos", 50).toInt();
         secondColumnHandlePosFromRight = s.value("secondColumnHandlePosFromRight", 50).toInt();
         timestampFormat = s.value("timestampFormat", "hh:mm:ss").toString();


### PR DESCRIPTION
E.g. #3777

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3778)

<!-- Reviewable:end -->
