### PR TITLE
fix(settings): changing language sets title to "Add Friend"

### DIFF
--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -2318,8 +2318,9 @@ void Widget::retranslateUi()
     actionQuit->setText(tr("Exit", "Tray action menu to exit tox"));
     actionShow->setText(tr("Show", "Tray action menu to show qTox window"));
 
-    if (!Settings::getInstance().getSeparateWindow())
-        setWindowTitle(fromDialogType(DialogType::AddDialog));
+    if (!Settings::getInstance().getSeparateWindow() && (settingsWidget && settingsWidget->isShown())) {
+        setWindowTitle(fromDialogType(DialogType::SettingDialog));
+    }
 
     friendRequestsUpdate();
     groupInvitesUpdate();


### PR DESCRIPTION
This fixes #3708.
Changing language sets title of settings widget to "Settings" instead
of wrong "Add Friend".

Note that there is an other user who committed similar changes to his fork, but he has not been active for over half a year now, so I think its OK to get this minor bug fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4340)
<!-- Reviewable:end -->
