### PR TITLE
chore: Update qTox to the latest toxencryptsave API.

### DIFF
--- a/src/core/core.h
+++ b/src/core/core.h
@@ -81,10 +81,10 @@ public:
     ToxId getSelfId() const;
     QPair<QByteArray, QByteArray> getKeypair() const;
 
-    static std::unique_ptr<TOX_PASS_KEY> createPasskey(const QString &password, uint8_t* salt = nullptr);
-    static QByteArray encryptData(const QByteArray& data, const TOX_PASS_KEY& encryptionKey);
+    static std::shared_ptr<Tox_Pass_Key> createPasskey(const QString &password, uint8_t* salt = nullptr);
+    static QByteArray encryptData(const QByteArray& data, const Tox_Pass_Key& encryptionKey);
     static QByteArray encryptData(const QByteArray& data);
-    static QByteArray decryptData(const QByteArray& data, const TOX_PASS_KEY &encryptionKey);
+    static QByteArray decryptData(const QByteArray& data, const Tox_Pass_Key &encryptionKey);
     static QByteArray decryptData(const QByteArray& data);
 
     bool isReady() const;

--- a/src/persistence/db/encrypteddb.h
+++ b/src/persistence/db/encrypteddb.h
@@ -26,6 +26,8 @@
 #include <QList>
 #include <QFile>
 
+#include <memory>
+
 class EncryptedDb : public PlainDb
 {
 public:
@@ -33,7 +35,7 @@ public:
     virtual ~EncryptedDb();
 
     virtual QSqlQuery exec(const QString &query);
-    static bool check(const TOX_PASS_KEY &passkey, const QString &fname);
+    static bool check(std::shared_ptr<Tox_Pass_Key> passkey, const QString &fname);
 
 private:
     bool pullFileContent(const QString& fname, QByteArray &buf);
@@ -46,7 +48,7 @@ private:
     static qint64 plainChunkSize;
     static qint64 encryptedChunkSize;
 
-    static TOX_PASS_KEY decryptionKey;
+    static std::shared_ptr<Tox_Pass_Key> decryptionKey;
 
     qint64 chunkPosition;
     QByteArray buffer;

--- a/src/persistence/historykeeper.cpp
+++ b/src/persistence/historykeeper.cpp
@@ -86,7 +86,7 @@ HistoryKeeper *HistoryKeeper::getInstance(const Profile& profile)
     return historyInstance;
 }
 
-bool HistoryKeeper::checkPassword(const TOX_PASS_KEY &passkey, int encrypted)
+bool HistoryKeeper::checkPassword(std::shared_ptr<Tox_Pass_Key> passkey, int encrypted)
 {
     if (!Settings::getInstance().getEnableLogging() && (encrypted == -1))
         return true;

--- a/src/persistence/historykeeper.h
+++ b/src/persistence/historykeeper.h
@@ -27,6 +27,8 @@
 #include <QMutex>
 #include <tox/toxencryptsave.h>
 
+#include <memory>
+
 class Profile;
 class GenericDdInterface;
 
@@ -59,7 +61,7 @@ public:
     static void resetInstance();
 
     static QString getHistoryPath(QString currentProfile = QString(), int encrypted = -1); // -1 defaults to checking settings, 0 or 1 to specify
-    static bool checkPassword(const TOX_PASS_KEY& passkey, int encrypted = -1);
+    static bool checkPassword(std::shared_ptr<Tox_Pass_Key> passkey, int encrypted = -1);
     static bool isFileExist(bool encrypted);
     void removeHistory();
     static QList<HistMessage> exportMessagesDeleteFile();

--- a/src/persistence/profile.h
+++ b/src/persistence/profile.h
@@ -52,7 +52,7 @@ public:
     bool checkPassword();
     QString getPassword() const;
     void setPassword(const QString& newPassword);
-    const TOX_PASS_KEY& getPasskey() const;
+    const Tox_Pass_Key& getPasskey() const;
 
     QByteArray loadToxSave();
     void saveToxSave();
@@ -92,7 +92,7 @@ private:
     Core* core;
     QThread* coreThread;
     QString name, password;
-    TOX_PASS_KEY passkey;
+    std::shared_ptr<Tox_Pass_Key> passkey;
     std::shared_ptr<RawDatabase> database;
     std::unique_ptr<History> history;
     bool newProfile;

--- a/src/persistence/settingsserializer.cpp
+++ b/src/persistence/settingsserializer.cpp
@@ -370,7 +370,7 @@ void SettingsSerializer::readSerialized()
         Core* core = Nexus::getCore();
 
         uint8_t salt[TOX_PASS_SALT_LENGTH];
-        tox_get_salt(reinterpret_cast<uint8_t *>(data.data()), salt);
+        tox_get_salt(reinterpret_cast<uint8_t *>(data.data()), salt, nullptr);
         auto passkey = core->createPasskey(password, salt);
 
         data = core->decryptData(data, *passkey);


### PR DESCRIPTION
Since ownership is somewhat unclear, we now use shared_ptr to pass
these around instead of unique_ptr.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3965)
<!-- Reviewable:end -->
