### PR TITLE
feat(chatform): mark message with triple click

### DIFF
--- a/src/chatlog/chatlinecontent.cpp
+++ b/src/chatlog/chatlinecontent.cpp
@@ -56,6 +56,10 @@ void ChatLineContent::selectionDoubleClick(QPointF)
 {
 }
 
+void ChatLineContent::selectionTripleClick(QPointF)
+{
+}
+
 void ChatLineContent::selectionFocusChanged(bool)
 {
 }

--- a/src/chatlog/chatlinecontent.h
+++ b/src/chatlog/chatlinecontent.h
@@ -45,6 +45,7 @@ public:
     virtual void selectionStarted(QPointF scenePos);
     virtual void selectionCleared();
     virtual void selectionDoubleClick(QPointF scenePos);
+    virtual void selectionTripleClick(QPointF scenePos);
     virtual void selectionFocusChanged(bool focusIn);
     virtual bool isOverSelection(QPointF scenePos) const;
     virtual QString getSelectedText() const;

--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -74,6 +74,7 @@ public slots:
 private slots:
     void onSelectionTimerTimeout();
     void onWorkerTimeout();
+    void onMultiClickTimeout();
 
 protected:
     QRectF calculateSceneRect() const;
@@ -111,6 +112,7 @@ protected:
 private:
     void retranslateUi();
     bool isActiveFileTransfer(ChatLine::Ptr l);
+    void handleMultiClickEvent();
 
 private:
     enum SelectionMode
@@ -147,7 +149,10 @@ private:
     QGraphicsRectItem* selGraphItem = nullptr;
     QTimer* selectionTimer = nullptr;
     QTimer* workerTimer = nullptr;
+    QTimer* multiClickTimer = nullptr;
     AutoScrollDirection selectionScrollDir = NoDirection;
+    int clickCount = 0;
+    QPoint lastClickPos;
 
     // worker vars
     int workerLastIndex = 0;

--- a/src/chatlog/content/text.cpp
+++ b/src/chatlog/content/text.cpp
@@ -121,6 +121,30 @@ void Text::selectionDoubleClick(QPointF scenePos)
     update();
 }
 
+void Text::selectionTripleClick(QPointF scenePos)
+{
+    if (!doc)
+        return;
+
+    int cur = cursorFromPos(scenePos);
+
+    if (cur >= 0) {
+        QTextCursor cursor(doc);
+        cursor.setPosition(cur);
+        cursor.select(QTextCursor::BlockUnderCursor);
+
+        selectionAnchor = cursor.selectionStart();
+        selectionEnd = cursor.selectionEnd();
+
+        if (cursor.block().isValid() && cursor.block().blockNumber() != 0)
+            selectionAnchor++;
+
+        selectedText = extractSanitizedText(getSelectionStart(), getSelectionEnd());
+    }
+
+    update();
+}
+
 void Text::selectionFocusChanged(bool focusIn)
 {
     selectionHasFocus = focusIn;

--- a/src/chatlog/content/text.h
+++ b/src/chatlog/content/text.h
@@ -43,6 +43,7 @@ public:
     virtual void selectionStarted(QPointF scenePos) final;
     virtual void selectionCleared() final;
     virtual void selectionDoubleClick(QPointF scenePos) final;
+    virtual void selectionTripleClick(QPointF scenePos) final;
     virtual void selectionFocusChanged(bool focusIn) final;
     virtual bool isOverSelection(QPointF scenePos) const final;
     virtual QString getSelectedText() const final;


### PR DESCRIPTION
This is an implementation of proposal #4003. It allows the user to select a line of a chat by triple click.
Note: This will select received lines not displayed lines. So if you receive a long line, which is displayed as multiple lines you still select the long line which visually spans several lines on your display.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4305)
<!-- Reviewable:end -->
