### PR TITLE
Install dependencies

### DIFF
--- a/simple_make.sh
+++ b/simple_make.sh
@@ -149,7 +149,10 @@ zypper_install() {
 }
 
 main() {
-    if command -v apt-get
+    if command -v zypper && [ -f /etc/products.d/openSUSE.prod ]
+    then
+        zypper_install
+    elif command -v apt-get
     then
         apt_install
     elif command -v pacman
@@ -159,9 +162,6 @@ main() {
     then
         dnf_install
         fedora_locallib
-    elif command -v zypper
-    then
-        zypper_install
     else
         echo "Unknown package manager, attempting to compile anyways"
     fi

--- a/simple_make.sh
+++ b/simple_make.sh
@@ -117,51 +117,57 @@ fedora_locallib() {
 
 zypper_install() {
     local zypper_packages=(
+        automake
         cmake
+        ffmpeg2-devel
         git
+        libopus-devel
         libQt5Concurrent-devel
+        libqt5-linguist
+        libqt5-linguist-devel
         libQt5Network-devel
         libQt5OpenGL-devel
-        libQt5Sql-devel
-        libQt5Sql5-sqlite
-        libQt5Xml-devel
-        libXScrnSaver-devel
-        libffmpeg-devel
-        libopus-devel
-        libqt5-linguist
         libqt5-qtbase-common-devel
         libqt5-qtsvg-devel
+        libQt5Sql5-sqlite
+        libQt5Sql-devel
+        libQt5Test-devel
+        libQt5Xml-devel
         libsodium-devel
         libvpx-devel
+        libXScrnSaver-devel
         openal-soft-devel
-        patterns-openSUSE-devel_basis
         patterns-openSUSE-devel_basis
         qrencode-devel
         sqlcipher-devel
     )
+
+    # if not sudo is installed, e.g. in docker image, install it
+    command -v sudo || zypper in sudo
+
     sudo zypper in "${zypper_packages[@]}"
 }
 
 main() {
-    if which apt-get
+    if command -v apt-get
     then
         apt_install
-    elif which pacman
+    elif command -v pacman
     then
         pacman_install
-    elif which dnf
+    elif command -v dnf
     then
         dnf_install
         fedora_locallib
-    elif which zypper
+    elif command -v zypper
     then
         zypper_install
     else
         echo "Unknown package manager, attempting to compile anyways"
     fi
 
-    ./bootstrap.sh
-    cmake -H. -B_build
-    make -j$(nproc)
+    ./bootstrap.sh || exit $?
+    cmake -H. -B_build || exit $?
+    cd _build && make -j$(nproc) || exit $?
 }
 main


### PR DESCRIPTION
In order to build via "opensuse" docker image, I had to:
 - zypper in sudo (if not installed)
 - replace external  "which" with native shell command "command -v"
 - update dependencies
 - added a missing cd into _build so that make actually works

Then I discovered that the OpenSUSE installation on my disk did have apt installed, which made build fail there, so I had to improve the test, but could not use lsb_release because that would fail in the docker image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4270)
<!-- Reviewable:end -->
