### PR TITLE
fix: gcc-7 build

### DIFF
--- a/src/persistence/db/rawdatabase.h
+++ b/src/persistence/db/rawdatabase.h
@@ -10,6 +10,7 @@
 #include <QVariant>
 #include <QVector>
 #include <atomic>
+#include <functional>
 #include <memory>
 
 struct sqlite3;


### PR DESCRIPTION
Added missing include for this error: rawdatabase.h:27:20: error: 'std::function' has not been declared

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4404)
<!-- Reviewable:end -->
