### PR TITLE
fix(avform): Fixed empty value in autio and video lists

### DIFF
--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -456,11 +456,11 @@ void AVForm::getAudioInDevices()
     inDevCombobox->blockSignals(false);
 
     int idx = 0;
-    if (Settings::getInstance().getAudioInDevEnabled() && deviceNames.size() > 1)
+    bool enabled = Settings::getInstance().getAudioInDevEnabled();
+    if (enabled && deviceNames.size() > 1)
     {
-        idx = deviceNames.indexOf(Settings::getInstance().getInDev()) + 1;
-        if (idx <= 0)
-            idx = 1;
+        QString dev = Settings::getInstance().getInDev();
+        idx = qMax(deviceNames.indexOf(dev), 1);
     }
     inDevCombobox->setCurrentIndex(idx);
 }
@@ -476,11 +476,11 @@ void AVForm::getAudioOutDevices()
     outDevCombobox->blockSignals(false);
 
     int idx = 0;
-    if (Settings::getInstance().getAudioOutDevEnabled() && deviceNames.size() > 1)
+    bool enabled = Settings::getInstance().getAudioOutDevEnabled();
+    if (enabled && deviceNames.size() > 1)
     {
-        idx = deviceNames.indexOf(Settings::getInstance().getOutDev()) + 1;
-        if (idx <= 0)
-            idx = 1;
+        QString dev = Settings::getInstance().getOutDev();
+        idx = qMax(deviceNames.indexOf(dev), 1);
     }
     outDevCombobox->setCurrentIndex(idx);
 }


### PR DESCRIPTION
Removed extra `+1` for index and small refactoring
@antis81 [Here](https://github.com/qTox/qTox/pull/3714#issuecomment-246987436) you said, that `idx = deviceNames.indexOf(Settings::getInstance().getInDev()) + 1; // <-- the bug was here, as the index was "off-by-one"!!` Why?

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3791)

<!-- Reviewable:end -->
