### PR TITLE
Fixes a variety of Tox URI & IPC handling bugs, deadlocks & infinite loops.

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -94,10 +94,13 @@ Core::~Core()
                                       Q_ARG(bool, false));
     }
     coreThread->exit(0);
-    while (coreThread->isRunning())
+    if (QThread::currentThread() != coreThread)
     {
-        qApp->processEvents();
-        coreThread->wait(500);
+        while (coreThread->isRunning())
+        {
+            qApp->processEvents();
+            coreThread->wait(500);
+        }
     }
 
     deadifyTox();

--- a/src/ipc.cpp
+++ b/src/ipc.cpp
@@ -175,6 +175,10 @@ bool IPC::isCurrentOwner()
     }
 }
 
+/**
+ * @brief Register a handler for an IPC event
+ * @param handler The handler callback. Should not block for more than a second, at worst
+ */
 void IPC::registerEventHandler(const QString &name, IPCEventHandler handler)
 {
     eventHandlers[name] = handler;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -295,7 +295,8 @@ int main(int argc, char *argv[])
         }
     }
 
-    Nexus::getInstance().start();
+    Nexus& nexus = Nexus::getInstance();
+    nexus.start();
 
     // Event was not handled by already running instance therefore we handle it ourselves
     if (eventType == "uri")
@@ -303,8 +304,10 @@ int main(int argc, char *argv[])
     else if (eventType == "save")
         handleToxSave(firstParam.toUtf8());
 
-    // Run
-    int errorcode = a.exec();
+    // Run (unless we already quit before starting!)
+    int errorcode = 0;
+    if (nexus.isRunning())
+        errorcode = a.exec();
 
     Nexus::destroyInstance();
     CameraSource::destroyInstance();

--- a/src/net/toxuri.cpp
+++ b/src/net/toxuri.cpp
@@ -33,6 +33,7 @@
 #include <QPlainTextEdit>
 #include <QPushButton>
 #include <QCoreApplication>
+#include <QThread>
 
 bool toxURIEventHandler(const QByteArray& eventData)
 {
@@ -61,6 +62,7 @@ bool handleToxURI(const QString &toxURI)
 
         core = nexus.getCore();
         qApp->processEvents();
+        QThread::msleep(10);
     }
 
     while (!core->isReady())
@@ -69,6 +71,7 @@ bool handleToxURI(const QString &toxURI)
             return false;
 
         qApp->processEvents();
+        QThread::msleep(10);
     }
 
     QString toxaddr = toxURI.mid(4);

--- a/src/net/toxuri.cpp
+++ b/src/net/toxuri.cpp
@@ -64,13 +64,17 @@ bool handleToxURI(const QString &toxURI)
 
     QString toxaddr = toxURI.mid(4);
 
