### PR TITLE
test: disable compiling tests on OSX since compiling them fails there

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -522,5 +522,8 @@ target_link_libraries(${PROJECT_NAME}
   ${PROJECT_NAME}_static
   ${ALL_LIBRARIES})
 
-include(Testing)
+# test(s?) are broken on osx (just travis?)
+if (NOT APPLE)
+    include(Testing)
+endif()
 include(Installation)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4222)
<!-- Reviewable:end -->
