### PR TITLE
feat(UI): make font in message input field use font settings

### DIFF
--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -83,6 +83,8 @@ GenericChatForm::GenericChatForm(QWidget *parent)
             chatWidget, &ChatLog::forceRelayout);
 
     msgEdit = new ChatTextEdit();
+    // TODO: make it work without restart
+    msgEdit->setCurrentFont(s.getChatMessageFont());
 
     sendButton = new QPushButton();
     emoteButton = new QPushButton();


### PR DESCRIPTION
Right now it requires qTox restart to take effect in all chats.

Should help with 4k high-dpi displays.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3973)
<!-- Reviewable:end -->
