### PR TITLE
fix: set CSS font-weight of editbox always to normal

### DIFF
--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -673,14 +673,13 @@ void GenericChatForm::retranslateUi()
 
 QString GenericChatForm::fontToCss(const QFont& font, const char* name)
 {
-    return QString("%1{font-family: \"%2\"; font-size: %3px; font-style: \"%4\"; font-weight: %5;}")
+    return QString("%1{font-family: \"%2\"; font-size: %3px; font-style: \"%4\"; font-weight: normal;}")
         .arg(name)
         .arg(font.family())
         .arg(font.pixelSize())
         .arg(font.style() == QFont::StyleNormal ? "normal" : font.style() == QFont::StyleItalic
                                                                  ? "italic"
-                                                                 : "bold")
-        .arg(font.weight() * 10); // QFont weight is 0..100, but CSS font-weight is 0..1000
+                                                                 : "oblique");
 }
 
 void GenericChatForm::showNetcam()


### PR DESCRIPTION
This fixes issue #4292 that is caused by incorrect conversion between `QFont::weight()` which has a range of 0 to 99 (see [here](http://doc.qt.io/qt-5/qfont.html#Weight-enum)) and CSS `font-weight` which has a range 100 to 900 (according to [Mozilla](https://developer.mozilla.org/en/docs/Web/CSS/font-weight#Common_weight_name_mapping)). This issue is present since commit [c84837d662b6838a55caae7b3d4a121abd2d0192](https://github.com/qTox/qTox/commit/c84837d662b6838a55caae7b3d4a121abd2d0192).
This was fixed by setting `font-weight: normal;` always, because it seems that all fonts derived from `QFontComboBox` have normal weight.

Also fixed `font-style` by replacing `bold` with `oblique` (see [QFont Class](http://doc.qt.io/qt-5/qfont.html#Style-enum) and [QSS](http://doc.qt.io/qt-4.8/stylesheet-reference.html#font-style)).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4300)
<!-- Reviewable:end -->
