### PR TITLE
fix: fix warning about missing (removed) `cdata.h`

### DIFF
--- a/qtox.pro
+++ b/qtox.pro
@@ -405,7 +405,6 @@ HEADERS  += \
     src/chatlog/customtextdocument.h \
     src/chatlog/documentcache.h \
     src/chatlog/pixmapcache.h \
-    src/core/cdata.h \
     src/core/core.h \
     src/core/coreav.h \
     src/core/coredefines.h \


### PR DESCRIPTION
Missed in 152c134a4bf402e9fe613076ac3e154ee0429238.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4026)
<!-- Reviewable:end -->
