### PR TITLE
Prevent text style from being reset during retranslation of UI

### DIFF
--- a/src/widget/form/settings/userinterfaceform.cpp
+++ b/src/widget/form/settings/userinterfaceform.cpp
@@ -310,7 +310,14 @@ void UserInterfaceForm::on_themeColorCBox_currentIndexChanged(int)
  */
 void UserInterfaceForm::retranslateUi()
 {
+    // Block signals during translation to prevent settings change
+    RecursiveSignalBlocker signalBlocker{this};
+
     bodyUI->retranslateUi(this);
+
+    // Restore text style index once translation is complete
+    bodyUI->textStyleComboBox->setCurrentIndex(
+        static_cast<int>(Settings::getInstance().getStylePreference()));
 
     QStringList colorThemes(Style::getThemeColorNames());
     for (int i = 0; i < colorThemes.size(); ++i)


### PR DESCRIPTION
During retranslation of the UI, combo boxes get cleared and have their elements repopulated. Due to the way the combo box index changed slot was designed, this would override the settings value as well.

This PR changes the behaviour by temporarily blocking the signal to the combo box during retranslation and then restoring the combo box's index from settings after retranslation is complete.

Fixes #3805.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3860)
<!-- Reviewable:end -->
