### PR TITLE
fix: silence warning by not using dynamic arrays on stack

### DIFF
--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -487,10 +487,11 @@ void Audio::playAudioBuffer(ALuint alSource, const int16_t* data, int samples, u
     alSourcei(alSource, AL_LOOPING, AL_FALSE);
 
     if (processed) {
-        ALuint bufids[processed];
+        ALuint* bufids = new ALuint[processed];
         alSourceUnqueueBuffers(alSource, processed, bufids);
         alDeleteBuffers(processed - 1, bufids + 1);
         bufid = bufids[0];
+        delete[] bufids;
     } else if (queued < 16) {
         alGenBuffers(1, &bufid);
     } else {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4261)
<!-- Reviewable:end -->
