### PR TITLE
fix(includes): Added missing #include <ctime>

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -32,6 +32,7 @@
 #include <QTimer>
 
 #include <cassert>
+#include <ctime>
 
 const QString Core::CONFIG_FILE_NAME = "data";
 const QString Core::TOX_EXT = ".tox";

--- a/src/ipc.cpp
+++ b/src/ipc.cpp
@@ -24,6 +24,7 @@
 #include <QThread>
 #include <random>
 #include <unistd.h>
+#include <ctime>
 
 /**
  * @var time_t IPC::lastEvent

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,6 +40,7 @@
 
 #include <sodium.h>
 #include <stdio.h>
+#include <ctime>
 
 #if defined(Q_OS_OSX)
 #include "platform/install_osx.h"

--- a/test/chatlog/textformatter_test.cpp
+++ b/test/chatlog/textformatter_test.cpp
@@ -27,6 +27,7 @@
 #include <QVector>
 
 #include <check.h>
+#include <ctime>
 
 using StringToString = QMap<QString, QString>;
 

--- a/test/core/toxid_test.cpp
+++ b/test/core/toxid_test.cpp
@@ -23,6 +23,7 @@
 
 #include <QString>
 #include <check.h>
+#include <ctime>
 
 const QString corrupted =
     QStringLiteral("C7719C6808C14B77348004956D1D98046CE09A34370E7608150EAD74C3815D30C8BA3AB9BEBA");


### PR DESCRIPTION
time(3) requires this include. Found when qTox failed to build on the FreeBSD due to the missing include.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4328)
<!-- Reviewable:end -->
