### PR TITLE
fix(UI): make link in `About` setting page point to all contributors

### DIFF
--- a/src/widget/form/settings/aboutform.cpp
+++ b/src/widget/form/settings/aboutform.cpp
@@ -140,7 +140,7 @@ void AboutForm::replaceVersions()
                  .arg(createLink("https://github.com/tux3", "tux3")))
             .arg(tr("See a full list of %1 at Github",
                     "`%1` is replaced with translation of word `contributors`")
-                 .arg(createLink("https://github.com/qTox/qTox/graphs/contributors",
+                 .arg(createLink("https://qtox.github.io/gitstats/authors.html",
                                  tr("contributors",
                                     "Replaces `%1` in `See a full list of…`"))));
 


### PR DESCRIPTION
Github shows only top 100 contributors, so point to an automatically
generated from qTox source page with all contributors shown.

Fix #3898.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3979)
<!-- Reviewable:end -->
