### PR TITLE
chore(build): use hardening linker flags only on Linux/*BSD

### DIFF
--- a/qtox.pro
+++ b/qtox.pro
@@ -53,8 +53,8 @@ QMAKE_CXXFLAGS += -fstack-protector-all \
                   -Wstrict-overflow \
                   -Wstrict-aliasing \
                   --param ssp-buffer-size=1
-# osx cannot into security (build on it fails with those enabled)
-!macx {
+# osx & windows cannot into security (build on it fails with those enabled)
+unix:!macx {
     QMAKE_LFLAGS += -Wl,-z,now -Wl,-z,relro
 }
 


### PR DESCRIPTION
windows & osx fail to compile with them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3994)
<!-- Reviewable:end -->
