### PR TITLE
chore(tools): add a script for creating and signing release tarballs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ Makefile
 # Rust
 target/
 .cargo/
+
+# Tarballs
+*.tar.*

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -147,6 +147,37 @@ To get translations into qTox:
 process, so that no translation effort would be lost when resetting Weblate.**
 
 
+# Releases
+
+- tag versions that are to be released, make sure that they are GPG-signed,
+  i.e. `git tag -s v1.8.0`
+- use semantic versions for tags: `vMAJOR.MINOR.PATCH`
+  - `MAJOR` – bump version when there are breaking changes to video, audio,
+    text chats, groupchats, file transfers, and any other basic functionality.
+    For other things, `MINOR` and `PATCH` are to be bumped.
+  - `MINOR` – bump version when there are:
+    - new features added
+    - UI/feature breaking changes
+    - other non-breaking changes
+  - `PATCH` – bump when there have been only fixes added. If changes include
+    something more than just bugfixes, bump `MAJOR` or `MINOR` version
+    accordingly.
+- before creating a `MAJOR`/`MINOR` release generate changelog with `clog`.
+  - in a `MAJOR`/`MINOR` release tag should include information that changelog
+    is located in the `CHANGELOG.md` file, e.g. `For details see CHANGELOG.md`
+- to release a `PATCH` version after non-fix changes have landed on `master`
+  branch, checkout latest `MAJOR`/`MINOR` version and `git cherry-pick -x`
+  commits from `master` that you want `PATCH` release to include. Once
+  cherry-picking has been done, tag HEAD of the branch.
+  - when making a `PATCH` tag, include in tag message short summary of what the
+    tag release fixes, and to whom it's interesting (often only some
+    OSes/distributions would find given `PATCH` release interesting).
+- bumping a higher-level version "resets" lower-version numbers, e.g.
+  `v1.7.1 → v2.0.0`
+- create and GPG-sign tarball using [`./tools/create-tarball.sh`] script, and
+  upload the tarball to a github release.
+
+
 # How to become a maintainer?
 
 Contribute, review & test pull requests, be active, oh and don't forget to
@@ -164,3 +195,4 @@ helping for a while, ask to be added to the `qTox` organization on GitHub.
 [`merge-pr.sh`]: /merge-pr.sh
 [`test-pr.sh`]: /test-pr.sh
 [`./tools/deweblate-translation-file.sh`]: /tools/deweblate-translation-file.sh
+[`./tools/create-tarball.sh`]: /tools/create-tarball.sh

--- a/tools/create-tarball.sh
+++ b/tools/create-tarball.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+#
+#    Copyright © 2017 The qTox Project Contributors
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# Create a `lzip` archive and make a detached GPG signature for it.
+#
+# When tag name is supplied, it's used to create archive. If there is no tag
+# name supplied, latest tag is used.
+
+# Requires:
+#   * GPG
+#   * git
+#   * lzip
+
+# usage:
+#   ./$script [$tag_name]
+
+
+# Fail as soon as error appears
+set -eu -o pipefail
+
+
+archive_from_tag() {
+    git archive --format=tar "$@" \
+    | lzip --best \
+    > "$@".tar.lz
+    echo "$@.tar.lz archive has been created."
+}
+
+sign_archive() {
+    gpg \
+        --armor \
+        --detach-sign \
+        "$@".tar.lz
+    echo "$@.tar.lz.asc signature has been created."
+}
+
+create_and_sign() {
+    archive_from_tag "$@"
+    sign_archive "$@"
+}
+
+get_tag() {
+    local tname="$@"
+    if [[ -n "$tname" ]]
+    then
+        echo "$tname"
+    else
+        git describe --abbrev=0
+    fi
+}
+
+main() {
+    create_and_sign "$(get_tag $@)"
+}
+main "$@"


### PR DESCRIPTION
`lzip` is used for its great compression (better even than `xz`) and
properties that make it a viable format for long-term archiving (feature
that `xz` is missing).

http://www.nongnu.org/lzip/xz_inadequate.html

Also add some docs regarding release process.

Re: #3912, #4045

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4047)
<!-- Reviewable:end -->
