### PR TITLE
docs(profile): Removed @example tag from createProfile method

### DIFF
--- a/src/persistence/profile.cpp
+++ b/src/persistence/profile.cpp
@@ -167,7 +167,7 @@ Profile* Profile::loadProfile(QString name, const QString& password)
  * @param password If password is not empty, the profile will be encrypted.
  * @return Returns a nullptr on error. Profile pointer otherwise.
  *
- * @example If the profile is already in use return nullptr.
+ * @note If the profile is already in use return nullptr.
  */
 Profile* Profile::createProfile(QString name, QString password)
 {

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -2375,7 +2375,8 @@ void Settings::setAutoLogin(bool state)
 /**
  * @brief Write a default personal .ini settings file for a profile.
  * @param basename Filename without extension to save settings.
- * @example If basename is "profile", settings will be saved in profile.ini
+ *
+ * @note If basename is "profile", settings will be saved in profile.ini
  */
 void Settings::createPersonal(QString basename)
 {


### PR DESCRIPTION
[18:08] \<zetok\> >/home/travis/build/qTox/qTox/src/persistence/profile.cpp:170: warning: Example If was already documented. Ignoring documentation found here.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3981)
<!-- Reviewable:end -->
