### PR TITLE
refactor: correct indentation in filetransferwidget.cpp

### DIFF
--- a/src/chatlog/content/filetransferwidget.cpp
+++ b/src/chatlog/content/filetransferwidget.cpp
@@ -214,12 +214,10 @@ void FileTransferWidget::paintEvent(QPaintEvent*)
     const int buttonFieldWidth = 32;
     const int lineWidth = 1;
 
-    // draw background
-    if (drawButtonAreaNeeded())
-        // Draw the widget background:
-        painter.setClipRect(QRect(0, 0, width(), height()));
-        painter.setBrush(QBrush(backgroundColor));
-        painter.drawRoundRect(geometry(), r * ratio, r);
+    // Draw the widget background:
+    painter.setClipRect(QRect(0, 0, width(), height()));
+    painter.setBrush(QBrush(backgroundColor));
+    painter.drawRoundRect(geometry(), r * ratio, r);
 
     if (drawButtonAreaNeeded()) {
         // Draw the button background:


### PR DESCRIPTION
This fixes a compiler warning. @Chiitoo can you please check if that's the intended logic?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4235)
<!-- Reviewable:end -->
