### PR TITLE
feat(shortcut): Implemented F11 shortcut for toggling fullscreen.

### DIFF
--- a/doc/user_manual_en.md
+++ b/doc/user_manual_en.md
@@ -415,6 +415,7 @@ The following shortcuts are currently supported:
 | `CTRL` + `TAB` | Switch to the next contact |
 | `CTRL` + `SHIFT` + `TAB` | Switch to the previous contact|
 | `ALT` + `q` | Quote selected text |
+| `F11` | Toggle fullscreen mode |
 
 ## Emoji Packs
 

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -261,6 +261,7 @@ void Widget::init()
     new QShortcut(Qt::CTRL + Qt::Key_Tab, this, SLOT(nextContact()));
     new QShortcut(Qt::CTRL + Qt::Key_PageUp, this, SLOT(previousContact()));
     new QShortcut(Qt::CTRL + Qt::Key_PageDown, this, SLOT(nextContact()));
+    new QShortcut(Qt::Key_F11, this, SLOT(toggleFullscreen()));
 
 #ifdef Q_OS_MAC
     QMenuBar* globalMenu = Nexus::getInstance().globalMenuBar;
@@ -1574,6 +1575,17 @@ void Widget::onFriendDialogShown(Friend* f)
 void Widget::onGroupDialogShown(Group* g)
 {
     onDialogShown(g->getGroupWidget());
+}
+
+void Widget::toggleFullscreen() {
+    if (windowState().testFlag(Qt::WindowFullScreen))
+    {
+        setWindowState(windowState() & ~Qt::WindowFullScreen);
+    }
+    else
+    {
+        setWindowState(windowState() | Qt::WindowFullScreen);
+    }
 }
 
 ContentDialog* Widget::createContentDialog() const

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -151,6 +151,7 @@ public slots:
     void previousContact();
     void onFriendDialogShown(Friend* f);
     void onGroupDialogShown(Group* g);
+    void toggleFullscreen();
 
 signals:
     void friendRequestAccepted(const ToxPk& friendPk);


### PR DESCRIPTION
Allow to make qTox fullscreen, similar to how browsers switch to fullscreen.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4141)
<!-- Reviewable:end -->
