### PR TITLE
revert: "docs(README): remove link to the experimental osx build"

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ while running on all major platforms.
 Windows | Linux | OS X | FreeBSD
 --------|-------|------|--------
 **[64 bit installer]**, [signature][sig-64] | **[CentOS, Debian, Fedora, openSUSE, Ubuntu]** | **[Building instructions]** | **[Port]**
-[32 bit installer], [signature][sig-32] | **[Arch]**, **[Gentoo]** | |
+[32 bit installer], [signature][sig-32] | **[Arch]**, **[Gentoo]** | [Experimental download] |
 [64 bit][64portable], [32 bit][32portable] portable | [Other] | |
 
 _**Bold** options are recommended._
@@ -145,6 +145,7 @@ Linux OBS repositories, managed by `abbat`:
 [CentOS, Debian, Fedora, openSUSE, Ubuntu]: https://software.opensuse.org/download.html?project=home%3Aantonbatenev%3Atox&package=qtox
 [Contributing]: /CONTRIBUTING.md#how-to-start-contributing
 [easy issues]: https://github.com/qTox/qTox/labels/E-easy
+[Experimental download]: https://github.com/qTox/qTox/releases/latest
 [Gentoo]: /INSTALL.md#gentoo
 [Install/Build]: /INSTALL.md
 [IRC logs]: https://github.com/qTox/qtox-irc-logs


### PR DESCRIPTION
Build has been fixed, so the link can be restored.

Closes #3610.

This reverts commit 37b0ed050c24b8116376ce3b48feda476035c939.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4152)
<!-- Reviewable:end -->
