### PR TITLE
fix(avatar): wrong conversion of own ToxId

### DIFF
--- a/src/persistence/profile.cpp
+++ b/src/persistence/profile.cpp
@@ -434,7 +434,7 @@ QString Profile::avatarPath(const QString& ownerId, bool forceUnencrypted)
  */
 QPixmap Profile::loadAvatar()
 {
-    return loadAvatar(core->getSelfId().getPublicKey().getKey());
+    return loadAvatar(core->getSelfId().getPublicKey().toString());
 }
 
 /**


### PR DESCRIPTION
e07d8d358f6fc890a77e029aa230b69bdecd325e broke the loading of the own
avatar

fix #4048

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4049)
<!-- Reviewable:end -->
