### PR TITLE
fix(settings): compute toxcore version in runtime

### DIFF
--- a/src/widget/form/settings/aboutform.cpp
+++ b/src/widget/form/settings/aboutform.cpp
@@ -73,9 +73,9 @@ void AboutForm::replaceVersions()
     // TODO: When we finally have stable releases: build-in a way to tell
     // nightly builds from stable releases.
 
-    QString TOXCORE_VERSION = QString::number(TOX_VERSION_MAJOR) + "."
-                              + QString::number(TOX_VERSION_MINOR) + "."
-                              + QString::number(TOX_VERSION_PATCH);
+    QString TOXCORE_VERSION = QString::number(tox_version_major()) + "."
+                              + QString::number(tox_version_minor()) + "."
+                              + QString::number(tox_version_patch());
 
     bodyUI->youAreUsing->setText(tr("You are using qTox version %1.").arg(QString(GIT_DESCRIBE)));
 


### PR DESCRIPTION
Past this change toxcore version was set during compilation.  This
caused a problem when you changed version of toxcore while qTox would
still display its old.  This behaviour was misleading.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4391)
<!-- Reviewable:end -->
