### PR TITLE
CMake migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,7 @@ _testmain.go
 /qtox.app
 
 # Qt
-*.pro.user*
+*.user
 moc_*
 ui_*
 qrc_*

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ build-*-Profile
 build-*-Debug
 
 # Folders
+_[Bb]uild*/
 _obj
 _test
 libs

--- a/.travis/build-ubuntu-14-04.sh
+++ b/.travis/build-ubuntu-14-04.sh
@@ -147,7 +147,7 @@ export PKG_CONFIG_PATH="$PWD/libs/lib/pkgconfig"
 
 # first build qTox without support for optional dependencies
 echo '*** BUILDING "MINIMAL" VERSION ***'
-qmake qtox.pro QMAKE_CC="$CC" QMAKE_CXX="$CXX" ENABLE_SYSTRAY_STATUSNOTIFIER_BACKEND=NO ENABLE_SYSTRAY_GTK_BACKEND=NO DISABLE_PLATFORM_EXT=YES SMILEYS=NO
+qmake qtox.pro QMAKE_CC="$CC" QMAKE_CXX="$CXX" ENABLE_SYSTRAY_STATUSNOTIFIER_BACKEND=NO ENABLE_SYSTRAY_GTK_BACKEND=NO DISABLE_PLATFORM_EXT=YES SMILEYS=DISABLED
 # ↓ reduce if build fails with OOM
 make -j$(nproc)
 # clean it up, and build normal version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -411,7 +411,10 @@ set(${PROJECT_NAME}_SOURCES
   src/widget/widget.cpp
   src/widget/widget.h)
 
-if(GDK_PIXBUF_FOUND AND GLIB_FOUND AND GTK_FOUND)
+if (NOT ENABLE_STATUSNOTIFIER)
+    set(ENABLE_STATUSNOTIFIER True)
+endif()
+if(${ENABLE_STATUSNOTIFIER} AND GDK_PIXBUF_FOUND AND GLIB_FOUND AND GTK_FOUND)
   set(${PROJECT_NAME}_SOURCES ${${PROJECT_NAME}_SOURCES}
     src/platform/statusnotifier/closures.c
     src/platform/statusnotifier/closures.h
@@ -429,11 +432,18 @@ if(AVFOUNDATION_FOUND)
     src/platform/camera/avfoundation.h)
 endif()
 
-if(APPINDICATOR_FOUND)
+if (NOT ENABLE_APPINDICATOR)
+    set(ENABLE_APPINDICATOR False)
+endif()
+if(${ENABLE_APPINDICATOR} AND APPINDICATOR_FOUND)
   add_definitions(-DENABLE_SYSTRAY_UNITY_BACKEND=1)
 endif()
 
