### PR TITLE
fix(UI): copy friend's non-truncated status message instead of truncated

### DIFF
--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -876,7 +876,8 @@ void ChatForm::insertChatMessage(ChatMessage::Ptr msg)
 
 void ChatForm::onCopyStatusMessage()
 {
-    QString text = statusMessageLabel->text();
+    // make sure to copy not truncated text directly from the friend
+    QString text = f->getStatusMessage();
     QClipboard* clipboard = QApplication::clipboard();
 
     if (clipboard)


### PR DESCRIPTION
qTox still internally replaces newlines with spaces which breaks
formatting, but now at least whole status message gets copied.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3959)
<!-- Reviewable:end -->
