### PR TITLE
fix(core): Ignore online connection status

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -475,11 +475,13 @@ void Core::onUserStatusChanged(Tox* /* tox*/, uint32_t friendId, TOX_USER_STATUS
 void Core::onConnectionStatusChanged(Tox* /* tox*/, uint32_t friendId, TOX_CONNECTION status, void* core)
 {
     Status friendStatus = status != TOX_CONNECTION_NONE ? Status::Online : Status::Offline;
-    emit static_cast<Core*>(core)->friendStatusChanged(friendId, friendStatus);
-    if (friendStatus == Status::Offline)
+    // Ignore Online because it will be emited from onUserStatusChanged
+    if (friendStatus == Status::Offline) {
+        emit static_cast<Core*>(core)->friendStatusChanged(friendId, friendStatus);
         static_cast<Core*>(core)->checkLastOnline(friendId);
-    CoreFile::onConnectionStatusChanged(static_cast<Core*>(core), friendId,
-                                        friendStatus != Status::Offline);
+        CoreFile::onConnectionStatusChanged(static_cast<Core*>(core), friendId, 
+                friendStatus != Status::Offline);
+    }
 }
 
 void Core::onGroupInvite(Tox*, uint32_t friendId, TOX_CONFERENCE_TYPE type, const uint8_t* data,


### PR DESCRIPTION
Fix #4010.

qTox use status system, where offline is one of the status, but toxcore
use two different meaning: 'connection' and 'user status'. To correct
qTox status handling we should ignore online connection status.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4205)
<!-- Reviewable:end -->
