### PR TITLE
refactor: Remove busy notification

### DIFF
--- a/src/chatlog/chatmessage.cpp
+++ b/src/chatlog/chatmessage.cpp
@@ -173,27 +173,6 @@ ChatMessage::Ptr ChatMessage::createTypingNotification()
     return msg;
 }
 
-/**
- * @brief Create message placeholder while chatform restructures text
- *
- * It can take a while for chatform to resize large amounts of text, thus
- * a message placeholder is needed to inform users about it.
- *
- * @return created message
- */
-ChatMessage::Ptr ChatMessage::createBusyNotification()
-{
-    ChatMessage::Ptr msg = ChatMessage::Ptr(new ChatMessage);
-    QFont baseFont = Settings::getInstance().getChatMessageFont();
-    baseFont.setPixelSize(baseFont.pixelSize() + 2);
-    baseFont.setBold(true);
-
-    msg->addColumn(new Text(QObject::tr("Reformatting text in progress.."), baseFont, false, ""),
-                   ColumnFormat(1.0, ColumnFormat::VariableSize, ColumnFormat::Center));
-
-    return msg;
-}
-
 void ChatMessage::markAsSent(const QDateTime& time)
 {
     QFont baseFont = Settings::getInstance().getChatMessageFont();

--- a/src/chatlog/chatmessage.h
+++ b/src/chatlog/chatmessage.h
@@ -55,7 +55,6 @@ public:
     static ChatMessage::Ptr createFileTransferMessage(const QString& sender, ToxFile file,
                                                       bool isMe, const QDateTime& date);
     static ChatMessage::Ptr createTypingNotification();
-    static ChatMessage::Ptr createBusyNotification();
 
     void markAsSent(const QDateTime& time);
     QString toString() const;

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -85,7 +85,17 @@ GenericChatForm::GenericChatForm(QWidget* parent)
     QGridLayout* buttonsLayout = new QGridLayout();
 
     chatWidget = new ChatLog(this);
-    chatWidget->setBusyNotification(ChatMessage::createBusyNotification());
+    QString busyText = QObject::tr("Reformatting text in progress..");
+
+    /**
+     * Create message placeholder while chatform restructures text
+     * It can take a while for chatform to resize large amounts of text, thus
+     * a message placeholder is needed to inform users about it.
+     */
+    ChatMessage::SystemMessageType type = ChatMessage::SystemMessageType::ERROR;
+    QDateTime curTime = QDateTime::currentDateTime();
+    ChatMessage::Ptr msg = ChatMessage::createChatInfoMessage(busyText, type, curTime);
+    chatWidget->setBusyNotification(msg);
 
     // settings
     const Settings& s = Settings::getInstance();


### PR DESCRIPTION
IDK why busy notification is separate type of message. Replaced on InfoMessage with error type

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4342)
<!-- Reviewable:end -->
