### PR TITLE
fix: change useless line to what was intended

### DIFF
--- a/src/chatlog/textformatter.cpp
+++ b/src/chatlog/textformatter.cpp
@@ -228,7 +228,6 @@ void TextFormatter::wrapUrl()
  */
 QString TextFormatter::applyStyling(bool showFormattingSymbols)
 {
-    message.toHtmlEscaped();
     applyHtmlFontStyling(showFormattingSymbols);
     wrapUrl();
     return message;


### PR DESCRIPTION
fixes the osx warning from #4272

@noavarice can you confirm that was the intended behavior of the code?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4276)
<!-- Reviewable:end -->
