### PR TITLE
fix(UI): improve unclear message about text being resized in chatform

### DIFF
--- a/src/chatlog/chatmessage.cpp
+++ b/src/chatlog/chatmessage.cpp
@@ -173,6 +173,14 @@ ChatMessage::Ptr ChatMessage::createTypingNotification()
     return msg;
 }
 
+/**
+ * @brief Create message placeholder while chatform restructures text
+ *
+ * It can take a while for chatform to resize large amounts of text, thus
+ * a message placeholder is needed to inform users about it.
+ *
+ * @return created message
+ */
 ChatMessage::Ptr ChatMessage::createBusyNotification()
 {
     ChatMessage::Ptr msg = ChatMessage::Ptr(new ChatMessage);
@@ -180,7 +188,7 @@ ChatMessage::Ptr ChatMessage::createBusyNotification()
     baseFont.setPixelSize(baseFont.pixelSize() + 2);
     baseFont.setBold(true);
 
-    msg->addColumn(new Text(QObject::tr("Resizing"), baseFont, false, ""),
+    msg->addColumn(new Text(QObject::tr("Reformatting text in progress.."), baseFont, false, ""),
                    ColumnFormat(1.0, ColumnFormat::VariableSize, ColumnFormat::Center));
 
     return msg;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4317)
<!-- Reviewable:end -->
