### PR TITLE
fix(jenkins): preserve the correct linking order

### DIFF
--- a/qtox.pro
+++ b/qtox.pro
@@ -128,8 +128,20 @@ win32 {
     LIBS += -L$$PWD/libs/lib \
             -ltoxav \
             -ltoxcore \
-            -ltoxencryptsave \
-            -lsodium \
+            -ltoxencryptsave
+
+    # must be exactly here, to preserve link order
+    contains(TOX_CMAKE, YES) {
+        LIBS += -ltoxgroup \
+                -ltoxmessenger \
+                -ltoxfriends \
+                -ltoxnetcrypto \
+                -ltoxdht \
+                -ltoxnetwork \
+                -ltoxcrypto
+    }
+
+    LIBS += -lsodium \
             -lvpx \
             -lpthread \
             -lavdevice \
@@ -152,16 +164,6 @@ win32 {
             -lshlwapi \
             -luuid
     LIBS += -lstrmiids # For DirectShow
-
-    contains(TOX_CMAKE, YES) {
-        LIBS += -ltoxgroup \
-                -ltoxmessenger \
-                -ltoxfriends \
-                -ltoxnetcrypto \
-                -ltoxdht \
-                -ltoxnetwork \
-                -ltoxcrypto
-    }
 } else {
     macx {
         BUNDLEID = chat.tox.qtox


### PR DESCRIPTION
fix #4079

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4081)
<!-- Reviewable:end -->