-    ToxId toxId = Toxme::lookup(toxaddr);
+    ToxId toxId(toxaddr);
     if (!toxId.isValid())
     {
-        QMessageBox::warning(0, "qTox",
-                             ToxURIDialog::tr("%1 is not a valid Toxme address.")
-                             .arg(toxaddr));
-        return false;
+        toxId = Toxme::lookup(toxaddr);
+        if (!toxId.isValid())
+        {
+            QMessageBox::warning(0, "qTox",
+                                         ToxURIDialog::tr("%1 is not a valid Toxme address.")
+                                         .arg(toxaddr));
+            return false;
+        }
     }
 
     ToxURIDialog dialog(0, toxaddr, QObject::tr("%1 here! Tox me maybe?",

--- a/src/net/toxuri.cpp
+++ b/src/net/toxuri.cpp
@@ -79,14 +79,28 @@ bool handleToxURI(const QString &toxURI)
         toxId = Toxme::lookup(toxaddr);
         if (!toxId.isValid())
         {
-            QMessageBox *messageBox = new QMessageBox(QMessageBox::Warning, "qTox",
-                                   QMessageBox::tr("%1 is not a valid Toxme address.")
-                                   .arg(toxaddr), QMessageBox::Ok, nullptr);
+            QMessageBox *messageBox = new QMessageBox(QMessageBox::Warning,
+                                                      QMessageBox::tr("Couldn't add friend"),
+                                                      QMessageBox::tr("%1 is not a valid Toxme address.")
+                                                      .arg(toxaddr), QMessageBox::Ok, nullptr);
             messageBox->setButtonText(QMessageBox::Ok, QMessageBox::tr("Ok"));
             QObject::connect(messageBox, &QMessageBox::finished, messageBox, &QMessageBox::deleteLater);
             messageBox->show();
             return false;
         }
+    }
+
+    if (toxId == core->getSelfId())
+    {
+        QMessageBox *messageBox = new QMessageBox(QMessageBox::Warning,
+                                                  QMessageBox::tr("Couldn't add friend"),
+                                                  QMessageBox::tr("You can't add yourself as a friend!",
+                                                     "When trying to add your own Tox ID as friend"),
+                                                  QMessageBox::Ok, nullptr);
+        messageBox->setButtonText(QMessageBox::Ok, QMessageBox::tr("Ok"));
+        QObject::connect(messageBox, &QMessageBox::finished, messageBox, &QMessageBox::deleteLater);
+        messageBox->show();
+        return false;
     }
 
     ToxURIDialog *dialog = new ToxURIDialog(0, toxaddr, QObject::tr("%1 here! Tox me maybe?",

--- a/src/nexus.h
+++ b/src/nexus.h
@@ -43,6 +43,8 @@ class Nexus : public QObject
 public:
     void start();
     void showMainGUI();
+    void quit();
+    bool isRunning();
 
     static Nexus& getInstance();
     static void destroyInstance();
@@ -84,6 +86,9 @@ private:
     QActionGroup* windowActions = nullptr;
 #endif
 
+private slots:
+    void onLastWindowClosed();
+
 private:
     explicit Nexus(QObject *parent = 0);
     ~Nexus();
@@ -92,6 +97,8 @@ private:
     Profile* profile;
     Widget* widget;
     LoginScreen* loginScreen;
+    bool running;
+    bool quitOnLastWindowClosed;
 };
 
 #endif // NEXUS_H

--- a/src/persistence/profile.cpp
+++ b/src/persistence/profile.cpp
@@ -211,7 +211,10 @@ Profile::~Profile()
         saveToxSave();
     }
 
-    delete core;
+    core->deleteLater();
+    while (coreThread->isRunning())
+        qApp->processEvents();
+
     delete coreThread;
     if (!isRemoved)
     {

--- a/src/widget/gui.cpp
+++ b/src/widget/gui.cpp
@@ -322,25 +322,34 @@ QString GUI::passwordDialog(const QString& cancel, const QString& body)
 
 void GUI::_clearContacts()
 {
-    Nexus::getDesktopGUI()->clearContactsList();
+    Widget* w = Nexus::getDesktopGUI();
+    if (w)
+        w->clearContactsList();
 }
 
 void GUI::_setEnabled(bool state)
 {
-    Nexus::getDesktopGUI()->setEnabled(state);
+    Widget* w = Nexus::getDesktopGUI();
+    if (w)
+        w->setEnabled(state);
 }
 
 void GUI::_setWindowTitle(const QString& title)
 {
+    QWidget* w = getMainWidget();
+    if (!w)
+        return;
     if (title.isEmpty())
-        getMainWidget()->setWindowTitle("qTox");
+        w->setWindowTitle("qTox");
     else
-        getMainWidget()->setWindowTitle("qTox - " + title);
+        w->setWindowTitle("qTox - " + title);
 }
 
 void GUI::_reloadTheme()
 {
-    Nexus::getDesktopGUI()->reloadTheme();
+    Widget* w = Nexus::getDesktopGUI();
+    if (w)
+        w->reloadTheme();
 }
 
 void GUI::_showInfo(const QString& title, const QString& msg)
@@ -366,7 +375,9 @@ void GUI::_showError(const QString& title, const QString& msg)
 
 void GUI::_showUpdateDownloadProgress()
 {
-    Nexus::getDesktopGUI()->showUpdateDownloadProgress();
+    Widget* w = Nexus::getDesktopGUI();
+    if (w)
+        w->showUpdateDownloadProgress();
 }
 
 bool GUI::_askQuestion(const QString& title, const QString& msg,

--- a/src/widget/loginscreen.cpp
+++ b/src/widget/loginscreen.cpp
@@ -126,6 +126,11 @@ bool LoginScreen::event(QEvent* event)
     return QWidget::event(event);
 }
 
+void LoginScreen::closeEvent(QCloseEvent*)
+{
+    emit closed();
+}
+
 void LoginScreen::onNewProfilePageClicked()
 {
     ui->stackedWidget->setCurrentIndex(0);

--- a/src/widget/loginscreen.h
+++ b/src/widget/loginscreen.h
@@ -42,6 +42,10 @@ public:
 
 signals:
     void windowStateChanged(Qt::WindowStates states);
+    void closed();
+
+protected:
+    virtual void closeEvent(QCloseEvent *event) final override;
 
 private slots:
     void onAutoLoginToggled(int state);

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -594,7 +594,7 @@ void Widget::closeEvent(QCloseEvent *event)
         saveWindowGeometry();
         saveSplitterGeometry();
         QWidget::closeEvent(event);
-        qApp->quit();
+        Nexus::getInstance().quit();
     }
 }
 
@@ -647,7 +647,7 @@ void Widget::onFailedToStartCore()
     critical.setText(tr("toxcore failed to start, the application will terminate after you close this message."));
     critical.setIcon(QMessageBox::Critical);
     critical.exec();
-    qApp->quit();
+    Nexus::getInstance().quit();
 }
 
 void Widget::onBadProxyCore()


### PR DESCRIPTION
Fixes #1925 in the first commit.

The second commit fixes some more bugs, there was a baroque situation with processEvents() loops running before the main event loop, causing an infinite loop due to QApplication::quit() being 1) ignored before the first call to exec() and 2) just plain useless in a processEvents() loop (this is the #1926 100% CPU bug), this was often triggered by IPC event senders timing out because the handler was blocking, just pure Fun™ all around!
I also fixed a potential deadlock between the Core and Main thread in the case of an early exit, that I hit while fixing the other problems.

@zetok Can you confirm that this fixes it for you?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4183)
<!-- Reviewable:end -->
