### PR TITLE
feat(ui): grey out proxy address and port if no proxy selected

### DIFF
--- a/ui/chatArea/chatArea.css
+++ b/ui/chatArea/chatArea.css
@@ -4,7 +4,7 @@ QTextEdit
     color: black;
 }
 
-QGraphicsView 
+QGraphicsView
 {
     border: none;
 }

--- a/ui/emoticonWidget/emoticonWidget.css
+++ b/ui/emoticonWidget/emoticonWidget.css
@@ -13,7 +13,7 @@ QRadioButton::indicator
      height: 10px;
 }
 
-QRadioButton::indicator::unchecked
+QRadioButton::indicator:unchecked
 {
      image: url(:/ui/emoticonWidget/dot_page.svg);
 }
@@ -28,7 +28,7 @@ QRadioButton::indicator:unchecked:pressed
      image: url(:/ui/emoticonWidget/dot_page_hover.svg);
 }
 
-QRadioButton::indicator::checked
+QRadioButton::indicator:checked
 {
      image: url(:/ui/emoticonWidget/dot_page_current.svg);
 }

--- a/ui/emoticonWidget/emoticonWidget.css
+++ b/ui/emoticonWidget/emoticonWidget.css
@@ -1,7 +1,7 @@
 QPushButton
 {
     background-color: transparent;
-    background-repeat: none;    
+    background-repeat: none;
     border: none;
     width: 24px;
     height: 24px;
@@ -13,22 +13,22 @@ QRadioButton::indicator
      height: 10px;
 }
 
-QRadioButton::indicator::unchecked 
+QRadioButton::indicator::unchecked
 {
      image: url(:/ui/emoticonWidget/dot_page.svg);
 }
 
-QRadioButton::indicator:unchecked:hover 
+QRadioButton::indicator:unchecked:hover
 {
      image: url(:/ui/emoticonWidget/dot_page_hover.svg);
 }
 
-QRadioButton::indicator:unchecked:pressed 
+QRadioButton::indicator:unchecked:pressed
 {
      image: url(:/ui/emoticonWidget/dot_page_hover.svg);
 }
 
-QRadioButton::indicator::checked 
+QRadioButton::indicator::checked
 {
      image: url(:/ui/emoticonWidget/dot_page_current.svg);
 }

