### PR TITLE
fix: remove unnecessary variable when checking whether save is a TES

### DIFF
--- a/src/persistence/profile.cpp
+++ b/src/persistence/profile.cpp
@@ -46,10 +46,6 @@
  *
  * @var bool Profile::isRemoved
  * @brief True if the profile has been removed by remove().
- *
- * @var static constexpr int Profile::encryptHeaderSize = 8
- * @brief How much data we need to read to check if the file is encrypted.
- * @note Must be >= TOX_ENC_SAVE_MAGIC_LENGTH (8), which isn't publicly defined.
  */
 
 QVector<QString> Profile::profiles;
@@ -631,7 +627,7 @@ bool Profile::isEncrypted() const
  */
 bool Profile::isEncrypted(QString name)
 {
-    uint8_t data[encryptHeaderSize] = {0};
+    uint8_t data[TOX_PASS_ENCRYPTION_EXTRA_LENGTH] = {0};
     QString path = Settings::getInstance().getSettingsDirPath() + name + ".tox";
     QFile saveFile(path);
     if (!saveFile.open(QIODevice::ReadOnly))
@@ -640,7 +636,7 @@ bool Profile::isEncrypted(QString name)
         return false;
     }
 
-    saveFile.read((char*)data, encryptHeaderSize);
+    saveFile.read((char*)data, TOX_PASS_ENCRYPTION_EXTRA_LENGTH);
     saveFile.close();
 
     return tox_is_data_encrypted(data);

--- a/src/persistence/profile.h
+++ b/src/persistence/profile.h
@@ -98,7 +98,6 @@ private:
     bool newProfile;
     bool isRemoved;
     static QVector<QString> profiles;
-    static constexpr int encryptHeaderSize = 8;
 };
 
 #endif // PROFILE_H


### PR DESCRIPTION
There is a reason why magic length is not exposed via TES header –
knowing it is not needed. Client should check whether file is a TES with
a define that is provided in the public API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3956)
<!-- Reviewable:end -->
