### PR TITLE
refactor(widget): wrap content layout in a "weak" pointer

### DIFF
--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -341,7 +341,6 @@ void Widget::init()
     connect(this, &Widget::windowStateChanged, &Nexus::getInstance(), &Nexus::onWindowStateChanged);
 #endif
 
-    contentLayout = nullptr;
     onSeparateWindowChanged(s.getSeparateWindow(), false);
 
     ui->addButton->setCheckable(true);
@@ -510,7 +509,6 @@ Widget::~Widget()
     delete filesForm;
     delete timer;
     delete offlineMsgTimer;
-    delete contentLayout;
 
     FriendList::clear();
     GroupList::clear();
@@ -675,7 +673,6 @@ void Widget::onSeparateWindowChanged(bool separate, bool clicked)
             contentLayout->parentWidget()->hide();
             contentLayout->parentWidget()->deleteLater();
             contentLayout->deleteLater();
-            contentLayout = nullptr;
         }
 
         setMinimumWidth(ui->tooliconsZone->sizeHint().width());

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -267,7 +267,7 @@ private:
     Ui::MainWindow* ui;
     QSplitter* centralLayout;
     QPoint dragPosition;
-    ContentLayout* contentLayout;
+    QPointer<ContentLayout> contentLayout;
     AddFriendForm* addFriendForm;
     GroupInviteForm* groupInviteForm;
     ProfileForm* profileForm;


### PR DESCRIPTION
Like every layout, the content layout is parented and owned by a widget.
This owner is responsible for layout destruction.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4333)
<!-- Reviewable:end -->
