### PR TITLE
fix: Remove old ChatForm code from Widget

### DIFF
--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1084,44 +1084,6 @@ void Widget::onFriendStatusChanged(int friendId, Status status)
     }
 
     ContentDialog::updateFriendStatus(friendId);
-
-    if (Settings::getInstance().getStatusChangeNotificationEnabled())
-    {
-        QString fStatus = "";
-        switch (f->getStatus())
-        {
-        case Status::Away:
-            fStatus = tr("away", "contact status");
-            break;
-        case Status::Busy:
-            fStatus = tr("busy", "contact status");
-            break;
-        case Status::Offline:
-            fStatus = tr("offline", "contact status");
-            // Hide the "is typing" message when a friend goes offline
-            f->getChatForm()->setFriendTyping(false);
-            break;
-        case Status::Online:
-            fStatus = tr("online", "contact status");
-            break;
-        }
-
-        if (isActualChange)
-        {
-            QString message = tr("%1 is now %2", "e.g. \"Dubslow is now online\"")
-                    .arg(f->getDisplayedName()).arg(fStatus);
-
-            f->getChatForm()->addSystemInfoMessage(message, ChatMessage::INFO,
-                                                   QDateTime::currentDateTime());
-        }
-    }
-
-    if (isActualChange && status != Status::Offline)
-    {
-        // wait a little
-        OfflineMsgEngine* ome = f->getChatForm()->getOfflineMsgEngine();
-        QTimer::singleShot(250, ome, SLOT(deliverOfflineMsgs()));
-    }
 }
 
 void Widget::onFriendStatusMessageChanged(int friendId, const QString& message)


### PR DESCRIPTION
Now it's moved to [ChatForm](https://github.com/qTox/qTox/blob/master/src/widget/form/chatform.cpp#L533)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4066)
<!-- Reviewable:end -->
