### PR TITLE
feat(UI): remove unnecessary spacings on the Profile page

### DIFF
--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -31,6 +31,7 @@
 /**
  * Spacing in px inserted when the author of the last message changes
  * @note Why the hell is this a thing? surely the different font is enough?
+ *        - Even a different font is not enough – TODO #1307 ~~zetok
  */
 #define AUTHOR_CHANGE_SPACING 5
 

--- a/src/widget/form/profileform.cpp
+++ b/src/widget/form/profileform.cpp
@@ -55,22 +55,6 @@ ProfileForm::ProfileForm(QWidget* parent) :
     bodyUI->setupUi(this);
     core = Core::getInstance();
 
-    head = new QWidget(this);
-    QHBoxLayout* headLayout = new QHBoxLayout();
-    head->setLayout(headLayout);
-
-    QLabel* imgLabel = new QLabel();
-    headLayout->addWidget(imgLabel);
-
-    nameLabel = new QLabel();
-    QFont bold;
-    bold.setBold(true);
-    nameLabel->setFont(bold);
-    headLayout->addWidget(nameLabel);
-    headLayout->addStretch(1);
-
-    imgLabel->setPixmap(QPixmap(":/img/settings/identity.png").scaledToHeight(40, Qt::SmoothTransformation));
-
     // tox
     toxId = new ClickableTE();
     toxId->setReadOnly(true);
@@ -86,9 +70,13 @@ ProfileForm::ProfileForm(QWidget* parent) :
     bodyUI->toxmeServersList->addItem("toxme.io");
     QString toxmeInfo = Settings::getInstance().getToxmeInfo();
     if (toxmeInfo.isEmpty()) // User not registered
+    {
         showRegisterToxme();
+    }
     else
+    {
         showExistingToxme();
+    }
 
     bodyUI->qrLabel->setWordWrap(true);
 
@@ -155,12 +143,11 @@ ProfileForm::~ProfileForm()
     Translator::unregister(this);
     delete qr;
     delete bodyUI;
-    head->deleteLater();
 }
 
 bool ProfileForm::isShown() const
 {
-    if (head->isVisible())
+    if (profilePicture->isVisible())
     {
         window()->windowHandle()->alert(0);
         return true;
@@ -171,9 +158,7 @@ bool ProfileForm::isShown() const
 
 void ProfileForm::show(ContentLayout* contentLayout)
 {
-    contentLayout->mainHead->layout()->addWidget(head);
     contentLayout->mainContent->layout()->addWidget(this);
-    head->show();
     QWidget::show();
     prFileLabelUpdate();
     bool portable = Settings::getInstance().getMakeToxPortable();
@@ -473,7 +458,6 @@ void ProfileForm::onChangePassClicked()
 void ProfileForm::retranslateUi()
 {
     bodyUI->retranslateUi(this);
-    nameLabel->setText(tr("User Profile"));
     setPasswordButtonsText();
     // We have to add the toxId tooltip here and not in the .ui or Qt won't know how to translate it dynamically
     toxId->setToolTip(tr("This bunch of characters tells other Tox clients how to contact you.\nShare it with your friends to communicate."));

--- a/src/widget/form/profileform.h
+++ b/src/widget/form/profileform.h
@@ -96,8 +96,6 @@ private:
     void refreshProfiles();
     Ui::IdentitySettings* bodyUI;
     MaskablePixmapWidget* profilePicture;
-    QLabel* nameLabel;
-    QWidget* head;
     Core* core;
     QTimer timer;
     bool hasCheck = false;

--- a/src/widget/form/profileform.ui
+++ b/src/widget/form/profileform.ui
@@ -14,17 +14,20 @@
    <string notr="true">Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>0</number>
+   </property>
    <property name="leftMargin">
-    <number>9</number>
+    <number>0</number>
    </property>
    <property name="topMargin">
-    <number>9</number>
+    <number>0</number>
    </property>
    <property name="rightMargin">
-    <number>9</number>
+    <number>0</number>
    </property>
    <property name="bottomMargin">
-    <number>9</number>
+    <number>0</number>
    </property>
    <item>
     <widget class="QScrollArea" name="scrollArea">
@@ -39,14 +42,99 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>612</width>
-        <height>800</height>
+        <width>604</width>
+        <height>853</height>
        </rect>
       </property>
-      <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,0,0,1">
+      <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,0,0,0,0,1">
        <property name="spacing">
         <number>9</number>
        </property>
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>4</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <layout class="QHBoxLayout" name="header">
+         <property name="spacing">
+          <number>6</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="imgLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>60</width>
+             <height>40</height>
+            </size>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="pixmap">
+            <pixmap resource="../../../res.qrc">:/img/settings/identity.png</pixmap>
+           </property>
+           <property name="scaledContents">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="nameLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="font">
+            <font>
+             <weight>75</weight>
+             <bold>true</bold>
+            </font>
+           </property>
+           <property name="text">
+            <string>My profile</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="Line" name="line">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>5</height>
+          </size>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
        <item>
         <widget class="QGroupBox" name="publicGroup">
          <property name="title">
@@ -544,6 +632,8 @@ Profile does not contain your history.</string>
   <tabstop>deletePassButton</tabstop>
   <tabstop>changePassButton</tabstop>
  </tabstops>
- <resources/>
+ <resources>
+  <include location="../../../res.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1409,15 +1409,15 @@ QString Widget::fromDialogType(DialogType type)
     switch (type)
     {
         case AddDialog:
-            return tr("Add friend");
+            return tr("Add friend", "title of the window");
         case GroupDialog:
-            return tr("Group invites");
+            return tr("Group invites", "title of the window");
         case TransferDialog:
-            return tr("File transfers");
+            return tr("File transfers", "title of the window");
         case SettingDialog:
-            return tr("Settings");
+            return tr("Settings", "title of the window");
         case ProfileDialog:
-            return tr("Profile");
+            return tr("My profile", "title of the window");
         default:
             return QString();
     }


### PR DESCRIPTION
With corrected window title of own profile it's quite clear what the
page is about. Aside from that, removed elements didn't help at all to
explain what the page is about.

![spectacle ad3738](https://cloud.githubusercontent.com/assets/3148759/21290079/68c454b8-c4a5-11e6-881c-4778c1edf8cb.png)
↓
![spectacle aq3171](https://cloud.githubusercontent.com/assets/3148759/21290080/6db04ca2-c4a5-11e6-8977-d03ff907033c.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3977)
<!-- Reviewable:end -->
