### PR TITLE
Cleanup core

### DIFF
--- a/qtox.pro
+++ b/qtox.pro
@@ -435,6 +435,7 @@ HEADERS  += \
     src/core/recursivesignalblocker.h \
     src/core/toxcall.h \
     src/core/toxid.h \
+    src/core/toxpk.h \
     src/friend.h \
     src/friendlist.h \
     src/group.h \
@@ -554,6 +555,7 @@ SOURCES += \
     src/core/recursivesignalblocker.cpp \
     src/core/toxcall.cpp \
     src/core/toxid.cpp \
+    src/core/toxpk.cpp \
     src/friend.cpp \
     src/friendlist.cpp \
     src/group.cpp \

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -276,8 +276,8 @@ void Core::start()
     if (!msg.isEmpty())
         emit statusMessageSet(msg);
 
-    QString id = getSelfId().toString();
-    if (!id.isEmpty())
+    ToxId id = getSelfId();
+    if (id.isValid())       // TODO: probably useless check, comes basically directly from toxcore
         emit idSet(id);
 
     // TODO: This is a backwards compatibility check,
@@ -424,9 +424,10 @@ void Core::bootstrapDht()
                     +':'+QString().setNum(dhtServer.port)+" ("+dhtServer.name+')';
 
         QByteArray address = dhtServer.address.toLatin1();
-        QByteArray pk = ToxId{dhtServer.userId}.getPublicKey();
+        // TODO: constucting the pk via ToxId is a workaround
+        ToxPk pk = ToxId{dhtServer.userId}.getPublicKey();
 
