### PR TITLE
chore(build): Remove '-pie' linker flag and fix strmiids dependency on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,11 +46,11 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIE")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wstrict-overflow")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wstrict-aliasing")
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie")
 
 if (NOT WIN32)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-all")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wstack-protector")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie")
 endif()
 
 if (UNIX AND NOT APPLE)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -119,6 +119,10 @@ if(APPLE)
   search_dependency(IOKIT             FRAMEWORK IOKit       OPTIONAL)
 endif()
 
+if(WIN32)
+  set(ALL_LIBRARIES ${ALL_LIBRARIES} strmiids)
+endif()
+
 if (NOT GIT_DESCRIBE)
   execute_process(
     COMMAND git describe --tags


### PR DESCRIPTION
One part fixes #4280 (removing this flag giving qTox on Windows able to start properly), another part fixes my mistake in #4258 (strmiids still needed for linking, but previous searching of this libstrmiids.a wasn't include, for example, '/mingw32/i686-w64-mingw32/lib'. So I just add this lib to $ALL_LIBRARIES, because it exists in system by default).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4281)
<!-- Reviewable:end -->
