### PR TITLE
build: don't ask for strmiids

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -119,10 +119,6 @@ if(APPLE)
   search_dependency(IOKIT             FRAMEWORK IOKit       OPTIONAL)
 endif()
 
-if(WIN32)
-  search_dependency(STRMIIDS          LIBRARY strmiids)
-endif()
-
 if (NOT GIT_DESCRIBE)
   execute_process(
     COMMAND git describe --tags


### PR DESCRIPTION
Fixes bulding with cmake on Windows. strmiids is exists as a libstrmiids.a static library, but cmake can't find it. Because of useless of this search and successful building without it, I'm removed it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4258)
<!-- Reviewable:end -->