-        const uint8_t* pkPtr = reinterpret_cast<const uint8_t*>(pk.constData());
+        const uint8_t* pkPtr = reinterpret_cast<const uint8_t*>(pk.getBytes());
 
         if (!tox_bootstrap(tox, address.constData(), dhtServer.port, pkPtr, nullptr))
         {
@@ -446,7 +447,7 @@ void Core::bootstrapDht()
 void Core::onFriendRequest(Tox*/* tox*/, const uint8_t* cFriendPk,
                            const uint8_t* cMessage, size_t cMessageSize, void* core)
 {
-    QString friendPk = ToxId(cFriendPk, TOX_PUBLIC_KEY_SIZE).getPublicKeyString();
+    ToxPk friendPk(cFriendPk);
     emit static_cast<Core*>(core)->friendRequestReceived(friendPk, CString::toString(cMessage, cMessageSize));
 }
 
@@ -556,67 +557,81 @@ void Core::onReadReceiptCallback(Tox*, uint32_t friendId, uint32_t receipt, void
     emit static_cast<Core*>(core)->receiptRecieved(friendId, receipt);
 }
 
-void Core::acceptFriendRequest(const QString& userId)
+void Core::acceptFriendRequest(const ToxPk& friendPk)
 {
-    uint32_t friendId = tox_friend_add_norequest(tox, ToxId(userId).getPublicKeyBytes(), nullptr);
+    // TODO: error handling
+    uint32_t friendId = tox_friend_add_norequest(tox, friendPk.getBytes(), nullptr);
     if (friendId == std::numeric_limits<uint32_t>::max())
     {
-        emit failedToAddFriend(userId);
+        emit failedToAddFriend(friendPk);
     }
     else
     {
         profile.saveToxSave();
-        emit friendAdded(friendId, userId);
+        emit friendAdded(friendId, friendPk);
         emit friendshipChanged(friendId);
     }
 }
 
-void Core::requestFriendship(const QString& friendAddress, const QString& message)
+void Core::requestFriendship(const ToxId& friendAddress, const QString& message)
 {
-    ToxId friendToxId(friendAddress);
-    const QString userId = friendAddress.mid(0, TOX_PUBLIC_KEY_SIZE * 2);
+    ToxPk friendPk = friendAddress.getPublicKey();
 
-    if (!friendToxId.isValid())
+    if (!friendAddress.isValid())
     {
-        emit failedToAddFriend(userId,
+        emit failedToAddFriend(friendPk,
                                tr("Invalid Tox ID"));
     }
     else if (message.isEmpty())
     {
-        emit failedToAddFriend(userId, tr("You need to write a message with your request"));
+        emit failedToAddFriend(friendPk,
+                               tr("You need to write a message with your request"));
     }
     else if (message.size() > TOX_MAX_FRIEND_REQUEST_LENGTH)
     {
-        emit failedToAddFriend(userId, tr("Your message is too long!"));
+        emit failedToAddFriend(friendPk,
+                               tr("Your message is too long!"));
     }
-    else if (hasFriendWithAddress(userId))
+    else if (hasFriendWithPublicKey(friendPk))
     {
-        emit failedToAddFriend(userId, tr("Friend is already added"));
+        emit failedToAddFriend(friendPk,
+                               tr("Friend is already added"));
     }
     else
     {
         CString cMessage(message);
 
-        uint32_t friendId = tox_friend_add(tox, ToxId(friendAddress).getBytes(),
+        uint32_t friendId = tox_friend_add(tox, friendAddress.getBytes(),
                                       cMessage.data(), cMessage.size(), nullptr);
         if (friendId == std::numeric_limits<uint32_t>::max())
         {
             qDebug() << "Failed to request friendship";
-            emit failedToAddFriend(userId);
+            emit failedToAddFriend(friendPk);
         }
         else
         {
-            qDebug() << "Requested friendship of "<<friendId;
+            qDebug() << "Requested friendship of " << friendId;
             // Update our friendAddresses
-            Settings::getInstance().updateFriendAddress(userId);
+            Settings::getInstance().updateFriendAddress(friendAddress.toString());
+
+            // TODO: start: this really shouldn't be in Core
             QString inviteStr = tr("/me offers friendship.");
             if (message.length())
                 inviteStr = tr("/me offers friendship, \"%1\"").arg(message);
 
             Profile* profile = Nexus::getProfile();
             if (profile->isHistoryEnabled())
-                profile->getHistory()->addNewMessage(userId, inviteStr, getSelfId().getPublicKeyString(), QDateTime::currentDateTime(), true, QString());
-            emit friendAdded(friendId, userId);
+            {
+                profile->getHistory()->addNewMessage(friendAddress.toString(),
+                                                     inviteStr,
+                                                     getSelfId().getPublicKey().toString(),
+                                                     QDateTime::currentDateTime(),
+                                                     true,
+                                                     QString());
+            }
+            // TODO: end
+
+            emit friendAdded(friendId, friendAddress.getPublicKey());
             emit friendshipChanged(friendId);
         }
     }
@@ -847,7 +862,7 @@ void Core::setAvatar(const QByteArray& data)
     {
         QPixmap pic;
         pic.loadFromData(data);
-        profile.saveAvatar(data, getSelfId().getPublicKeyString());
+        profile.saveAvatar(data, getSelfId().getPublicKey().toString());
         emit selfAvatarChanged(pic);
     }
     else
@@ -997,7 +1012,7 @@ void Core::loadFriends()
         {
             if (tox_friend_get_public_key(tox, ids[i], friendPk, nullptr))
             {
-                emit friendAdded(ids[i], ToxId(friendPk, TOX_PUBLIC_KEY_SIZE).getPublicKeyString());
+                emit friendAdded(ids[i], ToxPk(friendPk));
 
                 const size_t nameSize = tox_friend_get_name_size(tox, ids[i], nullptr);
                 if (nameSize && nameSize != SIZE_MAX)
@@ -1108,7 +1123,7 @@ QString Core::getGroupPeerName(int groupId, int peerId) const
 /**
  * @brief Get the public key of a peer of a group
  */
-ToxId Core::getGroupPeerToxId(int groupId, int peerId) const
+ToxPk Core::getGroupPeerPk(int groupId, int peerId) const
 {
     uint8_t friendPk[TOX_PUBLIC_KEY_SIZE] = {0x00};
     TOX_ERR_CONFERENCE_PEER_QUERY error;
@@ -1116,10 +1131,10 @@ ToxId Core::getGroupPeerToxId(int groupId, int peerId) const
     if (!parsePeerQueryError(error) || !success)
     {
         qWarning() << "getGroupPeerToxId: Unknown error";
-        return ToxId();
+        return ToxPk();
     }
 
-    return ToxId(friendPk, TOX_PUBLIC_KEY_SIZE);
+    return ToxPk(friendPk);
 }
 
 /**
@@ -1325,82 +1340,35 @@ bool Core::isFriendOnline(uint32_t friendId) const
 }
 
 /**
- * @brief Checks if we have a friend by address
- */
-bool Core::hasFriendWithAddress(const QString &addr) const
-{
-    // Valid length check
-    if (addr.length() != (TOX_ADDRESS_SIZE * 2))
-    {
-        return false;
-    }
-
-    QString pubkey = addr.left(TOX_PUBLIC_KEY_SIZE * 2);
-    return hasFriendWithPublicKey(pubkey);
-}
-
-/**
  * @brief Checks if we have a friend by public key
  */
-bool Core::hasFriendWithPublicKey(const QString &pubkey) const
+bool Core::hasFriendWithPublicKey(const ToxPk &publicKey) const
 {
-    // Valid length check
-    if (pubkey.length() != (TOX_PUBLIC_KEY_SIZE * 2))
-        return false;
-
-    bool found = false;
-    const size_t friendCount = tox_self_get_friend_list_size(tox);
-    if (friendCount > 0)
+    // Validity check
+    if (publicKey.isEmpty())
     {
-        uint32_t *ids = new uint32_t[friendCount];
-        tox_self_get_friend_list(tox, ids);
-        for (int32_t i = 0; i < static_cast<int32_t>(friendCount); ++i)
-        {
-            // getFriendAddress may return either id (public key) or address
-            QString addrOrId = getFriendAddress(ids[i]);
-
-            // Set true if found
-            if (addrOrId.toUpper().startsWith(pubkey.toUpper()))
-            {
-                found = true;
-                break;
-            }
-        }
-
-        delete[] ids;
+        return false;
     }
 
-    return found;
-}
+    // TODO: error handling
+    uint32_t  friendId = tox_friend_by_public_key(tox, publicKey.getBytes(), nullptr);
 
-/**
- * @brief Get the full address if known, or public key of a friend
- */
-QString Core::getFriendAddress(uint32_t friendNumber) const
-{
-    QString id = getFriendPublicKey(friendNumber);
-    QString addr = Settings::getInstance().getFriendAddress(id);
-    if (addr.size() > id.size())
-        return addr;
-
-    return id;
+    return friendId != std::numeric_limits<uint32_t>::max();
 }
 
 /**
  * @brief Get the public key part of the ToxID only
  */
-QString Core::getFriendPublicKey(uint32_t friendNumber) const
+ToxPk Core::getFriendPublicKey(uint32_t friendNumber) const
 {
     uint8_t rawid[TOX_PUBLIC_KEY_SIZE];
     if (!tox_friend_get_public_key(tox, friendNumber, rawid, nullptr))
     {
         qWarning() << "getFriendPublicKey: Getting public key failed";
-        return QString();
+        return ToxPk();
     }
-    QByteArray data((char*)rawid, TOX_PUBLIC_KEY_SIZE);
-    QString id = data.toHex().toUpper();
 
-    return id;
+    return ToxPk(rawid);
 }
 
 /**
@@ -1450,7 +1418,7 @@ QList<CString> Core::splitMessage(const QString &message, int maxLen)
     return splittedMsgs;
 }
 
-QString Core::getPeerName(const ToxId& id) const
+QString Core::getPeerName(const ToxPk& id) const
 {
     QString name;
     uint32_t friendId = tox_friend_by_public_key(tox, id.getBytes(), nullptr);
@@ -1485,13 +1453,16 @@ bool Core::isReady() const
     return av && av->getToxAv() && tox && ready;
 }
 
+
+/**
+ * @brief Sets the NoSpam value to prevent friend request spam
+ * @param nospam an arbitrary which becomes part of the Tox ID
+ */
 void Core::setNospam(uint32_t nospam)
 {
-    uint8_t *nspm = reinterpret_cast<uint8_t*>(&nospam);
-    std::reverse(nspm, nspm + 4);
     tox_self_set_nospam(tox, nospam);
 
-    emit idSet(getSelfId().toString());
+    emit idSet(getSelfId());
 }
 
 /**

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -58,20 +58,18 @@ public:
 
     static QByteArray getSaltFromFile(QString filename);
 
-    QString getPeerName(const ToxId& id) const;
+    QString getPeerName(const ToxPk& id) const;
 
     QVector<uint32_t> getFriendList() const;
     uint32_t getGroupNumberPeers(int groupId) const;
     QString getGroupPeerName(int groupId, int peerId) const;
-    ToxId getGroupPeerToxId(int groupId, int peerId) const;
+    ToxPk getGroupPeerPk(int groupId, int peerId) const;
     QList<QString> getGroupPeerNames(int groupId) const;
-    QString getFriendAddress(uint32_t friendNumber) const;
-    QString getFriendPublicKey(uint32_t friendNumber) const;
+    ToxPk getFriendPublicKey(uint32_t friendNumber) const;
     QString getFriendUsername(uint32_t friendNumber) const;
 
     bool isFriendOnline(uint32_t friendId) const;
-    bool hasFriendWithAddress(const QString &addr) const;
-    bool hasFriendWithPublicKey(const QString &pubkey) const;
+    bool hasFriendWithPublicKey(const ToxPk &publicKey) const;
     uint32_t joinGroupchat(int32_t friendId, uint8_t type, const uint8_t* pubkey,uint16_t length) const;
     void quitGroupChat(int groupId) const;
 
@@ -99,8 +97,8 @@ public slots:
 
     QByteArray getToxSaveData();
 
-    void acceptFriendRequest(const QString& userId);
-    void requestFriendship(const QString& friendAddress, const QString& message);
+    void acceptFriendRequest(const ToxPk &friendPk);
+    void requestFriendship(const ToxId &friendAddress, const QString& message);
     void groupInviteFriend(uint32_t friendId, int groupId);
     int createGroup(uint8_t type = TOX_CONFERENCE_TYPE_AV);
 
@@ -133,10 +131,10 @@ signals:
     void connected();
     void disconnected();
 
-    void friendRequestReceived(const QString& userId, const QString& message);
+    void friendRequestReceived(const ToxPk& friendPk, const QString& message);
     void friendMessageReceived(uint32_t friendId, const QString& message, bool isAction);
 
-    void friendAdded(uint32_t friendId, const QString& userId);
+    void friendAdded(uint32_t friendId, const ToxPk& friendPk);
     void friendshipChanged(uint32_t friendId);
 
     void friendStatusChanged(uint32_t friendId, Status status);
@@ -160,7 +158,7 @@ signals:
     void usernameSet(const QString& username);
     void statusMessageSet(const QString& message);
     void statusSet(Status status);
-    void idSet(const QString& id);
+    void idSet(const ToxId& id);
     void selfAvatarChanged(const QPixmap& pic);
 
     void messageSentResult(uint32_t friendId, const QString& message, int messageId);
@@ -169,7 +167,7 @@ signals:
 
     void receiptRecieved(int friedId, int receipt);
 
-    void failedToAddFriend(const QString& userId, const QString& errorInfo = QString());
+    void failedToAddFriend(const ToxPk& friendPk, const QString& errorInfo = QString());
     void failedToRemoveFriend(uint32_t friendId);
     void failedToSetUsername(const QString& username);
     void failedToSetStatusMessage(const QString& message);

--- a/src/core/corefile.cpp
+++ b/src/core/corefile.cpp
@@ -52,7 +52,7 @@ unsigned CoreFile::corefileIterationInterval()
     /*
        Sleep at most 1000ms if we have no FT, 10 for user FTs
        There is no real difference between 10ms sleep and 50ms sleep when it
-       comes to CPU usage – just keep the CPU usage low when there are no file
+       comes to CPU usage – just keep the CPU usage low when there are no file
        transfers, and speed things up when there is an ongoing file transfer.
     */
     constexpr unsigned fileInterval =   10,
@@ -311,7 +311,8 @@ void CoreFile::onFileReceiveCallback(Tox*, uint32_t friendId, uint32_t fileId,
 
     if (kind == TOX_FILE_KIND_AVATAR)
     {
-        QString friendAddr = core->getFriendPublicKey(friendId);
+        // TODO: port this to ToxPk
+        QString friendAddr = core->getFriendPublicKey(friendId).toString();
         if (!filesize)
         {
             qDebug() << QString("Received empty avatar request %1:%2").arg(friendId).arg(fileId);
@@ -482,7 +483,7 @@ void CoreFile::onFileRecvChunkCallback(Tox *tox, uint32_t friendId,
             if (!pic.isNull())
             {
                 qDebug() << "Got"<<file->avatarData.size()<<"bytes of avatar data from" <<friendId;
-                core->profile.saveAvatar(file->avatarData, core->getFriendPublicKey(friendId));
+                core->profile.saveAvatar(file->avatarData, core->getFriendPublicKey(friendId).toString());
                 emit core->friendAvatarChanged(friendId, pic);
             }
         }

--- a/src/core/toxid.cpp
+++ b/src/core/toxid.cpp
@@ -20,6 +20,7 @@
 
 #include "toxid.h"
 #include "core.h"
+#include "toxpk.h"
 
 #include <tox/tox.h>
 
@@ -201,27 +202,9 @@ const uint8_t* ToxId::getBytes() const
  * @brief Gets the Public Key part of the ToxID
  * @return Public Key of the ToxID
  */
-QByteArray ToxId::getPublicKey() const
+ToxPk ToxId::getPublicKey() const
 {
-    return toxId.mid(0, TOX_PUBLIC_KEY_SIZE);
-}
-
-/**
- * @brief Gets the Public Key part of the ToxID, convenience function for toxcore interface.
- * @return Public Key of the ToxID as uint8_t*
- */
-const uint8_t* ToxId::getPublicKeyBytes() const
-{
-    return reinterpret_cast<const uint8_t*>(toxId.mid(0, TOX_PUBLIC_KEY_SIZE).constData());
-}
-
-/**
- * @brief Returns the Public Key converted to QString.
- * @return The Public Key as QString.
- */
-QString ToxId::getPublicKeyString() const
-{
-    return getPublicKey().toHex().toUpper();
+    return ToxPk(toxId.mid(0, TOX_PUBLIC_KEY_SIZE));
 }
 
 /**

--- a/src/core/toxid.h
+++ b/src/core/toxid.h
@@ -21,6 +21,10 @@
 #ifndef TOXID_H
 #define TOXID_H
 
+#include "toxpk.h"
+
+#include <cstdint>
+#include <QByteArray>
 #include <QString>
 
 class ToxId
@@ -42,9 +46,7 @@ public:
     static bool isToxId(const QString &id);
     const uint8_t* getBytes() const;
     QByteArray getToxId() const;
-    QByteArray getPublicKey() const;
-    const uint8_t* getPublicKeyBytes() const;
-    QString getPublicKeyString() const;
+    ToxPk getPublicKey() const;
     QString getNoSpamString() const;
 
 private:

--- a/src/core/toxpk.cpp
+++ b/src/core/toxpk.cpp
@@ -19,16 +19,16 @@ ToxPk::ToxPk()
 
 /**
  * @brief The copy constructor.
- * @param other ToxKey to copy
+ * @param other ToxPk to copy
  */
 ToxPk::ToxPk(const ToxPk& other)
 : key(other.key)
 {}
 
 /**
- * @brief Constructs a ToxKey from bytes.
- * @param rawId The bytes to construct the ToxKey from. The lenght must be exactly
- *              TOX_PUBLIC_KEY_SIZE, else the ToxKey will be empty.
+ * @brief Constructs a ToxPk from bytes.
+ * @param rawId The bytes to construct the ToxPk from. The lenght must be exactly
+ *              TOX_PUBLIC_KEY_SIZE, else the ToxPk will be empty.
  */
 ToxPk::ToxPk(const QByteArray& rawId)
 {
@@ -43,8 +43,8 @@ ToxPk::ToxPk(const QByteArray& rawId)
 }
 
 /**
- * @brief Constructs a ToxKey from bytes.
- * @param rawId The bytes to construct the ToxKey from, will read exactly
+ * @brief Constructs a ToxPk from bytes.
+ * @param rawId The bytes to construct the ToxPk from, will read exactly
  * TOX_PUBLIC_KEY_SIZE from the specified buffer.
  */
 ToxPk::ToxPk(const uint8_t* rawId)
@@ -53,9 +53,9 @@ ToxPk::ToxPk(const uint8_t* rawId)
 }
 
 /**
- * @brief Compares the equality of the ToxKey.
- * @param other ToxKey to compare.
- * @return True if both ToxKeys are equal, false otherwise.
+ * @brief Compares the equality of the ToxPk.
+ * @param other ToxPk to compare.
+ * @return True if both ToxPks are equal, false otherwise.
  */
 bool ToxPk::operator==(const ToxPk& other) const
 {
@@ -63,9 +63,9 @@ bool ToxPk::operator==(const ToxPk& other) const
 }
 
 /**
- * @brief Compares the inequality of the ToxKey.
- * @param other ToxKey to compare.
- * @return True if both ToxKeys are not equal, false otherwise.
+ * @brief Compares the inequality of the ToxPk.
+ * @param other ToxPk to compare.
+ * @return True if both ToxPks are not equal, false otherwise.
  */
 bool ToxPk::operator!=(const ToxPk& other) const
 {
@@ -73,7 +73,7 @@ bool ToxPk::operator!=(const ToxPk& other) const
 }
 
 /**
- * @brief Converts the ToxKey to a uppercase hex string.
+ * @brief Converts the ToxPk to a uppercase hex string.
  * @return QString containing the hex representation of the key
  */
 QString ToxPk::toString() const
@@ -84,7 +84,7 @@ QString ToxPk::toString() const
 /**
  * @brief Returns a pointer to the raw key data.
  * @return Pointer to the raw key data, which is exactly TOX_PUBLIC_KEY_SIZE bytes
- *         long. Returns a nullptr if the ToxKey is empty.
+ *         long. Returns a nullptr if the ToxPk is empty.
  */
 const uint8_t* ToxPk::getBytes() const
 {
@@ -97,7 +97,16 @@ const uint8_t* ToxPk::getBytes() const
 }
 
 /**
- * @brief Checks if the ToxKey contains a key.
+ * @brief Get a copy of the key
+ * @return Copied key bytes
+ */
+QByteArray ToxPk::getKey() const
+{
+    return QByteArray(key); // TODO: Is a copy really necessary?
+}
+
+/**
+ * @brief Checks if the ToxPk contains a key.
  * @return True if there is a key, False otherwise.
  */
 bool ToxPk::isEmpty() const

--- a/src/core/toxpk.cpp
+++ b/src/core/toxpk.cpp
@@ -1,0 +1,106 @@
+#include "toxpk.h"
+
+#include <tox/tox.h>
+
+#include <QByteArray>
+#include <QString>
+
+/**
+ * @class ToxPk
+ * @brief This class represents a Tox Public Key, which is a part of Tox ID.
+ */
+
+/**
+ * @brief The default constructor. Creates an empty Tox key.
+ */
+ToxPk::ToxPk()
+: key()
+{}
+
+/**
+ * @brief The copy constructor.
+ * @param other ToxKey to copy
+ */
+ToxPk::ToxPk(const ToxPk& other)
+: key(other.key)
+{}
+
+/**
+ * @brief Constructs a ToxKey from bytes.
+ * @param rawId The bytes to construct the ToxKey from. The lenght must be exactly
+ *              TOX_PUBLIC_KEY_SIZE, else the ToxKey will be empty.
+ */
+ToxPk::ToxPk(const QByteArray& rawId)
+{
+    if(rawId.length() == TOX_PUBLIC_KEY_SIZE)
+    {
+        key = QByteArray(rawId);
+    }
+    else
+    {
+        key = QByteArray();
+    }
+}
+
+/**
+ * @brief Constructs a ToxKey from bytes.
+ * @param rawId The bytes to construct the ToxKey from, will read exactly
+ * TOX_PUBLIC_KEY_SIZE from the specified buffer.
+ */
+ToxPk::ToxPk(const uint8_t* rawId)
+{
+    key = QByteArray(reinterpret_cast<const char*>(rawId), TOX_PUBLIC_KEY_SIZE);
+}
+
+/**
+ * @brief Compares the equality of the ToxKey.
+ * @param other ToxKey to compare.
+ * @return True if both ToxKeys are equal, false otherwise.
+ */
+bool ToxPk::operator==(const ToxPk& other) const
+{
+    return key == other.key;
+}
+
+/**
+ * @brief Compares the inequality of the ToxKey.
+ * @param other ToxKey to compare.
+ * @return True if both ToxKeys are not equal, false otherwise.
+ */
+bool ToxPk::operator!=(const ToxPk& other) const
+{
+    return key != other.key;
+}
+
+/**
+ * @brief Converts the ToxKey to a uppercase hex string.
+ * @return QString containing the hex representation of the key
+ */
+QString ToxPk::toString() const
+{
+    return key.toHex().toUpper();
+}
+
+/**
+ * @brief Returns a pointer to the raw key data.
+ * @return Pointer to the raw key data, which is exactly TOX_PUBLIC_KEY_SIZE bytes
+ *         long. Returns a nullptr if the ToxKey is empty.
+ */
+const uint8_t* ToxPk::getBytes() const
+{
+    if(key.isEmpty())
+    {
+        return nullptr;
+    }
+
+    return reinterpret_cast<const uint8_t*>(key.constData());
+}
+
+/**
+ * @brief Checks if the ToxKey contains a key.
+ * @return True if there is a key, False otherwise.
+ */
+bool ToxPk::isEmpty() const
+{
+    return key.isEmpty();
+}

--- a/src/core/toxpk.h
+++ b/src/core/toxpk.h
@@ -1,0 +1,26 @@
+#ifndef TOXPK_H
+#define TOXPK_H
+
+#include <cstdint>
+#include <QByteArray>
+#include <QByteArray>
+
+class ToxPk
+{
+public:
+    ToxPk();
+    ToxPk(const ToxPk& other);
+    explicit ToxPk(const QByteArray& rawId);
+    explicit ToxPk(const uint8_t* rawId);
+
+    bool operator==(const ToxPk& other) const;
+    bool operator!=(const ToxPk& other) const;
+    QString toString() const;
+    const uint8_t* getBytes() const;
+    bool isEmpty() const;
+
+private:
+    QByteArray key;
+};
+
+#endif // TOXPK_H

--- a/src/core/toxpk.h
+++ b/src/core/toxpk.h
@@ -3,7 +3,7 @@
 
 #include <cstdint>
 #include <QByteArray>
-#include <QByteArray>
+#include <QString>
 
 class ToxPk
 {
@@ -16,6 +16,7 @@ public:
     bool operator==(const ToxPk& other) const;
     bool operator!=(const ToxPk& other) const;
     QString toString() const;
+    QByteArray getKey() const;
     const uint8_t* getBytes() const;
     bool isEmpty() const;
 

--- a/src/friend.cpp
+++ b/src/friend.cpp
@@ -30,16 +30,16 @@
 #include "src/grouplist.h"
 #include "src/group.h"
 
-Friend::Friend(uint32_t FriendId, const ToxId &UserId)
-    : userName{Core::getInstance()->getPeerName(UserId)}
-    , userID(UserId), friendId(FriendId)
+Friend::Friend(uint32_t FriendId, const ToxPk& FriendPk)
+    : userName{Core::getInstance()->getPeerName(FriendPk)}
+    , friendPk(FriendPk), friendId(FriendId)
     , hasNewEvents(0), friendStatus(Status::Offline)
 
 {
     if (userName.size() == 0)
-        userName = UserId.getPublicKeyString();
+        userName = FriendPk.toString();
 
-    userAlias = Settings::getInstance().getFriendAlias(UserId);
+    userAlias = Settings::getInstance().getFriendAlias(FriendPk);
 
     chatForm = new ChatForm(this);
 }
@@ -65,7 +65,7 @@ void Friend::loadHistory()
 void Friend::setName(QString name)
 {
    if (name.isEmpty())
-       name = userID.getPublicKeyString();
+       name = friendPk.toString();
 
     userName = name;
     if (userAlias.size() == 0)
@@ -124,9 +124,9 @@ bool Friend::hasAlias() const
     return !userAlias.isEmpty();
 }
 
-const ToxId &Friend::getToxId() const
+const ToxPk& Friend::getPublicKey() const
 {
-    return userID;
+    return friendPk;
 }
 
 uint32_t Friend::getFriendID() const

--- a/src/friend.h
+++ b/src/friend.h
@@ -32,7 +32,7 @@ class Friend : public QObject
 {
     Q_OBJECT
 public:
-    Friend(uint32_t FriendId, const ToxId &UserId);
+    Friend(uint32_t FriendId, const ToxPk& FriendPk);
     Friend(const Friend& other)=delete;
     ~Friend();
     Friend& operator=(const Friend& other)=delete;
@@ -50,7 +50,7 @@ public:
     void setEventFlag(int f);
     int getEventFlag() const;
 
-    const ToxId &getToxId() const;
+    const ToxPk& getPublicKey() const;
     uint32_t getFriendID() const;
 
     void setStatus(Status s);
@@ -67,7 +67,7 @@ signals:
 
 private:
     QString userAlias, userName, statusMessage;
-    ToxId userID;
+    ToxPk friendPk;
     uint32_t friendId;
     int hasNewEvents;
     Status friendStatus;

--- a/src/friendlist.cpp
+++ b/src/friendlist.cpp
@@ -25,17 +25,17 @@
 #include <QHash>
 
 QHash<int, Friend*> FriendList::friendList;
-QHash<QByteArray, int> FriendList::tox2id;
+QHash<QByteArray, int> FriendList::key2id;
 
-Friend* FriendList::addFriend(int friendId, const ToxId& userId)
+Friend* FriendList::addFriend(int friendId, const ToxPk& friendPk)
 {
     auto friendChecker = friendList.find(friendId);
     if (friendChecker != friendList.end())
         qWarning() << "addFriend: friendId already taken";
 
-    Friend* newfriend = new Friend(friendId, userId);
+    Friend* newfriend = new Friend(friendId, friendPk);
     friendList[friendId] = newfriend;
-    tox2id[userId.getPublicKey()] = friendId;
+    key2id[friendPk.getKey()] = friendId;
 
     return newfriend;
 }
@@ -55,7 +55,7 @@ void FriendList::removeFriend(int friendId, bool fake)
     if (f_it != friendList.end())
     {
         if (!fake)
-            Settings::getInstance().removeFriendSettings(f_it.value()->getToxId());
+            Settings::getInstance().removeFriendSettings(f_it.value()->getPublicKey());
         friendList.erase(f_it);
     }
 }
@@ -67,15 +67,15 @@ void FriendList::clear()
     friendList.clear();
 }
 
-Friend* FriendList::findFriend(const ToxId& userId)
+Friend* FriendList::findFriend(const ToxPk& friendPk)
 {
-    auto id = tox2id.find(userId.getPublicKey());
-    if (id != tox2id.end())
+    auto id = key2id.find(friendPk.getKey());
+    if (id != key2id.end())
     {
         Friend *f = findFriend(*id);
         if (!f)
             return nullptr;
-        if (f->getToxId() == userId)
+        if (f->getPublicKey() == friendPk)
             return f;
     }
 

--- a/src/friendlist.h
+++ b/src/friendlist.h
@@ -24,21 +24,21 @@ template <class T> class QList;
 template <class A, class B> class QHash;
 class Friend;
 class QByteArray;
-class ToxId;
+class ToxPk;
 
 class FriendList
 {
 public:
-    static Friend* addFriend(int friendId, const ToxId &userId);
+    static Friend* addFriend(int friendId, const ToxPk& friendPk);
     static Friend* findFriend(int friendId);
-    static Friend* findFriend(const ToxId &userId);
+    static Friend* findFriend(const ToxPk& friendPk);
     static QList<Friend*> getAllFriends();
     static void removeFriend(int friendId, bool fake = false);
     static void clear();
 
 private:
     static QHash<int, Friend*> friendList;
-    static QHash<QByteArray, int> tox2id;
+    static QHash<QByteArray, int> key2id;
 };
 
 #endif // FRIENDLIST_H

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -48,16 +48,16 @@ Group::~Group()
 
 void Group::updatePeer(int peerId, QString name)
 {
-    ToxId id = Core::getInstance()->getGroupPeerToxId(groupId, peerId);
-    QString toxid = id.getPublicKey();
+    ToxPk peerKey = Core::getInstance()->getGroupPeerPk(groupId, peerId);
+    QByteArray peerPk = peerKey.getKey();
     peers[peerId] = name;
-    toxids[toxid] = name;
+    toxids[peerPk] = name;
 
-    Friend *f = FriendList::findFriend(id);
+    Friend *f = FriendList::findFriend(peerKey);
     if (f != nullptr && f->hasAlias())
     {
         peers[peerId] = f->getDisplayedName();
-        toxids[toxid] = f->getDisplayedName();
+        toxids[peerPk] = f->getDisplayedName();
     }
     else
     {
@@ -90,21 +90,21 @@ void Group::regeneratePeerList()
     nPeers = peers.size();
     for (int i = 0; i < nPeers; ++i)
     {
-        ToxId id = core->getGroupPeerToxId(groupId, i);
-        ToxId self = core->getSelfId();
+        ToxPk id = core->getGroupPeerPk(groupId, i);
+        ToxPk self = core->getSelfId().getPublicKey();
         if (id == self)
             selfPeerNum = i;
 
-        QString toxid = id.getPublicKey();
-        toxids[toxid] = peers[i];
-        if (toxids[toxid].isEmpty())
-            toxids[toxid] = tr("<Empty>", "Placeholder when someone's name in a group chat is empty");
+        QByteArray peerPk = id.getKey();
+        toxids[peerPk] = peers[i];
+        if (toxids[peerPk].isEmpty())
+            toxids[peerPk] = tr("<Empty>", "Placeholder when someone's name in a group chat is empty");
 
         Friend *f = FriendList::findFriend(id);
         if (f != nullptr && f->hasAlias())
         {
             peers[i] = f->getDisplayedName();
-            toxids[toxid] = f->getDisplayedName();
+            toxids[peerPk] = f->getDisplayedName();
         }
     }
 
@@ -168,9 +168,9 @@ int Group::getMentionedFlag() const
     return userWasMentioned;
 }
 
-QString Group::resolveToxId(const ToxId &id) const
+QString Group::resolveToxId(const ToxPk &id) const
 {
-    QString key = id.getPublicKeyString();
+    QByteArray key = id.getKey();
     auto it = toxids.find(key);
 
     if (it != toxids.end())

--- a/src/group.h
+++ b/src/group.h
@@ -29,7 +29,7 @@
 class Friend;
 class GroupWidget;
 class GroupChatForm;
-class ToxId;
+class ToxPk;
 
 class Group : public QObject
 {
@@ -58,7 +58,7 @@ public:
     void setName(const QString& name);
     QString getName() const;
 
-    QString resolveToxId(const ToxId &id) const;
+    QString resolveToxId(const ToxPk& id) const;
 
 signals:
     void titleChanged(GroupWidget* widget);
@@ -68,7 +68,7 @@ private:
     GroupWidget* widget;
     GroupChatForm* chatForm;
     QStringList peers;
-    QMap<QString, QString> toxids;
+    QMap<QByteArray, QString> toxids;
     int hasNewMessages, userWasMentioned;
     int groupId;
     int nPeers;

--- a/src/net/toxme.cpp
+++ b/src/net/toxme.cpp
@@ -300,9 +300,9 @@ QString Toxme::getPass(QString json, ExecCode &code) {
  * @param id ToxId to delete.
  * @return Status code returned from server.
  */
-Toxme::ExecCode Toxme::deleteAddress(QString server, ToxId id)
+Toxme::ExecCode Toxme::deleteAddress(QString server, ToxPk id)
 {
-    const QString payload{"{\"public_key\":\""+id.toString().left(64)+"\","
+    const QString payload{"{\"public_key\":\""+id.toString()+"\","
                           "\"timestamp\":"+QString().setNum(time(0))+"}"};
 
     server = server.trimmed();

--- a/src/net/toxme.h
+++ b/src/net/toxme.h
@@ -45,7 +45,7 @@ public:
     static ToxId lookup(QString address);
     static QString createAddress(ExecCode &code, QString server, ToxId id, QString address,
                               bool keepPrivate=true, QString bio=QString());
-    static ExecCode deleteAddress(QString server, ToxId id);
+    static ExecCode deleteAddress(QString server, ToxPk id);
     static QString getErrorMessage(int errorCode);
     static QString translateErrorMessage(int errorCode);
 

--- a/src/net/toxuri.cpp
+++ b/src/net/toxuri.cpp
@@ -64,8 +64,8 @@ bool handleToxURI(const QString &toxURI)
 
     QString toxaddr = toxURI.mid(4);
 
-    QString toxId = Toxme::lookup(toxaddr).toString();
-    if (toxId.isEmpty())
+    ToxId toxId = Toxme::lookup(toxaddr);
+    if (!toxId.isValid())
     {
         QMessageBox::warning(0, "qTox",
                              ToxURIDialog::tr("%1 is not a valid Toxme address.")

--- a/src/persistence/profile.h
+++ b/src/persistence/profile.h
@@ -21,14 +21,18 @@
 #ifndef PROFILE_H
 #define PROFILE_H
 
-#include <QVector>
-#include <QString>
-#include <QByteArray>
-#include <QPixmap>
-#include <QObject>
+#include "src/core/toxid.h"
+
 #include <tox/toxencryptsave.h>
-#include <memory>
+
 #include "src/persistence/history.h"
+
+#include <memory>
+#include <QByteArray>
+#include <QObject>
+#include <QPixmap>
+#include <QString>
+#include <QVector>
 
 class Core;
 class QThread;
@@ -82,7 +86,7 @@ public:
     static QString getDbPath(const QString& profileName);
 
 private slots:
-    void loadDatabase(const QString& id);
+    void loadDatabase(const ToxId& id);
 private:
     Profile(QString name, const QString& password, bool newProfile);
     static QVector<QString> getFilesByExt(QString extension);

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -31,7 +31,7 @@
 #include <QFlags>
 #include "src/core/corestructs.h"
 
-class ToxId;
+class ToxPk;
 class Profile;
 
 namespace Db {
@@ -152,11 +152,11 @@ public:
     void createPersonal(QString basename);
 
     void savePersonal();
-    void savePersonal(Profile *profile);
+    void savePersonal(Profile* profile);
 
     void loadGlobal();
     void loadPersonal();
-    void loadPersonal(Profile *profile);
+    void loadPersonal(Profile* profile);
 
     void resetToDefault();
 
@@ -203,7 +203,7 @@ signals:
     void globalAutoAcceptDirChanged(const QString& path);
     void checkUpdatesChanged(bool enabled);
     void widgetDataChanged(const QString& key);
-    void autoAcceptCallChanged(const ToxId& id, AutoAcceptCallFlags accept);
+    void autoAcceptCallChanged(const ToxPk& id, AutoAcceptCallFlags accept);
 
     // GUI
     void autoLoginChanged(bool enabled);
@@ -407,14 +407,14 @@ public:
     int getEmojiFontPointSize() const;
     void setEmojiFontPointSize(int value);
 
-    QString getContactNote(const ToxId& id) const;
-    void setContactNote(const ToxId& id, const QString& note);
+    QString getContactNote(const ToxPk& id) const;
+    void setContactNote(const ToxPk& id, const QString& note);
 
-    QString getAutoAcceptDir(const ToxId& id) const;
-    void setAutoAcceptDir(const ToxId& id, const QString& dir);
+    QString getAutoAcceptDir(const ToxPk& id) const;
+    void setAutoAcceptDir(const ToxPk& id, const QString& dir);
 
-    AutoAcceptCallFlags getAutoAcceptCall(const ToxId& id) const;
-    void setAutoAcceptCall(const ToxId& id, AutoAcceptCallFlags accept);
+    AutoAcceptCallFlags getAutoAcceptCall(const ToxPk& id) const;
+    void setAutoAcceptCall(const ToxPk& id, AutoAcceptCallFlags accept);
 
     QString getGlobalAutoAcceptDir() const;
     void setGlobalAutoAcceptDir(const QString& dir);
@@ -461,16 +461,16 @@ public:
     QString getFriendAddress(const QString& publicKey) const;
     void updateFriendAddress(const QString& newAddr);
 
-    QString getFriendAlias(const ToxId& id) const;
-    void setFriendAlias(const ToxId& id, const QString& alias);
+    QString getFriendAlias(const ToxPk& id) const;
+    void setFriendAlias(const ToxPk& id, const QString& alias);
 
-    int getFriendCircleID(const ToxId& id) const;
-    void setFriendCircleID(const ToxId& id, int circleID);
+    int getFriendCircleID(const ToxPk& id) const;
+    void setFriendCircleID(const ToxPk& id, int circleID);
 
-    QDate getFriendActivity(const ToxId& id) const;
-    void setFriendActivity(const ToxId& id, const QDate &date);
+    QDate getFriendActivity(const ToxPk& id) const;
+    void setFriendActivity(const ToxPk& id, const QDate &date);
 
-    void removeFriendSettings(const ToxId& id);
+    void removeFriendSettings(const ToxPk& id);
 
     bool getFauxOfflineMessaging() const;
     void setFauxOfflineMessaging(bool value);
@@ -533,7 +533,7 @@ private:
     Settings& operator=(const Settings&) = delete;
 
 private slots:
-    void savePersonal(QString profileName, const QString &password);
+    void savePersonal(QString profileName, const QString& password);
 
 private:
     bool loaded;
@@ -649,7 +649,7 @@ private:
         bool expanded;
     };
 
-    QHash<QString, friendProp> friendLst;
+    QHash<QByteArray, friendProp> friendLst;
 
     QVector<circleProp> circleLst;
 

--- a/src/video/groupnetcamview.cpp
+++ b/src/video/groupnetcamview.cpp
@@ -172,7 +172,7 @@ void GroupNetCamView::clearPeers()
 
 void GroupNetCamView::addPeer(int peer, const QString& name)
 {
-    QPixmap groupAvatar = Nexus::getProfile()->loadAvatar(Core::getInstance()->getGroupPeerToxId(group, peer).toString());
+    QPixmap groupAvatar = Nexus::getProfile()->loadAvatar(Core::getInstance()->getGroupPeerPk(group, peer).toString());
     LabeledVideo* labeledVideo = new LabeledVideo(groupAvatar, this);
     labeledVideo->setText(name);
     horLayout->insertWidget(horLayout->count() - 1, labeledVideo);
@@ -262,7 +262,7 @@ void GroupNetCamView::friendAvatarChanged(int FriendId, const QPixmap &pixmap)
 
     for (uint32_t i = 0; i < Core::getInstance()->getGroupNumberPeers(group); ++i)
     {
-        if (Core::getInstance()->getGroupPeerToxId(group, i) == f->getToxId())
+        if (Core::getInstance()->getGroupPeerPk(group, i) == f->getPublicKey())
         {
             auto peerVideo = videoList.find(i);
 

--- a/src/video/netcamview.cpp
+++ b/src/video/netcamview.cpp
@@ -37,7 +37,7 @@ NetCamView::NetCamView(int friendId, QWidget* parent)
     , friendId{friendId}
     , e(false)
 {
-    QString id = FriendList::findFriend(friendId)->getToxId().toString();
+    QString id = FriendList::findFriend(friendId)->getPublicKey().toString();
     videoSurface = new VideoSurface(Nexus::getProfile()->loadAvatar(id), this);
     videoSurface->setMinimumHeight(256);
     videoSurface->setContentsMargins(6, 6, 6, 6);

--- a/src/widget/about/aboutuser.cpp
+++ b/src/widget/about/aboutuser.cpp
@@ -8,7 +8,7 @@
 #include <QFileDialog>
 #include <QMessageBox>
 
-AboutUser::AboutUser(ToxId &toxId, QWidget *parent) :
+AboutUser::AboutUser(ToxPk &toxId, QWidget *parent) :
     QDialog(parent),
     ui(new Ui::AboutUser)
 {
@@ -22,27 +22,27 @@ AboutUser::AboutUser(ToxId &toxId, QWidget *parent) :
     connect(ui->selectSaveDir, &QPushButton::clicked, this,  &AboutUser::onSelectDirClicked);
     connect(ui->removeHistory, &QPushButton::clicked, this, &AboutUser::onRemoveHistoryClicked);
 
-    this->toxId = toxId;
-    QString dir = Settings::getInstance().getAutoAcceptDir(this->toxId);
+    this->friendPk = toxId;
+    QString dir = Settings::getInstance().getAutoAcceptDir(this->friendPk);
     ui->autoacceptfile->setChecked(!dir.isEmpty());
 
-    ui->autoacceptcall->setCurrentIndex(Settings::getInstance().getAutoAcceptCall(this->toxId));
+    ui->autoacceptcall->setCurrentIndex(Settings::getInstance().getAutoAcceptCall(this->friendPk));
 
     ui->selectSaveDir->setEnabled(ui->autoacceptfile->isChecked());
 
     if(ui->autoacceptfile->isChecked())
-        ui->selectSaveDir->setText(Settings::getInstance().getAutoAcceptDir(this->toxId));
+        ui->selectSaveDir->setText(Settings::getInstance().getAutoAcceptDir(this->friendPk));
 }
 
 void AboutUser::setFriend(Friend *f)
 {
     this->setWindowTitle(f->getDisplayedName());
     ui->userName->setText(f->getDisplayedName());
-    ui->publicKey->setText(QString(f->getToxId().toString()));
+    ui->publicKey->setText(QString(f->getPublicKey().toString()));
     ui->publicKey->setCursorPosition(0); //scroll textline to left
-    ui->note->setPlainText(Settings::getInstance().getContactNote(f->getToxId()));
+    ui->note->setPlainText(Settings::getInstance().getContactNote(f->getPublicKey()));
 
-    QPixmap avatar = Nexus::getProfile()->loadAvatar(f->getToxId().toString());
+    QPixmap avatar = Nexus::getProfile()->loadAvatar(f->getPublicKey().toString());
     ui->statusMessage->setText(f->getStatusMessage());
     if(!avatar.isNull()) {
         ui->avatar->setPixmap(avatar);
@@ -59,7 +59,7 @@ void AboutUser::onAutoAcceptDirClicked()
     {
         dir = QDir::homePath();
         ui->autoacceptfile->setChecked(false);
-        Settings::getInstance().setAutoAcceptDir(this->toxId, "");
+        Settings::getInstance().setAutoAcceptDir(this->friendPk, "");
         ui->selectSaveDir->setText(tr("Auto accept for this contact is disabled"));
     }
     else if (ui->autoacceptfile->isChecked())
@@ -73,8 +73,8 @@ void AboutUser::onAutoAcceptDirClicked()
             ui->autoacceptfile->setChecked(false);
             return; // user canellced
         }
-        Settings::getInstance().setAutoAcceptDir(this->toxId, dir);
-        ui->selectSaveDir->setText(Settings::getInstance().getAutoAcceptDir(this->toxId));
+        Settings::getInstance().setAutoAcceptDir(this->friendPk, dir);
+        ui->selectSaveDir->setText(Settings::getInstance().getAutoAcceptDir(this->friendPk));
     }
     Settings::getInstance().saveGlobal();
     ui->selectSaveDir->setEnabled(ui->autoacceptfile->isChecked());
@@ -82,7 +82,7 @@ void AboutUser::onAutoAcceptDirClicked()
 
 void AboutUser::onAutoAcceptCallClicked()
 {
-    Settings::getInstance().setAutoAcceptCall(this->toxId,Settings::AutoAcceptCallFlags(QFlag(ui->autoacceptcall->currentIndex())));
+    Settings::getInstance().setAutoAcceptCall(this->friendPk,Settings::AutoAcceptCallFlags(QFlag(ui->autoacceptcall->currentIndex())));
     Settings::getInstance().savePersonal();
 }
 
@@ -94,7 +94,7 @@ void AboutUser::onSelectDirClicked()
                                             dir,
                                             QFileDialog::DontUseNativeDialog);
     ui->autoacceptfile->setChecked(true);
-    Settings::getInstance().setAutoAcceptDir(this->toxId, dir);
+    Settings::getInstance().setAutoAcceptDir(this->friendPk, dir);
     Settings::getInstance().savePersonal();
 }
 
@@ -103,8 +103,7 @@ void AboutUser::onSelectDirClicked()
  */
 void AboutUser::onAcceptedClicked()
 {
-    ToxId toxId = ToxId(ui->publicKey->text());
-    Settings::getInstance().setContactNote(toxId, ui->note->toPlainText());
+    Settings::getInstance().setContactNote(friendPk, ui->note->toPlainText());
     Settings::getInstance().saveGlobal();
 }
 
@@ -112,7 +111,7 @@ void AboutUser::onRemoveHistoryClicked()
 {
     History* history = Nexus::getProfile()->getHistory();
     if (history)
-        history->removeFriendHistory(toxId.getPublicKeyString());
+        history->removeFriendHistory(friendPk.toString());
     QMessageBox::information(this,
                                      tr("History removed"),
                                      tr("Chat history with %1 removed!").arg(ui->userName->text().toHtmlEscaped()),

--- a/src/widget/about/aboutuser.h
+++ b/src/widget/about/aboutuser.h
@@ -14,13 +14,13 @@ class AboutUser : public QDialog
     Q_OBJECT
 
 public:
-    explicit AboutUser(ToxId &toxID, QWidget *parent = 0);
+    explicit AboutUser(ToxPk &toxID, QWidget *parent = 0);
     ~AboutUser();
     void setFriend(Friend *f);
 
 private:
     Ui::AboutUser *ui;
-    ToxId toxId;
+    ToxPk friendPk;
 
 private slots:
     void onAcceptedClicked();

--- a/src/widget/circlewidget.cpp
+++ b/src/widget/circlewidget.cpp
@@ -154,7 +154,7 @@ void CircleWidget::contextMenuEvent(QContextMenuEvent* event)
 void CircleWidget::dragEnterEvent(QDragEnterEvent* event)
 {
     ToxId toxId(event->mimeData()->text());
-    Friend *f = FriendList::findFriend(toxId);
+    Friend *f = FriendList::findFriend(toxId.getPublicKey());
     if (f != nullptr)
         event->acceptProposedAction();
 
@@ -178,12 +178,12 @@ void CircleWidget::dropEvent(QDropEvent* event)
 
     // Check, that the user has a friend with the same ToxId
     ToxId toxId(event->mimeData()->text());
-    Friend *f = FriendList::findFriend(toxId);
+    Friend *f = FriendList::findFriend(toxId.getPublicKey());
     if (!f)
         return;
 
     // Save CircleWidget before changing the Id
-    int circleId = Settings::getInstance().getFriendCircleID(toxId);
+    int circleId = Settings::getInstance().getFriendCircleID(toxId.getPublicKey());
     CircleWidget* circleWidget = getFromID(circleId);
 
     addFriendWidget(widget, f->getStatus());
@@ -212,7 +212,7 @@ void CircleWidget::onExpand()
 void CircleWidget::onAddFriendWidget(FriendWidget* w)
 {
     Friend* f = FriendList::findFriend(w->friendId);
-    ToxId toxId = f->getToxId();
+    ToxPk toxId = f->getPublicKey();
     Settings::getInstance().setFriendCircleID(toxId, id);
 }
 
@@ -232,13 +232,13 @@ void CircleWidget::updateID(int index)
         FriendWidget* friendWidget = qobject_cast<FriendWidget*>(friendOnlineLayout()->itemAt(i)->widget());
 
         if (friendWidget != nullptr)
-            Settings::getInstance().setFriendCircleID(FriendList::findFriend(friendWidget->friendId)->getToxId(), id);
+            Settings::getInstance().setFriendCircleID(FriendList::findFriend(friendWidget->friendId)->getPublicKey(), id);
     }
     for (int i = 0; i < friendOfflineLayout()->count(); ++i)
     {
         FriendWidget* friendWidget = qobject_cast<FriendWidget*>(friendOfflineLayout()->itemAt(i)->widget());
 
         if (friendWidget != nullptr)
-            Settings::getInstance().setFriendCircleID(FriendList::findFriend(friendWidget->friendId)->getToxId(), id);
+            Settings::getInstance().setFriendCircleID(FriendList::findFriend(friendWidget->friendId)->getPublicKey(), id);
     }
 }

--- a/src/widget/contentdialog.cpp
+++ b/src/widget/contentdialog.cpp
@@ -541,7 +541,7 @@ void ContentDialog::dragEnterEvent(QDragEnterEvent *event)
     if (frnd)
     {
         ToxId toxId(event->mimeData()->text());
-        Friend *contact = FriendList::findFriend(toxId);
+        Friend *contact = FriendList::findFriend(toxId.getPublicKey());
         if (!contact)
             return;
 
@@ -576,7 +576,7 @@ void ContentDialog::dropEvent(QDropEvent *event)
     if (frnd)
     {
         ToxId toxId(event->mimeData()->text());
-        Friend *contact = FriendList::findFriend(toxId);
+        Friend *contact = FriendList::findFriend(toxId.getPublicKey());
         if (!contact)
             return;
 

--- a/src/widget/form/addfriendform.h
+++ b/src/widget/form/addfriendform.h
@@ -20,6 +20,8 @@
 #ifndef ADDFRIENDFORM_H
 #define ADDFRIENDFORM_H
 
+#include "src/core/toxid.h"
+
 #include <QVBoxLayout>
 #include <QLabel>
 #include <QLineEdit>
@@ -55,8 +57,8 @@ public:
     bool addFriendRequest(const QString& friendAddress, const QString& message);
 
 signals:
-    void friendRequested(const QString& friendAddress, const QString& message);
-    void friendRequestAccepted(const QString& friendAddress);
+    void friendRequested(const ToxId& friendAddress, const QString& message);
+    void friendRequestAccepted(const ToxPk& friendAddress);
     void friendRequestsSeen();
 
 public slots:
@@ -75,7 +77,7 @@ private:
     void removeFriendRequestWidget(QWidget *friendWidget);
     void retranslateAcceptButton(QPushButton* acceptButton);
     void retranslateRejectButton(QPushButton* rejectButton);
-    void deleteFriendRequest(const QString &toxId);
+    void deleteFriendRequest(const ToxId& toxId);
     void setIdFromClipboard();
 
 private:

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -337,11 +337,11 @@ void GenericChatForm::onChatContextMenuRequested(QPoint pos)
     menu.exec(pos);
 }
 
-ChatMessage::Ptr GenericChatForm::addMessage(const ToxId& author, const QString &message, bool isAction,
+ChatMessage::Ptr GenericChatForm::addMessage(const ToxPk& author, const QString &message, bool isAction,
                                              const QDateTime &datetime, bool isSent)
 {
     const Core* core = Core::getInstance();
-    bool authorIsActiveProfile = author == core->getSelfId();
+    bool authorIsActiveProfile = author == core->getSelfId().getPublicKey();
     QString authorStr = authorIsActiveProfile ? core->getUsername() : resolveToxId(author);
 
 
@@ -356,7 +356,7 @@ ChatMessage::Ptr GenericChatForm::addMessage(const ToxId& author, const QString 
     if (isAction)
     {
         msg = ChatMessage::createChatMessage(authorStr, message, ChatMessage::ACTION, authorIsActiveProfile);
-        previousId.clear();
+        previousId = ToxPk();
     }
     else
     {
@@ -378,13 +378,13 @@ ChatMessage::Ptr GenericChatForm::addMessage(const ToxId& author, const QString 
 
 ChatMessage::Ptr GenericChatForm::addSelfMessage(const QString &message, bool isAction, const QDateTime &datetime, bool isSent)
 {
-    return addMessage(Core::getInstance()->getSelfId(), message, isAction, datetime, isSent);
+    return addMessage(Core::getInstance()->getSelfId().getPublicKey(), message, isAction, datetime, isSent);
 }
 
-void GenericChatForm::addAlertMessage(const ToxId &author, QString message, QDateTime datetime)
+void GenericChatForm::addAlertMessage(const ToxPk &author, QString message, QDateTime datetime)
 {
     QString authorStr = resolveToxId(author);
-    bool isSelf = author == Core::getInstance()->getSelfId();
+    bool isSelf = author == Core::getInstance()->getSelfId().getPublicKey();
     ChatMessage::Ptr msg = ChatMessage::createChatMessage(authorStr, message, ChatMessage::ALERT, isSelf, datetime);
     insertChatMessage(msg);
 
@@ -468,7 +468,7 @@ void GenericChatForm::focusInput()
 
 void GenericChatForm::addSystemInfoMessage(const QString &message, ChatMessage::SystemMessageType type, const QDateTime &datetime)
 {
-    previousId.clear();
+    previousId = ToxPk();
     insertChatMessage(ChatMessage::createChatInfoMessage(message, type, datetime));
 }
 
@@ -480,7 +480,7 @@ void GenericChatForm::clearChatArea()
 void GenericChatForm::clearChatArea(bool notinform)
 {
     chatWidget->clear();
-    previousId = ToxId();
+    previousId = ToxPk();
 
     if (!notinform)
         addSystemInfoMessage(tr("Cleared"), ChatMessage::INFO, QDateTime::currentDateTime());
@@ -496,7 +496,7 @@ void GenericChatForm::onSelectAllClicked()
     chatWidget->selectAll();
 }
 
-QString GenericChatForm::resolveToxId(const ToxId &id)
+QString GenericChatForm::resolveToxId(const ToxPk &id)
 {
     Friend *f = FriendList::findFriend(id);
     if (f)

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -62,11 +62,11 @@ public:
     virtual void show() final{}
     virtual void show(ContentLayout* contentLayout);
 
-    ChatMessage::Ptr addMessage(const ToxId& author, const QString &message, bool isAction, const QDateTime &datetime, bool isSent);
+    ChatMessage::Ptr addMessage(const ToxPk& author, const QString &message, bool isAction, const QDateTime &datetime, bool isSent);
     ChatMessage::Ptr addSelfMessage(const QString &message, bool isAction, const QDateTime &datetime, bool isSent);
 
     void addSystemInfoMessage(const QString &message, ChatMessage::SystemMessageType type, const QDateTime &datetime);
-    void addAlertMessage(const ToxId& author, QString message, QDateTime datetime);
+    void addAlertMessage(const ToxPk& author, QString message, QDateTime datetime);
     bool isEmpty();
 
     ChatLog* getChatLog() const;
@@ -104,7 +104,7 @@ protected:
     void showNetcam();
     void hideNetcam();
     virtual GenericNetCamView* createNetcam() = 0;
-    QString resolveToxId(const ToxId &id);
+    QString resolveToxId(const ToxPk &id);
     virtual void insertChatMessage(ChatMessage::Ptr msg);
     void adjustFileMenuPosition();
     virtual void hideEvent(QHideEvent* event) override;
@@ -115,7 +115,7 @@ protected:
 
 protected:
     QAction* saveChatAction, *clearAction, *quoteAction, *copyLinkAction;
-    ToxId previousId;
+    ToxPk previousId;
     QDateTime prevMsgDateTime;
     Widget *parent;
     QMenu menu;

--- a/src/widget/form/groupchatform.cpp
+++ b/src/widget/form/groupchatform.cpp
@@ -283,7 +283,7 @@ void GroupChatForm::peerAudioPlaying(int peer)
 void GroupChatForm::dragEnterEvent(QDragEnterEvent *ev)
 {
     ToxId toxId = ToxId(ev->mimeData()->text());
-    Friend *frnd = FriendList::findFriend(toxId);
+    Friend *frnd = FriendList::findFriend(toxId.getPublicKey());
     if (frnd)
         ev->acceptProposedAction();
 }
@@ -291,7 +291,7 @@ void GroupChatForm::dragEnterEvent(QDragEnterEvent *ev)
 void GroupChatForm::dropEvent(QDropEvent *ev)
 {
     ToxId toxId = ToxId(ev->mimeData()->text());
-    Friend *frnd = FriendList::findFriend(toxId);
+    Friend *frnd = FriendList::findFriend(toxId.getPublicKey());
     if (!frnd)
         return;
 

--- a/src/widget/form/profileform.cpp
+++ b/src/widget/form/profileform.cpp
@@ -248,14 +248,14 @@ void ProfileForm::onSelfAvatarLoaded(const QPixmap& pic)
     profilePicture->setPixmap(pic);
 }
 
-void ProfileForm::setToxId(const QString& id)
+void ProfileForm::setToxId(const ToxId& id)
 {
-    toxId->setText(id);
+    toxId->setText(id.toString());
     toxId->setCursorPosition(0);
 
     delete qr;
     qr = new QRWidget();
-    qr->setQRData("tox:"+id);
+    qr->setQRData("tox:"+id.toString());
     bodyUI->qrCode->setPixmap(QPixmap::fromImage(qr->getImage()->scaledToWidth(150)));
 }
 

--- a/src/widget/form/profileform.h
+++ b/src/widget/form/profileform.h
@@ -71,7 +71,7 @@ public slots:
 
 private slots:
     void setPasswordButtonsText();
-    void setToxId(const QString& id);
+    void setToxId(const ToxId &id);
     void copyIdClicked();
     void onUserNameEdited();
     void onStatusMessageEdited();

--- a/src/widget/friendlistwidget.cpp
+++ b/src/widget/friendlistwidget.cpp
@@ -111,7 +111,7 @@ Time getTime(const QDate& date)
 
 QDate getDateFriend(Friend* contact)
 {
-    return Settings::getInstance().getFriendActivity(contact->getToxId());
+    return Settings::getInstance().getFriendActivity(contact->getPublicKey());
 }
 
 qint64 timeUntilTomorrow()
@@ -202,7 +202,7 @@ void FriendListWidget::setMode(Mode mode)
         QList<Friend*> friendList = FriendList::getAllFriends();
         for (Friend* contact : friendList)
         {
-            int circleId = Settings::getInstance().getFriendCircleID(contact->getToxId());
+            int circleId = Settings::getInstance().getFriendCircleID(contact->getPublicKey());
             addFriendWidget(contact->getFriendWidget(), contact->getStatus(), circleId);
         }
 
@@ -362,7 +362,7 @@ void FriendListWidget::removeFriendWidget(FriendWidget* w)
     }
     else
     {
-        int id = Settings::getInstance().getFriendCircleID(contact->getToxId());
+        int id = Settings::getInstance().getFriendCircleID(contact->getPublicKey());
         CircleWidget* circleWidget = CircleWidget::getFromID(id);
         if (circleWidget != nullptr)
         {
@@ -384,7 +384,7 @@ void FriendListWidget::addCircleWidget(FriendWidget* friendWidget)
     {
         if (friendWidget != nullptr)
         {
-            CircleWidget* circleOriginal = CircleWidget::getFromID(Settings::getInstance().getFriendCircleID(FriendList::findFriend(friendWidget->friendId)->getToxId()));
+            CircleWidget* circleOriginal = CircleWidget::getFromID(Settings::getInstance().getFriendCircleID(FriendList::findFriend(friendWidget->friendId)->getPublicKey()));
 
             circleWidget->addFriendWidget(friendWidget, FriendList::findFriend(friendWidget->friendId)->getStatus());
             circleWidget->setExpanded(true);
@@ -522,7 +522,7 @@ void FriendListWidget::cycleContacts(GenericChatroomWidget* activeChatroomWidget
 
     if (friendWidget != nullptr)
     {
-        circleWidget = CircleWidget::getFromID(Settings::getInstance().getFriendCircleID(FriendList::findFriend(friendWidget->friendId)->getToxId()));
+        circleWidget = CircleWidget::getFromID(Settings::getInstance().getFriendCircleID(FriendList::findFriend(friendWidget->friendId)->getPublicKey()));
         if (circleWidget != nullptr)
         {
             if (circleWidget->cycleContacts(friendWidget, forward))
@@ -608,7 +608,7 @@ void FriendListWidget::cycleContacts(GenericChatroomWidget* activeChatroomWidget
 void FriendListWidget::dragEnterEvent(QDragEnterEvent* event)
 {
     ToxId toxId(event->mimeData()->text());
-    Friend *frnd = FriendList::findFriend(toxId);
+    Friend *frnd = FriendList::findFriend(toxId.getPublicKey());
     if (frnd)
         event->acceptProposedAction();
 }
@@ -623,12 +623,12 @@ void FriendListWidget::dropEvent(QDropEvent* event)
 
     // Check, that the user has a friend with the same ToxId
     ToxId toxId(event->mimeData()->text());
-    Friend *f = FriendList::findFriend(toxId);
+    Friend *f = FriendList::findFriend(toxId.getPublicKey());
     if (!f)
         return;
 
     // Save CircleWidget before changing the Id
-    int circleId = Settings::getInstance().getFriendCircleID(f->getToxId());
+    int circleId = Settings::getInstance().getFriendCircleID(f->getPublicKey());
     CircleWidget* circleWidget = CircleWidget::getFromID(circleId);
 
     moveWidget(widget, f->getStatus(), true);
@@ -652,13 +652,13 @@ void FriendListWidget::moveWidget(FriendWidget* w, Status s, bool add)
 {
     if (mode == Name)
     {
-        int circleId = Settings::getInstance().getFriendCircleID(FriendList::findFriend(w->friendId)->getToxId());
+        int circleId = Settings::getInstance().getFriendCircleID(FriendList::findFriend(w->friendId)->getPublicKey());
         CircleWidget* circleWidget = CircleWidget::getFromID(circleId);
 
         if (circleWidget == nullptr || add)
         {
             if (circleId != -1)
-                Settings::getInstance().setFriendCircleID(FriendList::findFriend(w->friendId)->getToxId(), -1);
+                Settings::getInstance().setFriendCircleID(FriendList::findFriend(w->friendId)->getPublicKey(), -1);
 
             listLayout->addFriendWidget(w, s);
             return;

--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -70,7 +70,7 @@ void FriendWidget::contextMenuEvent(QContextMenuEvent * event)
     installEventFilter(this); // Disable leave event.
 
     QPoint pos = event->globalPos();
-    ToxId id = FriendList::findFriend(friendId)->getToxId();
+    ToxPk id = FriendList::findFriend(friendId)->getPublicKey();
     QString dir = Settings::getInstance().getAutoAcceptDir(id);
     QMenu menu;
     QAction* openChatWindow = nullptr;
@@ -103,7 +103,7 @@ void FriendWidget::contextMenuEvent(QContextMenuEvent * event)
         groupActions[groupAction] =  group;
     }
 
-    int circleId = Settings::getInstance().getFriendCircleID(FriendList::findFriend(friendId)->getToxId());
+    int circleId = Settings::getInstance().getFriendCircleID(FriendList::findFriend(friendId)->getPublicKey());
     CircleWidget *circleWidget = CircleWidget::getFromID(circleId);
 
     QMenu* circleMenu = nullptr;
@@ -314,7 +314,7 @@ void FriendWidget::updateStatusLight()
 
     if (f->getEventFlag())
     {
-        CircleWidget* circleWidget = CircleWidget::getFromID(Settings::getInstance().getFriendCircleID(FriendList::findFriend(friendId)->getToxId()));
+        CircleWidget* circleWidget = CircleWidget::getFromID(Settings::getInstance().getFriendCircleID(FriendList::findFriend(friendId)->getPublicKey()));
         if (circleWidget != nullptr)
             circleWidget->setExpanded(true);
 
@@ -353,7 +353,7 @@ Friend* FriendWidget::getFriend() const
 void FriendWidget::search(const QString &searchString, bool hide)
 {
     searchName(searchString, hide);
-    CircleWidget* circleWidget = CircleWidget::getFromID(Settings::getInstance().getFriendCircleID(FriendList::findFriend(friendId)->getToxId()));
+    CircleWidget* circleWidget = CircleWidget::getFromID(Settings::getInstance().getFriendCircleID(FriendList::findFriend(friendId)->getPublicKey()));
     if (circleWidget != nullptr)
         circleWidget->search(searchString);
 }
@@ -414,7 +414,7 @@ void FriendWidget::mouseMoveEvent(QMouseEvent *ev)
     if ((dragStartPos - ev->pos()).manhattanLength() > QApplication::startDragDistance())
     {
         QMimeData* mdata = new QMimeData;
-        mdata->setText(getFriend()->getToxId().toString());
+        mdata->setText(getFriend()->getPublicKey().toString());
 
         QDrag* drag = new QDrag(this);
         drag->setMimeData(mdata);
@@ -428,6 +428,6 @@ void FriendWidget::setAlias(const QString& _alias)
     QString alias = _alias.left(128); // same as TOX_MAX_NAME_LENGTH
     Friend* f = FriendList::findFriend(friendId);
     f->setAlias(alias);
-    Settings::getInstance().setFriendAlias(f->getToxId(), alias);
+    Settings::getInstance().setFriendAlias(f->getPublicKey(), alias);
     Settings::getInstance().savePersonal();
 }

--- a/src/widget/groupwidget.cpp
+++ b/src/widget/groupwidget.cpp
@@ -236,7 +236,7 @@ void GroupWidget::resetEventFlags()
 void GroupWidget::dragEnterEvent(QDragEnterEvent *ev)
 {
     ToxId toxId = ToxId(ev->mimeData()->text());
-    Friend *frnd = FriendList::findFriend(toxId);
+    Friend *frnd = FriendList::findFriend(toxId.getPublicKey());
     if (frnd)
         ev->acceptProposedAction();
 
@@ -253,7 +253,7 @@ void GroupWidget::dragLeaveEvent(QDragLeaveEvent *)
 void GroupWidget::dropEvent(QDropEvent *ev)
 {
     ToxId toxId = ToxId(ev->mimeData()->text());
-    Friend *frnd = FriendList::findFriend(toxId);
+    Friend *frnd = FriendList::findFriend(toxId.getPublicKey());
     if (!frnd)
         return;
 

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -993,10 +993,9 @@ void Widget::reloadHistory()
     }
 }
 
-void Widget::addFriend(int friendId, const QString &userId)
+void Widget::addFriend(int friendId, const ToxPk& friendPk)
 {
-    ToxId userToxId = ToxId(userId);
-    Friend* newfriend = FriendList::addFriend(friendId, userToxId);
+    Friend* newfriend = FriendList::addFriend(friendId, friendPk);
 
     QString name = newfriend->getDisplayedName();
     FriendWidget* widget = new FriendWidget(friendId, name);
@@ -1009,14 +1008,14 @@ void Widget::addFriend(int friendId, const QString &userId)
 
     const Settings& s = Settings::getInstance();
 
-    QDate activityDate = s.getFriendActivity(userToxId);
+    QDate activityDate = s.getFriendActivity(friendPk);
     QDate chatDate = friendForm->getLatestDate();
     if (chatDate > activityDate && chatDate.isValid())
     {
-        Settings::getInstance().setFriendActivity(userToxId, chatDate);
+        Settings::getInstance().setFriendActivity(friendPk, chatDate);
     }
 
-    contactListWidget->addFriendWidget(widget, Status::Offline, s.getFriendCircleID(userToxId));
+    contactListWidget->addFriendWidget(widget, Status::Offline, s.getFriendCircleID(friendPk));
 
     connect(newfriend, &Friend::displayedNameChanged, this, &Widget::onFriendDisplayChanged);
     connect(widget, &FriendWidget::chatroomWidgetClicked, this, &Widget::onChatroomWidgetClicked);
@@ -1025,7 +1024,7 @@ void Widget::addFriend(int friendId, const QString &userId)
     connect(widget, SIGNAL(removeFriend(int)), this, SLOT(removeFriend(int)));
 
     // Try to get the avatar from the cache
-    QPixmap avatar = Nexus::getProfile()->loadAvatar(userId);
+    QPixmap avatar = Nexus::getProfile()->loadAvatar(friendPk.toString());
     if (!avatar.isNull())
     {
         friendForm->onAvatarChange(friendId, avatar);
@@ -1036,7 +1035,7 @@ void Widget::addFriend(int friendId, const QString &userId)
     widget->search(ui->searchContactText->text(), filterOffline(filter));
 }
 
-void Widget::addFriendFailed(const QString&, const QString& errorInfo)
+void Widget::addFriendFailed(const ToxPk&, const QString& errorInfo)
 {
     QString info = QString(tr("Couldn't request friendship"));
     if (!errorInfo.isEmpty())
@@ -1226,7 +1225,7 @@ void Widget::onFriendMessageReceived(int friendId, const QString& message, bool 
     Profile* profile = Nexus::getProfile();
     if (profile->isHistoryEnabled())
     {
-        QString publicKey = f->getToxId().getPublicKeyString();
+        QString publicKey = f->getPublicKey().toString();
         QString name = f->getDisplayedName();
         QString text = message;
         if (isAction)
@@ -1278,7 +1277,7 @@ void Widget::addFriendDialog(Friend *frnd, ContentDialog *dialog)
     connect(core, &Core::friendAvatarRemoved,
             friendWidget, &FriendWidget::onAvatarRemoved);
 
-    QPixmap avatar = Nexus::getProfile()->loadAvatar(frnd->getToxId().toString());
+    QPixmap avatar = Nexus::getProfile()->loadAvatar(frnd->getPublicKey().toString());
     if (!avatar.isNull())
     {
         friendWidget->onAvatarChange(frnd->getFriendID(), avatar);
@@ -1469,9 +1468,9 @@ bool Widget::newMessageAlert(QWidget* currentWindow, bool isActive, bool sound, 
     return true;
 }
 
-void Widget::onFriendRequestReceived(const QString& userId, const QString& message)
+void Widget::onFriendRequestReceived(const ToxPk& friendPk, const QString& message)
 {
-    if (addFriendForm->addFriendRequest(userId, message))
+    if (addFriendForm->addFriendRequest(friendPk.toString(), message))
     {
         friendRequestsUpdate();
         newMessageAlert(window(), isActiveWindow(), true, true);
@@ -1480,12 +1479,12 @@ void Widget::onFriendRequestReceived(const QString& userId, const QString& messa
 
 void Widget::updateFriendActivity(Friend *frnd)
 {
-    QDate date = Settings::getInstance().getFriendActivity(frnd->getToxId());
+    QDate date = Settings::getInstance().getFriendActivity(frnd->getPublicKey());
     if (date != QDate::currentDate())
     {
         // Update old activity before after new one. Store old date first.
-        QDate oldDate = Settings::getInstance().getFriendActivity(frnd->getToxId());
-        Settings::getInstance().setFriendActivity(frnd->getToxId(), QDate::currentDate());
+        QDate oldDate = Settings::getInstance().getFriendActivity(frnd->getPublicKey());
+        Settings::getInstance().setFriendActivity(frnd->getPublicKey(), QDate::currentDate());
         contactListWidget->moveWidget(friendWidgets[frnd->getFriendID()], frnd->getStatus());
         contactListWidget->updateActivityDate(oldDate);
     }
@@ -1505,7 +1504,7 @@ void Widget::removeFriend(Friend* f, bool fake)
 
         if (ask.removeHistory())
         {
-            Nexus::getProfile()->getHistory()->removeFriendHistory(f->getToxId().getPublicKeyString());
+            Nexus::getProfile()->getHistory()->removeFriendHistory(f->getPublicKey().toString());
         }
     }
 
@@ -1669,7 +1668,7 @@ void Widget::copyFriendIdToClipboard(int friendId)
     if (f != nullptr)
     {
         QClipboard *clipboard = QApplication::clipboard();
-        clipboard->setText(Nexus::getCore()->getFriendAddress(f->getFriendID()), QClipboard::Clipboard);
+        clipboard->setText(Nexus::getCore()->getFriendPublicKey(f->getFriendID()).toString(), QClipboard::Clipboard);
     }
 }
 
@@ -1710,8 +1709,8 @@ void Widget::onGroupMessageReceived(int groupnumber, int peernumber, const QStri
     }
 
     const Core* core = Core::getInstance();
-    ToxId author = core->getGroupPeerToxId(groupnumber, peernumber);
-    bool isSelf = author == core->getSelfId();
+    ToxPk author = core->getGroupPeerPk(groupnumber, peernumber);
+    bool isSelf = author == core->getSelfId().getPublicKey();
 
     bool targeted = !isSelf && (message.contains(nameMention) || message.contains(sanitizedNameMention));
     if (targeted && !isAction)

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -27,7 +27,9 @@
 #include <QFileInfo>
 
 #include "genericchatitemwidget.h"
+
 #include "src/core/corestructs.h"
+#include "src/core/toxid.h"
 
 #define PIXELS_TO_ACT 7
 
@@ -121,18 +123,18 @@ public slots:
     void onStatusSet(Status status);
     void onFailedToStartCore();
     void onBadProxyCore();
-    void onSelfAvatarLoaded(const QPixmap &pic);
+    void onSelfAvatarLoaded(const QPixmap& pic);
     void setUsername(const QString& username);
     void setStatusMessage(const QString &statusMessage);
-    void addFriend(int friendId, const QString& userId);
-    void addFriendFailed(const QString& userId, const QString& errorInfo = QString());
+    void addFriend(int friendId, const ToxPk& friendPk);
+    void addFriendFailed(const ToxPk& userId, const QString& errorInfo = QString());
     void onFriendshipChanged(int friendId);
     void onFriendStatusChanged(int friendId, Status status);
     void onFriendStatusMessageChanged(int friendId, const QString& message);
     void onFriendUsernameChanged(int friendId, const QString& username);
     void onFriendDisplayChanged(FriendWidget* friendWidget, Status s);
     void onFriendMessageReceived(int friendId, const QString& message, bool isAction);
-    void onFriendRequestReceived(const QString& userId, const QString& message);
+    void onFriendRequestReceived(const ToxPk& friendPk, const QString& message);
     void updateFriendActivity(Friend* frnd);
     void onMessageSendResult(uint32_t friendId, const QString& message, int messageId);
     void onReceiptRecieved(int friendId, int receipt);
@@ -151,8 +153,8 @@ public slots:
     void onGroupDialogShown(Group* g);
 
 signals:
-    void friendRequestAccepted(const QString& userId);
-    void friendRequested(const QString& friendAddress, const QString& message);
+    void friendRequestAccepted(const ToxPk& friendPk);
+    void friendRequested(const ToxId& friendAddress, const QString& message);
     void statusSet(Status status);
     void statusSelected(Status status);
     void usernameChanged(const QString& username);
@@ -221,7 +223,7 @@ private:
     bool newMessageAlert(QWidget* currentWindow, bool isActive, bool sound = true, bool notify = true);
     void setActiveToolMenuButton(ActiveToolMenuButton newActiveButton);
     void hideMainForms(GenericChatroomWidget* chatroomWidget);
-    Group *createGroup(int groupId);
+    Group* createGroup(int groupId);
     void removeFriend(Friend* f, bool fake = false);
     void removeGroup(Group* g, bool fake = false);
     void saveWindowGeometry();


### PR DESCRIPTION
**WARNING: MAKE A BACKUP BEFORE TESTING**

I'm not yet entirely sure this doesn't crash the database and the settings file.

I intend to clean up all the low level data structures in qTox.

- [X] Build low level classes for Tox ID and Keys
- [X] Stop passing `QString`s, use the low level classes instead (mostly done in low level classes, I'm not quite sure if I should also do this for the UI classes)
~- [ ] Switch all internal data structures from using badly defined strings to well defined classes~ Will be in another PR

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4027)
<!-- Reviewable:end -->
