### PR TITLE
fix(ui): Set `Qt::Window` flag in multi windows mode

### DIFF
--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1515,7 +1515,7 @@ ContentLayout* Widget::createContentDialog(DialogType type) const
     {
     public:
         explicit Dialog(DialogType type)
-            : ActivateDialog()
+            : ActivateDialog(nullptr, Qt::Window)
             , type(type)
         {
             restoreGeometry(Settings::getInstance().getDialogSettingsGeometry());


### PR DESCRIPTION
This sets the flag to `Qt::Window` for open dialogs in multi windows mode.
Commit changes the appearance of non-chat windows (Settings, Add Friend, ...).

This solves the problem that non-chat windows have a help button in the title bar (see attachment).
I could reproduce this behavior on KDE 5 and Windows 10.
![qtox_settings_001](https://cloud.githubusercontent.com/assets/16089150/26498783/80c00928-4230-11e7-9176-9e0402998b86.png)

It might also fix issue #2270, however I could not test this, since I can not reproduce.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4421)
<!-- Reviewable:end -->
