### PR TITLE
fix(UI): fix own status message not being properly displayed in tooltip

### DIFF
--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -976,7 +976,11 @@ void Widget::setStatusMessage(const QString& statusMessage)
     else
     {
         ui->statusLabel->setText(statusMessage);
-        ui->statusLabel->setToolTip(Qt::convertFromPlainText(statusMessage, Qt::WhiteSpaceNormal)); // for overlength messsages
+        // escape HTML from tooltips and preserve newlines
+        // TODO: move newspace preservance to a generic function
+        ui->statusLabel->setToolTip("<p style='white-space:pre'>" +
+                                    statusMessage.toHtmlEscaped() +
+                                    "</p>");
     }
 }
 


### PR DESCRIPTION
Based on #3937; ignore the same commit(s).

This causes a slight regression where own status can become quite huge
when user sets e.g. 120 newlines between first and last character of the
status message.

Given that this fixes a problem with incorrect (broken) formatting of
display of own status messages, the slight regression is insignificant.

Current broken tooltip formatting:
![spectacle nb8647](https://cloud.githubusercontent.com/assets/3148759/20901241/8a21873c-bb29-11e6-906e-f0f673f65d91.png)

Fixed tooltip formatting, just like in #935:
![spectacle ed8647](https://cloud.githubusercontent.com/assets/3148759/20901264/9f644d96-bb29-11e6-840f-16225b2a2215.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3938)
<!-- Reviewable:end -->
