### PR TITLE
fix(profile): set maxLength on userName QLineEdit

### DIFF
--- a/src/widget/form/profileform.cpp
+++ b/src/widget/form/profileform.cpp
@@ -56,6 +56,10 @@ ProfileForm::ProfileForm(QWidget* parent)
     bodyUI->setupUi(this);
     core = Core::getInstance();
 
+    bodyUI->userNameLabel->setToolTip(tr("Tox user names cannot exceed %1 characters.")
+                                      .arg(TOX_MAX_NAME_LENGTH));
+    bodyUI->userName->setMaxLength(TOX_MAX_NAME_LENGTH);
+
     // tox
     toxId = new ClickableTE();
     toxId->setReadOnly(true);


### PR DESCRIPTION
Set maxLength of userName QLineEdit to TOX_MAX_NAME_LENGTH
Fixes #4335

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4382)
<!-- Reviewable:end -->
