### PR TITLE
chore(travis): fix jenkins branch deploy error on deploy-gitstats job

### DIFF
--- a/.travis/deploy-jenkins-branch.sh
+++ b/.travis/deploy-jenkins-branch.sh
@@ -24,7 +24,12 @@
 set -eu -o pipefail
 
 main() {
-    git clone https://github.com/qTox/qTox.git qTox
+    # can already be cloned by the `build-gitstats` job
+    if [[ ! -e qTox ]]
+    then
+        git clone https://github.com/qTox/qTox.git qTox
+    fi
+
     cd qTox
     git checkout $(git describe --abbrev=0) -b for-jenkins-release
     git push --force "https://${GH_DEPLOY_JENKINS}@github.com/qTox/qTox.git"


### PR DESCRIPTION
Error was caused by qTox repo already being cloned by the
`deploy-gitstats` job.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4145)
<!-- Reviewable:end -->
