### PR TITLE
fix(chatlog): silence warning about unused parameters

### DIFF
--- a/src/chatlog/content/text.cpp
+++ b/src/chatlog/content/text.cpp
@@ -150,6 +150,8 @@ QRectF Text::boundingRect() const
 
 void Text::paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget)
 {
+    Q_UNUSED(option);
+    Q_UNUSED(widget);
 
     if (!doc)
         return;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3870)
<!-- Reviewable:end -->
