### PR TITLE
fix(chatform): disable Tab in add friend message text  area

### DIFF
--- a/src/widget/form/addfriendform.cpp
+++ b/src/widget/form/addfriendform.cpp
@@ -85,6 +85,7 @@ AddFriendForm::AddFriendForm()
     messageLabel.setAccessibleDescription(tr("Friend request message"));
     message.setAccessibleDescription(tr(
         "Type message to send with the friend request or leave empty to send a default message"));
+    message.setTabChangesFocus(true);
 
     retranslateUi();
     Translator::registerHandler(std::bind(&AddFriendForm::retranslateUi, this), this);


### PR DESCRIPTION
This is related to #2100 that is part of #300.
Tab is no longer accepted as input in add friend message text area,
instead it changes the focus.

I do not know if this fixes #2100 completely, but it solves the problem that the user gets stuck in the text area when using Tab to change focus.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4341)
<!-- Reviewable:end -->
