### PR TITLE
fix(db): Ensured that RawDatabase::execLater executes statements asynchronously.

### DIFF
--- a/src/persistence/db/rawdatabase.cpp
+++ b/src/persistence/db/rawdatabase.cpp
@@ -294,7 +294,7 @@ void RawDatabase::execLater(const QVector<RawDatabase::Query>& statements)
         pendingTransactions.enqueue(trans);
     }
 
-    QMetaObject::invokeMethod(this, "process");
+    QMetaObject::invokeMethod(this, "process", Qt::QueuedConnection);
 }
 
 /**


### PR DESCRIPTION
Current version sometimes executes them synchronously because the default type=Qt::AutoConnection uses Qt::DirectConnection when the thread is the same.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4230)
<!-- Reviewable:end -->
