### PR TITLE
feat(UI): make link to filled issue template on About page visible

### DIFF
--- a/src/widget/form/settings/aboutform.cpp
+++ b/src/widget/form/settings/aboutform.cpp
@@ -112,26 +112,37 @@ void AboutForm::replaceVersions()
     issueBody.replace("#", "%23").replace(":", "%3A");
 
     bodyUI->knownIssues->setText(
-                tr("A list of all known issues may be found at our %1 at Github."
-                   " If you discover a bug or security vulnerability within"
-                   " qTox, please %3 according to the guidelines in our %2"
-                   " wiki article.")
-                .arg(createLink("https://github.com/qTox/qTox/issues",
-                     tr("bug-tracker")))
-                .arg(createLink("https://github.com/qTox/qTox/wiki/Writing-Useful-Bug-Reports",
-                     tr("Writing Useful Bug Reports")))
-                .arg(createLink("https://github.com/qTox/qTox/issues/new?body="
-                                + QUrl(issueBody).toEncoded(),
-                     tr("report it")))
-                );
+        tr("A list of all known issues may be found at our %1 at Github."
+           " If you discover a bug or security vulnerability within"
+           " qTox, please report it according to the guidelines in our"
+           " %2 wiki article.",
+
+           "`%1` is replaced by translation of `bug tracker`"
+           "\n`%2` is replaced by translation of `Writing Useful Bug Reports`")
+        .arg(createLink("https://github.com/qTox/qTox/issues",
+             tr("bug-tracker",
+                "Replaces `%1` in the `A list of all known…`")))
+        .arg(createLink("https://github.com/qTox/qTox/wiki/Writing-Useful-Bug-Reports",
+             tr("Writing Useful Bug Reports",
+                "Replaces `%2` in the `A list of all known…`")))
+    );
+
+    bodyUI->clickToReport->setText(
+        createLink("https://github.com/qTox/qTox/issues/new?body="
+                        + QUrl(issueBody).toEncoded(),
+                   QString("<b>%1</b>")
+                      .arg(tr("Click here to report a bug.")))
+    );
 
 
     QString authorInfo = QString("<p>%1</p><p>%2</p>")
             .arg(tr("Original author: %1")
                  .arg(createLink("https://github.com/tux3", "tux3")))
-            .arg(tr("See a full list of %1 at Github")
+            .arg(tr("See a full list of %1 at Github",
+                    "`%1` is replaced with translation of word `contributors`")
                  .arg(createLink("https://github.com/qTox/qTox/graphs/contributors",
-                                 tr("contributors"))));
+                                 tr("contributors",
+                                    "Replaces `%1` in `See a full list of…`"))));
 
     bodyUI->authorInfo->setText(authorInfo);
 }

--- a/src/widget/form/settings/aboutsettings.ui
+++ b/src/widget/form/settings/aboutsettings.ui
@@ -30,8 +30,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>496</width>
-        <height>554</height>
+        <width>494</width>
+        <height>551</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2" stretch="0,1,0,0">
@@ -305,7 +305,7 @@ p, li { white-space: pre-wrap; }
          <property name="title">
           <string>Known Issues</string>
          </property>
-         <layout class="QHBoxLayout" name="horizontalLayout">
+         <layout class="QVBoxLayout" name="verticalLayout_8">
           <item>
            <widget class="QLabel" name="knownIssues">
             <property name="sizePolicy">
@@ -330,6 +330,22 @@ p, li { white-space: pre-wrap; }
             </property>
             <property name="textInteractionFlags">
              <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="clickToReport">
+            <property name="text">
+             <string notr="true">{CLICK TO REPORT TEXT}</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+            <property name="openExternalLinks">
+             <bool>true</bool>
+            </property>
+            <property name="textInteractionFlags">
+             <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse</set>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
Should help with no one realizing that qTox even has the functionality.

currently:
![spectacle vy3401](https://cloud.githubusercontent.com/assets/3148759/20894416/3cd19538-bb0d-11e6-9b40-14a8e1cae0e2.png)


after change:
![spectacle nt3401](https://cloud.githubusercontent.com/assets/3148759/20894392/213e93b6-bb0d-11e6-9c35-88a65c63b6e1.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3936)
<!-- Reviewable:end -->
