### PR TITLE
fix(core): use correct byte representation when bootstrapping

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -413,7 +413,9 @@ void Core::bootstrapDht()
         QString name = dhtServer.name;
         qDebug() << QString("Connecting to %1:%2 (%3)").arg(dhtServerAddress, port, name);
         QByteArray address = dhtServer.address.toLatin1();
-        ToxPk pk{dhtServer.userId.toLatin1()};
+        // TODO: constucting the pk via ToxId is a workaround
+        ToxPk pk = ToxId{dhtServer.userId}.getPublicKey();
+
 
         const uint8_t* pkPtr = reinterpret_cast<const uint8_t*>(pk.getBytes());
 


### PR DESCRIPTION
Revert a bug introduced in d126b18d76150700caa52c801e91d94460fe4346
where qTox calls tox_bootstrap() and tox_add_relay() with an invalid
argument, which results in qTox not connecting to the bootstrap nodes
from its list of bootsrap nodes and therefore failing to connect to the
Tox DHT network in the case when that list is the only source of nodes
to connect to. The invalid argument is node's public key, which is
non-nullable but is passed a null due to invalid ToxPk object being
constructed. ToxPk's constructor expects the QByteArray argument to be
the byte representation of a public key, but a textual representation
is passed to it instead, which creats an invalid ToxPk that resolves to
null when queried for public key's bytes for calls to  tox_bootstrap()
and tox_add_relay().

Fixes #4385

I have tested it (built on Jenkins) and it fixes the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4396)
<!-- Reviewable:end -->
