### PR TITLE
chore(build): Remove '-pie' linker flag in qtox.pro for Windows

### DIFF
--- a/qtox.pro
+++ b/qtox.pro
@@ -49,9 +49,9 @@ CONFIG   += silent
 QMAKE_CXXFLAGS += -fPIE \
                   -Wstrict-overflow \
                   -Wstrict-aliasing
-QMAKE_LFLAGS   += -pie
 
 !win32 {
+    QMAKE_LFLAGS   += -pie
     QMAKE_CXXFLAGS += -fstack-protector-all \
                       -Wstack-protector
 }


### PR DESCRIPTION
This, again, fixes #4280, but now for qmake, which I forgot to edit.

This should finally fix Windows Jenkins builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4285)
<!-- Reviewable:end -->