--- a/ui/friendList/friendList.css
+++ b/ui/friendList/friendList.css
@@ -5,7 +5,7 @@ QScrollArea {
 QScrollBar:vertical  {
     background: @themeMedium;
     width: 16px;
-    padding: 0px 3px 0px 3px; 
+    padding: 0px 3px 0px 3px;
 }
 
 QScrollBar:handle:vertical  {
@@ -26,7 +26,7 @@ QScrollBar:handle:vertical:pressed  {
 QScrollBar:add-line:vertical {height: 0px;subcontrol-position: bottom;subcontrol-origin: margin;}
 
 QScrollBar:sub-line:vertical {height: 0px;subcontrol-position: top;subcontrol-origin: margin;}
- 
+
 QScrollBar:add-page:vertical, QScrollBar::sub-page:vertical  {
     background: none;
 }

--- a/ui/loginScreen/loginScreen.css
+++ b/ui/loginScreen/loginScreen.css
@@ -53,6 +53,6 @@ QLabel, QCheckBox, QProgressBar {
   color: black;
 }
 
-QCheckBox::disabled {
+QCheckBox:disabled {
   color: gray;
 }

--- a/ui/settings/mainContent.css
+++ b/ui/settings/mainContent.css
@@ -39,6 +39,11 @@ QSpinBox
     background: white;
 }
 
+QSpinBox:disabled
+{
+    background: lightGrey;
+}
+
 QPushButton
 {
     background: white;
@@ -64,6 +69,11 @@ QComboBox QAbstractItemView {
 QLineEdit
 {
     background-color: white;
+}
+
+QLineEdit:disabled
+{
+    background-color: lightGrey;
 }
 
 QTabWidget

--- a/ui/settings/mainContent.css
+++ b/ui/settings/mainContent.css
@@ -26,7 +26,7 @@ QMessageBox
 QCheckBox
 {
     background: white;
-    color: black;    
+    color: black;
 }
 
 QCheckBox:disabled
@@ -79,11 +79,11 @@ QTabBar
 QScrollArea
 {
     background-color: white;
-    background: transparent; 
+    background: transparent;
 }
 
-QScrollArea > QWidget > QWidget 
-{ 
+QScrollArea > QWidget > QWidget
+{
     background: transparent;
 }
 
@@ -148,7 +148,7 @@ QScrollBar:QScrollBar::up-arrow:vertical
     height: 10px;
     background: white;
 }
- 
+
 QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical
 {
     background: none;
@@ -208,7 +208,7 @@ QScrollBar:QScrollBar::up-arrow:horizontal
     height: 10px;
     background: white;
 }
- 
+
 QScrollBar::add-page:horizontal, QScrollBar::sub-page:horizontal
 {
     background: none;

--- a/ui/statusButton/statusButton.css
+++ b/ui/statusButton/statusButton.css
@@ -8,13 +8,13 @@ QPushButton
     height: 40px;
 }
 
-QPushButton:default 
+QPushButton:default
 {
    background-color: @themeMediumDark;
 }
 
 /*Bugged in Qt, but it's probably better to leave enabled so that users can tell it's clickable*/
-QPushButton:hover 
+QPushButton:hover
 {
    background-color: @themeMedium;
 }
@@ -30,7 +30,7 @@ QPushButton:focus {
 
 QPushButton::menu-indicator {image: none;}
 
-QPushButton::menu-indicator:pressed, QPushButton::menu-indicator:open 
+QPushButton::menu-indicator:pressed, QPushButton::menu-indicator:open
 {
   image: url(":ui/statusButton/menu_indicator.svg");
   subcontrol-origin: padding;

--- a/ui/window/statusPanel.css
+++ b/ui/window/statusPanel.css
@@ -92,12 +92,12 @@ QListView {
 }
 
 /*Bugged in Qt, but it's probably better to leave enabled so that users can tell it's clickable*/
-#statusPanel > #statusHead > #statusButton:hover 
+#statusPanel > #statusHead > #statusButton:hover
 {
   background-color: @themeLight;
 }
 
-#statusPanel > #statusHead > #statusButton:pressed 
+#statusPanel > #statusHead > #statusButton:pressed
 {
   background-color: @themeMedium;
 }
@@ -108,7 +108,7 @@ QListView {
 
 #statusPanel > #statusHead > #statusButton::menu-indicator {image: none;}
 
-#statusPanel > #statusHead > #statusButton::menu-indicator:pressed, #statusPanel > #statusHead > #statusButton::menu-indicator:open 
+#statusPanel > #statusHead > #statusButton::menu-indicator:pressed, #statusPanel > #statusHead > #statusButton::menu-indicator:open
 {
   image: url(":ui/statusButton/menu_indicator.png");
   subcontrol-origin: padding;


### PR DESCRIPTION
This is a feature proposed in #2760.
Disabled port (QSpinBox) and address (QLineEdit) are greyed out if no proxy is selected.
This is done via stylesheets.

I also removed unnecessary whitespaces from end of lines of ui stylesheets and fixed some typos in pseudo-states (see [The Style Sheet Syntax](http://doc.qt.io/qt-5/stylesheet-syntax.html) and the lists of [sub-controls](http://doc.qt.io/qt-5/stylesheet-reference.html#list-of-sub-controls) and [pseudo-states](http://doc.qt.io/qt-5/stylesheet-reference.html#list-of-pseudo-states)).

Edit: added images of ui changes

Proxy enabled:
![proxy_enabled](https://cloud.githubusercontent.com/assets/16089150/25577593/842a87c8-2e67-11e7-8865-d322fdfffc50.png)

Proxy disabled:
![proxy_disabled](https://cloud.githubusercontent.com/assets/16089150/25577594/8793f7dc-2e67-11e7-8f61-9d4d2f24f855.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4356)
<!-- Reviewable:end -->