### PR TITLE
Fix incorrect headers order for windows builds

### DIFF
--- a/src/net/autoupdate.cpp
+++ b/src/net/autoupdate.cpp
@@ -35,8 +35,12 @@
 #include <iostream>
 
 #ifdef Q_OS_WIN
-#include <shellapi.h>
+// Because of replacing to incorrect order, which leads to building failing,
+// this region is ignored for clang-format
+// clang-format off
 #include <windows.h>
+#include <shellapi.h>
+// clang-format on
 #endif
 
 /**

--- a/src/platform/camera/directshow.cpp
+++ b/src/platform/camera/directshow.cpp
@@ -21,14 +21,18 @@
 
 #include "directshow.h"
 
-#include <QDebug>
-#include <amvideo.h>
-#include <cassert>
+// Because of replacing to incorrect order, which leads to building failing,
+// this region is ignored for clang-format
+// clang-format off
 #include <cstdint>
-#include <dvdmedia.h>
 #include <objbase.h>
 #include <strmif.h>
+#include <amvideo.h>
+#include <dvdmedia.h>
 #include <uuids.h>
+#include <cassert>
+#include <QDebug>
+// clang-format on
 
 /**
  * Most of this file is adapted from libavdevice's dshow.c,


### PR DESCRIPTION
Fixes #4220.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4257)
<!-- Reviewable:end -->
