### PR TITLE
fix(build): Avoid 64bit atomics for compatibility

### DIFF
--- a/src/video/videoframe.h
+++ b/src/video/videoframe.h
@@ -54,8 +54,8 @@ class VideoFrame
 {
 public:
     // Declare type aliases
-    using IDType = std::uint_fast64_t;
-    using AtomicIDType = std::atomic_uint_fast64_t;
+    using IDType = std::uint_fast32_t;
+    using AtomicIDType = std::atomic_uint_fast32_t;
 
 public:
     VideoFrame(IDType sourceID, AVFrame* sourceFrame, QRect dimensions, int pixFmt, bool freeSourceFrame = false);


### PR DESCRIPTION
UNTESTED fix for a compile error on 32bit linux.
Opinions welcome.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3847)
<!-- Reviewable:end -->
