### PR TITLE
fix(UI): prevent status message from stretching profile corner

### DIFF
--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -880,6 +880,12 @@ QSplitter:handle{
                    <verstretch>0</verstretch>
                   </sizepolicy>
                  </property>
+                 <property name="maximumSize">
+                  <size>
+                   <width>16777215</width>
+                   <height>15</height>
+                  </size>
+                 </property>
                  <property name="palette">
                   <palette>
                    <active>


### PR DESCRIPTION
Profile corner could stretch vertically if status message contained
newlines.

Nothing else beside setting a maximum vertical size worked.


currently:
![spectacle pe2998](https://cloud.githubusercontent.com/assets/3148759/20900277/89413ee2-bb25-11e6-8d17-eb80fbfac6dd.png)


with PR:
![spectacle rw2355](https://cloud.githubusercontent.com/assets/3148759/20900294/8ef718ac-bb25-11e6-9cc9-95229d3e994c.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3937)
<!-- Reviewable:end -->
