### PR TITLE
fix(ui): switch to settings after multiple windows mode

### DIFF
--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -665,7 +665,7 @@ void Widget::onSeparateWindowChanged(bool separate, bool clicked)
         SplitterRestorer restorer(ui->mainSplitter);
         restorer.restore(Settings::getInstance().getSplitterState(), size());
 
-        onAddClicked();
+        onShowSettings();
     } else {
         int width = ui->friendList->size().width();
         QSize size;


### PR DESCRIPTION
Switch back to settings after disabling multiple windows mode instead of switch to add friend page.

**Problem:** Disabling multiple windows mode (MWM) opens add friend page in single window mode.
**Expected Behavior:** The user would expect that the last window he has used is displayed in single window mode. This would be settings where one can disable MWM.
This would make reverting changes a lot easier e.g. if one clicked by accident on MWM checkbox in settings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4407)
<!-- Reviewable:end -->
