### PR TITLE
fix: emoji packs path in user manual

### DIFF
--- a/doc/user_manual_en.md
+++ b/doc/user_manual_en.md
@@ -420,7 +420,7 @@ The following shortcuts are currently supported:
 ## Emoji Packs
 
 qTox provides support for custom emoji packs. To install a new emoji pack
-put it in `%AppData%/Local/emoticons` for Windows or `~/.local/share/emoticons`
+put it in `%LOCALAPPDATA%/emoticons` for Windows or `~/.local/share/emoticons`
 for Linux. If these directories don't exist, you have to create them. The emoji
 files have to be in a subfolder also containing `emoticon.xml`, see the
 structure of https://github.com/qTox/qTox/tree/v1.5.2/smileys for further


### PR DESCRIPTION
The previously used `%AppData%/Local` is wrong. This will point to `C:\Users\{username}\AppData\Roaming\Local` (see [here)](https://ss64.com/nt/syntax-variables.html) where as the used code looks for the `emoticons` folder in `QStandardPaths::standardLocations(QStandardPaths::GenericDataLocation))` that points to `C:\Users\{username}\AppData\Local` (see [here](http://doc.qt.io/qt-5/qstandardpaths.html#StandardLocation-enum)).

Using `%LOCALAPPDATA%` points to `C:\Users\{username}\AppData\Local` which is right.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4255)
<!-- Reviewable:end -->
