### PR TITLE
Fix Jenkins Windows builds

### DIFF
--- a/qtox.pro
+++ b/qtox.pro
@@ -46,12 +46,19 @@ CONFIG   += silent
 
 # Hardening flags (ASLR, warnings, etc)
 # TODO: add `-Werror` to hardening flags once all warnings are fixed
-QMAKE_CXXFLAGS += -fstack-protector-all \
-                  -fPIE \
-                  -Wstack-protector \
-                  -Wstrict-overflow \
-                  -Wstrict-aliasing \
-                  --param ssp-buffer-size=1
+win32 {
+    QMAKE_CXXFLAGS += -fPIE \
+                      -Wstrict-overflow \
+                      -Wstrict-aliasing
+} else {
+    QMAKE_CXXFLAGS += -fstack-protector-all \
+                      -fPIE \
+                      -Wstack-protector \
+                      -Wstrict-overflow \
+                      -Wstrict-aliasing \
+                      --param ssp-buffer-size=1
+}
+
 # osx & windows cannot into security (build on it fails with those enabled)
 unix:!macx {
     QMAKE_LFLAGS += -Wl,-z,now -Wl,-z,relro
@@ -273,6 +280,13 @@ win32 {
                    ./libs/lib/libopus.a \
                    ./libs/lib/libtoxencryptsave.a \
                    ./libs/lib/libtoxcore.a \
+                   ./libs/lib/libtoxgroup.a \
+                   ./libs/lib/libtoxmessenger.a \
+                   ./libs/lib/libtoxfriends.a \
+                   ./libs/lib/libtoxnetcrypto.a \
+                   ./libs/lib/libtoxdht.a \
+                   ./libs/lib/libtoxnetwork.a \
+                   ./libs/lib/libtoxcrypto.a \
                    ./libs/lib/libopenal.a \
                    ./libs/lib/libsodium.a \
                    ./libs/lib/libavdevice.a \


### PR DESCRIPTION
Two things:
- The stack protector caused compilation failures on Windows
- Linking statically with c-toxcore required new libraries

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4037)
<!-- Reviewable:end -->
