### PR TITLE
fix(addfriend): do not load own Tox ID from clipboard

### DIFF
--- a/src/widget/form/addfriendform.cpp
+++ b/src/widget/form/addfriendform.cpp
@@ -225,7 +225,7 @@ void AddFriendForm::setIdFromClipboard()
     const Core* core = Core::getInstance();
     if (core->isReady() && !id.isEmpty()
             && ToxId::isToxId(id)
-            && ToxId(id) == core->getSelfId())
+            && ToxId(id) != core->getSelfId())
     {
         toxId.setText(id);
     }


### PR DESCRIPTION
fix #4024

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4025)
<!-- Reviewable:end -->
