### PR TITLE
chore(style): add coding style file for Qt Creator

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -377,6 +377,9 @@ or Qt classes use `<>` tags, e.g. `cstdio` and `QString` from `src/main.cpp`:
 
 ## Coding style
 
+There's a [coding style file](/tools/configs/qTox-Coding-Style.xml) for Qt
+Creator that handles some of the rules below.
+
 ```C++
 function()
 {

--- a/tools/configs/qTox-Coding-Style.xml
+++ b/tools/configs/qTox-Coding-Style.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE QtCreatorCodeStyle>
+<!-- Written by QtCreator 3.1.2, 2017-01-03T14:11:26. -->
+<qtcreator>
+ <data>
+  <variable>CodeStyleData</variable>
+  <valuemap type="QVariantMap">
+   <value type="bool" key="AlignAssignments">false</value>
+   <value type="bool" key="AutoSpacesForTabs">false</value>
+   <value type="bool" key="BindStarToIdentifier">false</value>
+   <value type="bool" key="BindStarToLeftSpecifier">false</value>
+   <value type="bool" key="BindStarToRightSpecifier">false</value>
+   <value type="bool" key="BindStarToTypeName">true</value>
+   <value type="bool" key="ExtraPaddingForConditionsIfConfusingAlign">false</value>
+   <value type="bool" key="IndentAccessSpecifiers">false</value>
+   <value type="bool" key="IndentBlockBody">true</value>
+   <value type="bool" key="IndentBlockBraces">false</value>
+   <value type="bool" key="IndentBlocksRelativeToSwitchLabels">false</value>
+   <value type="bool" key="IndentClassBraces">false</value>
+   <value type="bool" key="IndentControlFlowRelativeToSwitchLabels">true</value>
+   <value type="bool" key="IndentDeclarationsRelativeToAccessSpecifiers">true</value>
+   <value type="bool" key="IndentEnumBraces">false</value>
+   <value type="bool" key="IndentFunctionBody">true</value>
+   <value type="bool" key="IndentFunctionBraces">false</value>
+   <value type="bool" key="IndentNamespaceBody">false</value>
+   <value type="bool" key="IndentNamespaceBraces">false</value>
+   <value type="int" key="IndentSize">4</value>
+   <value type="bool" key="IndentStatementsRelativeToSwitchLabels">true</value>
+   <value type="bool" key="IndentSwitchLabels">false</value>
+   <value type="int" key="PaddingMode">2</value>
+   <value type="bool" key="SpacesForTabs">true</value>
+   <value type="int" key="TabSize">4</value>
+  </valuemap>
+ </data>
+ <data>
+  <variable>DisplayName</variable>
+  <value type="QString">qTox</value>
+ </data>
+</qtcreator>


### PR DESCRIPTION
After correcting "& follows type" mistakes one to many times, I want to share the Coding Style config for Qt Creator which prevents these mistakes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4041)
<!-- Reviewable:end -->