-if(GTK_FOUND)
+if (NOT ENABLE_GTK_SYSTRAY)
+    set(ENABLE_GTK_SYSTRAY True)
+endif()
+
+if(${ENABLE_GTK_SYSTRAY} AND GTK_FOUND)
   add_definitions(-DENABLE_SYSTRAY_GTK_BACKEND=1)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,9 +91,9 @@ qt5_add_translation(${PROJECT_NAME}_QM_FILES
   translations/ja.ts
   translations/jbo.ts
   translations/ko.ts
+  translations/lt.ts
   translations/nl.ts
   translations/no_nb.ts
-  translations/lt.ts
   translations/pl.ts
   translations/pr.ts
   translations/pt.ts

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,14 +23,6 @@ execute_process(
   OUTPUT_VARIABLE QT_PREFIX_PATH
   OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-if(NOT QT_PREFIX_PATH)
-  set(QT_PREFIX_PATH
-    /usr/src/mxe/usr/x86_64-w64-mingw32.shared/qt5
-    /usr/src/mxe/usr/i686-w64-mingw32.shared/qt5)
-endif()
-
-set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${QT_PREFIX_PATH})
-
 execute_process(
   COMMAND xcode-select -p
   OUTPUT_VARIABLE CMAKE_OSX_SYSROOT
@@ -124,7 +116,7 @@ qt5_add_resources(
 )
 
 if(NOT ${SMILEYS})
-    set(SMILEYS, "")
+  set(SMILEYS, "")
 endif()
 
 if(NOT ${SMILEYS} MATCHES "NO")
@@ -253,12 +245,6 @@ set(${PROJECT_NAME}_SOURCES
   src/persistence/smileypack.h
   src/persistence/toxsave.cpp
   src/persistence/toxsave.h
-  src/platform/camera/directshow.cpp
-  src/platform/camera/directshow.h
-  src/platform/camera/v4l2.cpp
-  src/platform/camera/v4l2.h
-  src/platform/install_osx.cpp
-  src/platform/install_osx.h
   src/platform/autorun.h
   src/platform/capslock.h
   src/platform/timer.h
@@ -409,11 +395,32 @@ set(${PROJECT_NAME}_SOURCES
   src/widget/translator.cpp
   src/widget/translator.h
   src/widget/widget.cpp
-  src/widget/widget.h)
+  src/widget/widget.h
+)
+
+if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+  set(${PROJECT_NAME}_SOURCES ${${PROJECT_NAME}_SOURCES}
+    src/platform/camera/directshow.cpp
+    src/platform/camera/directshow.h
+  )
+elseif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  set(${PROJECT_NAME}_SOURCES ${${PROJECT_NAME}_SOURCES}
+    src/platform/camera/v4l2.cpp
+    src/platform/camera/v4l2.h
+  )
+elseif (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  set(${PROJECT_NAME}_SOURCES ${${PROJECT_NAME}_SOURCES}
+    src/platform/install_osx.cpp
+    src/platform/install_osx.h
+  )
+endif()
+
+add_definitions(-DQT_MESSAGELOGCONTEXT=1)
 
 if (NOT ENABLE_STATUSNOTIFIER)
-    set(ENABLE_STATUSNOTIFIER True)
+  set(ENABLE_STATUSNOTIFIER True)
 endif()
+
 if(${ENABLE_STATUSNOTIFIER} AND GDK_PIXBUF_FOUND AND GLIB_FOUND AND GTK_FOUND)
   set(${PROJECT_NAME}_SOURCES ${${PROJECT_NAME}_SOURCES}
     src/platform/statusnotifier/closures.c
@@ -433,14 +440,14 @@ if(AVFOUNDATION_FOUND)
 endif()
 
 if (NOT ENABLE_APPINDICATOR)
-    set(ENABLE_APPINDICATOR False)
+  set(ENABLE_APPINDICATOR False)
 endif()
 if(${ENABLE_APPINDICATOR} AND APPINDICATOR_FOUND)
   add_definitions(-DENABLE_SYSTRAY_UNITY_BACKEND=1)
 endif()
 
 if (NOT ENABLE_GTK_SYSTRAY)
-    set(ENABLE_GTK_SYSTRAY True)
+  set(ENABLE_GTK_SYSTRAY True)
 endif()
 
 if(${ENABLE_GTK_SYSTRAY} AND GTK_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,492 @@
+################################################################################
+#
+# :: CMake configuration
+#
+################################################################################
+
+cmake_minimum_required(VERSION 2.8.11)
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Debug)
+endif()
+
+set(ENV{PKG_CONFIG_PATH}
+  ${CMAKE_SOURCE_DIR}/libs/lib/pkgconfig:/opt/ffmpeg/lib/pkgconfig:$ENV{PKG_CONFIG_PATH})
+set(ENV{PKG_CONFIG_PATH_i686_w64_mingw32_shared}
+  ${CMAKE_SOURCE_DIR}/libs/lib/pkgconfig)
+set(ENV{PKG_CONFIG_PATH_x86_64_w64_mingw32_shared}
+  ${CMAKE_SOURCE_DIR}/libs/lib/pkgconfig)
+
+execute_process(
+  COMMAND brew --prefix qt5
+  OUTPUT_VARIABLE QT_PREFIX_PATH
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
+if(NOT QT_PREFIX_PATH)
+  set(QT_PREFIX_PATH
+    /usr/src/mxe/usr/x86_64-w64-mingw32.shared/qt5
+    /usr/src/mxe/usr/i686-w64-mingw32.shared/qt5)
+endif()
+
+set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${QT_PREFIX_PATH})
+
+execute_process(
+  COMMAND xcode-select -p
+  OUTPUT_VARIABLE CMAKE_OSX_SYSROOT
+  OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+set(CMAKE_OSX_DEPLOYMENT_TARGET 10.12)
+set(CMAKE_OSX_SYSROOT
+  ${CMAKE_OSX_SYSROOT}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX${CMAKE_OSX_DEPLOYMENT_TARGET}.sdk)
+
+project(qtox)
+include(CTest)
+
+# Instruct CMake to run moc automatically when needed.
+set(CMAKE_AUTOMOC ON)
+
+# Use C++11.
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
+
+# Search for headers in current directory.
+include_directories(${CMAKE_BINARY_DIR})
+include_directories(${CMAKE_SOURCE_DIR})
+
+include(Dependencies)
+
+################################################################################
+#
+# :: qTox main library sources
+#
+################################################################################
+
+qt5_wrap_ui(${PROJECT_NAME}_FORMS
+  src/chatlog/content/filetransferwidget.ui
+  src/loginscreen.ui
+  src/mainwindow.ui
+  src/widget/about/aboutuser.ui
+  src/widget/form/loadhistorydialog.ui
+  src/widget/form/profileform.ui
+  src/widget/form/removefrienddialog.ui
+  src/widget/form/setpassworddialog.ui
+  src/widget/form/settings/aboutsettings.ui
+  src/widget/form/settings/advancedsettings.ui
+  src/widget/form/settings/avform.ui
+  src/widget/form/settings/generalsettings.ui
+  src/widget/form/settings/privacysettings.ui
+  src/widget/form/settings/userinterfacesettings.ui)
+
+qt5_add_translation(${PROJECT_NAME}_QM_FILES
+  translations/ar.ts
+  translations/be.ts
+  translations/bg.ts
+  translations/cs.ts
+  translations/da.ts
+  translations/de.ts
+  translations/el.ts
+  translations/eo.ts
+  translations/es.ts
+  translations/et.ts
+  translations/fi.ts
+  translations/fr.ts
+  translations/he.ts
+  translations/hr.ts
+  translations/hu.ts
+  translations/it.ts
+  translations/ja.ts
+  translations/jbo.ts
+  translations/ko.ts
+  translations/nl.ts
+  translations/no_nb.ts
+  translations/lt.ts
+  translations/pl.ts
+  translations/pr.ts
+  translations/pt.ts
+  translations/ru.ts
+  translations/sk.ts
+  translations/sl.ts
+  translations/sv.ts
+  translations/sw.ts
+  translations/tr.ts
+  translations/ug.ts
+  translations/uk.ts
+  translations/zh.ts
+)
+
+qt5_add_resources(${PROJECT_NAME}_RESOURCES
+  res.qrc
+  smileys/smileys.qrc
+  ${CMAKE_CURRENT_BINARY_DIR}/translations.qrc
+  DEPENDS ${${PROJECT_NAME}_QM_FILES})
+
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/translations.qrc.in"
+"<!DOCTYPE RCC>
+<RCC version=\"1.0\">
+  <qresource prefix=\"/translations\">
+")
+foreach(qm ${${PROJECT_NAME}_QM_FILES})
+  get_filename_component(qm_name ${qm} NAME)
+  file(APPEND "${CMAKE_CURRENT_BINARY_DIR}/translations.qrc.in"
+    "    <file alias=\"${qm_name}\">${qm}</file>\n")
+endforeach(qm)
+file(APPEND "${CMAKE_CURRENT_BINARY_DIR}/translations.qrc.in"
+"  </qresource>
+</RCC>
+")
+
+execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different
+  ${CMAKE_CURRENT_BINARY_DIR}/translations.qrc.in
+  ${CMAKE_CURRENT_BINARY_DIR}/translations.qrc)
+
+set(${PROJECT_NAME}_SOURCES
+  src/audio/audio.cpp
+  src/audio/audio.h
+  src/chatlog/chatlinecontent.cpp
+  src/chatlog/chatlinecontent.h
+  src/chatlog/chatlinecontentproxy.cpp
+  src/chatlog/chatlinecontentproxy.h
+  src/chatlog/chatline.cpp
+  src/chatlog/chatline.h
+  src/chatlog/chatlog.cpp
+  src/chatlog/chatlog.h
+  src/chatlog/chatmessage.cpp
+  src/chatlog/chatmessage.h
+  src/chatlog/content/filetransferwidget.cpp
+  src/chatlog/content/filetransferwidget.h
+  src/chatlog/content/image.cpp
+  src/chatlog/content/image.h
+  src/chatlog/content/notificationicon.cpp
+  src/chatlog/content/notificationicon.h
+  src/chatlog/content/spinner.cpp
+  src/chatlog/content/spinner.h
+  src/chatlog/content/text.cpp
+  src/chatlog/content/text.h
+  src/chatlog/content/timestamp.cpp
+  src/chatlog/content/timestamp.h
+  src/chatlog/customtextdocument.cpp
+  src/chatlog/customtextdocument.h
+  src/chatlog/documentcache.cpp
+  src/chatlog/documentcache.h
+  src/chatlog/pixmapcache.cpp
+  src/chatlog/pixmapcache.h
+  src/core/coreav.cpp
+  src/core/coreav.h
+  src/core/core.cpp
+  src/core/coredefines.h
+  src/core/coreencryption.cpp
+  src/core/corefile.cpp
+  src/core/corefile.h
+  src/core/core.h
+  src/core/corestructs.cpp
+  src/core/corestructs.h
+  src/core/cstring.cpp
+  src/core/cstring.h
+  src/core/indexedlist.h
+  src/core/recursivesignalblocker.cpp
+  src/core/recursivesignalblocker.h
+  src/core/toxcall.cpp
+  src/core/toxcall.h
+  src/core/toxid.cpp
+  src/core/toxid.h
+  src/core/toxpk.cpp
+  src/core/toxpk.h
+  src/friend.cpp
+  src/friend.h
+  src/friendlist.cpp
+  src/friendlist.h
+  src/group.cpp
+  src/group.h
+  src/grouplist.cpp
+  src/grouplist.h
+  src/ipc.cpp
+  src/ipc.h
+  src/net/autoupdate.cpp
+  src/net/autoupdate.h
+  src/net/avatarbroadcaster.cpp
+  src/net/avatarbroadcaster.h
+  src/net/toxme.cpp
+  src/net/toxme.h
+  src/net/toxuri.cpp
+  src/net/toxuri.h
+  src/nexus.cpp
+  src/nexus.h
+  src/persistence/db/encrypteddb.cpp
+  src/persistence/db/encrypteddb.h
+  src/persistence/db/genericddinterface.cpp
+  src/persistence/db/genericddinterface.h
+  src/persistence/db/plaindb.cpp
+  src/persistence/db/plaindb.h
+  src/persistence/db/rawdatabase.cpp
+  src/persistence/db/rawdatabase.h
+  src/persistence/history.cpp
+  src/persistence/history.h
+  src/persistence/historykeeper.cpp
+  src/persistence/historykeeper.h
+  src/persistence/offlinemsgengine.cpp
+  src/persistence/offlinemsgengine.h
+  src/persistence/profile.cpp
+  src/persistence/profile.h
+  src/persistence/profilelocker.cpp
+  src/persistence/profilelocker.h
+  src/persistence/serialize.cpp
+  src/persistence/serialize.h
+  src/persistence/settings.cpp
+  src/persistence/settings.h
+  src/persistence/settingsserializer.cpp
+  src/persistence/settingsserializer.h
+  src/persistence/smileypack.cpp
+  src/persistence/smileypack.h
+  src/persistence/toxsave.cpp
+  src/persistence/toxsave.h
+  src/platform/camera/directshow.cpp
+  src/platform/camera/directshow.h
+  src/platform/camera/v4l2.cpp
+  src/platform/camera/v4l2.h
+  src/platform/install_osx.cpp
+  src/platform/install_osx.h
+  src/platform/autorun.h
+  src/platform/capslock.h
+  src/platform/timer.h
+  src/platform/autorun_osx.cpp
+  src/platform/autorun_win.cpp
+  src/platform/autorun_xdg.cpp
+  src/platform/capslock_osx.cpp
+  src/platform/capslock_win.cpp
+  src/platform/capslock_x11.cpp
+  src/platform/timer_osx.cpp
+  src/platform/timer_win.cpp
+  src/platform/timer_x11.cpp
+  src/video/cameradevice.cpp
+  src/video/cameradevice.h
+  src/video/camerasource.cpp
+  src/video/camerasource.h
+  src/video/corevideosource.cpp
+  src/video/corevideosource.h
+  src/video/genericnetcamview.cpp
+  src/video/genericnetcamview.h
+  src/video/groupnetcamview.cpp
+  src/video/groupnetcamview.h
+  src/video/netcamview.cpp
+  src/video/netcamview.h
+  src/video/videoframe.cpp
+  src/video/videoframe.h
+  src/video/videomode.cpp
+  src/video/videomode.h
+  src/video/videosource.cpp
+  src/video/videosource.h
+  src/video/videosurface.cpp
+  src/video/videosurface.h
+  src/widget/about/aboutuser.cpp
+  src/widget/about/aboutuser.h
+  src/widget/categorywidget.cpp
+  src/widget/categorywidget.h
+  src/widget/circlewidget.cpp
+  src/widget/circlewidget.h
+  src/widget/contentdialog.cpp
+  src/widget/contentdialog.h
+  src/widget/contentlayout.cpp
+  src/widget/contentlayout.h
+  src/widget/emoticonswidget.cpp
+  src/widget/emoticonswidget.h
+  src/widget/flowlayout.cpp
+  src/widget/flowlayout.h
+  src/widget/form/addfriendform.cpp
+  src/widget/form/addfriendform.h
+  src/widget/form/chatform.cpp
+  src/widget/form/chatform.h
+  src/widget/form/filesform.cpp
+  src/widget/form/filesform.h
+  src/widget/form/genericchatform.cpp
+  src/widget/form/genericchatform.h
+  src/widget/form/groupchatform.cpp
+  src/widget/form/groupchatform.h
+  src/widget/form/groupinviteform.cpp
+  src/widget/form/groupinviteform.h
+  src/widget/form/loadhistorydialog.cpp
+  src/widget/form/loadhistorydialog.h
+  src/widget/form/profileform.cpp
+  src/widget/form/profileform.h
+  src/widget/form/setpassworddialog.cpp
+  src/widget/form/setpassworddialog.h
+  src/widget/form/settings/aboutform.cpp
+  src/widget/form/settings/aboutform.h
+  src/widget/form/settings/advancedform.cpp
+  src/widget/form/settings/advancedform.h
+  src/widget/form/settings/avform.cpp
+  src/widget/form/settings/avform.h
+  src/widget/form/settings/generalform.cpp
+  src/widget/form/settings/generalform.h
+  src/widget/form/settings/genericsettings.cpp
+  src/widget/form/settings/genericsettings.h
+  src/widget/form/settings/privacyform.cpp
+  src/widget/form/settings/privacyform.h
+  src/widget/form/settings/userinterfaceform.h
+  src/widget/form/settings/userinterfaceform.cpp
+  src/widget/form/settings/verticalonlyscroller.cpp
+  src/widget/form/settings/verticalonlyscroller.h
+  src/widget/form/settingswidget.cpp
+  src/widget/form/settingswidget.h
+  src/widget/form/tabcompleter.cpp
+  src/widget/form/tabcompleter.h
+  src/widget/friendlistlayout.cpp
+  src/widget/friendlistlayout.h
+  src/widget/friendlistwidget.cpp
+  src/widget/friendlistwidget.h
+  src/widget/friendwidget.cpp
+  src/widget/friendwidget.h
+  src/widget/genericchatitemlayout.cpp
+  src/widget/genericchatitemlayout.h
+  src/widget/genericchatitemwidget.cpp
+  src/widget/genericchatitemwidget.h
+  src/widget/genericchatroomwidget.cpp
+  src/widget/genericchatroomwidget.h
+  src/widget/groupwidget.cpp
+  src/widget/groupwidget.h
+  src/widget/gui.cpp
+  src/widget/gui.h
+  src/widget/loginscreen.cpp
+  src/widget/loginscreen.h
+  src/widget/maskablepixmapwidget.cpp
+  src/widget/maskablepixmapwidget.h
+  src/widget/notificationedgewidget.cpp
+  src/widget/notificationedgewidget.h
+  src/widget/notificationscrollarea.cpp
+  src/widget/notificationscrollarea.h
+  src/widget/passwordedit.cpp
+  src/widget/passwordedit.h
+  src/widget/qrwidget.cpp
+  src/widget/qrwidget.h
+  src/widget/style.cpp
+  src/widget/style.h
+  src/widget/systemtrayicon.cpp
+  src/widget/systemtrayicon.h
+  src/widget/systemtrayicon_private.h
+  src/widget/tool/activatedialog.cpp
+  src/widget/tool/activatedialog.h
+  src/widget/tool/adjustingscrollarea.cpp
+  src/widget/tool/adjustingscrollarea.h
+  src/widget/tool/callconfirmwidget.cpp
+  src/widget/tool/callconfirmwidget.h
+  src/widget/tool/chattextedit.cpp
+  src/widget/tool/chattextedit.h
+  src/widget/tool/croppinglabel.cpp
+  src/widget/tool/croppinglabel.h
+  src/widget/tool/flyoutoverlaywidget.cpp
+  src/widget/tool/flyoutoverlaywidget.h
+  src/widget/tool/friendrequestdialog.cpp
+  src/widget/tool/friendrequestdialog.h
+  src/widget/tool/micfeedbackwidget.cpp
+  src/widget/tool/micfeedbackwidget.h
+  src/widget/tool/movablewidget.cpp
+  src/widget/tool/movablewidget.h
+  src/widget/tool/profileimporter.cpp
+  src/widget/tool/profileimporter.h
+  src/widget/tool/removefrienddialog.cpp
+  src/widget/tool/removefrienddialog.h
+  src/widget/tool/screengrabberchooserrectitem.cpp
+  src/widget/tool/screengrabberchooserrectitem.h
+  src/widget/tool/screengrabberoverlayitem.cpp
+  src/widget/tool/screengrabberoverlayitem.h
+  src/widget/tool/screenshotgrabber.cpp
+  src/widget/tool/screenshotgrabber.h
+  src/widget/tool/toolboxgraphicsitem.cpp
+  src/widget/tool/toolboxgraphicsitem.h
+  src/widget/translator.cpp
+  src/widget/translator.h
+  src/widget/widget.cpp
+  src/widget/widget.h)
+
+if(GDK_PIXBUF_FOUND AND GLIB_FOUND AND GTK_FOUND)
+  set(${PROJECT_NAME}_SOURCES ${${PROJECT_NAME}_SOURCES}
+    src/platform/statusnotifier/closures.c
+    src/platform/statusnotifier/closures.h
+    src/platform/statusnotifier/enums.c
+    src/platform/statusnotifier/enums.h
+    src/platform/statusnotifier/interfaces.h
+    src/platform/statusnotifier/statusnotifier.c
+    src/platform/statusnotifier/statusnotifier.h)
+  add_definitions(-DENABLE_SYSTRAY_STATUSNOTIFIER_BACKEND=1)
+endif()
+
+if(AVFOUNDATION_FOUND)
+  set(${PROJECT_NAME}_SOURCES ${${PROJECT_NAME}_SOURCES}
+    src/platform/camera/avfoundation.mm
+    src/platform/camera/avfoundation.h)
+endif()
+
+if(APPINDICATOR_FOUND)
+  add_definitions(-DENABLE_SYSTRAY_UNITY_BACKEND=1)
+endif()
+
+if(GTK_FOUND)
+  add_definitions(-DENABLE_SYSTRAY_GTK_BACKEND=1)
+endif()
+
+add_library(${PROJECT_NAME}_static
+  STATIC
+  ${${PROJECT_NAME}_FORMS}
+  ${${PROJECT_NAME}_SOURCES}
+  ${${PROJECT_NAME}_QM_FILES})
+target_link_libraries(${PROJECT_NAME}_static
+  ${ALL_LIBRARIES})
+
+add_executable(${PROJECT_NAME}
+  WIN32
+  MACOSX_BUNDLE
+  ${${PROJECT_NAME}_RESOURCES}
+  src/main.cpp)
+target_link_libraries(${PROJECT_NAME}
+  ${PROJECT_NAME}_static
+  ${ALL_LIBRARIES})
+
+################################################################################
+#
+# :: Tests
+#
+################################################################################
+
+function(auto_test subsystem module)
+  add_executable(${module}_test
+    test/${subsystem}/${module}_test.cpp)
+  target_link_libraries(${module}_test
+    ${PROJECT_NAME}_static
+    ${ALL_LIBRARIES}
+    Qt5::Test)
+  add_test(
+    NAME test_${module}
+    COMMAND ${module}_test)
+endfunction()
+
+################################################################################
+#
+# :: Installation
+#
+################################################################################
+
+if(APPLE)
+  set(MACOSX_BUNDLE_SHORT_VERSION_STRING 1.4.1)
+  set(SHORT_VERSION ${MACOSX_BUNDLE_SHORT_VERSION_STRING})
+  set_target_properties(${PROJECT_NAME} PROPERTIES
+    MACOSX_BUNDLE_INFO_PLIST "${CMAKE_SOURCE_DIR}/osx/info.plist")
+
+  find_path(MACDEPLOYQT_PATH macdeployqt PATH_SUFFIXES bin)
+  if(NOT MACDEPLOYQT_PATH)
+    message(FATAL_ERROR "Could not find macdeployqt for OSX bundling. You can point MACDEPLOYQT_PATH to it's path.")
+  endif()
+
+  set(BUNDLE_PATH "${CMAKE_BINARY_DIR}/${PROJECT_NAME}.app")
+
+  install(CODE "
+  message(STATUS \"Creating app bundle\")
+  execute_process(COMMAND ${MACDEPLOYQT_PATH}/macdeployqt ${BUNDLE_PATH} -no-strip)
+  message(STATUS \"Updating library paths\")
+  execute_process(COMMAND ${CMAKE_SOURCE_DIR}/osx/macfixrpath ${BUNDLE_PATH})
+  message(STATUS \"Creating dmg image\")
+  execute_process(COMMAND hdiutil create -volname ${PROJECT_NAME} -srcfolder ${BUNDLE_PATH} -ov -format UDZO ${PROJECT_NAME}.dmg)
+  " COMPONENT Runtime
+  )
+else()
+  install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION "bin")
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,15 +115,21 @@ qt5_add_resources(
   DEPENDS ${${PROJECT_NAME}_QM_FILES}
 )
 
-if(NOT ${SMILEYS})
-  set(SMILEYS, "")
+if(NOT SMILEYS)
+  set(SMILEYS "")
 endif()
 
-if(NOT ${SMILEYS} MATCHES "NO")
-  qt5_add_resources(smileys/emojione.qrc)
-  if(NOT ${SMILEYS} MATCHES "MIN")
-    qt5_add_resources(smileys/smileys.qrc)
+if(NOT "${SMILEYS}" STREQUAL "DISABLED")
+  qt5_add_resources(
+          ${PROJECT_NAME}_RESOURCES
+          smileys/emojione.qrc)
+
+  if(NOT "${SMILEYS}" STREQUAL "MIN")
+    qt5_add_resources(
+            ${PROJECT_NAME}_RESOURCES
+            smileys/smileys.qrc)
   endif()
+
 endif()
 
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/translations.qrc.in"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ execute_process(
   COMMAND brew --prefix qt5
   OUTPUT_VARIABLE QT_PREFIX_PATH
   OUTPUT_STRIP_TRAILING_WHITESPACE)
+
 if(NOT QT_PREFIX_PATH)
   set(QT_PREFIX_PATH
     /usr/src/mxe/usr/x86_64-w64-mingw32.shared/qt5
@@ -115,11 +116,23 @@ qt5_add_translation(${PROJECT_NAME}_QM_FILES
   translations/zh.ts
 )
 
-qt5_add_resources(${PROJECT_NAME}_RESOURCES
+qt5_add_resources(
+  ${PROJECT_NAME}_RESOURCES
   res.qrc
-  smileys/smileys.qrc
   ${CMAKE_CURRENT_BINARY_DIR}/translations.qrc
-  DEPENDS ${${PROJECT_NAME}_QM_FILES})
+  DEPENDS ${${PROJECT_NAME}_QM_FILES}
+)
+
+if(NOT ${SMILEYS})
+    set(SMILEYS, "")
+endif()
+
+if(NOT ${SMILEYS} MATCHES "NO")
+  qt5_add_resources(smileys/emojione.qrc)
+  if(NOT ${SMILEYS} MATCHES "MIN")
+    qt5_add_resources(smileys/smileys.qrc)
+  endif()
+endif()
 
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/translations.qrc.in"
 "<!DOCTYPE RCC>

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -111,9 +111,46 @@ if(WIN32)
   search_dependency(STRMIIDS          LIBRARY strmiids)
 endif()
 
+execute_process(
+  COMMAND git describe --tags
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  OUTPUT_VARIABLE GIT_DESCRIBE
+  ERROR_QUIET
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+if(NOT GIT_DESCRIBE)
+  set(GIT_DESCRIBE "Nightly")
+endif()
+
 add_definitions(
+  -DGIT_DESCRIBE="${GIT_DESCRIBE}"
+)
+
+# GIT_VERSION
+execute_process(
+  COMMAND git rev-parse HEAD
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  OUTPUT_VARIABLE GIT_VERSION
+  ERROR_QUIET
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+if(NOT GIT_VERSION)
+  set(GIT_VERSION "build without git")
+endif()
+
+add_definitions(
+  -DGIT_VERSION="${GIT_VERSION}"
+)
+
+execute_process(
+  COMMAND date +%s
+  OUTPUT_VARIABLE TIMESTAMP
+)
+
+add_definitions(
+  -DTIMESTAMP=${TIMESTAMP}
+  -DLOG_TO_FILE=1
   -DQTOX_PLATFORM_EXT=1
-  -DGIT_COMMIT="N/A"
-  -DGIT_DESCRIBE="N/A"
-  -DGIT_VERSION="N/A"
-  -DTIMESTAMP="N/A")
+)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -154,8 +154,29 @@ if (NOT TIMESTAMP)
     )
 endif()
 
+set(APPLE_EXT False)
+if (AVFOUNDATION_FOUND OR FRAMEWORK_FOUND OR COREMEDIA_FOUND 
+        OR COREGRAPHICS_FOUND OR FOUNDATION_FOUND OR IOKIT_FOUND)
+    set(APPLE_EXT True)
+endif()
+
+set(LINUX_EXT False)
+if (APPINDICATOR_FOUND OR GDK_PIXBUF_FOUND OR GLIB_FOUND 
+        OR GTK_FOUND OR X11_FOUND OR XSS_FOUND)
+    set(LINUX_EXT True)
+endif()
+
+if (${APPLE_EXT} OR ${LINUX_EXT})
+    add_definitions(
+      -DQTOX_PLATFORM_EXT=1
+    )
+else()
+    add_definitions(
+      -DQTOX_PLATFORM_EXT=0
+    )
+endif()
+
 add_definitions(
   -DTIMESTAMP=${TIMESTAMP}
   -DLOG_TO_FILE=1
-  -DQTOX_PLATFORM_EXT=1
 )

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -48,7 +48,12 @@ function(search_dependency pkg)
 
   # Then, try OSX frameworks.
   if(NOT ${pkg}_FOUND AND arg_FRAMEWORK)
-    find_library(${pkg}_LIBRARIES NAMES ${arg_FRAMEWORK} PATHS ${CMAKE_OSX_SYSROOT}/System/Library PATH_SUFFIXES Frameworks NO_DEFAULT_PATH)
+    find_library(${pkg}_LIBRARIES 
+            NAMES ${arg_FRAMEWORK} 
+            PATHS ${CMAKE_OSX_SYSROOT}/System/Library 
+            PATH_SUFFIXES Frameworks 
+            NO_DEFAULT_PATH
+    )
     if(${pkg}_LIBRARIES)
       set(${pkg}_FOUND TRUE)
     endif()
@@ -80,7 +85,6 @@ search_dependency(APPINDICATOR        PACKAGE appindicator-0.1 OPTIONAL)
 search_dependency(GDK_PIXBUF          PACKAGE gdk-pixbuf-2.0   OPTIONAL)
 search_dependency(GLIB                PACKAGE glib-2.0         OPTIONAL)
 search_dependency(GTK                 PACKAGE gtk+-2.0         OPTIONAL)
-search_dependency(X11                 PACKAGE x11              OPTIONAL)
 
 search_dependency(LIBAVCODEC          PACKAGE libavcodec)
 search_dependency(LIBAVDEVICE         PACKAGE libavdevice)
@@ -96,15 +100,17 @@ search_dependency(VPX                 PACKAGE vpx)
 
 search_dependency(OPENAL              PACKAGE openal FRAMEWORK OpenAL)
 
-# XScreenSaver support.
+# Automatic auto-away support. (X11 also using for capslock detection)
+search_dependency(X11                 PACKAGE x11 OPTIONAL)
 search_dependency(XSS                 LIBRARY Xss OPTIONAL)
 
 if(APPLE)
   search_dependency(AVFOUNDATION      FRAMEWORK AVFoundation)
   search_dependency(COREMEDIA         FRAMEWORK CoreMedia   )
   search_dependency(COREGRAPHICS      FRAMEWORK CoreGraphics)
-  search_dependency(FOUNDATION        FRAMEWORK Foundation  )
-  search_dependency(IOKIT             FRAMEWORK IOKit       )
+
+  search_dependency(FOUNDATION        FRAMEWORK Foundation  OPTIONAL)
+  search_dependency(IOKIT             FRAMEWORK IOKit       OPTIONAL)
 endif()
 
 if(WIN32)
@@ -112,17 +118,17 @@ if(WIN32)
 endif()
 
 if (NOT GIT_DESCRIBE)
-    execute_process(
-      COMMAND git describe --tags
-      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-      OUTPUT_VARIABLE GIT_DESCRIBE
-      ERROR_QUIET
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
+  execute_process(
+    COMMAND git describe --tags
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_DESCRIBE
+    ERROR_QUIET
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
 
-    if(NOT GIT_DESCRIBE)
-      set(GIT_DESCRIBE "Nightly")
-    endif()
+  if(NOT GIT_DESCRIBE)
+    set(GIT_DESCRIBE "Nightly")
+  endif()
 endif()
 
 add_definitions(
@@ -130,17 +136,17 @@ add_definitions(
 )
 
 if (NOT GIT_VERSION)
-    execute_process(
-      COMMAND git rev-parse HEAD
-      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-      OUTPUT_VARIABLE GIT_VERSION
-      ERROR_QUIET
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
+  execute_process(
+    COMMAND git rev-parse HEAD
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_VERSION
+    ERROR_QUIET
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
 
-    if(NOT GIT_VERSION)
-      set(GIT_VERSION "build without git")
-    endif()
+  if(NOT GIT_VERSION)
+    set(GIT_VERSION "build without git")
+  endif()
 endif()
 
 add_definitions(
@@ -148,32 +154,30 @@ add_definitions(
 )
 
 if (NOT TIMESTAMP)
-    execute_process(
-      COMMAND date +%s
-      OUTPUT_VARIABLE TIMESTAMP
-    )
+  execute_process(
+    COMMAND date +%s
+    OUTPUT_VARIABLE TIMESTAMP
+  )
 endif()
 
 set(APPLE_EXT False)
-if (AVFOUNDATION_FOUND OR FRAMEWORK_FOUND OR COREMEDIA_FOUND 
-        OR COREGRAPHICS_FOUND OR FOUNDATION_FOUND OR IOKIT_FOUND)
-    set(APPLE_EXT True)
+if (FOUNDATION_FOUND AND IOKIT_FOUND)
+  set(APPLE_EXT True)
 endif()
 
-set(LINUX_EXT False)
-if (APPINDICATOR_FOUND OR GDK_PIXBUF_FOUND OR GLIB_FOUND 
-        OR GTK_FOUND OR X11_FOUND OR XSS_FOUND)
-    set(LINUX_EXT True)
+set(X11_EXT False)
+if (X11_FOUND AND XSS_FOUND)
+  set(X11_EXT True)
 endif()
 
-if (${APPLE_EXT} OR ${LINUX_EXT})
-    add_definitions(
-      -DQTOX_PLATFORM_EXT=1
-    )
+if (${APPLE_EXT} OR ${X11_EXT})
+  add_definitions(
+    -DQTOX_PLATFORM_EXT=1
+  )
 else()
-    add_definitions(
-      -DQTOX_PLATFORM_EXT=0
-    )
+  add_definitions(
+    -DQTOX_PLATFORM_EXT=0
+  )
 endif()
 
 add_definitions(

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -111,43 +111,48 @@ if(WIN32)
   search_dependency(STRMIIDS          LIBRARY strmiids)
 endif()
 
-execute_process(
-  COMMAND git describe --tags
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-  OUTPUT_VARIABLE GIT_DESCRIBE
-  ERROR_QUIET
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-)
+if (NOT GIT_DESCRIBE)
+    execute_process(
+      COMMAND git describe --tags
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+      OUTPUT_VARIABLE GIT_DESCRIBE
+      ERROR_QUIET
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
 
-if(NOT GIT_DESCRIBE)
-  set(GIT_DESCRIBE "Nightly")
+    if(NOT GIT_DESCRIBE)
+      set(GIT_DESCRIBE "Nightly")
+    endif()
 endif()
 
 add_definitions(
   -DGIT_DESCRIBE="${GIT_DESCRIBE}"
 )
 
-# GIT_VERSION
-execute_process(
-  COMMAND git rev-parse HEAD
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-  OUTPUT_VARIABLE GIT_VERSION
-  ERROR_QUIET
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-)
+if (NOT GIT_VERSION)
+    execute_process(
+      COMMAND git rev-parse HEAD
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+      OUTPUT_VARIABLE GIT_VERSION
+      ERROR_QUIET
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
 
-if(NOT GIT_VERSION)
-  set(GIT_VERSION "build without git")
+    if(NOT GIT_VERSION)
+      set(GIT_VERSION "build without git")
+    endif()
 endif()
 
 add_definitions(
   -DGIT_VERSION="${GIT_VERSION}"
 )
 
-execute_process(
-  COMMAND date +%s
-  OUTPUT_VARIABLE TIMESTAMP
-)
+if (NOT TIMESTAMP)
+    execute_process(
+      COMMAND date +%s
+      OUTPUT_VARIABLE TIMESTAMP
+    )
+endif()
 
 add_definitions(
   -DTIMESTAMP=${TIMESTAMP}

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1,0 +1,119 @@
+################################################################################
+#
+# :: Dependencies
+#
+################################################################################
+
+# This should go into subdirectories later.
+find_package(PkgConfig        REQUIRED)
+find_package(Qt5Core          REQUIRED)
+find_package(Qt5Gui           REQUIRED)
+find_package(Qt5LinguistTools REQUIRED)
+find_package(Qt5Network       REQUIRED)
+find_package(Qt5OpenGL        REQUIRED)
+find_package(Qt5Sql           REQUIRED)
+find_package(Qt5Svg           REQUIRED)
+find_package(Qt5Test          REQUIRED)
+find_package(Qt5Widgets       REQUIRED)
+find_package(Qt5Xml           REQUIRED)
+
+function(add_dependency)
+  set(ALL_LIBRARIES ${ALL_LIBRARIES} ${ARGN} PARENT_SCOPE)
+endfunction()
+
+# Everything links to these Qt libraries.
+add_dependency(
+  Qt5::Core
+  Qt5::Gui
+  Qt5::Network
+  Qt5::OpenGL
+  Qt5::Sql
+  Qt5::Svg
+  Qt5::Widgets
+  Qt5::Xml)
+
+include(CMakeParseArguments)
+include(Qt5CorePatches)
+
+function(search_dependency pkg)
+  set(options OPTIONAL)
+  set(oneValueArgs PACKAGE LIBRARY FRAMEWORK)
+  set(multiValueArgs)
+  cmake_parse_arguments(arg "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  # Try pkg-config first.
+  if(NOT ${pkg}_FOUND AND arg_PACKAGE)
+    pkg_search_module(${pkg} ${arg_PACKAGE})
+  endif()
+
+  # Then, try OSX frameworks.
+  if(NOT ${pkg}_FOUND AND arg_FRAMEWORK)
+    find_library(${pkg}_LIBRARIES NAMES ${arg_FRAMEWORK} PATHS ${CMAKE_OSX_SYSROOT}/System/Library PATH_SUFFIXES Frameworks NO_DEFAULT_PATH)
+    if(${pkg}_LIBRARIES)
+      set(${pkg}_FOUND TRUE)
+    endif()
+  endif()
+
+  # Last, search for the library itself globally.
+  if(NOT ${pkg}_FOUND AND arg_LIBRARY)
+    find_library(${pkg}_LIBRARIES NAMES ${arg_LIBRARY})
+    if(${pkg}_LIBRARIES)
+      set(${pkg}_FOUND TRUE)
+    endif()
+  endif()
+
+  if(NOT ${pkg}_FOUND)
+    if(NOT arg_OPTIONAL)
+      message(FATAL_ERROR "${pkg} package, library or framework not found")
+    endif()
+  else()
+    link_directories(${${pkg}_LIBRARY_DIRS})
+    include_directories(${${pkg}_INCLUDE_DIRS})
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${${pkg}_CFLAGS_OTHER}" PARENT_SCOPE)
+    set(ALL_LIBRARIES ${ALL_LIBRARIES} ${${pkg}_LIBRARIES} PARENT_SCOPE)
+  endif()
+
+  set(${pkg}_FOUND ${${pkg}_FOUND} PARENT_SCOPE)
+endfunction()
+
+search_dependency(APPINDICATOR        PACKAGE appindicator-0.1 OPTIONAL)
+search_dependency(GDK_PIXBUF          PACKAGE gdk-pixbuf-2.0   OPTIONAL)
+search_dependency(GLIB                PACKAGE glib-2.0         OPTIONAL)
+search_dependency(GTK                 PACKAGE gtk+-2.0         OPTIONAL)
+search_dependency(X11                 PACKAGE x11              OPTIONAL)
+
+search_dependency(LIBAVCODEC          PACKAGE libavcodec)
+search_dependency(LIBAVDEVICE         PACKAGE libavdevice)
+search_dependency(LIBAVFORMAT         PACKAGE libavformat)
+search_dependency(LIBAVUTIL           PACKAGE libavutil)
+search_dependency(LIBQRENCODE         PACKAGE libqrencode)
+search_dependency(LIBSODIUM           PACKAGE libsodium)
+search_dependency(LIBSWSCALE          PACKAGE libswscale)
+search_dependency(SQLCIPHER           PACKAGE sqlcipher)
+search_dependency(TOXCORE             PACKAGE libtoxcore)
+search_dependency(TOXAV               PACKAGE libtoxav)
+search_dependency(VPX                 PACKAGE vpx)
+
+search_dependency(OPENAL              PACKAGE openal FRAMEWORK OpenAL)
+
+# XScreenSaver support.
+search_dependency(XSS                 LIBRARY Xss OPTIONAL)
+
+if(APPLE)
+  search_dependency(AVFOUNDATION      FRAMEWORK AVFoundation)
+  search_dependency(COREMEDIA         FRAMEWORK CoreMedia   )
+  search_dependency(COREGRAPHICS      FRAMEWORK CoreGraphics)
+  search_dependency(FOUNDATION        FRAMEWORK Foundation  )
+  search_dependency(IOKIT             FRAMEWORK IOKit       )
+endif()
+
+if(WIN32)
+  search_dependency(STRMIIDS          LIBRARY strmiids)
+endif()
+
+add_definitions(
+  -DQTOX_PLATFORM_EXT=1
+  -DGIT_COMMIT="N/A"
+  -DGIT_DESCRIBE="N/A"
+  -DGIT_VERSION="N/A"
+  -DTIMESTAMP="N/A")

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -94,9 +94,20 @@ search_dependency(LIBQRENCODE         PACKAGE libqrencode)
 search_dependency(LIBSODIUM           PACKAGE libsodium)
 search_dependency(LIBSWSCALE          PACKAGE libswscale)
 search_dependency(SQLCIPHER           PACKAGE sqlcipher)
-search_dependency(TOXCORE             PACKAGE libtoxcore)
-search_dependency(TOXAV               PACKAGE libtoxav)
 search_dependency(VPX                 PACKAGE vpx)
+
+# Try to find cmake toxcore libraries
+search_dependency(TOXCORE             PACKAGE toxcore          OPTIONAL)
+search_dependency(TOXAV               PACKAGE toxav            OPTIONAL)
+search_dependency(TOXENCRYPTSAVE      PACKAGE toxencryptsave   OPTIONAL)
+
+# If not found, use automake toxcore libraries
+if (NOT TOXCORE_FOUND OR
+        NOT TOXAV_FOUND OR
+        NOT TOXENCRYPTSAVE_FOUND)
+    search_dependency(TOXCORE             PACKAGE libtoxcore)
+    search_dependency(TOXAV               PACKAGE libtoxav)
+endif()
 
 search_dependency(OPENAL              PACKAGE openal FRAMEWORK OpenAL)
 

--- a/cmake/Qt5CorePatches.cmake
+++ b/cmake/Qt5CorePatches.cmake
@@ -1,0 +1,90 @@
+#=============================================================================
+# Copyright 2005-2011 Kitware, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# * Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+#
+# * Neither the name of Kitware, Inc. nor the names of its
+#   contributors may be used to endorse or promote products derived
+#   from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#=============================================================================
+
+#########################################################################
+#
+#       Patched versions of macros defined in Qt5CoreMacros.cmake
+#
+#########################################################################
+
+# qt5_add_resources(outfiles inputfile ... )
+
+function(QT5_ADD_RESOURCES outfiles )
+
+    set(options)
+    set(oneValueArgs)
+    set(multiValueArgs OPTIONS DEPENDS)
+
+    cmake_parse_arguments(_RCC "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    set(rcc_files ${_RCC_UNPARSED_ARGUMENTS})
+    set(rcc_options ${_RCC_OPTIONS})
+
+    foreach(it ${rcc_files})
+        get_filename_component(outfilename ${it} NAME_WE)
+        get_filename_component(infile ${it} ABSOLUTE)
+        get_filename_component(rc_path ${infile} PATH)
+        set(outfile ${CMAKE_CURRENT_BINARY_DIR}/qrc_${outfilename}.cpp)
+
+        set(_RC_DEPENDS)
+        if(EXISTS "${infile}")
+            #  parse file for dependencies
+            #  all files are absolute paths or relative to the location of the qrc file
+            file(READ "${infile}" _RC_FILE_CONTENTS)
+            string(REGEX MATCHALL "<file[^<]+" _RC_FILES "${_RC_FILE_CONTENTS}")
+            foreach(_RC_FILE ${_RC_FILES})
+                string(REGEX REPLACE "^<file[^>]*>" "" _RC_FILE "${_RC_FILE}")
+                if(NOT IS_ABSOLUTE "${_RC_FILE}")
+                    set(_RC_FILE "${rc_path}/${_RC_FILE}")
+                endif()
+                set(_RC_DEPENDS ${_RC_DEPENDS} "${_RC_FILE}")
+            endforeach()
+            # Since this cmake macro is doing the dependency scanning for these files,
+            # let's make a configured file and add it as a dependency so cmake is run
+            # again when dependencies need to be recomputed.
+            qt5_make_output_file("${infile}" "" "qrc.depends" out_depends)
+            configure_file("${infile}" "${out_depends}")
+        else()
+            # The .qrc file does not exist (yet). Let's add a dependency and hope
+            # that it will be generated later
+            set(out_depends)
+        endif()
+
+        add_custom_command(OUTPUT ${outfile}
+                           COMMAND ${Qt5Core_RCC_EXECUTABLE}
+                           ARGS ${rcc_options} -name ${outfilename} -o ${outfile} ${infile}
+                           MAIN_DEPENDENCY ${infile}
+                           DEPENDS ${_RC_DEPENDS} "${out_depends}" ${_RCC_DEPENDS} VERBATIM)
+        list(APPEND ${outfiles} ${outfile})
+    endforeach()
+    set(${outfiles} ${${outfiles}} PARENT_SCOPE)
+endfunction()

--- a/qtox.pro
+++ b/qtox.pro
@@ -406,7 +406,7 @@ freebsd {
 RESOURCES += res.qrc \
              translations/translations.qrc
 
-!contains(SMILEYS, NO) {
+!contains(SMILEYS, DISABLED) {
     RESOURCES += smileys/emojione.qrc
     !contains(SMILEYS, MIN) {
         RESOURCES += smileys/smileys.qrc

--- a/qtox.pro
+++ b/qtox.pro
@@ -403,7 +403,8 @@ freebsd {
     INSTALLS = target desktop icon
 }
 
-RESOURCES += res.qrc
+RESOURCES += res.qrc \
+             translations/translations.qrc
 
 !contains(SMILEYS, NO) {
     RESOURCES += smileys/emojione.qrc

--- a/res.qrc
+++ b/res.qrc
@@ -42,40 +42,6 @@
         <file>img/taskbar/light/taskbar_offline.svg</file>
         <file>img/taskbar/light/taskbar_event.svg</file>
         <file>img/transfer.svg</file>
-        <file>translations/ar.qm</file>
-        <file>translations/be.qm</file>
-        <file>translations/bg.qm</file>
-        <file>translations/cs.qm</file>
-        <file>translations/da.qm</file>
-        <file>translations/de.qm</file>
-        <file>translations/el.qm</file>
-        <file>translations/eo.qm</file>
-        <file>translations/es.qm</file>
-        <file>translations/et.qm</file>
-        <file>translations/fi.qm</file>
-        <file>translations/fr.qm</file>
-        <file>translations/he.qm</file>
-        <file>translations/hr.qm</file>
-        <file>translations/hu.qm</file>
-        <file>translations/it.qm</file>
-        <file>translations/ja.qm</file>
-        <file>translations/jbo.qm</file>
-        <file>translations/ko.qm</file>
-        <file>translations/lt.qm</file>
-        <file>translations/nl.qm</file>
-        <file>translations/no_nb.qm</file>
-        <file>translations/pl.qm</file>
-        <file>translations/pr.qm</file>
-        <file>translations/pt.qm</file>
-        <file>translations/ru.qm</file>
-        <file>translations/sk.qm</file>
-        <file>translations/sl.qm</file>
-        <file>translations/sv.qm</file>
-        <file>translations/sw.qm</file>
-        <file>translations/tr.qm</file>
-        <file>translations/ug.qm</file>
-        <file>translations/uk.qm</file>
-        <file>translations/zh.qm</file>
         <file>ui/fileTransferWidget/fileDone.svg</file>
         <file>ui/callButton/callButton.css</file>
         <file>ui/callButton/callButton.svg</file>

--- a/res.qrc
+++ b/res.qrc
@@ -61,9 +61,9 @@
         <file>translations/ja.qm</file>
         <file>translations/jbo.qm</file>
         <file>translations/ko.qm</file>
+        <file>translations/lt.qm</file>
         <file>translations/nl.qm</file>
         <file>translations/no_nb.qm</file>
-        <file>translations/lt.qm</file>
         <file>translations/pl.qm</file>
         <file>translations/pr.qm</file>
         <file>translations/pt.qm</file>

--- a/translations/translations.qrc
+++ b/translations/translations.qrc
@@ -1,0 +1,38 @@
+<RCC>
+    <qresource prefix="/translations">
+        <file>ar.qm</file>
+        <file>be.qm</file>
+        <file>bg.qm</file>
+        <file>cs.qm</file>
+        <file>da.qm</file>
+        <file>de.qm</file>
+        <file>el.qm</file>
+        <file>eo.qm</file>
+        <file>es.qm</file>
+        <file>et.qm</file>
+        <file>fi.qm</file>
+        <file>fr.qm</file>
+        <file>he.qm</file>
+        <file>hr.qm</file>
+        <file>hu.qm</file>
+        <file>it.qm</file>
+        <file>ja.qm</file>
+        <file>jbo.qm</file>
+        <file>ko.qm</file>
+        <file>lt.qm</file>
+        <file>nl.qm</file>
+        <file>no_nb.qm</file>
+        <file>pl.qm</file>
+        <file>pr.qm</file>
+        <file>pt.qm</file>
+        <file>ru.qm</file>
+        <file>sk.qm</file>
+        <file>sl.qm</file>
+        <file>sv.qm</file>
+        <file>sw.qm</file>
+        <file>tr.qm</file>
+        <file>ug.qm</file>
+        <file>uk.qm</file>
+        <file>zh.qm</file>
+    </qresource>
+</RCC>


### PR DESCRIPTION
Reasons for migration:
1. CMake more flexible, then qmake
1.1. It's possible to store subprojects with any directory structure instead of `{subproject}/{subproject}.pro`
2. Make possible to fix #3899

Also, some travis scripts improvement by @iphydf
I have some trouble on old toxcore: qtox crash on `tox_new` function. But work fine on toktok toxcore

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3913)
<!-- Reviewable:end -->
