### PR TITLE
fix: silence various warnings

### DIFF
--- a/src/chatlog/chatlinecontent.cpp
+++ b/src/chatlog/chatlinecontent.cpp
@@ -72,6 +72,7 @@ QString ChatLineContent::getSelectedText() const
 
 void ChatLineContent::fontChanged(const QFont& font)
 {
+    Q_UNUSED(font);
 }
 
 qreal ChatLineContent::getAscent() const

--- a/src/widget/form/groupinviteform.cpp
+++ b/src/widget/form/groupinviteform.cpp
@@ -46,11 +46,11 @@
  */
 
 GroupInviteForm::GroupInviteForm()
-    : createButton(new QPushButton(this))
+    : headWidget(new QWidget(this))
+    , headLabel(new QLabel(this))
+    , createButton(new QPushButton(this))
     , inviteBox(new QGroupBox(this))
     , scroll(new QScrollArea(this))
-    , headLabel(new QLabel(this))
-    , headWidget(new QWidget(this))
 {
     QVBoxLayout* layout = new QVBoxLayout(this);
     connect(createButton, &QPushButton::clicked,

--- a/src/widget/form/groupinvitewidget.cpp
+++ b/src/widget/form/groupinvitewidget.cpp
@@ -37,10 +37,10 @@
 
 GroupInviteWidget::GroupInviteWidget(QWidget* parent, const GroupInvite& invite)
     : QWidget(parent)
-    , widgetLayout(new QHBoxLayout(this))
     , acceptButton(new QPushButton(this))
     , rejectButton(new QPushButton(this))
     , inviteMessageLabel(new CroppingLabel(this))
+    , widgetLayout(new QHBoxLayout(this))
     , inviteInfo(invite)
 {
     connect(acceptButton, &QPushButton::clicked, [=]() { emit accepted(inviteInfo); });

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -2063,6 +2063,7 @@ QString Widget::getStatusIconPath(Status status)
     case Status::Offline:
         return ":/img/status/dot_offline.svg";
     }
+    assert(false);
 }
 
 //Preparing needed to set correct size of icons for GTK tray backend


### PR DESCRIPTION
@Diadlo do you know if the fix in `widget.cpp` is the right way to tell the compiler that it will never reach this case?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4264)
<!-- Reviewable:end -->
