### PR TITLE
fix(core): don't continue when the tox file is corrupted

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -180,8 +180,9 @@ void Core::makeTox(QByteArray savedata)
         break;
 
     case TOX_ERR_NEW_LOAD_BAD_FORMAT:
-        qWarning() << "failed to parse Tox save data";
-        break;
+        qCritical() << "failed to parse Tox save data";
+        emit failedToStart();
+        return;
 
     case TOX_ERR_NEW_PORT_ALLOC:
         if (Settings::getInstance().getEnableIPv6()) {


### PR DESCRIPTION
to fully solve  #4269 we still need to ask the user what to do.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4311)
<!-- Reviewable:end -->
