### PR TITLE
fix(core): don't emit idSet signal twice

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -324,13 +324,9 @@ void Core::start()
 
     ready = true;
 
-    // If we created a new profile earlier,
-    // now that we're ready save it and ONLY THEN broadcast the new ID.
-    // This is useful for e.g. the profileForm that searches for saves.
     if (isNewProfile)
     {
         profile.saveToxSave();
-        emit idSet(getSelfId().toString());
     }
 
     if (isReady())


### PR DESCRIPTION
This signal was emitted twice when a new profile was created. I don't think that's how it's supposed to be.
The comment also doesn't make any sense so I removed everything.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3864)
<!-- Reviewable:end -->
