### PR TITLE
fix(font): Made font changes in settings apply on screen instantly.

### DIFF
--- a/src/chatlog/chatline.cpp
+++ b/src/chatlog/chatline.cpp
@@ -118,6 +118,12 @@ void ChatLine::selectionFocusChanged(bool focusIn)
         c->selectionFocusChanged(focusIn);
 }
 
+void ChatLine::fontChanged(const QFont& font)
+{
+    for (ChatLineContent* c : content)
+        c->fontChanged(font);
+}
+
 int ChatLine::getColumnCount()
 {
     return content.size();

--- a/src/chatlog/chatline.h
+++ b/src/chatlog/chatline.h
@@ -29,6 +29,7 @@ class ChatLog;
 class ChatLineContent;
 class QGraphicsScene;
 class QStyleOptionGraphicsItem;
+class QFont;
 
 struct ColumnFormat
 {
@@ -75,6 +76,7 @@ public:
     void setVisible(bool visible);
     void selectionCleared();
     void selectionFocusChanged(bool focusIn);
+    void fontChanged(const QFont& font);
 
     int getColumnCount();
     int getRow() const;

--- a/src/chatlog/chatlinecontent.cpp
+++ b/src/chatlog/chatlinecontent.cpp
@@ -75,6 +75,10 @@ QString ChatLineContent::getSelectedText() const
     return QString();
 }
 
+void ChatLineContent::fontChanged(const QFont& font)
+{
+}
+
 qreal ChatLineContent::getAscent() const
 {
     return 0.0;

--- a/src/chatlog/chatlinecontent.h
+++ b/src/chatlog/chatlinecontent.h
@@ -48,6 +48,7 @@ public:
     virtual void selectionFocusChanged(bool focusIn);
     virtual bool isOverSelection(QPointF scenePos) const;
     virtual QString getSelectedText() const;
+    virtual void fontChanged(const QFont& font);
 
     virtual QString getText() const;
 

--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -651,6 +651,14 @@ void ChatLog::selectAll()
     updateMultiSelectionRect();
 }
 
+void ChatLog::fontChanged(const QFont& font)
+{
+    for (ChatLine::Ptr l : lines)
+    {
+        l->fontChanged(font);
+    }
+}
+
 void ChatLog::forceRelayout()
 {
     startResizeWorker();

--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -52,6 +52,7 @@ public:
     void setTypingNotificationVisible(bool visible);
     void scrollToLine(ChatLine::Ptr line);
     void selectAll();
+    void fontChanged(const QFont& font);
 
     QString getSelectedText() const;
 

--- a/src/chatlog/content/text.cpp
+++ b/src/chatlog/content/text.cpp
@@ -143,6 +143,11 @@ QString Text::getSelectedText() const
     return selectedText;
 }
 
+void Text::fontChanged(const QFont& font)
+{
+    defFont = font;
+}
+
 QRectF Text::boundingRect() const
 {
     return QRectF(QPointF(0, 0), size);

--- a/src/chatlog/content/text.h
+++ b/src/chatlog/content/text.h
@@ -45,6 +45,7 @@ public:
     virtual void selectionFocusChanged(bool focusIn) final;
     virtual bool isOverSelection(QPointF scenePos) const final;
     virtual QString getSelectedText() const final;
+    virtual void fontChanged(const QFont& font) final;
 
     virtual QRectF boundingRect() const final;
     virtual void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget) final;

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -93,6 +93,8 @@ GenericChatForm::GenericChatForm(QWidget *parent)
     const Settings& s = Settings::getInstance();
     connect(&s, &Settings::emojiFontPointSizeChanged,
             chatWidget, &ChatLog::forceRelayout);
+    connect(&s, &Settings::chatMessageFontChanged,
+            this, &GenericChatForm::onChatMessageFontChanged);
 
     msgEdit = new ChatTextEdit();
 
@@ -477,6 +479,15 @@ void GenericChatForm::onCopyLogClicked()
 void GenericChatForm::focusInput()
 {
     msgEdit->setFocus();
+}
+
+void GenericChatForm::onChatMessageFontChanged(const QFont& font) {
+    // chat log
+    chatWidget->fontChanged(font);
+    chatWidget->forceRelayout();
+    // message editor
+    msgEdit->setStyleSheet(Style::getStylesheet(":/ui/msgEdit/msgEdit.css")
+                         + fontToCss(font, "QTextEdit"));
 }
 
 void GenericChatForm::addSystemInfoMessage(const QString &message, ChatMessage::SystemMessageType type, const QDateTime &datetime)

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -83,6 +83,7 @@ signals:
 
 public slots:
     void focusInput();
+    void onChatMessageFontChanged(const QFont& font);
 
 protected slots:
     void onChatContextMenuRequested(QPoint pos);


### PR DESCRIPTION
Before the user had to restart qTox for the font change to take effect.
Now it changes instantly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4137)
<!-- Reviewable:end -->
