### PR TITLE
Add audio backend that supports echo canceling

### DIFF
--- a/.travis/build-ubuntu-14-04.sh
+++ b/.travis/build-ubuntu-14-04.sh
@@ -140,6 +140,13 @@ echo '/usr/local/lib/' | sudo tee -a /etc/ld.so.conf.d/locallib.conf
 sudo ldconfig
 cd ..
 
+# filteraudio
+git clone --branch v0.0.1 --depth=1 https://github.com/irungentoo/filter_audio filteraudio
+cd filteraudio
+CC="ccache $CC" CXX="ccache $CXX" sudo make install -j$(nproc)
+sudo ldconfig
+cd ..
+
 $CC --version
 $CXX --version
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,6 +185,8 @@ set(${PROJECT_NAME}_SOURCES
   src/audio/audio.h
   src/audio/backend/openal.cpp
   src/audio/backend/openal.h
+  src/audio/backend/openal2.cpp
+  src/audio/backend/openal2.h
   src/chatlog/chatlinecontent.cpp
   src/chatlog/chatlinecontent.h
   src/chatlog/chatlinecontentproxy.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ cmake_minimum_required(VERSION 2.8.11)
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 option(PLATFORM_EXTENSIONS "Enable platform specific extensions, requires extra dependencies" ON)
+option(USE_FILTERAUDIO "Enable the echo canceling backend" ON)
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Debug)
@@ -15,6 +16,12 @@ endif()
 
 set(ENV{PKG_CONFIG_PATH}
   ${CMAKE_SOURCE_DIR}/libs/lib/pkgconfig:/opt/ffmpeg/lib/pkgconfig:$ENV{PKG_CONFIG_PATH})
