### PR TITLE
chore(build): make sure that OSX building script cleans up files

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -447,6 +447,9 @@ To use this script you must launch terminal which can be found:
 
 If you wish to lean more you can run `./qTox-Mac-Deployer-ULTIMATE.sh -h`
 
+Note that the script will revert any non-committed changes to qTox repository
+during the `update` phase.
+
 #### First Run / Install
 If you are running the script for the first time you will want to make sure your
 system is ready. To do this simply run `./qTox-Mac-Deployer-ULTIMATE.sh -i` to

--- a/osx/qTox-Mac-Deployer-ULTIMATE.sh
+++ b/osx/qTox-Mac-Deployer-ULTIMATE.sh
@@ -185,6 +185,9 @@ update() {
     cd $TOXCORE_DIR
     fcho "Now in ${PWD}"
     fcho "Pulling ..."
+    # make sure that pull can be applied, i.e. clean up files from any
+    # changes that could have been applied to them
+    git checkout -f
     git pull
     read -r -p "Did Toxcore update from git? [y/N] " response
     if [[ $response =~ ^([yY][eE][sS]|[yY])$ ]]
@@ -198,6 +201,9 @@ update() {
     cd $QTOX_DIR
     fcho "Now in ${PWD}"
     fcho "Pulling ..."
+    # make sure that pull can be applied, i.e. clean up files from any
+    # changes that could have been applied to them
+    git checkout -f
     git pull
     read -r -p "Did qTox update from git? [y/N] " response
     if [[ $response =~ ^([yY][eE][sS]|[yY])$ ]]


### PR DESCRIPTION
It should clean up any files tracked by the git from changes before
trying to get newer versions, otherwise script could fail to update.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3949)
<!-- Reviewable:end -->
