### PR TITLE
fix(build): add an option to compile with autotools toxcore on Windows

### DIFF
--- a/qtox.pro
+++ b/qtox.pro
@@ -97,6 +97,7 @@ contains(DISABLE_PLATFORM_EXT, YES) {
 
 contains(JENKINS,YES) {
     INCLUDEPATH += ./libs/include/
+    TOX_CMAKE = YES
 } else {
     INCLUDEPATH += libs/include
 }
@@ -128,13 +129,6 @@ win32 {
             -ltoxav \
             -ltoxcore \
             -ltoxencryptsave \
-            -ltoxgroup \
-            -ltoxmessenger \
-            -ltoxfriends \
-            -ltoxnetcrypto \
-            -ltoxdht \
-            -ltoxnetwork \
-            -ltoxcrypto \
             -lsodium \
             -lvpx \
             -lpthread \
@@ -158,6 +152,16 @@ win32 {
             -lshlwapi \
             -luuid
     LIBS += -lstrmiids # For DirectShow
+
+    contains(TOX_CMAKE, YES) {
+        LIBS += -ltoxgroup \
+                -ltoxmessenger \
+                -ltoxfriends \
+                -ltoxnetcrypto \
+                -ltoxdht \
+                -ltoxnetwork \
+                -ltoxcrypto
+    }
 } else {
     macx {
         BUNDLEID = chat.tox.qtox


### PR DESCRIPTION
Introduces the qmake option `TOX_AUTOTOOLS=YES` to only link to the libraries that are produced on a toxcore autotools build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4076)
<!-- Reviewable:end -->
