### PR TITLE
fix(toxencrypt): return the plaintext after decryption

### DIFF
--- a/src/core/toxencrypt.cpp
+++ b/src/core/toxencrypt.cpp
@@ -147,7 +147,7 @@ QByteArray ToxEncrypt::decryptPass(const QString& password, const QByteArray& ci
         return QByteArray{};
     }
 
-    return ciphertext;
+    return plaintext;
 }
 
 /**
@@ -275,7 +275,7 @@ QByteArray ToxEncrypt::decrypt(const QByteArray& ciphertext) const
         return QByteArray{};
     }
 
-    return ciphertext;
+    return plaintext;
 }
 
 /**


### PR DESCRIPTION
fix #4162

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4163)
<!-- Reviewable:end -->
