### PR TITLE
fix(macro): Fixed clang warning about USING_V4L

### DIFF
--- a/src/video/cameradevice.cpp
+++ b/src/video/cameradevice.cpp
@@ -28,7 +28,11 @@ extern "C" {
 #include "cameradevice.h"
 #include "src/persistence/settings.h"
 
-#define USING_V4L defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+#define USING_V4L 1
+#else
+#define USING_V4L 0
+#endif
 
 #ifdef Q_OS_WIN
 #include "src/platform/camera/directshow.h"


### PR DESCRIPTION
Clang produced this warning: "macro expansion producing 'defined' has undefined behavior"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4381)
<!-- Reviewable:end -->