+
+# necessary to find openal-soft on mac os
+if(APPLE)
+  set(ENV{PKG_CONFIG_PATH}
+    /usr/local/opt/openal-soft/lib/pkgconfig:$ENV{PKG_CONFIG_PATH})
+endif()
 
 execute_process(
   COMMAND brew --prefix qt5
@@ -185,8 +192,6 @@ set(${PROJECT_NAME}_SOURCES
   src/audio/audio.h
   src/audio/backend/openal.cpp
   src/audio/backend/openal.h
-  src/audio/backend/openal2.cpp
-  src/audio/backend/openal2.h
   src/chatlog/chatlinecontent.cpp
   src/chatlog/chatlinecontent.h
   src/chatlog/chatlinecontentproxy.cpp
@@ -518,6 +523,19 @@ if(${ENABLE_GTK_SYSTRAY})
   if(GTK_FOUND)
     add_definitions(-DENABLE_SYSTRAY_GTK_BACKEND=1)
   endif()
+endif()
+
+if(${USE_FILTERAUDIO})
+    search_dependency(FILTERAUDIO LIBRARY filteraudio OPTIONAL)
+    if(${FILTERAUDIO_FOUND})
+        set(${PROJECT_NAME}_SOURCES ${${PROJECT_NAME}_SOURCES}
+            src/audio/backend/openal2.cpp
+            src/audio/backend/openal2.h)
+        add_definitions(-DUSE_FILTERAUDIO=1)
+        message(STATUS "using filteraudio")
+    else()
+         message(STATUS "not using filteraudio, libfilteraudio not found")
+    endif()
 endif()
 
 # the compiler flags for compiling C sources

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -882,3 +882,4 @@ Switches:
 [Qt]: https://www.qt.io/
 [sqlcipher]: https://www.zetetic.net/sqlcipher/
 [toxcore]: https://github.com/TokTok/c-toxcore/
+[filteraudio]: https://github.com/irungentoo/filter_audio

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -51,6 +51,7 @@
 | [qrencode]    | >= 3.0.3    |                                                   |
 | [sqlcipher]   | >= 3.2.0    |                                                   |
 | [pkg-config]  | >= 0.28     |                                                   |
+| [filteraudio] | >= 0.0.1    |                                                   |
 
 ## Optional dependencies
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -51,7 +51,7 @@
 | [qrencode]    | >= 3.0.3    |                                                   |
 | [sqlcipher]   | >= 3.2.0    |                                                   |
 | [pkg-config]  | >= 0.28     |                                                   |
-| [filteraudio] | >= 0.0.1    |                                                   |
+| [filteraudio] | >= 0.0.1    | optional dependency                               |
 
 ## Optional dependencies
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -116,7 +116,7 @@ if (NOT TOXCORE_FOUND OR
     search_dependency(TOXAV           PACKAGE libtoxav)
 endif()
 
-search_dependency(OPENAL              PACKAGE openal FRAMEWORK OpenAL)
+search_dependency(OPENAL              PACKAGE openal)
 search_dependency(FILTERAUDIO         LIBRARY filteraudio)
 
 if (PLATFORM_EXTENSIONS AND UNIX AND NOT APPLE)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -117,6 +117,7 @@ if (NOT TOXCORE_FOUND OR
 endif()
 
 search_dependency(OPENAL              PACKAGE openal FRAMEWORK OpenAL)
+search_dependency(FILTERAUDIO         LIBRARY filteraudio)
 
 if (PLATFORM_EXTENSIONS AND UNIX AND NOT APPLE)
   # Automatic auto-away support. (X11 also using for capslock detection)

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -117,7 +117,6 @@ if (NOT TOXCORE_FOUND OR
 endif()
 
 search_dependency(OPENAL              PACKAGE openal)
-search_dependency(FILTERAUDIO         LIBRARY filteraudio)
 
 if (PLATFORM_EXTENSIONS AND UNIX AND NOT APPLE)
   # Automatic auto-away support. (X11 also using for capslock detection)

--- a/osx/qTox-Mac-Deployer-ULTIMATE.sh
+++ b/osx/qTox-Mac-Deployer-ULTIMATE.sh
@@ -41,6 +41,7 @@ QT_VER=($(ls ${QT_DIR} | sed -n -e 's/^\([0-9]*\.([0-9]*\.([0-9]*\).*/\1/' -e '1
 QT_DIR_VER="${QT_DIR}/${QT_VER[1]}"
 
 TOXCORE_DIR="${MAIN_DIR}/toxcore" # Change to Git location
+FILTERAUIO_DIR="${MAIN_DIR}/filter_audio" # Change to Git location
 
 LIB_INSTALL_PREFIX="${QTOX_DIR}/libs"
 
@@ -166,7 +167,13 @@ install() {
     else
         brew install cmake
     fi
-    brew install ffmpeg qrencode qt5 sqlcipher
+    brew install ffmpeg qrencode qt5 sqlcipher openal-soft
+
+    fcho "Cloning filter_audio ... "
+    git clone --branch v0.0.1 --depth=1 https://github.com/irungentoo/filter_audio "$FILTERAUIO_DIR"
+    cd "$FILTERAUIO_DIR"
+    fcho "Installing filter_audio ... "
+    make install PREFIX="$LIB_INSTALL_PREFIX"
 
     QT_VER=($(ls ${QT_DIR} | sed -n -e 's/^\([0-9]*\.([0-9]*\.([0-9]*\).*/\1/' -e '1p;$p'))
     QT_DIR_VER="${QT_DIR}/${QT_VER[1]}"

--- a/qtox.pro
+++ b/qtox.pro
@@ -252,7 +252,8 @@ win32 {
                 -lavutil \
                 -lswscale \
                 -lqrencode \
-                -lsqlcipher
+                -lsqlcipher \
+                -lfilteraudio
     }
 
     contains(DEFINES, QTOX_PLATFORM_EXT) {
@@ -337,6 +338,7 @@ RESOURCES += res.qrc \
 HEADERS  += \
     src/audio/audio.h \
     src/audio/backend/openal.h \
+    src/audio/backend/openal2.h \
     src/chatlog/chatline.h \
     src/chatlog/chatlinecontent.h \
     src/chatlog/chatlinecontentproxy.h \
@@ -458,6 +460,7 @@ HEADERS  += \
 SOURCES += \
     src/audio/audio.cpp \
     src/audio/backend/openal.cpp \
+    src/audio/backend/openal2.cpp \
     src/chatlog/chatline.cpp \
     src/chatlog/chatlinecontent.cpp \
     src/chatlog/chatlinecontentproxy.cpp \

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -59,9 +59,6 @@
  * @var Audio::AUDIO_FRAME_SAMPLE_COUNT
  * @brief Frame sample count
  *
- * @var Audio::AUDIO_CHANNELS
- * @brief Ideally, we'd auto-detect, but that's a sane default
- *
  * @fn qreal Audio::outputVolume() const
  * @brief Returns the current output volume (between 0 and 1)
  *

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -19,7 +19,9 @@
 
 #include "audio.h"
 #include "src/audio/backend/openal.h"
+#ifdef USE_FILTERAUDIO
 #include "src/audio/backend/openal2.h"
+#endif
 #include "src/persistence/settings.h"
 
 #include <QDebug>
@@ -167,6 +169,7 @@
  */
 Audio& Audio::getInstance()
 {
+#ifdef USE_FILTERAUDIO
     static bool initialized = false;
     static bool Backend2 = false;
 
@@ -178,7 +181,9 @@ Audio& Audio::getInstance()
     if (Backend2) {
         static OpenAL2 instance;
         return instance;
-    } else {
+    } else
+#endif
+    {
         static OpenAL instance;
         return instance;
     }

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -20,6 +20,7 @@
 #include "audio.h"
 #include "src/audio/backend/openal.h"
 #include "src/audio/backend/openal2.h"
+#include "src/persistence/settings.h"
 
 #include <QDebug>
 
@@ -169,6 +170,19 @@
  */
 Audio& Audio::getInstance()
 {
-    static OpenAL2 instance;
-    return instance;
+    static bool initialized = false;
+    static bool Backend2 = false;
+
+    if(!initialized) {
+        Backend2 = Settings::getInstance().getEnableBackend2();
+        initialized = true;
+    }
+
+    if(Backend2) {
+        static OpenAL2 instance;
+        return instance;
+    } else {
+        static OpenAL instance;
+        return instance;
+    }
 }

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -169,6 +169,7 @@
  */
 Audio& Audio::getInstance()
 {
+    // TODO: replace backend selection by inversion of control
 #ifdef USE_FILTERAUDIO
     static bool initialized = false;
     static bool Backend2 = false;

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -19,6 +19,7 @@
 
 #include "audio.h"
 #include "src/audio/backend/openal.h"
+#include "src/audio/backend/openal2.h"
 
 #include <QDebug>
 
@@ -168,6 +169,6 @@
  */
 Audio& Audio::getInstance()
 {
-    static OpenAL instance;
+    static OpenAL2 instance;
     return instance;
 }

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -173,12 +173,12 @@ Audio& Audio::getInstance()
     static bool initialized = false;
     static bool Backend2 = false;
 
-    if(!initialized) {
+    if (!initialized) {
         Backend2 = Settings::getInstance().getEnableBackend2();
         initialized = true;
     }
 
-    if(Backend2) {
+    if (Backend2) {
         static OpenAL2 instance;
         return instance;
     } else {

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -94,13 +94,12 @@ public:
     virtual void playAudioBuffer(uint sourceId, const int16_t* data, int samples, unsigned channels,
                                  int sampleRate) = 0;
 
-public:
+protected:
     // Public default audio settings
     static constexpr uint32_t AUDIO_SAMPLE_RATE = 48000;
     static constexpr uint32_t AUDIO_FRAME_DURATION = 20;
     static constexpr uint32_t AUDIO_FRAME_SAMPLE_COUNT =
         AUDIO_FRAME_DURATION * AUDIO_SAMPLE_RATE / 1000;
-    static constexpr uint32_t AUDIO_CHANNELS = 1;
 
 signals:
     void frameAvailable(const int16_t* pcm, size_t sample_count, uint8_t channels,

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -100,7 +100,7 @@ public:
     static constexpr uint32_t AUDIO_FRAME_DURATION = 20;
     static constexpr uint32_t AUDIO_FRAME_SAMPLE_COUNT =
         AUDIO_FRAME_DURATION * AUDIO_SAMPLE_RATE / 1000;
-    static constexpr uint32_t AUDIO_CHANNELS = 2;
+    static constexpr uint32_t AUDIO_CHANNELS = 1;
 
 signals:
     void frameAvailable(const int16_t* pcm, size_t sample_count, uint8_t channels,

--- a/src/audio/backend/openal.cpp
+++ b/src/audio/backend/openal.cpp
@@ -38,9 +38,13 @@
  *
  * @var BUFFER_COUNT
  * @brief Number of buffers to use per audio source
+ *
+ * @var AUDIO_CHANNELS
+ * @brief Ideally, we'd auto-detect, but that's a sane default
  */
 
 static const unsigned int BUFFER_COUNT = 16;
+static const uint32_t AUDIO_CHANNELS = 2;
 
 OpenAL::OpenAL()
     : audioThread{new QThread}

--- a/src/audio/backend/openal.h
+++ b/src/audio/backend/openal.h
@@ -32,14 +32,8 @@
 
 #include <cassert>
 
-#if defined(__APPLE__) && defined(__MACH__)
-#include <OpenAL/al.h>
-#include <OpenAL/alc.h>
-#else
 #include <AL/al.h>
 #include <AL/alc.h>
-#endif
-
 
 #ifndef ALC_ALL_DEVICES_SPECIFIER
 // compatibility with older versions of OpenAL

--- a/src/audio/backend/openal.h
+++ b/src/audio/backend/openal.h
@@ -46,7 +46,7 @@ class OpenAL : public Audio
 
 public:
     OpenAL();
-    ~OpenAL();
+    virtual ~OpenAL();
 
     qreal outputVolume() const;
     void setOutputVolume(qreal volume);
@@ -82,21 +82,26 @@ public:
     void playAudioBuffer(uint sourceId, const int16_t* data, int samples, unsigned channels,
                          int sampleRate);
 
-private:
+protected:
     static void checkAlError() noexcept;
     static void checkAlcError(ALCdevice* device) noexcept;
 
+    qreal inputGainFactor() const;
+    virtual void cleanupInput();
+    virtual void cleanupOutput();
+
     bool autoInitInput();
     bool autoInitOutput();
-    bool initInput(const QString& deviceName);
-    bool initOutput(const QString& outDevDescr);
-    void cleanupInput();
-    void cleanupOutput();
-    void playMono16SoundCleanup();
-    void doCapture();
-    qreal inputGainFactor() const;
+
+    bool initInput(const QString& deviceName, uint32_t channels);
 
 private:
+    virtual bool initInput(const QString& deviceName);
+    virtual bool initOutput(const QString& outDevDescr);
+    void playMono16SoundCleanup();
+    void doCapture();
+
+protected:
     QThread* audioThread;
     mutable QMutex audioLock;
 
@@ -110,7 +115,7 @@ private:
     ALuint alMainBuffer;
     bool outputInitialized;
 
-    QList<ALuint> outSources;
+    QList<ALuint> peerSources;
     qreal gain;
     qreal gainFactor;
     qreal minInGain = -30;

--- a/src/audio/backend/openal2.cpp
+++ b/src/audio/backend/openal2.cpp
@@ -17,7 +17,7 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "openal.h"
+#include "openal2.h"
 #include "src/core/core.h"
 #include "src/core/coreav.h"
 #include "src/persistence/settings.h"
@@ -41,18 +41,21 @@
  */
 
 static const unsigned int BUFFER_COUNT = 16;
+static const unsigned int PROXY_BUFFER_COUNT = 4;
 
-OpenAL::OpenAL()
-    : audioThread{new QThread}
+OpenAL2::OpenAL2() :
+      audioThread{new QThread}
     , alInDev{nullptr}
     , inSubscriptions{0}
     , alOutDev{nullptr}
     , alOutContext{nullptr}
+    , alProxyDev{nullptr}
+    , alProxyContext{nullptr}
     , alMainSource{0}
     , alMainBuffer{0}
+    , alProxySource{0}
+    , alProxyBuffer{0}
     , outputInitialized{false}
-    , minInGain{-30}
-    , maxInGain{30}
 {
     // initialize OpenAL error stack
     alGetError();
@@ -63,17 +66,17 @@ OpenAL::OpenAL()
 
     moveToThread(audioThread);
 
-    connect(&captureTimer, &QTimer::timeout, this, &OpenAL::doCapture);
+    connect(&captureTimer, &QTimer::timeout, this, &OpenAL2::doAudio);
     captureTimer.setInterval(AUDIO_FRAME_DURATION / 2);
     captureTimer.setSingleShot(false);
     captureTimer.start();
-    connect(&playMono16Timer, &QTimer::timeout, this, &OpenAL::playMono16SoundCleanup);
+    connect(&playMono16Timer, &QTimer::timeout, this, &OpenAL2::playMono16SoundCleanup);
     playMono16Timer.setSingleShot(true);
 
     audioThread->start();
 }
 
-OpenAL::~OpenAL()
+OpenAL2::~OpenAL2()
 {
     audioThread->exit();
     audioThread->wait();
@@ -81,14 +84,14 @@ OpenAL::~OpenAL()
     cleanupOutput();
 }
 
-void OpenAL::checkAlError() noexcept
+void OpenAL2::checkAlError() noexcept
 {
     const ALenum al_err = alGetError();
     if (al_err != AL_NO_ERROR)
         qWarning("OpenAL error: %d", al_err);
 }
 
-void OpenAL::checkAlcError(ALCdevice* device) noexcept
+void OpenAL2::checkAlcError(ALCdevice* device) noexcept
 {
     const ALCenum alc_err = alcGetError(device);
     if (alc_err)
@@ -98,7 +101,7 @@ void OpenAL::checkAlcError(ALCdevice* device) noexcept
 /**
  * @brief Returns the current output volume (between 0 and 1)
  */
-qreal OpenAL::outputVolume() const
+qreal OpenAL2::outputVolume() const
 {
     QMutexLocker locker(&audioLock);
 
@@ -117,7 +120,7 @@ qreal OpenAL::outputVolume() const
  *
  * @param[in] volume   the master volume (between 0 and 1)
  */
-void OpenAL::setOutputVolume(qreal volume)
+void OpenAL2::setOutputVolume(qreal volume)
 {
     QMutexLocker locker(&audioLock);
 
@@ -132,7 +135,7 @@ void OpenAL::setOutputVolume(qreal volume)
  *
  * @return minimum gain value in dB
  */
-qreal OpenAL::minInputGain() const
+qreal OpenAL2::minInputGain() const
 {
     QMutexLocker locker(&audioLock);
     return minInGain;
@@ -143,7 +146,7 @@ qreal OpenAL::minInputGain() const
  *
  * @note Default is -30dB; usually you don't need to alter this value;
  */
-void OpenAL::setMinInputGain(qreal dB)
+void OpenAL2::setMinInputGain(qreal dB)
 {
     QMutexLocker locker(&audioLock);
     minInGain = dB;
@@ -154,7 +157,7 @@ void OpenAL::setMinInputGain(qreal dB)
  *
  * @return maximum gain value in dB
  */
-qreal OpenAL::maxInputGain() const
+qreal OpenAL2::maxInputGain() const
 {
     QMutexLocker locker(&audioLock);
     return maxInGain;
@@ -165,20 +168,20 @@ qreal OpenAL::maxInputGain() const
  *
  * @note Default is 30dB; usually you don't need to alter this value.
  */
-void OpenAL::setMaxInputGain(qreal dB)
+void OpenAL2::setMaxInputGain(qreal dB)
 {
     QMutexLocker locker(&audioLock);
     maxInGain = dB;
 }
 
-void OpenAL::reinitInput(const QString& inDevDesc)
+void OpenAL2::reinitInput(const QString& inDevDesc)
 {
     QMutexLocker locker(&audioLock);
     cleanupInput();
     initInput(inDevDesc);
 }
 
-bool OpenAL::reinitOutput(const QString& outDevDesc)
+bool OpenAL2::reinitOutput(const QString& outDevDesc)
 {
     QMutexLocker locker(&audioLock);
     cleanupOutput();
@@ -190,7 +193,7 @@ bool OpenAL::reinitOutput(const QString& outDevDesc)
  *
  * If the input device is not open, it will be opened before capturing.
  */
-void OpenAL::subscribeInput()
+void OpenAL2::subscribeInput()
 {
     QMutexLocker locker(&audioLock);
 
@@ -208,7 +211,7 @@ void OpenAL::subscribeInput()
  *
  * If the input device has no more subscriptions, it will be closed.
  */
-void OpenAL::unsubscribeInput()
+void OpenAL2::unsubscribeInput()
 {
     QMutexLocker locker(&audioLock);
 
@@ -228,7 +231,7 @@ void OpenAL::unsubscribeInput()
  *
  * @return true, if device was initialized; false otherwise
  */
-bool OpenAL::autoInitInput()
+bool OpenAL2::autoInitInput()
 {
     return alInDev ? true : initInput(Settings::getInstance().getInDev());
 }
@@ -238,12 +241,12 @@ bool OpenAL::autoInitInput()
  *
  * @return true, if device was initialized; false otherwise
  */
-bool OpenAL::autoInitOutput()
+bool OpenAL2::autoInitOutput()
 {
     return alOutDev ? true : initOutput(Settings::getInstance().getOutDev());
 }
 
-bool OpenAL::initInput(const QString& deviceName)
+bool OpenAL2::initInput(const QString& deviceName)
 {
     if (!Settings::getInstance().getAudioInDevEnabled())
         return false;
@@ -279,9 +282,9 @@ bool OpenAL::initInput(const QString& deviceName)
 /**
  * @brief Open an audio output device
  */
-bool OpenAL::initOutput(const QString& deviceName)
+bool OpenAL2::initOutput(const QString& deviceName)
 {
-    outSources.clear();
+    peerSources.clear();
 
     outputInitialized = false;
     if (!Settings::getInstance().getAudioOutDevEnabled())
@@ -308,6 +311,49 @@ bool OpenAL::initOutput(const QString& deviceName)
         return false;
     }
 
+    // check for the needed extensions for echo cancelation
+    if (echoCancelSupported = (alcIsExtensionPresent(NULL, "ALC_SOFT_loopback") == AL_TRUE)) {
+        qDebug() << "Device supports loopback";
+    }
+    if (alIsExtensionPresent("AL_SOFT_source_latency") == AL_TRUE) {
+        qDebug() << "Device supports source latency";
+    }
+    else
+    {
+        echoCancelSupported = false;
+    }
+
+    if(echoCancelSupported) {
+        qDebug() << "Echo cancelation supported with this device";
+        // source for proxy output
+        alGenSources(1, &alProxySource);
+
+        LPALCLOOPBACKOPENDEVICESOFT alcLoopbackOpenDeviceSOFT =
+                reinterpret_cast<LPALCLOOPBACKOPENDEVICESOFT> (alcGetProcAddress(alOutDev, "alcLoopbackOpenDeviceSOFT"));
+        LPALCISRENDERFORMATSUPPORTEDSOFT alcIsRenderFormatSupportedSOFT =
+                reinterpret_cast<LPALCISRENDERFORMATSUPPORTEDSOFT> (alcGetProcAddress(alOutDev, "alcIsRenderFormatSupportedSOFT"));
+
+        ALCint attrs[] = { ALC_FORMAT_CHANNELS_SOFT, AUDIO_CHANNELS == 1 ? ALC_MONO_SOFT : ALC_STEREO_SOFT,
+                         ALC_FORMAT_TYPE_SOFT, ALC_SHORT_SOFT,
+                         ALC_FREQUENCY, Audio::AUDIO_SAMPLE_RATE,
+                         0 }; // End of List
+
+        alProxyDev = alcLoopbackOpenDeviceSOFT(NULL);
+        checkAlcError(alProxyDev);
+        if(!alcIsRenderFormatSupportedSOFT(alProxyDev, attrs[5], attrs[1], attrs[3])) {
+            qDebug() << "Unsupported format for loopback";
+        }
+
+        alProxyContext = alcCreateContext(alProxyDev, attrs);
+        checkAlcError(alProxyDev);
+        alcMakeContextCurrent(alProxyContext);
+    }
+    else {
+        // no proxy device needed
+        alProxyDev = alOutDev;
+        alProxyContext = alOutContext;
+    }
+
     alGenSources(1, &alMainSource);
     checkAlError();
 
@@ -330,7 +376,7 @@ bool OpenAL::initOutput(const QString& deviceName)
  *
  * @param[in] path the path to the sound file
  */
-void OpenAL::playMono16Sound(const QString& path)
+void OpenAL2::playMono16Sound(const QString& path)
 {
     QFile sndFile(path);
     sndFile.open(QIODevice::ReadOnly);
@@ -340,13 +386,14 @@ void OpenAL::playMono16Sound(const QString& path)
 /**
  * @brief Play a 44100Hz mono 16bit PCM sound
  */
-void OpenAL::playMono16Sound(const QByteArray& data)
+void OpenAL2::playMono16Sound(const QByteArray& data)
 {
     QMutexLocker locker(&audioLock);
 
     if (!autoInitOutput())
         return;
 
+    alcMakeContextCurrent(alProxyContext);
     if (!alMainBuffer)
         alGenBuffers(1, &alMainBuffer);
 
@@ -365,14 +412,16 @@ void OpenAL::playMono16Sound(const QByteArray& data)
     playMono16Timer.start(durationMs + 50);
 }
 
-void OpenAL::playAudioBuffer(uint sourceId, const int16_t* data, int samples, unsigned channels,
-                             int sampleRate)
+void OpenAL2::playAudioBuffer(uint sourceId, const int16_t* data, int samples, unsigned channels,
+                            int sampleRate)
 {
     assert(channels == 1 || channels == 2);
     QMutexLocker locker(&audioLock);
 
     if (!(alOutDev && outputInitialized))
         return;
+
+    alcMakeContextCurrent(alProxyContext);
 
     ALuint bufids[BUFFER_COUNT];
     ALint processed = 0, queued = 0;
@@ -408,7 +457,7 @@ void OpenAL::playAudioBuffer(uint sourceId, const int16_t* data, int samples, un
 /**
  * @brief Close active audio input device.
  */
-void OpenAL::cleanupInput()
+void OpenAL2::cleanupInput()
 {
     if (!alInDev)
         return;
@@ -424,11 +473,11 @@ void OpenAL::cleanupInput()
 /**
  * @brief Close active audio output device
  */
-void OpenAL::cleanupOutput()
+void OpenAL2::cleanupOutput()
 {
     outputInitialized = false;
 
-    if (alOutDev) {
+    if (alProxyDev) {
         alSourcei(alMainSource, AL_LOOPING, AL_FALSE);
         alSourceStop(alMainSource);
         alDeleteSources(1, &alMainSource);
@@ -442,20 +491,33 @@ void OpenAL::cleanupOutput()
             qWarning("Failed to clear audio context.");
 
         alcDestroyContext(alOutContext);
-        alOutContext = nullptr;
+        alProxyContext = nullptr;
 
         qDebug() << "Closing audio output";
-        if (alcCloseDevice(alOutDev))
-            alOutDev = nullptr;
+        if (alcCloseDevice(alProxyDev))
+            alProxyDev = nullptr;
         else
             qWarning("Failed to close output.");
+    }
+
+    if (echoCancelSupported) {
+        alcMakeContextCurrent(alOutContext);
+        alSourceStop(alProxySource);
+        //TODO: delete buffers
+        alcDestroyContext(alOutContext);
+        alOutContext = nullptr;
+        alcCloseDevice(alOutDev);
+        alOutDev = nullptr;
+    } else {
+        alOutContext = nullptr;
+        alOutDev = nullptr;
     }
 }
 
 /**
  * @brief Called after a mono16 sound stopped playing
  */
-void OpenAL::playMono16SoundCleanup()
+void OpenAL2::playMono16SoundCleanup()
 {
     QMutexLocker locker(&audioLock);
 
@@ -465,7 +527,9 @@ void OpenAL::playMono16SoundCleanup()
         alSourcei(alMainSource, AL_BUFFER, AL_NONE);
         alDeleteBuffers(1, &alMainBuffer);
         alMainBuffer = 0;
-    } else {
+    }
+    else
+    {
         // the audio didn't finish, try again later
         playMono16Timer.start(10);
     }
@@ -474,9 +538,58 @@ void OpenAL::playMono16SoundCleanup()
 /**
  * @brief Called on the captureTimer events to capture audio
  */
-void OpenAL::doCapture()
+void OpenAL2::doAudio()
 {
     QMutexLocker lock(&audioLock);
+
+    static ALshort outBuf[AUDIO_FRAME_SAMPLE_COUNT * AUDIO_CHANNELS] = {0};
+
+    // output section
+    if(echoCancelSupported && outputInitialized) {
+        alcMakeContextCurrent(alOutContext);
+        ALuint bufids[PROXY_BUFFER_COUNT];
+        ALint processed = 0, queued = 0;
+        alGetSourcei(alProxySource, AL_BUFFERS_PROCESSED, &processed);
+        alGetSourcei(alProxySource, AL_BUFFERS_QUEUED, &queued);
+
+        //qDebug() << "Speedtest processed: " << processed << " queued: " << queued;
+
+        if (processed > 0) {
+            // unqueue all processed buffers
+            alSourceUnqueueBuffers(alProxySource, 1, bufids);
+        } else if (queued < PROXY_BUFFER_COUNT) {
+            // create new buffer until the maximum is reached
+            alGenBuffers(1, bufids);
+        } else {
+            return;
+        }
+
+        LPALGETSOURCEDVSOFT alGetSourcedvSOFT =
+                reinterpret_cast<LPALGETSOURCEDVSOFT> (alcGetProcAddress(alOutDev, "alGetSourcedvSOFT"));
+        ALdouble latency[2] = {0};
+        alGetSourcedvSOFT(alProxySource, AL_SEC_OFFSET_LATENCY_SOFT, latency);
+        checkAlError();
+        qDebug() << "Playback latency: " << latency[1];
+
+        alcMakeContextCurrent(alProxyContext);
+        LPALCRENDERSAMPLESSOFT alcRenderSamplesSOFT =
+                reinterpret_cast<LPALCRENDERSAMPLESSOFT> (alcGetProcAddress(alOutDev, "alcRenderSamplesSOFT"));
+        alcRenderSamplesSOFT(alProxyDev, outBuf, AUDIO_FRAME_SAMPLE_COUNT);
+
+        alcMakeContextCurrent(alOutContext);
+        alBufferData(bufids[0], (AUDIO_CHANNELS == 1) ? AL_FORMAT_MONO16 : AL_FORMAT_STEREO16, outBuf,
+                     AUDIO_FRAME_SAMPLE_COUNT * 2 * AUDIO_CHANNELS, AUDIO_SAMPLE_RATE);
+        alSourceQueueBuffers(alProxySource, 1, bufids);
+
+        ALint state;
+        alGetSourcei(alProxySource, AL_SOURCE_STATE, &state);
+        if (state != AL_PLAYING) {
+            qDebug() << "Proxy source underflow detected";
+            alSourcePlay(alProxySource);
+        }
+    }
+
+    // input section
 
     if (!alInDev || !inSubscriptions)
         return;
@@ -504,18 +617,18 @@ void OpenAL::doCapture()
 /**
  * @brief Returns true if the output device is open
  */
-bool OpenAL::isOutputReady() const
+bool OpenAL2::isOutputReady() const
 {
     QMutexLocker locker(&audioLock);
     return alOutDev && outputInitialized;
 }
 
-QStringList OpenAL::outDeviceNames()
+QStringList OpenAL2::outDeviceNames()
 {
     QStringList list;
     const ALchar* pDeviceList = (alcIsExtensionPresent(NULL, "ALC_ENUMERATE_ALL_EXT") != AL_FALSE)
-                                    ? alcGetString(NULL, ALC_ALL_DEVICES_SPECIFIER)
-                                    : alcGetString(NULL, ALC_DEVICE_SPECIFIER);
+                                ? alcGetString(NULL, ALC_ALL_DEVICES_SPECIFIER)
+                                : alcGetString(NULL, ALC_DEVICE_SPECIFIER);
 
     if (pDeviceList) {
         while (*pDeviceList) {
@@ -528,7 +641,7 @@ QStringList OpenAL::outDeviceNames()
     return list;
 }
 
-QStringList OpenAL::inDeviceNames()
+QStringList OpenAL2::inDeviceNames()
 {
     QStringList list;
     const ALchar* pDeviceList = alcGetString(NULL, ALC_CAPTURE_DEVICE_SPECIFIER);
@@ -544,7 +657,7 @@ QStringList OpenAL::inDeviceNames()
     return list;
 }
 
-void OpenAL::subscribeOutput(uint& sid)
+void OpenAL2::subscribeOutput(uint& sid)
 {
     QMutexLocker locker(&audioLock);
 
@@ -553,23 +666,23 @@ void OpenAL::subscribeOutput(uint& sid)
         return;
     }
 
-    if (!alcMakeContextCurrent(alOutContext)) {
+    if (!alcMakeContextCurrent(alProxyContext)) {
         qWarning("Failed to activate output context.");
         return;
     }
 
     alGenSources(1, &sid);
     assert(sid);
-    outSources << sid;
+    peerSources << sid;
 
-    qDebug() << "Audio source" << sid << "created. Sources active:" << outSources.size();
+    qDebug() << "Audio source" << sid << "created. Sources active:" << peerSources.size();
 }
 
-void OpenAL::unsubscribeOutput(uint& sid)
+void OpenAL2::unsubscribeOutput(uint& sid)
 {
     QMutexLocker locker(&audioLock);
 
-    outSources.removeAll(sid);
+    peerSources.removeAll(sid);
 
     if (sid) {
         if (alIsSource(sid)) {
@@ -584,7 +697,7 @@ void OpenAL::unsubscribeOutput(uint& sid)
             alDeleteBuffers(processed, bufids);
             delete[] bufids;
             alDeleteSources(1, &sid);
-            qDebug() << "Audio source" << sid << "deleted. Sources active:" << outSources.size();
+            qDebug() << "Audio source" << sid << "deleted. Sources active:" << peerSources.size();
         } else {
             qWarning() << "Trying to delete invalid audio source" << sid;
         }
@@ -592,17 +705,17 @@ void OpenAL::unsubscribeOutput(uint& sid)
         sid = 0;
     }
 
-    if (outSources.isEmpty())
+    if (peerSources.isEmpty())
         cleanupOutput();
 }
 
-void OpenAL::startLoop()
+void OpenAL2::startLoop()
 {
     QMutexLocker locker(&audioLock);
     alSourcei(alMainSource, AL_LOOPING, AL_TRUE);
 }
 
-void OpenAL::stopLoop()
+void OpenAL2::stopLoop()
 {
     QMutexLocker locker(&audioLock);
     alSourcei(alMainSource, AL_LOOPING, AL_FALSE);
@@ -617,17 +730,17 @@ void OpenAL::stopLoop()
     }
 }
 
-qreal OpenAL::inputGain() const
+qreal OpenAL2::inputGain() const
 {
     return gain;
 }
 
-qreal OpenAL::inputGainFactor() const
+qreal OpenAL2::inputGainFactor() const
 {
     return gainFactor;
 }
 
-void OpenAL::setInputGain(qreal dB)
+void OpenAL2::setInputGain(qreal dB)
 {
     gain = qBound(minInGain, dB, maxInGain);
     gainFactor = qPow(10.0, (gain / 20.0));

--- a/src/audio/backend/openal2.cpp
+++ b/src/audio/backend/openal2.cpp
@@ -47,8 +47,8 @@ extern "C" {
 static const unsigned int BUFFER_COUNT = 16;
 static const unsigned int PROXY_BUFFER_COUNT = 4;
 
-OpenAL2::OpenAL2() :
-      audioThread{new QThread}
+OpenAL2::OpenAL2()
+    : audioThread{new QThread}
     , alInDev{nullptr}
     , inSubscriptions{0}
     , alOutDev{nullptr}
@@ -286,34 +286,34 @@ bool OpenAL2::initInput(const QString& deviceName)
 bool OpenAL2::loadOpenALExtensions(ALCdevice* dev)
 {
     // load OpenAL extension functions
-    alcLoopbackOpenDeviceSOFT = reinterpret_cast<LPALCLOOPBACKOPENDEVICESOFT>
-            (alcGetProcAddress(dev, "alcLoopbackOpenDeviceSOFT"));
+    alcLoopbackOpenDeviceSOFT = reinterpret_cast<LPALCLOOPBACKOPENDEVICESOFT>(
+        alcGetProcAddress(dev, "alcLoopbackOpenDeviceSOFT"));
     checkAlcError(dev);
-    if(!alcLoopbackOpenDeviceSOFT) {
+    if (!alcLoopbackOpenDeviceSOFT) {
         qDebug() << "Failed to load alcLoopbackOpenDeviceSOFT function!";
         return false;
     }
 
-    alcIsRenderFormatSupportedSOFT = reinterpret_cast<LPALCISRENDERFORMATSUPPORTEDSOFT>
-            (alcGetProcAddress(dev, "alcIsRenderFormatSupportedSOFT"));
+    alcIsRenderFormatSupportedSOFT = reinterpret_cast<LPALCISRENDERFORMATSUPPORTEDSOFT>(
+        alcGetProcAddress(dev, "alcIsRenderFormatSupportedSOFT"));
     checkAlcError(dev);
-    if(!alcIsRenderFormatSupportedSOFT) {
+    if (!alcIsRenderFormatSupportedSOFT) {
         qDebug() << "Failed to load alcIsRenderFormatSupportedSOFT function!";
         return false;
     }
 
-    alGetSourcedvSOFT = reinterpret_cast<LPALGETSOURCEDVSOFT>
-            (alcGetProcAddress(dev, "alGetSourcedvSOFT"));
+    alGetSourcedvSOFT =
+        reinterpret_cast<LPALGETSOURCEDVSOFT>(alcGetProcAddress(dev, "alGetSourcedvSOFT"));
     checkAlcError(dev);
-    if(!alGetSourcedvSOFT) {
+    if (!alGetSourcedvSOFT) {
         qDebug() << "Failed to load alGetSourcedvSOFT function!";
         return false;
     }
 
-    alcRenderSamplesSOFT = reinterpret_cast<LPALCRENDERSAMPLESSOFT>
-            (alcGetProcAddress(alOutDev, "alcRenderSamplesSOFT"));
+    alcRenderSamplesSOFT = reinterpret_cast<LPALCRENDERSAMPLESSOFT>(
+        alcGetProcAddress(alOutDev, "alcRenderSamplesSOFT"));
     checkAlcError(dev);
-    if(!alcRenderSamplesSOFT) {
+    if (!alcRenderSamplesSOFT) {
         qDebug() << "Failed to load alcRenderSamplesSOFT function!";
         return false;
     }
@@ -340,7 +340,7 @@ bool OpenAL2::initOutputEchoCancel()
         return false;
     }
 
-    if(!loadOpenALExtensions(alOutDev)) {
+    if (!loadOpenALExtensions(alOutDev)) {
         qDebug() << "Couldn't load needed OpenAL extensions";
         return false;
     }
@@ -350,20 +350,23 @@ bool OpenAL2::initOutputEchoCancel()
     checkAlError();
 
     // configuration for the loopback device
-    ALCint attrs[] = { ALC_FORMAT_CHANNELS_SOFT, ALC_MONO_SOFT,
-                     ALC_FORMAT_TYPE_SOFT, ALC_SHORT_SOFT,
-                     ALC_FREQUENCY, Audio::AUDIO_SAMPLE_RATE,
-                     0 }; // End of List
+    ALCint attrs[] = {ALC_FORMAT_CHANNELS_SOFT,
+                      ALC_MONO_SOFT,
+                      ALC_FORMAT_TYPE_SOFT,
+                      ALC_SHORT_SOFT,
+                      ALC_FREQUENCY,
+                      Audio::AUDIO_SAMPLE_RATE,
+                      0}; // End of List
 
     alProxyDev = alcLoopbackOpenDeviceSOFT(NULL);
     checkAlcError(alProxyDev);
-    if(!alProxyDev) {
+    if (!alProxyDev) {
         qDebug() << "Couldn't create proxy device";
         alDeleteSources(1, &alProxySource); // cleanup source
         return false;
     }
 
-    if(!alcIsRenderFormatSupportedSOFT(alProxyDev, attrs[5], attrs[1], attrs[3])) {
+    if (!alcIsRenderFormatSupportedSOFT(alProxyDev, attrs[5], attrs[1], attrs[3])) {
         qDebug() << "Unsupported format for loopback";
         alcCloseDevice(alProxyDev);         // cleanup loopback dev
         alDeleteSources(1, &alProxySource); // cleanup source
@@ -372,7 +375,7 @@ bool OpenAL2::initOutputEchoCancel()
 
     alProxyContext = alcCreateContext(alProxyDev, attrs);
     checkAlcError(alProxyDev);
-    if(!alProxyContext) {
+    if (!alProxyContext) {
         qDebug() << "Couldn't create proxy context";
         alcCloseDevice(alProxyDev);         // cleanup loopback dev
         alDeleteSources(1, &alProxySource); // cleanup source
@@ -426,7 +429,7 @@ bool OpenAL2::initOutput(const QString& deviceName)
     // try to init echo cancellation
     echoCancelSupported = initOutputEchoCancel();
 
-    if(!echoCancelSupported) {
+    if (!echoCancelSupported) {
         // fallback to normal, no proxy device needed
         qDebug() << "Echo cancellation disabled";
         alProxyDev = alOutDev;
@@ -492,7 +495,7 @@ void OpenAL2::playMono16Sound(const QByteArray& data)
 }
 
 void OpenAL2::playAudioBuffer(uint sourceId, const int16_t* data, int samples, unsigned channels,
-                            int sampleRate)
+                              int sampleRate)
 {
     assert(channels == 1 || channels == 2);
     QMutexLocker locker(&audioLock);
@@ -582,7 +585,7 @@ void OpenAL2::cleanupOutput()
     if (echoCancelSupported) {
         alcMakeContextCurrent(alOutContext);
         alSourceStop(alProxySource);
-        //TODO: delete buffers
+        // TODO: delete buffers
         alcDestroyContext(alOutContext);
         alOutContext = nullptr;
         alcCloseDevice(alOutDev);
@@ -606,9 +609,7 @@ void OpenAL2::playMono16SoundCleanup()
         alSourcei(alMainSource, AL_BUFFER, AL_NONE);
         alDeleteBuffers(1, &alMainBuffer);
         alMainBuffer = 0;
-    }
-    else
-    {
+    } else {
         // the audio didn't finish, try again later
         playMono16Timer.start(10);
     }
@@ -625,7 +626,7 @@ void OpenAL2::doOutput()
     alGetSourcei(alProxySource, AL_BUFFERS_PROCESSED, &processed);
     alGetSourcei(alProxySource, AL_BUFFERS_QUEUED, &queued);
 
-    //qDebug() << "Speedtest processed: " << processed << " queued: " << queued;
+    // qDebug() << "Speedtest processed: " << processed << " queued: " << queued;
 
     if (processed > 0) {
         // unqueue all processed buffers
@@ -640,7 +641,7 @@ void OpenAL2::doOutput()
     ALdouble latency[2] = {0};
     alGetSourcedvSOFT(alProxySource, AL_SEC_OFFSET_LATENCY_SOFT, latency);
     checkAlError();
-    //qDebug() << "Playback latency: " << latency[1] << "offset: " << latency[0];
+    // qDebug() << "Playback latency: " << latency[1] << "offset: " << latency[0];
 
     ALshort outBuf[AUDIO_FRAME_SAMPLE_COUNT] = {0};
     alcMakeContextCurrent(alProxyContext);
@@ -648,14 +649,13 @@ void OpenAL2::doOutput()
     checkAlcError(alProxyDev);
 
     alcMakeContextCurrent(alOutContext);
-    alBufferData(bufids[0], AL_FORMAT_MONO16, outBuf,
-                 AUDIO_FRAME_SAMPLE_COUNT * 2, AUDIO_SAMPLE_RATE);
+    alBufferData(bufids[0], AL_FORMAT_MONO16, outBuf, AUDIO_FRAME_SAMPLE_COUNT * 2, AUDIO_SAMPLE_RATE);
     alSourceQueueBuffers(alProxySource, 1, bufids);
 
     // initialize echo canceler if supported
-    if(!filterer) {
+    if (!filterer) {
         filterer = new_filter_audio(AUDIO_SAMPLE_RATE);
-        int16_t filterLatency = latency[1]*1000*2 + AUDIO_FRAME_DURATION;
+        int16_t filterLatency = latency[1] * 1000 * 2 + AUDIO_FRAME_DURATION;
         qDebug() << "Setting filter delay to: " << filterLatency << "ms";
         set_echo_delay_ms(filterer, filterLatency);
         enable_disable_filters(filterer, 1, 1, 1, 0);
@@ -687,7 +687,7 @@ void OpenAL2::doInput()
     alcCaptureSamples(alInDev, buf, AUDIO_FRAME_SAMPLE_COUNT);
 
     int retVal = 0;
-    if(echoCancelSupported && filterer) {
+    if (echoCancelSupported && filterer) {
         retVal = filter_audio(filterer, buf, AUDIO_FRAME_SAMPLE_COUNT);
     }
 
@@ -711,7 +711,7 @@ void OpenAL2::doAudio()
     QMutexLocker lock(&audioLock);
 
     // output section
-    if(echoCancelSupported && outputInitialized && !peerSources.isEmpty()) {
+    if (echoCancelSupported && outputInitialized && !peerSources.isEmpty()) {
         doOutput();
     } else {
         kill_filter_audio(filterer);
@@ -737,8 +737,8 @@ QStringList OpenAL2::outDeviceNames()
 {
     QStringList list;
     const ALchar* pDeviceList = (alcIsExtensionPresent(NULL, "ALC_ENUMERATE_ALL_EXT") != AL_FALSE)
-                                ? alcGetString(NULL, ALC_ALL_DEVICES_SPECIFIER)
-                                : alcGetString(NULL, ALC_DEVICE_SPECIFIER);
+                                    ? alcGetString(NULL, ALC_ALL_DEVICES_SPECIFIER)
+                                    : alcGetString(NULL, ALC_DEVICE_SPECIFIER);
 
     if (pDeviceList) {
         while (*pDeviceList) {

--- a/src/audio/backend/openal2.h
+++ b/src/audio/backend/openal2.h
@@ -137,6 +137,14 @@ private:
     Filter_Audio* filterer = nullptr;
     LPALCLOOPBACKOPENDEVICESOFT alcLoopbackOpenDeviceSOFT = nullptr;
     LPALCISRENDERFORMATSUPPORTEDSOFT alcIsRenderFormatSupportedSOFT = nullptr;
+
+    // needed because Ubuntu 14.04 lacks the AL_SOFT_source_latency extension
+#ifndef AL_SOFT_source_latency
+    #define AL_SAMPLE_OFFSET_LATENCY_SOFT            0x1200
+    #define AL_SEC_OFFSET_LATENCY_SOFT               0x1201
+    typedef void (AL_APIENTRY*LPALGETSOURCEDVSOFT)(ALuint,ALenum,const ALdouble*);
+#endif
+
     LPALGETSOURCEDVSOFT alGetSourcedvSOFT = nullptr;
     LPALCRENDERSAMPLESSOFT alcRenderSamplesSOFT = nullptr;
 };

--- a/src/audio/backend/openal2.h
+++ b/src/audio/backend/openal2.h
@@ -139,6 +139,7 @@ private:
     LPALCLOOPBACKOPENDEVICESOFT alcLoopbackOpenDeviceSOFT = nullptr;
     LPALCISRENDERFORMATSUPPORTEDSOFT alcIsRenderFormatSupportedSOFT = nullptr;
     LPALGETSOURCEDVSOFT alGetSourcedvSOFT = nullptr;
+    LPALCRENDERSAMPLESSOFT alcRenderSamplesSOFT = nullptr;
 };
 
 #endif // OPENAL2_H

--- a/src/audio/backend/openal2.h
+++ b/src/audio/backend/openal2.h
@@ -106,6 +106,8 @@ private:
     void playMono16SoundCleanup();
     void doAudio();
     qreal inputGainFactor() const;
+    void doInput();
+    void doOutput();
 
 private:
     QThread* audioThread;

--- a/src/audio/backend/openal2.h
+++ b/src/audio/backend/openal2.h
@@ -21,6 +21,7 @@
 #ifndef OPENAL2_H
 #define OPENAL2_H
 
+#include "openal.h"
 #include "src/audio/audio.h"
 
 #include <atomic>
@@ -40,105 +41,41 @@ extern "C" {
 #include <filter_audio.h>
 }
 
-class OpenAL2 : public Audio
+// needed because Ubuntu 14.04 lacks the AL_SOFT_source_latency extension
+#ifndef AL_SOFT_source_latency
+#define AL_SAMPLE_OFFSET_LATENCY_SOFT 0x1200
+#define AL_SEC_OFFSET_LATENCY_SOFT 0x1201
+extern "C" typedef void(AL_APIENTRY* LPALGETSOURCEDVSOFT)(ALuint, ALenum, const ALdouble*);
+#endif
+
+class OpenAL2 : public OpenAL
 {
     Q_OBJECT
 
 public:
     OpenAL2();
-    ~OpenAL2();
-
-    qreal outputVolume() const;
-    void setOutputVolume(qreal volume);
-
-    qreal minInputGain() const;
-    void setMinInputGain(qreal dB);
-
-    qreal maxInputGain() const;
-    void setMaxInputGain(qreal dB);
-
-    qreal inputGain() const;
-    void setInputGain(qreal dB);
-
-    void reinitInput(const QString& inDevDesc);
-    bool reinitOutput(const QString& outDevDesc);
-
-    bool isOutputReady() const;
-
-    QStringList outDeviceNames();
-    QStringList inDeviceNames();
-
-    void subscribeOutput(uint& sourceId);
-    void unsubscribeOutput(uint& sourceId);
-
-    void subscribeInput();
-    void unsubscribeInput();
-
-    void startLoop();
-    void stopLoop();
-    void playMono16Sound(const QByteArray& data);
-    void playMono16Sound(const QString& path);
-
-    void playAudioBuffer(uint sourceId, const int16_t* data, int samples, unsigned channels,
-                         int sampleRate);
-
-signals:
-    void frameAvailable(const int16_t* pcm, size_t sample_count, uint8_t channels,
-                        uint32_t sampling_rate);
 
 private:
-    static void checkAlError() noexcept;
-    static void checkAlcError(ALCdevice* device) noexcept;
-
-    bool autoInitInput();
-    bool autoInitOutput();
     bool initInput(const QString& deviceName);
     bool initOutput(const QString& outDevDescr);
-    void cleanupInput();
     void cleanupOutput();
     void playMono16SoundCleanup();
     void doAudio();
-    qreal inputGainFactor() const;
     void doInput();
     void doOutput();
     bool loadOpenALExtensions(ALCdevice* dev);
     bool initOutputEchoCancel();
 
 private:
-    QThread* audioThread;
-    mutable QMutex audioLock;
-
-    ALCdevice* alInDev;
-    quint32 inSubscriptions;
-    QTimer captureTimer, playMono16Timer;
-
-    ALCdevice* alOutDev;
-    ALCcontext* alOutContext;
     ALCdevice* alProxyDev;
     ALCcontext* alProxyContext;
-    ALuint alMainSource;
-    ALuint alMainBuffer;
     ALuint alProxySource;
     ALuint alProxyBuffer;
-    bool outputInitialized;
     bool echoCancelSupported = false;
 
-    QList<ALuint> peerSources;
-    qreal gain;
-    qreal gainFactor;
-    qreal minInGain = -30;
-    qreal maxInGain = 30;
     Filter_Audio* filterer = nullptr;
     LPALCLOOPBACKOPENDEVICESOFT alcLoopbackOpenDeviceSOFT = nullptr;
     LPALCISRENDERFORMATSUPPORTEDSOFT alcIsRenderFormatSupportedSOFT = nullptr;
-
-    // needed because Ubuntu 14.04 lacks the AL_SOFT_source_latency extension
-#ifndef AL_SOFT_source_latency
-    #define AL_SAMPLE_OFFSET_LATENCY_SOFT            0x1200
-    #define AL_SEC_OFFSET_LATENCY_SOFT               0x1201
-    typedef void (AL_APIENTRY*LPALGETSOURCEDVSOFT)(ALuint,ALenum,const ALdouble*);
-#endif
-
     LPALGETSOURCEDVSOFT alGetSourcedvSOFT = nullptr;
     LPALCRENDERSAMPLESSOFT alcRenderSamplesSOFT = nullptr;
 };

--- a/src/audio/backend/openal2.h
+++ b/src/audio/backend/openal2.h
@@ -42,6 +42,10 @@
 #include <AL/alext.h>
 #endif
 
+extern "C" {
+#include <filter_audio.h>
+}
+
 class OpenAL2 : public Audio
 {
     Q_OBJECT
@@ -127,6 +131,7 @@ private:
     qreal gainFactor;
     qreal minInGain = -30;
     qreal maxInGain = 30;
+    Filter_Audio* filterer = nullptr;
 };
 
 #endif // OPENAL2_H

--- a/src/audio/backend/openal2.h
+++ b/src/audio/backend/openal2.h
@@ -1,0 +1,132 @@
+/*
+    Copyright © 2014-2017 by The qTox Project Contributors
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+#ifndef OPENAL2_H
+#define OPENAL2_H
+
+#include "src/audio/audio.h"
+
+#include <atomic>
+#include <cmath>
+
+#include <QMutex>
+#include <QObject>
+#include <QTimer>
+
+#include <cassert>
+
+#if defined(__APPLE__) && defined(__MACH__)
+#include <OpenAL/al.h>
+#include <OpenAL/alc.h>
+#include <OpenAL/alext.h>
+#else
+#include <AL/al.h>
+#include <AL/alc.h>
+#include <AL/alext.h>
+#endif
+
+class OpenAL2 : public Audio
+{
+    Q_OBJECT
+
+public:
+    OpenAL2();
+    ~OpenAL2();
+
+    qreal outputVolume() const;
+    void setOutputVolume(qreal volume);
+
+    qreal minInputGain() const;
+    void setMinInputGain(qreal dB);
+
+    qreal maxInputGain() const;
+    void setMaxInputGain(qreal dB);
+
+    qreal inputGain() const;
+    void setInputGain(qreal dB);
+
+    void reinitInput(const QString& inDevDesc);
+    bool reinitOutput(const QString& outDevDesc);
+
+    bool isOutputReady() const;
+
+    QStringList outDeviceNames();
+    QStringList inDeviceNames();
+
+    void subscribeOutput(uint& sourceId);
+    void unsubscribeOutput(uint& sourceId);
+
+    void subscribeInput();
+    void unsubscribeInput();
+
+    void startLoop();
+    void stopLoop();
+    void playMono16Sound(const QByteArray& data);
+    void playMono16Sound(const QString& path);
+
+    void playAudioBuffer(uint sourceId, const int16_t* data, int samples, unsigned channels,
+                         int sampleRate);
+
+signals:
+    void frameAvailable(const int16_t* pcm, size_t sample_count, uint8_t channels,
+                        uint32_t sampling_rate);
+
+private:
+
+    static void checkAlError() noexcept;
+    static void checkAlcError(ALCdevice* device) noexcept;
+
+    bool autoInitInput();
+    bool autoInitOutput();
+    bool initInput(const QString& deviceName);
+    bool initOutput(const QString& outDevDescr);
+    void cleanupInput();
+    void cleanupOutput();
+    void playMono16SoundCleanup();
+    void doAudio();
+    qreal inputGainFactor() const;
+
+private:
+    QThread* audioThread;
+    mutable QMutex audioLock;
+
+    ALCdevice* alInDev;
+    quint32 inSubscriptions;
+    QTimer captureTimer, playMono16Timer;
+
+    ALCdevice* alOutDev;
+    ALCcontext* alOutContext;
+    ALCdevice* alProxyDev;
+    ALCcontext* alProxyContext;
+    ALuint alMainSource;
+    ALuint alMainBuffer;
+    ALuint alProxySource;
+    ALuint alProxyBuffer;
+    bool outputInitialized;
+    bool echoCancelSupported = false;
+
+    QList<ALuint> peerSources;
+    qreal gain;
+    qreal gainFactor;
+    qreal minInGain = -30;
+    qreal maxInGain = 30;
+};
+
+#endif // OPENAL2_H

--- a/src/audio/backend/openal2.h
+++ b/src/audio/backend/openal2.h
@@ -93,7 +93,6 @@ signals:
                         uint32_t sampling_rate);
 
 private:
-
     static void checkAlError() noexcept;
     static void checkAlcError(ALCdevice* device) noexcept;
 

--- a/src/audio/backend/openal2.h
+++ b/src/audio/backend/openal2.h
@@ -32,15 +32,9 @@
 
 #include <cassert>
 
-#if defined(__APPLE__) && defined(__MACH__)
-#include <OpenAL/al.h>
-#include <OpenAL/alc.h>
-#include <OpenAL/alext.h>
-#else
 #include <AL/al.h>
 #include <AL/alc.h>
 #include <AL/alext.h>
-#endif
 
 extern "C" {
 #include <filter_audio.h>

--- a/src/audio/backend/openal2.h
+++ b/src/audio/backend/openal2.h
@@ -108,6 +108,8 @@ private:
     qreal inputGainFactor() const;
     void doInput();
     void doOutput();
+    bool loadOpenALExtensions(ALCdevice* dev);
+    bool initOutputEchoCancel();
 
 private:
     QThread* audioThread;
@@ -134,6 +136,9 @@ private:
     qreal minInGain = -30;
     qreal maxInGain = 30;
     Filter_Audio* filterer = nullptr;
+    LPALCLOOPBACKOPENDEVICESOFT alcLoopbackOpenDeviceSOFT = nullptr;
+    LPALCISRENDERFORMATSUPPORTEDSOFT alcIsRenderFormatSupportedSOFT = nullptr;
+    LPALGETSOURCEDVSOFT alGetSourcedvSOFT = nullptr;
 };
 
 #endif // OPENAL2_H

--- a/src/core/toxcall.cpp
+++ b/src/core/toxcall.cpp
@@ -125,6 +125,9 @@ ToxFriendCall::ToxFriendCall(uint32_t FriendNum, bool VideoEnabled, CoreAV& av)
                                                     uint8_t chans, uint32_t rate) {
                                        av.sendCallAudio(FriendNum, pcm, samples, chans, rate);
                                    });
+    if(!audioInConn) {
+        qDebug() << "Audio connection not working";
+    }
 
     if (videoEnabled) {
         videoSource = new CoreVideoSource;

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -265,6 +265,10 @@ void Settings::loadGlobal()
         audioOutDevEnabled = s.value("audioOutDevEnabled", true).toBool();
         audioInGainDecibel = s.value("inGain", 0).toReal();
         outVolume = s.value("outVolume", 100).toInt();
+        enableBackend2 = false;
+        #ifdef USE_FILTERAUDIO
+        enableBackend2 = s.value("enableBackend2", false).toBool();
+        #endif
     }
     s.endGroup();
 
@@ -561,6 +565,7 @@ void Settings::saveGlobal()
         s.setValue("audioOutDevEnabled", audioOutDevEnabled);
         s.setValue("inGain", audioInGainDecibel);
         s.setValue("outVolume", outVolume);
+        s.setValue("enableBackend2", enableBackend2);
     }
     s.endGroup();
 
@@ -1837,6 +1842,22 @@ void Settings::setOutVolume(int volume)
     if (volume != outVolume) {
         outVolume = volume;
         emit outVolumeChanged(outVolume);
+    }
+}
+
+bool Settings::getEnableBackend2() const
+{
+    QMutexLocker locker{&bigLock};
+    return enableBackend2;
+}
+
+void Settings::setEnableBackend2(bool enabled)
+{
+    QMutexLocker locker{&bigLock};
+
+    if (enabled != enableBackend2) {
+        enableBackend2 = enabled;
+        emit enableBackend2Changed(enabled);
     }
 }
 

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -100,7 +100,8 @@ class Settings : public QObject
     Q_PROPERTY(bool audioOutDevEnabled READ getAudioOutDevEnabled WRITE setAudioOutDevEnabled NOTIFY
                    audioOutDevEnabledChanged FINAL)
     Q_PROPERTY(int outVolume READ getOutVolume WRITE setOutVolume NOTIFY outVolumeChanged FINAL)
-    Q_PROPERTY(bool enableBackend2 READ getEnableBackend2 WRITE setEnableBackend2 NOTIFY enableBackend2Changed FINAL)
+    Q_PROPERTY(bool enableBackend2 READ getEnableBackend2 WRITE setEnableBackend2 NOTIFY
+                   enableBackend2Changed FINAL)
 
     // Video
     Q_PROPERTY(QString videoDev READ getVideoDev WRITE setVideoDev NOTIFY videoDevChanged FINAL)

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -100,6 +100,7 @@ class Settings : public QObject
     Q_PROPERTY(bool audioOutDevEnabled READ getAudioOutDevEnabled WRITE setAudioOutDevEnabled NOTIFY
                    audioOutDevEnabledChanged FINAL)
     Q_PROPERTY(int outVolume READ getOutVolume WRITE setOutVolume NOTIFY outVolumeChanged FINAL)
+    Q_PROPERTY(bool enableBackend2 READ getEnableBackend2 WRITE setEnableBackend2 NOTIFY enableBackend2Changed FINAL)
 
     // Video
     Q_PROPERTY(QString videoDev READ getVideoDev WRITE setVideoDev NOTIFY videoDevChanged FINAL)
@@ -234,6 +235,7 @@ signals:
     void audioOutDevEnabledChanged(bool enabled);
     void outVolumeChanged(int volume);
     void enableTestSoundChanged(bool enabled);
+    void enableBackend2Changed(bool enabled);
 
     // Video
     void videoDevChanged(const QString& name);
@@ -362,6 +364,9 @@ public:
 
     bool getEnableTestSound() const;
     void setEnableTestSound(bool newValue);
+
+    bool getEnableBackend2() const;
+    void setEnableBackend2(bool enabled);
 
     QString getVideoDev() const;
     void setVideoDev(const QString& deviceSpecifier);
@@ -617,6 +622,7 @@ private:
     bool audioOutDevEnabled;
     int outVolume;
     bool enableTestSound;
+    bool enableBackend2;
 
     // Video
     QString videoDev;

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -562,5 +562,3 @@ void AVForm::retranslateUi()
 {
     Ui::AVForm::retranslateUi(this);
 }
-
-

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -60,6 +60,9 @@ AVForm::AVForm()
 
     cbEnableTestSound->setToolTip(tr("Play a test sound while changing the output volume."));
 
+#ifndef USE_FILTERAUDIO
+    cbEnableBackend2->setVisible(false);
+#endif
     cbEnableBackend2->setChecked(s.getEnableBackend2());
 
     connect(rescanButton, &QPushButton::clicked, this, &AVForm::rescanDevices);

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -60,6 +60,8 @@ AVForm::AVForm()
 
     cbEnableTestSound->setToolTip(tr("Play a test sound while changing the output volume."));
 
+    cbEnableBackend2->setChecked(s.getEnableBackend2());
+
     connect(rescanButton, &QPushButton::clicked, this, &AVForm::rescanDevices);
 
     playbackSlider->setTracking(false);
@@ -139,6 +141,11 @@ void AVForm::rescanDevices()
     getAudioInDevices();
     getAudioOutDevices();
     getVideoDevices();
+}
+
+void AVForm::on_cbEnableBackend2_stateChanged()
+{
+    Settings::getInstance().setEnableBackend2(cbEnableBackend2->isChecked());
 }
 
 void AVForm::on_videoModescomboBox_currentIndexChanged(int index)
@@ -552,3 +559,5 @@ void AVForm::retranslateUi()
 {
     Ui::AVForm::retranslateUi(this);
 }
+
+

--- a/src/widget/form/settings/avform.h
+++ b/src/widget/form/settings/avform.h
@@ -73,6 +73,8 @@ private slots:
 
     void rescanDevices();
 
+    void on_cbEnableBackend2_stateChanged();
+
 protected:
     void updateVideoModes(int curIndex);
 

--- a/src/widget/form/settings/avform.ui
+++ b/src/widget/form/settings/avform.ui
@@ -30,8 +30,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>824</width>
-        <height>489</height>
+        <width>830</width>
+        <height>495</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -44,30 +44,20 @@
           <property name="bottomMargin">
            <number>6</number>
           </property>
-          <item row="0" column="1" colspan="2">
-           <widget class="QComboBox" name="outDevCombobox"/>
-          </item>
-          <item row="3" column="1" colspan="2">
-           <widget class="QSlider" name="microphoneSlider">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
+          <item row="2" column="0">
+           <widget class="QLabel" name="inDevLabel">
+            <property name="text">
+             <string>Capture device</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="microphoneLabel">
+          <item row="1" column="2">
+           <widget class="QCheckBox" name="cbEnableTestSound">
             <property name="text">
-             <string>Gain</string>
+             <string>Test Sound</string>
             </property>
-           </widget>
-          </item>
-          <item row="2" column="1" colspan="2">
-           <widget class="QComboBox" name="inDevCombobox"/>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="outDevLabel">
-            <property name="text">
-             <string>Playback device</string>
+            <property name="checked">
+             <bool>true</bool>
             </property>
            </widget>
           </item>
@@ -84,12 +74,11 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="inDevLabel">
-            <property name="text">
-             <string>Capture device</string>
-            </property>
-           </widget>
+          <item row="2" column="1" colspan="2">
+           <widget class="QComboBox" name="inDevCombobox"/>
+          </item>
+          <item row="0" column="1" colspan="2">
+           <widget class="QComboBox" name="outDevCombobox"/>
           </item>
           <item row="1" column="0">
            <widget class="QLabel" name="playbackLabel">
@@ -98,13 +87,37 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="2">
-           <widget class="QCheckBox" name="cbEnableTestSound">
+          <item row="3" column="0">
+           <widget class="QLabel" name="microphoneLabel">
             <property name="text">
-             <string>Test Sound</string>
+             <string>Gain</string>
             </property>
-            <property name="checked">
+           </widget>
+          </item>
+          <item row="3" column="1" colspan="2">
+           <widget class="QSlider" name="microphoneSlider">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="outDevLabel">
+            <property name="text">
+             <string>Playback device</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0" colspan="3">
+           <widget class="QCheckBox" name="cbEnableBackend2">
+            <property name="enabled">
              <bool>true</bool>
+            </property>
+            <property name="toolTip">
+             <string>Enables the experimental audio backend with echo cancelling support, needs qTox restart to take effect.</string>
+            </property>
+            <property name="text">
+             <string>Enable experimental audio backend</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
This PR adds a second audio backend (still using OpenAL) that can provide echo canceling. I don't think think this can be merged right away, but I think it's now in a state where testing can begin.

Working State:
- Echo canceling working on my laptop (Thinkpad T440p, Pulseaudio). I tested this with 2 qTox clients Alice and Bob. Alice was set to capture from the laptop mic and play back over the laptop speakers. Bob was set to capture from a virtual pulseaudio input streaming some music (any independent input will work) and playback over a headset. This way, Bob is emulating a Friend and Alice is yourself. Now without echo cancellation enabled, the music was clearly audible as noise in the headset, when enabling echo cancellation it wasn't. ✔️ 
- fallback if OpenAL extensions needed are missing implemented, but untested.

Not Working:

- echobot, It seems echobot creates an echo that is to strong to filter out using libfilteraudio, IDK what to do about this.
- stereo, libfilteraudio only supports mono audio, I don't think it will be a problem to limit echo canceling to mono since it's not suitable for high quality streaming anyway.

To Test:

- different systems, we need to test this on as many computers as possible, because they all have different audio latencies which are a critical part of echo canceling.
- Windows, theoretically this should also work on Windows out of the box, but it's not tested.

To Do:
- add libfilteraudio dependencies to documents and build system
- improve switching between the two audio backends

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4367)
<!-- Reviewable:end -->
