### PR TITLE
fix(nexus): Add qRegisterMetaType call for ToxPk

### DIFF
--- a/src/nexus.cpp
+++ b/src/nexus.cpp
@@ -99,6 +99,7 @@ void Nexus::start()
     qRegisterMetaType<ToxFile>("ToxFile");
     qRegisterMetaType<ToxFile::FileDirection>("ToxFile::FileDirection");
     qRegisterMetaType<std::shared_ptr<VideoFrame>>("std::shared_ptr<VideoFrame>");
+    qRegisterMetaType<ToxPk>("ToxPk");
     qRegisterMetaType<ToxId>("ToxId");
 
     loginScreen = new LoginScreen();


### PR DESCRIPTION
Fixed warning message: QObject::connect: Cannot queue arguments of type
'ToxPk' (Make sure 'ToxPk' is registered using qRegisterMetaType().)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4044)
<!-- Reviewable:end -->
