### PR TITLE
Remove plaintext passwords

### DIFF
--- a/src/persistence/profile.h
+++ b/src/persistence/profile.h
@@ -52,9 +52,8 @@ public:
     void restartCore();
     bool isNewProfile();
     bool isEncrypted() const;
-    QString getPassword() const;
-    void setPassword(const QString& newPassword);
-    const ToxEncrypt& getPasskey() const;
+    QString setPassword(const QString& newPassword);
+    const ToxEncrypt* getPasskey() const;
 
     void saveToxSave();
     void saveToxSave(QByteArray data);
@@ -62,7 +61,6 @@ public:
     QPixmap loadAvatar();
     QPixmap loadAvatar(const QString& ownerId);
     QByteArray loadAvatarData(const QString& ownerId);
-    QByteArray loadAvatarData(const QString& ownerId, const QString& password);
     void saveAvatar(QByteArray pic, const QString& ownerId);
     QByteArray getAvatarHash(const QString& ownerId);
     void removeAvatar(const QString& ownerId);
@@ -83,7 +81,7 @@ public:
     static QString getDbPath(const QString& profileName);
 
 private slots:
-    void loadDatabase(const ToxId& id);
+    void loadDatabase(const ToxId& id, QString password);
 
 private:
     Profile(QString name, const QString& password, bool newProfile, const QByteArray& toxsave);
@@ -93,12 +91,13 @@ private:
 private:
     Core* core;
     QThread* coreThread;
-    QString name, password;
-    std::unique_ptr<ToxEncrypt> passkey;
+    QString name;
+    std::unique_ptr<ToxEncrypt> passkey = nullptr;
     std::shared_ptr<RawDatabase> database;
     std::unique_ptr<History> history;
     bool newProfile;
     bool isRemoved;
+    bool encrypted = false;
     static QVector<QString> profiles;
 };
 

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -341,7 +341,7 @@ void Settings::loadPersonal(Profile* profile)
 
     qDebug() << "Loading personal settings from" << filePath;
 
-    SettingsSerializer ps(filePath, profile->getPassword());
+    SettingsSerializer ps(filePath, profile->getPasskey());
     ps.load();
     friendLst.clear();
 
@@ -618,15 +618,14 @@ void Settings::savePersonal(Profile* profile)
         qDebug() << "Could not save personal settings because there is no active profile";
         return;
     }
-    savePersonal(profile->getName(), profile->getPassword());
-}
-
-void Settings::savePersonal(QString profileName, const QString& password)
-{
     if (QThread::currentThread() != settingsThread)
         return (void)QMetaObject::invokeMethod(&getInstance(), "savePersonal",
-                                               Q_ARG(QString, profileName), Q_ARG(QString, password));
+                                               Q_ARG(Profile*, profile));
+    savePersonal(profile->getName(), profile->getPasskey());
+}
 
+void Settings::savePersonal(QString profileName, const ToxEncrypt* passkey)
+{
     QMutexLocker locker{&bigLock};
     if (!loaded)
         return;
@@ -635,7 +634,7 @@ void Settings::savePersonal(QString profileName, const QString& password)
 
     qDebug() << "Saving personal settings at " << path;
 
-    SettingsSerializer ps(path, password);
+    SettingsSerializer ps(path, passkey);
     ps.beginGroup("Friends");
     {
         ps.beginWriteArray("Friend", friendLst.size());

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -22,6 +22,7 @@
 #define SETTINGS_HPP
 
 #include "src/core/corestructs.h"
+#include "src/core/toxencrypt.h"
 #include <QDate>
 #include <QFlags>
 #include <QFont>
@@ -140,7 +141,6 @@ public:
     void createPersonal(QString basename);
 
     void savePersonal();
-    void savePersonal(Profile* profile);
 
     void loadGlobal();
     void loadPersonal();
@@ -523,9 +523,10 @@ private:
     ~Settings();
     Settings(Settings& settings) = delete;
     Settings& operator=(const Settings&) = delete;
+    void savePersonal(QString profileName, const ToxEncrypt* passkey);
 
-private slots:
-    void savePersonal(QString profileName, const QString& password);
+public slots:
+    void savePersonal(Profile* profile);
 
 private:
     bool loaded;

--- a/src/persistence/settingsserializer.h
+++ b/src/persistence/settingsserializer.h
@@ -20,6 +20,8 @@
 #ifndef SETTINGSSERIALIZER_H
 #define SETTINGSSERIALIZER_H
 
+#include "src/core/toxencrypt.h"
+
 #include <QDataStream>
 #include <QSettings>
 #include <QString>
@@ -28,7 +30,7 @@
 class SettingsSerializer
 {
 public:
-    SettingsSerializer(QString filePath, const QString& password = QString());
+    SettingsSerializer(QString filePath, const ToxEncrypt* passKey = nullptr);
 
     static bool isSerializedFormat(QString filePath);
 
@@ -102,7 +104,7 @@ private:
 
 private:
     QString path;
-    QString password;
+    const ToxEncrypt* passKey;
     int group, array, arrayIndex;
     QVector<QString> groups;
     QVector<Array> arrays;

--- a/src/widget/form/profileform.cpp
+++ b/src/widget/form/profileform.cpp
@@ -433,11 +433,15 @@ void ProfileForm::onDeletePassClicked()
                              "deletion confirmation text")))
         return;
 
-    Nexus::getProfile()->setPassword(QString());
+    QString errorMsg = pro->setPassword(QString());
+    if (!errorMsg.isEmpty()) {
+        GUI::showInfo(tr("Couldn't change password"), errorMsg);
+    }
 }
 
 void ProfileForm::onChangePassClicked()
 {
+    Profile* p = Nexus::getProfile();
     SetPasswordDialog* dialog =
         new SetPasswordDialog(tr("Please enter a new password."), QString(), 0);
     int r = dialog->exec();
@@ -445,7 +449,10 @@ void ProfileForm::onChangePassClicked()
         return;
 
     QString newPass = dialog->getPassword();
-    Nexus::getProfile()->setPassword(newPass);
+    QString errorMsg = p->setPassword(newPass);
+    if (!errorMsg.isEmpty()) {
+        GUI::showInfo(tr("Couldn't change password"), errorMsg);
+    }
 }
 
 void ProfileForm::retranslateUi()


### PR DESCRIPTION
This PR removes all instances where a passwords were stored as `QString` and replaces them with `ToxEncrypt` passkeys. This improves performance (key derivation is only run once) as well as security (can't leak plaintext passwords).

@Diadlo @noavarice I'm not entirely sure what I do with `const ToxEncrypt* Profile::getPasskey()` is the correct way to make the `ToxEncrypt` object usable for encryption and decryption. Is there maybe a better way not involving raw pointers?

Depends on #4287

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4289)
<!-- Reviewable:end -->
