### PR TITLE
fix(message size): Replaced TOX_MAX_*_LENGTH with API calls.

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -553,7 +553,7 @@ void Core::requestFriendship(const ToxId& friendAddress, const QString& message)
         emit failedToAddFriend(friendPk, tr("Invalid Tox ID"));
     } else if (message.isEmpty()) {
         emit failedToAddFriend(friendPk, tr("You need to write a message with your request"));
-    } else if (message.size() > TOX_MAX_FRIEND_REQUEST_LENGTH) {
+    } else if (message.size() > static_cast<int>(tox_max_friend_request_length())) {
         emit failedToAddFriend(friendPk, tr("Your message is too long!"));
     } else if (hasFriendWithPublicKey(friendPk)) {
         emit failedToAddFriend(friendPk, tr("Friend is already added"));

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -614,7 +614,7 @@ void ChatForm::dropEvent(QDropEvent* ev)
             QFile file(info.absoluteFilePath());
 
             if (url.isValid() && !url.isLocalFile()
-                && url.toString().length() < TOX_MAX_MESSAGE_LENGTH) {
+                && url.toString().length() <= static_cast<int>(tox_max_message_length())) {
                 SendMessageStr(url.toString());
                 continue;
             }
@@ -1009,7 +1009,7 @@ void ChatForm::SendMessageStr(QString msg)
         msg.remove(0, ACTION_PREFIX.length());
     }
 
-    QList<QString> splittedMsg = Core::splitMessage(msg, TOX_MAX_MESSAGE_LENGTH);
+    QList<QString> splittedMsg = Core::splitMessage(msg, tox_max_message_length());
     QDateTime timestamp = QDateTime::currentDateTime();
 
     for (QString& part : splittedMsg) {


### PR DESCRIPTION
It is good for flexibility to have fewer hardcoded values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4256)
<!-- Reviewable:end -->
