### PR TITLE
chore(build): Added warning message against using the project file

### DIFF
--- a/qtox.pro
+++ b/qtox.pro
@@ -17,6 +17,12 @@
 #    See the COPYING file for more details.
 
 
+message()
+message("Warning: This project file is deprecated and should not be used anymore except on FreeBSD.")
+message("Use the CMakeLists.txt file instead to open this as a CMake project.")
+message()
+
+
 QT       += core gui network xml opengl sql svg widgets
 
 TARGET    = qtox


### PR DESCRIPTION
The project file is deprecated and should not be used anymore as project
file for development. Adding a warning to that effect could help future
contributors while figuring out what they need to do to get started with
qTox.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4310)
<!-- Reviewable:end -->
