### PR TITLE
docs(INSTALL): add missing Debian dependency `qttools5-dev`

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -255,6 +255,7 @@ sudo apt-get install \
     qrencode \
     qt5-default \
     qt5-qmake \
+    qttools5-dev \
     qttools5-dev-tools \
     yasm
 ```

--- a/simple_make.sh
+++ b/simple_make.sh
@@ -6,10 +6,11 @@ apt_install() {
     local apt_packages=(
         automake
         autotools-dev
+        build-essential
         check
         checkinstall
         cmake
-        git build-essential
+        git
         libavdevice-dev
         libgdk-pixbuf2.0-dev
         libglib2.0-dev
@@ -27,6 +28,7 @@ apt_install() {
         qrencode
         qt5-default
         qt5-qmake
+        qttools5-dev
         qttools5-dev-tools
     )
 


### PR DESCRIPTION
Which provides needed `Qt5LinguistToolsConfig.cmake` for CMake.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4260)
<!-- Reviewable:end -->
