### PR TITLE
refactor: Split 'onChatrootWidgetClicked' on 2 methods

### DIFF
--- a/src/widget/contentdialog.h
+++ b/src/widget/contentdialog.h
@@ -100,7 +100,8 @@ protected:
     void keyPressEvent(QKeyEvent* event) override;
 
 private slots:
-    void onChatroomWidgetClicked(GenericChatroomWidget* widget, bool group);
+    void activate(GenericChatroomWidget* widget);
+    void openNewDiadlog(GenericChatroomWidget* widget);
     void updateFriendWidget(uint32_t friendId, QString alias);
     void updateGroupWidget(GroupWidget* w);
     void onGroupchatPositionChanged(bool top);

--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -199,18 +199,20 @@ void FriendWidget::onContextMenuCalled(QContextMenuEvent* event)
 
     removeEventFilter(this);
 
-    if (!active)
+    if (!active) {
         setBackgroundRole(QPalette::Window);
+    }
 
-    if (!selectedItem)
+    if (!selectedItem) {
         return;
+    }
 
     if (selectedItem == setAlias) {
         nameLabel->editBegin();
     } else if (selectedItem == removeFriendAction) {
         emit removeFriend(friendId);
     } else if (selectedItem == openChatWindow) {
-        emit chatroomWidgetClicked(this, true);
+        emit newWindowOpened(this);
     } else if (selectedItem == removeChatWindow) {
         ContentDialog* contentDialog = ContentDialog::getFriendDialog(friendId);
         contentDialog->removeFriend(friendId);

--- a/src/widget/genericchatroomwidget.h
+++ b/src/widget/genericchatroomwidget.h
@@ -68,7 +68,8 @@ public slots:
     void compactChange(bool compact);
 
 signals:
-    void chatroomWidgetClicked(GenericChatroomWidget* widget, bool group = false);
+    void chatroomWidgetClicked(GenericChatroomWidget* widget);
+    void newWindowOpened(GenericChatroomWidget* widget);
 
 protected:
     virtual void mouseReleaseEvent(QMouseEvent* event) override;

--- a/src/widget/groupwidget.cpp
+++ b/src/widget/groupwidget.cpp
@@ -101,19 +101,19 @@ void GroupWidget::contextMenuEvent(QContextMenuEvent* event)
     if (!active)
         setBackgroundRole(QPalette::Window);
 
-    if (selectedItem) {
-        if (selectedItem == quitGroup) {
-            emit removeGroup(groupId);
-        } else if (selectedItem == openChatWindow) {
-            emit chatroomWidgetClicked(this, true);
-            return;
-        } else if (selectedItem == removeChatWindow) {
-            ContentDialog* contentDialog = ContentDialog::getGroupDialog(groupId);
-            contentDialog->removeGroup(groupId);
-            return;
-        } else if (selectedItem == setTitle) {
-            editName();
-        }
+    if (!selectedItem) {
+        return;
+    }
+
+    if (selectedItem == quitGroup) {
+        emit removeGroup(groupId);
+    } else if (selectedItem == openChatWindow) {
+        emit newWindowOpened(this);
+    } else if (selectedItem == removeChatWindow) {
+        ContentDialog* contentDialog = ContentDialog::getGroupDialog(groupId);
+        contentDialog->removeGroup(groupId);
+    } else if (selectedItem == setTitle) {
+        editName();
     }
 }
 


### PR DESCRIPTION
onChatrootWidgetClicked was used for 2 different actions.
Now it's splitted on 'activate' and 'openNewDialog'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4425)
<!-- Reviewable:end -->
