### PR TITLE
docs(INSTALL): fix link in dependencies to CMake website

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -748,6 +748,7 @@ Switches:
 
 [Atk]: https://wiki.gnome.org/Accessibility
 [Cairo]: https://www.cairographics.org/
+[CMake]: https://cmake.org/
 [DBus Menu]: https://launchpad.net/libdbusmenu
 [FFmpeg]: https://www.ffmpeg.org/
 [GCC]: https://gcc.gnu.org/


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4153)
<!-- Reviewable:end -->
