### PR TITLE
fix(message size): Replaced TOX_MAX_*_LENGTH with API calls.

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -580,7 +580,7 @@ QString Core::getFriendRequestErrorMessage(const ToxId& friendId, const QString&
                   "Error while sending friendship request");
     }
 
-    if (message.length() > TOX_MAX_FRIEND_REQUEST_LENGTH) {
+    if (message.length() > static_cast<int>(tox_max_friend_request_length())) {
         return tr("Your message is too long!", "Error while sending friendship request");
     }
 
@@ -1098,7 +1098,7 @@ uint32_t Core::getGroupNumberPeers(int groupId) const
  */
 QString Core::getGroupPeerName(int groupId, int peerId) const
 {
-    uint8_t nameArray[TOX_MAX_NAME_LENGTH];
+    uint8_t nameArray[tox_max_name_length()];
     TOX_ERR_CONFERENCE_PEER_QUERY error;
     size_t length = tox_conference_peer_get_name_size(tox, groupId, peerId, &error);
     if (!parsePeerQueryError(error)) {
@@ -1159,7 +1159,8 @@ QStringList Core::getGroupPeerNames(int groupId) const
 
     QStringList names;
     for (uint32_t i = 0; i < nPeers; ++i) {
-        uint8_t name[TOX_MAX_NAME_LENGTH] = {0};
+        uint8_t name[tox_max_name_length()];
+        memset(name, 0, tox_max_name_length());
         size_t length = tox_conference_peer_get_name_size(tox, groupId, i, &error);
         bool ok = tox_conference_peer_get_name(tox, groupId, i, name, &error);
         if (ok && parsePeerQueryError(error)) {
@@ -1408,7 +1409,7 @@ QString Core::getPeerName(const ToxPk& id) const
         return name;
     }
 
-    uint8_t* cname = new uint8_t[nameSize < TOX_MAX_NAME_LENGTH ? TOX_MAX_NAME_LENGTH : nameSize];
+    uint8_t* cname = new uint8_t[nameSize < tox_max_name_length() ? tox_max_name_length() : nameSize];
     if (!tox_friend_get_name(tox, friendId, cname, nullptr)) {
         qWarning() << "getPeerName: Can't get name of friend " + QString().setNum(friendId);
         delete[] cname;

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -610,7 +610,7 @@ void ChatForm::dropEvent(QDropEvent* ev)
         QFile file(info.absoluteFilePath());
 
         QString urlString = url.toString();
-        if (url.isValid() && !url.isLocalFile() && urlString.length() < TOX_MAX_MESSAGE_LENGTH) {
+        if (url.isValid() && !url.isLocalFile() && urlString.length() < static_cast<int>(tox_max_message_length())) {
             SendMessageStr(urlString);
             continue;
         }
@@ -949,7 +949,7 @@ void ChatForm::SendMessageStr(QString msg)
         msg.remove(0, ACTION_PREFIX.length());
     }
 
-    QStringList splittedMsg = Core::splitMessage(msg, TOX_MAX_MESSAGE_LENGTH);
+    QStringList splittedMsg = Core::splitMessage(msg, tox_max_message_length());
     QDateTime timestamp = QDateTime::currentDateTime();
 
     for (const QString& part : splittedMsg) {

--- a/src/widget/form/profileform.cpp
+++ b/src/widget/form/profileform.cpp
@@ -57,8 +57,8 @@ ProfileForm::ProfileForm(QWidget* parent)
     core = Core::getInstance();
 
     bodyUI->userNameLabel->setToolTip(tr("Tox user names cannot exceed %1 characters.")
-                                      .arg(TOX_MAX_NAME_LENGTH));
-    bodyUI->userName->setMaxLength(TOX_MAX_NAME_LENGTH);
+                                      .arg(tox_max_name_length()));
+    bodyUI->userName->setMaxLength(tox_max_name_length());
 
     // tox
     toxId = new ClickableTE();

--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -432,7 +432,7 @@ void FriendWidget::mouseMoveEvent(QMouseEvent* ev)
 
 void FriendWidget::setAlias(const QString& _alias)
 {
-    QString alias = _alias.left(128); // same as TOX_MAX_NAME_LENGTH
+    QString alias = _alias.left(tox_max_name_length());
     Friend* f = FriendList::findFriend(friendId);
     f->setAlias(alias);
     Settings::getInstance().setFriendAlias(f->getPublicKey(), alias);


### PR DESCRIPTION
It is good for flexibility to have fewer hardcoded values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4394)
<!-- Reviewable:end -->
