### PR TITLE
fix(ui): restore splitter state

### DIFF
--- a/src/widget/contentdialog.cpp
+++ b/src/widget/contentdialog.cpp
@@ -124,7 +124,7 @@ ContentDialog::ContentDialog(SettingsWidget* settingsWidget, QWidget* parent)
     }
 
     SplitterRestorer restorer(splitter);
-    restorer.restore(s.getDialogSettingsGeometry(), size());
+    restorer.restore(s.getDialogSplitterState(), size());
 
     currentDialog = this;
     setAcceptDrops(true);

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -662,6 +662,9 @@ void Widget::onSeparateWindowChanged(bool separate, bool clicked)
 
         setMinimumWidth(775);
 
+        SplitterRestorer restorer(ui->mainSplitter);
+        restorer.restore(Settings::getInstance().getSplitterState(), size());
+
         onAddClicked();
     } else {
         int width = ui->friendList->size().width();


### PR DESCRIPTION
Fixes #4387.
This restores the state of the splitter correctly from settings.

Restoring `DialogSettingsGeometry` is wrong because it contains only information about the position and size of the window, nothing about the splitter. Handling of the window geometry is done correctly just above these changes.

Edit:
Fixes #2378.
Also added restoring of splitter state after one quiets multiple window mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4389)
<!-- Reviewable:end -->
