### PR TITLE
fix(audio): keep the data pointed to by tmpDevName in scope

### DIFF
--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -352,9 +352,12 @@ bool Audio::initInput(const QString& deviceName)
     const uint32_t chnls = AUDIO_CHANNELS;
     const ALCsizei bufSize = (frameDuration * sampleRate * 4) / 1000 * chnls;
 
+    const QByteArray qDevName = deviceName.isEmpty()
+                                ? nullptr
+                                : deviceName.toUtf8();
     const ALchar* tmpDevName = deviceName.isEmpty()
                                ? nullptr
-                               : deviceName.toUtf8().constData();
+                               : qDevName.constData();
     alInDev = alcCaptureOpenDevice(tmpDevName, sampleRate, stereoFlag, bufSize);
 
     // Restart the capture if necessary
@@ -386,9 +389,12 @@ bool Audio::initOutput(const QString& deviceName)
     qDebug() << "Opening audio output" << deviceName;
     assert(!alOutDev);
 
+    const QByteArray qDevName = deviceName.isEmpty()
+                                ? nullptr
+                                : deviceName.toUtf8();
     const ALchar* tmpDevName = deviceName.isEmpty()
                                ? nullptr
-                               : deviceName.toUtf8().constData();
+                               : qDevName.constData();
     alOutDev = alcOpenDevice(tmpDevName);
 
     if (!alOutDev)

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -352,10 +352,8 @@ bool Audio::initInput(const QString& deviceName)
     const uint32_t chnls = AUDIO_CHANNELS;
     const ALCsizei bufSize = (frameDuration * sampleRate * 4) / 1000 * chnls;
 
-    const QByteArray qDevName = deviceName.isEmpty()
-                                ? nullptr
-                                : deviceName.toUtf8();
-    const ALchar* tmpDevName = deviceName.isEmpty()
+    const QByteArray qDevName = deviceName.toUtf8();
+    const ALchar* tmpDevName = qDevName.isEmpty()
                                ? nullptr
                                : qDevName.constData();
     alInDev = alcCaptureOpenDevice(tmpDevName, sampleRate, stereoFlag, bufSize);
@@ -389,10 +387,8 @@ bool Audio::initOutput(const QString& deviceName)
     qDebug() << "Opening audio output" << deviceName;
     assert(!alOutDev);
 
-    const QByteArray qDevName = deviceName.isEmpty()
-                                ? nullptr
-                                : deviceName.toUtf8();
-    const ALchar* tmpDevName = deviceName.isEmpty()
+    const QByteArray qDevName = deviceName.toUtf8();
+    const ALchar* tmpDevName = qDevName.isEmpty()
                                ? nullptr
                                : qDevName.constData();
     alOutDev = alcOpenDevice(tmpDevName);


### PR DESCRIPTION
Fix the use after free in Audio::initInput and Audio::initOutput
by storing the buffer returned by QString::toUtf8 (which contains data
pointed to by tmpDevName) in an intermediate variable, preventing the
buffer from falling out of scope for the duration of the function.

Fixes #3786

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3788)

<!-- Reviewable:end -->
