### PR TITLE
docs(README): remove link to the experimental osx build

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ while running on all major platforms.
 Windows | Linux | OS X | FreeBSD
 --------|-------|------|--------
 **[64 bit installer]**, [signature][sig-64] | **[CentOS, Debian, Fedora, openSUSE, Ubuntu]** | **[Building instructions]** | **[Port]**
-[32 bit installer], [signature][sig-32] | **[Arch]**, **[Gentoo]** | [Experimental download] |
+[32 bit installer], [signature][sig-32] | **[Arch]**, **[Gentoo]** | |
 [64 bit][64portable], [32 bit][32portable] portable | [Other] | |
 
 _**Bold** options are recommended._
@@ -112,7 +112,6 @@ There are [IRC logs] available.
 [CentOS, Debian, Fedora, openSUSE, Ubuntu]: https://software.opensuse.org/download.html?project=home%3Aantonbatenev%3Atox&package=qtox
 [Contributing]: /CONTRIBUTING.md#how-to-start-contributing
 [easy issues]: https://github.com/qTox/qTox/labels/E-easy
-[Experimental download]: https://github.com/qTox/qTox/releases/latest
 [Gentoo]: /INSTALL.md#gentoo
 [Install/Build]: /INSTALL.md
 [IRC logs]: https://github.com/qTox/qtox-irc-logs


### PR DESCRIPTION
Since build doesn't work anyway there's no reason to point people to it.

Once we get back working osx builds this could be reverted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3989)
<!-- Reviewable:end -->
