### PR TITLE
Fix dataToString correctness regression

### DIFF
--- a/src/persistence/serialize.cpp
+++ b/src/persistence/serialize.cpp
@@ -42,7 +42,7 @@ QString dataToString(QByteArray data)
         return QString();
 
     // Remove the strlen
-    data.remove(0, i - 1);
+    data.remove(0, i);
     data.truncate(strlen);
 
     return QString(data);


### PR DESCRIPTION
It would incorrectly prepend garbage to the output and then truncate it, regression introduced in 6c150a04c0f7e960e0105e63abdeb742a1a99147

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3911)
<!-- Reviewable:end -->
