### PR TITLE
fix(ui): do not save splitter state in multiple windows mode

### DIFF
--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -2000,7 +2000,9 @@ void Widget::saveWindowGeometry()
 
 void Widget::saveSplitterGeometry()
 {
-    Settings::getInstance().setSplitterState(ui->mainSplitter->saveState());
+    if (!Settings::getInstance().getSeparateWindow()) {
+        Settings::getInstance().setSplitterState(ui->mainSplitter->saveState());
+    }
 }
 
 void Widget::onSplitterMoved(int pos, int index)


### PR DESCRIPTION
In multiple windows mode there are no two widgets that are separated by the splitter, there is just one widget. This changes the splitter state without the users intention.
The invalid splitter state is saved as soon as the user moves or resizes the main window.

**Steps to reproduce:**
1. Switch to multiple windows mode.
2. **Move** the **main** qTox window (window with friend list and own avatar).
3. Revert back to single window mode.

The splitter state is messed up now.

Note: Best visible if friend list is minimal width.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4424)
<!-- Reviewable:end -->
