### PR TITLE
fix: Add workaround for FreeBSD and ICU

### DIFF
--- a/src/persistence/smileypack.cpp
+++ b/src/persistence/smileypack.cpp
@@ -41,6 +41,10 @@
 #include <QStringBuilder>
 #include <QtConcurrent/QtConcurrentRun>
 
+#if defined(Q_OS_FREEBSD)
+#include <locale.h>
+#endif
+
 #define EMOTICONS_SUB_DIR QStringLiteral("emoticons")
 
 /**
@@ -84,6 +88,11 @@ SmileyPack& SmileyPack::getInstance()
 
 QStringList SmileyPack::loadDefaultPaths()
 {
+#if defined(Q_OS_FREEBSD)
+    // TODO: Remove when will be fixed.
+    // Workaround to fix https://bugreports.qt.io/browse/QTBUG-57522
+    setlocale(LC_ALL, "");
+#endif
     QStringList paths = QStringList{":/smileys", "~/.kde4/share/emoticons", "~/.kde/share/emoticons"};
     // qTox should find emoticons next to the binary
     paths.append('.' + QDir::separator() + EMOTICONS_SUB_DIR);


### PR DESCRIPTION
This patch fix problem with ICU on FreeBSD
Implementation by @VVD

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4090)
<!-- Reviewable:end -->
