### PR TITLE
Remove instance of dynamic cast in favor of static cast

### DIFF
--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -486,7 +486,7 @@ QString GenericChatForm::resolveToxId(const ToxId &id)
 
 void GenericChatForm::insertChatMessage(ChatMessage::Ptr msg)
 {
-    chatWidget->insertChatlineAtBottom(std::dynamic_pointer_cast<ChatLine>(msg));
+    chatWidget->insertChatlineAtBottom(std::static_pointer_cast<ChatLine>(msg));
     emit messageInserted();
 }
 


### PR DESCRIPTION
A stray `std::dynamic_pointer_cast` located in `genericchatform.cpp` was not caught during the removal of RTTI features. This causes issues with compilers that do not auto-substitute known polymorphic class relationships with static casts (or `std::static_pointer_cast`). In particular causing issues with the Windows builds on Jenkins.

Fixes #3801

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3830)

<!-- Reviewable:end -->
