### PR TITLE
chore(doxygen): treat .h as C++ includes when generating docs

### DIFF
--- a/doxygen.conf
+++ b/doxygen.conf
@@ -7,9 +7,10 @@ GENERATE_TODOLIST = YES
 GENERATE_TESTLIST = YES
 
 # Input
-INPUT         = src
-FILE_PATTERNS = *.h *.cpp
-RECURSIVE     = YES
+INPUT             = src
+FILE_PATTERNS     = *.h *.cpp
+EXTENSION_MAPPING = h=C++
+RECURSIVE         = YES
 
 # Output
 OUTPUT_DIRECTORY = doc


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3852)
<!-- Reviewable:end -->
