### PR TITLE
fix(README): Fix mardown to correct display on github

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
-<a name="qtox" \>
+<a name="qtox" />
+
 <p align="center">
 <img src="https://qtox.github.io/assets/imgs/logo_head.png" alt="qTox" />
 </p>
+
 ---
+
 <p align="center">
 <a href="https://github.com/qTox/qTox/blob/master/LICENSE">
 <img src="https://img.shields.io/badge/license-GPLv3%2B-blue.svg" alt="GPLv3+" />
@@ -17,10 +20,11 @@
 <a href="https://github.com/qTox/release-schedule/blob/master/README.md">
 <img src="https://qtox.github.io/release-schedule/status.svg"
 title="Week of Merges: population of Merges increases!
-
 Week of Testing: Your mana regenerates!" />
 </a></p>
+
 ---
+
 <p align="center"><b>
 qTox is a powerful Tox client that follows the Tox design guidelines
 while running on all major platforms.
@@ -34,7 +38,7 @@ while running on all major platforms.
  **[Mailing list] |**
  **IRC:** [#qtox@freenode]
 
-====
+---
 
 Windows | Linux | OS X | FreeBSD
 --------|-------|------|--------


### PR DESCRIPTION
Current README:
![image](https://cloud.githubusercontent.com/assets/6306608/24134553/328f9bf4-0e16-11e7-9117-e9fd100792a3.png)

Updated version:
![image](https://cloud.githubusercontent.com/assets/6306608/24134565/4d128a36-0e16-11e7-9459-8a577b8d2843.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4274)
<!-- Reviewable:end -->
