### PR TITLE
chore(build): use `-pie` flag only when linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,23 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
 
+# Hardening flags (ASLR, warnings, etc)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIE")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wstrict-overflow")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wstrict-aliasing")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie")
+
+if (NOT WIN32)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-all")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wstack-protector")
+endif()
+
+if (UNIX AND NOT APPLE)
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-z,now")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-z,relro")
+endif()
+
+
 # Use ccache when available to speed up builds.
 find_program(CCACHE_FOUND ccache)
 if(CCACHE_FOUND)

--- a/qtox.pro
+++ b/qtox.pro
@@ -46,18 +46,14 @@ CONFIG   += silent
 
 # Hardening flags (ASLR, warnings, etc)
 # TODO: add `-Werror` to hardening flags once all warnings are fixed
-win32 {
-    QMAKE_CXXFLAGS += -pie \
-                      -fPIE \
-                      -Wstrict-overflow \
-                      -Wstrict-aliasing
-} else {
+QMAKE_CXXFLAGS += -fPIE \
+                  -Wstrict-overflow \
+                  -Wstrict-aliasing
+QMAKE_LFLAGS   += -pie
+
+!win32 {
     QMAKE_CXXFLAGS += -fstack-protector-all \
-                      -pie \
-                      -fPIE \
-                      -Wstack-protector \
-                      -Wstrict-overflow \
-                      -Wstrict-aliasing
+                      -Wstack-protector
 }
 
 # osx & windows cannot into security (build on it fails with those enabled)


### PR DESCRIPTION
If used when compiling and not just linking, clang complains about it.

Fixes #4101.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4111)
<!-- Reviewable:end -->
