### PR TITLE
docs(INSTALL): updated Windows build instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -778,14 +778,14 @@ version of MinGW, corresponds to the version of the QT component!
 
 Download the Wget installer for Windows from
 http://gnuwin32.sourceforge.net/packages/wget.htm. Install them. The following
-steps assume that Wget is installed at `C:\Program Files\GnuWin32\`. If you
+steps assume that Wget is installed at `C:\Program Files (x86)\GnuWin32\`. If you
 decided to choose another location, replace corresponding parts.
 
 ### UnZip
 
 Download the UnZip installer for Windows from
 http://gnuwin32.sourceforge.net/packages/unzip.htm. Install it. The following
-steps assume that UnZip is installed at `C:\Program Files\GnuWin32\`. If you
+steps assume that UnZip is installed at `C:\Program Files (x86)\GnuWin32\`. If you
 decided to choose another location, replace corresponding parts.
 
 ### Setting up Path
@@ -797,7 +797,7 @@ select tab `Advanced system settings` -> button `Environment Variables`). In the
 second box search for the `PATH` variable and press `Edit...`. The input box
 `Variable value:` should already contain some directories. Each directory is
 separated with a semicolon. Extend the input box by adding
-`;C:\MinGW\bin;C:\MinGW\msys\1.0\bin;C:\Program Files (x86)\CMake 2.8\bin;C:\Program Files\GnuWin32\bin;C:\Program Files (x86)\GnuWin32\bin`.
+`;C:\MinGW\bin;C:\MinGW\msys\1.0\bin;C:\Program Files (x86)\CMake 2.8\bin;C:\Program Files (x86)\GnuWin32\bin`.
 The very first semicolon must only be added if it is missing. CMake may be added
 by installer automatically. Make sure that paths containing alternative `sh`, 
 `bash` implementations such as `C:\Program Files\OpenSSH\bin` are at the end of
@@ -805,8 +805,9 @@ by installer automatically. Make sure that paths containing alternative `sh`,
 
 ### Cloning the Repository
 
-Clone the repository (https://github.com/qTox/qTox.git) with your preferred  Git
-client. [SmartGit](http://www.syntevo.com/smartgit/) is very nice for this task
+Clone the repository (https://github.com/qTox/qTox.git) with your preferred Git
+client. [SmartGit](http://www.syntevo.com/smartgit/) or
+[TorteiseGit](https://tortoisegit.org) are both very nice for this task
 (you may need to add the path to the `git.exe` system variable Path). The
 following steps assume that you cloned the repository at `C:\qTox`. If you
 decided to choose another location, replace corresponding parts.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -808,15 +808,20 @@ by installer automatically. Make sure that paths containing alternative `sh`,
 Clone the repository (https://github.com/qTox/qTox.git) with your preferred Git
 client. [SmartGit](http://www.syntevo.com/smartgit/) or
 [TorteiseGit](https://tortoisegit.org) are both very nice for this task
-(you may need to add the path to the `git.exe` system variable Path). The
+(you may need to add `git.exe` to your `PATH` system variable). The
 following steps assume that you cloned the repository at `C:\qTox`. If you
 decided to choose another location, replace corresponding parts.
 
 ### Getting dependencies
 
-Run `bootstrap.bat` in cloned `C:\qTox` directory. Script will download rest of
-dependencies compile them and put to appropriate directories.
+Run `bootstrap.bat` in the previously cloned `C:\qTox` repository. The script will
+download the other necessary dependencies, compile them and put them into their
+appropriate directories.
 
+Note that there have been detections of false positives by some anti virus software
+in the past within some of the libraries used. Please refer to the wiki page
+[problematic antiviruses](https://github.com/qTox/qTox/wiki/Problematic-antiviruses)
+for more information if you run into troubles on that front.
 
 ## Compile-time switches
 


### PR DESCRIPTION
There was some folder mixup, probably due to some parts of the instruction being written out of a 32 bit Windows perspective (where “C:\Program Files” is the default location for installed programs) and other parts written out of 64 bit perspective (where there are two distinct folders for 32 and 64 bit content).

I’ve made sure all paths are compliant with the x64 version now (I’ve left out x86 instructions as I would have no way to test them, x86 is slowly but surely dying out AND people compiling on older systems should be aware anyway that instructions referring to install paths including “C:\Program Files (x86)\” will need some adjustment on their systems).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4304)
<!-- Reviewable:end -->
