### PR TITLE
fix: add missing Q_OBJECT macro to the PasswordEdit class

### DIFF
--- a/src/widget/passwordedit.h
+++ b/src/widget/passwordedit.h
@@ -6,6 +6,7 @@
 
 class PasswordEdit : public QLineEdit
 {
+    Q_OBJECT
 public:
     explicit PasswordEdit(QWidget *parent);
     ~PasswordEdit();


### PR DESCRIPTION
Silences a warning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3982)
<!-- Reviewable:end -->
