### PR TITLE
feat: UI to import a list of contacts from a file

### DIFF
--- a/src/widget/form/addfriendform.h
+++ b/src/widget/form/addfriendform.h
@@ -23,6 +23,7 @@
 #include "src/core/toxid.h"
 
 #include <QVBoxLayout>
+#include <QHBoxLayout>
 #include <QLabel>
 #include <QLineEdit>
 #include <QTextEdit>
@@ -51,7 +52,6 @@ public:
 
     bool isShown() const;
     void show(ContentLayout* contentLayout);
-    QString getMessage() const;
     void setMode(Mode mode);
 
     bool addFriendRequest(const QString& friendAddress, const QString& message);
@@ -66,6 +66,8 @@ public slots:
 
 private slots:
     void onSendTriggered();
+    void onImportSendClicked();
+    void onImportOpenClicked();
     void onIdChanged(const QString &id);
     void onFriendRequestAccepted();
     void onFriendRequestRejected();
@@ -79,19 +81,23 @@ private:
     void retranslateRejectButton(QPushButton* rejectButton);
     void deleteFriendRequest(const ToxId& toxId);
     void setIdFromClipboard();
+    QString getMessage() const;
+    QString getImportMessage() const;
 
 private:
-    QLabel headLabel, toxIdLabel, messageLabel;
-    QPushButton sendButton;
+    QLabel headLabel, toxIdLabel, messageLabel, importFileLabel, importMessageLabel;
+    QPushButton sendButton, importFileButton, importSendButton;
     QLineEdit toxId;
-    QTextEdit message;
-    QVBoxLayout layout, headLayout;
-    QWidget* head, *main;
+    QTextEdit message, importMessage;
+    QVBoxLayout layout, headLayout, importContactsLayout;
+    QHBoxLayout importFileLine;
+    QWidget *head, *main, *importContacts;
     QString lastUsername;
     QTabWidget* tabWidget;
     QVBoxLayout* requestsLayout;
     QList<QPushButton*> acceptButtons;
     QList<QPushButton*> rejectButtons;
+    QList<QString> contactsToImport;
 };
 
 #endif // ADDFRIENDFORM_H


### PR DESCRIPTION
Resolves #4181

Adds a new tab to the AddFriendForm to import a list of contacts (Tox IDs or ToxDNS addresses, one per line) from a file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4182)
<!-- Reviewable:end -->
