### PR TITLE
fix: use Qt tray backend instead of GTK on under Xfce

### DIFF
--- a/src/widget/systemtrayicon.cpp
+++ b/src/widget/systemtrayicon.cpp
@@ -31,9 +31,11 @@ SystemTrayIcon::SystemTrayIcon()
     QString desktop = getenv("XDG_CURRENT_DESKTOP");
     if (desktop.isEmpty())
         desktop = getenv("DESKTOP_SESSION");
+
     desktop = desktop.toLower();
-    if (false)
-        ;
+
+    if (false) {
+    }
 #ifdef ENABLE_SYSTRAY_UNITY_BACKEND
     else if (desktop == "unity") {
         qDebug() << "Using Unity backend";
@@ -56,8 +58,7 @@ SystemTrayIcon::SystemTrayIcon()
     }
 #endif
 #ifdef ENABLE_SYSTRAY_GTK_BACKEND
-    else if (desktop == "xfce" || desktop.contains("gnome") || desktop == "mate"
-             || desktop == "x-cinnamon") {
+    else if (desktop.contains("gnome") || desktop == "mate" || desktop == "x-cinnamon") {
         qDebug() << "Using GTK backend";
         backendType = SystrayBackendType::GTK;
         gtk_init(nullptr, nullptr);


### PR DESCRIPTION
GTK tray backend caused icons in tray under Xfce to be overly big.

Fixes #4221.

@DX37 would you mind testing? Should work with support for GTK tray compiled-in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4227)
<!-- Reviewable:end -->
