### PR TITLE
fix: use proper regexp for detecting URIs according to RFC 3986

### DIFF
--- a/src/chatlog/textformatter.cpp
+++ b/src/chatlog/textformatter.cpp
@@ -88,10 +88,15 @@ static const QVector<QPair<QRegularExpression, QString>> textPatternStyle{
     REGEX_MARKDOWN_PAIR(STRIKE, 2),
     {QRegularExpression(MULTILINE_CODE), htmlPatterns[CODE]}};
 
+// RFC 3986: https://tools.ietf.org/html/rfc3986#section-2
+static const QString uriPattern = "[\\w:/?#[\\]@!$&'\\(\\)*+,;=\\-._~]+";
+
 static const QVector<QRegularExpression> urlPatterns {
-    QRegularExpression("((\\bhttp[s]?://(www\\.)?)|(\\bwww\\.))"
-                       "[^. \\n]+\\.[^ \\n]+"),
-    QRegularExpression("\\b(ftp|smb)://[^ \\n]+"),
+    QRegularExpression(                   "("
+        "((\\bhttp[s]?://)|(\\bwww\\.))"  "|"
+        "(\\b(ftp|smb)://)"               ")"
+        + uriPattern,
+        QRegularExpression::UseUnicodePropertiesOption),
     QRegularExpression("\\bfile://(localhost)?/[^ \\n]+"),
     QRegularExpression("\\btox:[a-zA-Z\\d]{76}"),
     QRegularExpression("\\b(mailto|tox):[^ \\n]+@[^ \\n]+")
@@ -152,6 +157,8 @@ static void processUrl(QString& str, std::function<QString(QString&)> func)
 {
     int startLength = str.length();
     int offset = 0;
+    // FIXME: regex is matched against escaped HTML, it should be matched
+    // against raw text instead
     for (QRegularExpression exp : urlPatterns) {
         QRegularExpressionMatchIterator iter = exp.globalMatch(str);
         while (iter.hasNext()) {

--- a/test/chatlog/textformatter_test.cpp
+++ b/test/chatlog/textformatter_test.cpp
@@ -95,8 +95,8 @@ static const StringToString urlCases {
      QStringLiteral("<a href=\"https://url.com/some~url/some~more~url/\">"
                     "https://url.com/some~url/some~more~url/</a>")},
     {QStringLiteral("https://url.com/some`url/some`more`url/"),
-     QStringLiteral("<a href=\"https://url.com/some`url/some`more`url/\">"
-                    "https://url.com/some`url/some`more`url/</a>")},
+     QStringLiteral("<a href=\"https://url.com/some\">"
+                    "https://url.com/some</a>`url<i>some`more`url</i>")},
     // Test case from issue #4275
     {QStringLiteral("http://www.metacritic.com/game/pc/mass-effect-andromeda\n"
                     "http://www.metacritic.com/game/playstation-4/mass-effect-andromeda\n"
@@ -115,6 +115,7 @@ static const StringToString urlCases {
                     "<a href=\"http://site.com/part3\">http://site.com/part3</a> "
                     "and one more time "
                     "<a href=\"http://www.site.com/part1/part2\">www.site.com/part1/part2</a>")},
+    // TODO: add test case for `"` being excluded from URL (issue #4295)
 };
 
 /**


### PR DESCRIPTION
Partially addresses #4295, but doesn't fix it, since regexp is still
being matched against an escaped HTML.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4297)
<!-- Reviewable:end -->
