### PR TITLE
refactor(core): simplify code for tox interval during file transfer

### DIFF
--- a/src/core/corefile.cpp
+++ b/src/core/corefile.cpp
@@ -49,21 +49,23 @@ using namespace std;
  */
 unsigned CoreFile::corefileIterationInterval()
 {
-    /// Sleep at most 1000ms if we have no FT, 10 for user FTs, 50 for the rest (avatars, ...)
-    constexpr unsigned fastFileInterval = 10, slowFileInterval = 50, idleInterval = 1000;
-    unsigned interval = idleInterval;
+    /*
+       Sleep at most 1000ms if we have no FT, 10 for user FTs
+       There is no real difference between 10ms sleep and 50ms sleep when it
+       comes to CPU usage – just keep the CPU usage low when there are no file
+       transfers, and speed things up when there is an ongoing file transfer.
+    */
+    constexpr unsigned fileInterval =   10,
+                       idleInterval = 1000;
 
     for (ToxFile& file : fileMap)
     {
         if (file.status == ToxFile::TRANSMITTING)
         {
-            if (file.fileKind == TOX_FILE_KIND_DATA)
-                return fastFileInterval;
-            else
-                interval = slowFileInterval;
+            return fileInterval;
         }
     }
-    return interval;
+    return idleInterval;
 }
 
 void CoreFile::sendAvatarFile(Core* core, uint32_t friendId, const QByteArray& data)

--- a/src/core/corefile.h
+++ b/src/core/corefile.h
@@ -44,14 +44,33 @@ private:
 
     // Internal file sending APIs, used by Core. Public API in core.h
 private:
-    static void sendFile(Core *core, uint32_t friendId, QString filename, QString filePath, long long filesize);
-    static void sendAvatarFile(Core* core, uint32_t friendId, const QByteArray& data);
-    static void pauseResumeFileSend(Core* core, uint32_t friendId, uint32_t fileId);
-    static void pauseResumeFileRecv(Core* core, uint32_t friendId, uint32_t fileId);
-    static void cancelFileSend(Core* core, uint32_t friendId, uint32_t fileId);
-    static void cancelFileRecv(Core* core, uint32_t friendId, uint32_t fileId);
-    static void rejectFileRecvRequest(Core* core, uint32_t friendId, uint32_t fileId);
-    static void acceptFileRecvRequest(Core* core, uint32_t friendId, uint32_t fileId, QString path);
+    static void sendFile(Core *core,
+                         uint32_t friendId,
+                         QString filename,
+                         QString filePath,
+                         long long filesize);
+    static void sendAvatarFile(Core* core,
+                               uint32_t friendId,
+                               const QByteArray& data);
+    static void pauseResumeFileSend(Core* core,
+                                    uint32_t friendId,
+                                    uint32_t fileId);
+    static void pauseResumeFileRecv(Core* core,
+                                    uint32_t friendId,
+                                    uint32_t fileId);
+    static void cancelFileSend(Core* core,
+                               uint32_t friendId,
+                               uint32_t fileId);
+    static void cancelFileRecv(Core* core,
+                               uint32_t friendId,
+                               uint32_t fileId);
+    static void rejectFileRecvRequest(Core* core,
+                                      uint32_t friendId,
+                                      uint32_t fileId);
+    static void acceptFileRecvRequest(Core* core,
+                                      uint32_t friendId,
+                                      uint32_t fileId,
+                                      QString path);
     static ToxFile *findFile(uint32_t friendId, uint32_t fileId);
     static void addFile(uint32_t friendId, uint32_t fileId, const ToxFile& file);
     static void removeFile(uint32_t friendId, uint32_t fileId);
@@ -62,20 +81,28 @@ private:
     }
 
 private:
-    static void onFileReceiveCallback(Tox*, uint32_t friendId, uint32_t fileId,
-                                      uint32_t kind, uint64_t filesize,
-                                      const uint8_t* fname, size_t fnameLen,
+    static void onFileReceiveCallback(Tox*,
+                                      uint32_t friendId,
+                                      uint32_t fileId,
+                                      uint32_t kind,
+                                      uint64_t filesize,
+                                      const uint8_t* fname,
+                                      size_t fnameLen,
                                       void *vCore);
-    static void onFileControlCallback(Tox *tox, uint32_t friendId,
-                                      uint32_t fileId, TOX_FILE_CONTROL control,
-                                      void *core);
+    static void onFileControlCallback(Tox *tox, uint32_t friendId, uint32_t fileId,
+                                      TOX_FILE_CONTROL control, void *core);
     static void onFileDataCallback(Tox *tox, uint32_t friendId, uint32_t fileId,
                                    uint64_t pos, size_t length, void *core);
-    static void onFileRecvChunkCallback(Tox *tox, uint32_t friendId,
-                                        uint32_t fileId, uint64_t position,
-                                        const uint8_t* data, size_t length,
+    static void onFileRecvChunkCallback(Tox *tox,
+                                        uint32_t friendId,
+                                        uint32_t fileId,
+                                        uint64_t position,
+                                        const uint8_t* data,
+                                        size_t length,
                                         void *vCore);
-    static void onConnectionStatusChanged(Core* core, uint32_t friendId, bool online);
+    static void onConnectionStatusChanged(Core* core,
+                                          uint32_t friendId,
+                                          bool online);
 
 private:
     static QMutex fileSendMutex;


### PR DESCRIPTION
Also some style changes.

![spectacle se3004](https://cloud.githubusercontent.com/assets/3148759/21344950/257e568e-c696-11e6-8166-02c27a44bf0d.png)
↑ highlighted instance was made to run with tox interval hardcoded to `10`ms, while other instances were running on ~master code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/3996)
<!-- Reviewable:end -->
