### PR TITLE
docs(doxygen): fix some warnings for toxcall.cpp

### DIFF
--- a/src/core/toxcall.cpp
+++ b/src/core/toxcall.cpp
@@ -14,13 +14,13 @@
  * @var bool ToxCall::inactive
  * @brief True while we're not participating. (stopped group call, ringing but hasn't started yet, ...)
  *
- * @var bool ToxCall::videoEnabled
+ * @var bool ToxFriendCall::videoEnabled
  * @brief True if our user asked for a video call, sending and recieving.
  *
- * @var bool ToxCall::nullVideoBitrate
+ * @var bool ToxFriendCall::nullVideoBitrate
  * @brief True if our video bitrate is zero, i.e. if the device is closed.
  *
- * @var TOXAV_FRIEND_CALL_STATE ToxCall::state
+ * @var TOXAV_FRIEND_CALL_STATE ToxFriendCall::state
  * @brief State of the peer (not ours!)
  */
 


### PR DESCRIPTION
I have no idea what the change actually means, aside from fixing the warning.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3857)
<!-- Reviewable:end -->
