### PR TITLE
chore(travis): properly indent lists of commands in after_success step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,13 +51,13 @@ deploy:
 
 
 after_success:
-  ->
-  test $TRAVIS_PULL_REQUEST == "false"
-  && test $TRAVIS_BRANCH == "master"
-  && test $JOB == "build-docs"
-  && bash ./.travis/deploy-docs.sh
-  ->
-  test $TRAVIS_PULL_REQUEST == "false"
-  && test $TRAVIS_BRANCH == "master"
-  && test $JOB == "build-gitstats"
-  && bash ./.travis/deploy-gitstats.sh
+  - >
+    test $TRAVIS_PULL_REQUEST == "false"
+    && test $TRAVIS_BRANCH == "master"
+    && test $JOB == "build-docs"
+    && bash ./.travis/deploy-docs.sh
+  - >
+    test $TRAVIS_PULL_REQUEST == "false"
+    && test $TRAVIS_BRANCH == "master"
+    && test $JOB == "build-gitstats"
+    && bash ./.travis/deploy-gitstats.sh


### PR DESCRIPTION
Otherwise they are treated as a single position.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3974)
<!-- Reviewable:end -->
