### PR TITLE
refactor: Split 'onChatrootWidgetClicked' on 2 methods

### DIFF
--- a/src/widget/categorywidget.cpp
+++ b/src/widget/categorywidget.cpp
@@ -30,10 +30,11 @@
 
 void CategoryWidget::emitChatroomWidget(QLayout* layout, int index)
 {
-    GenericChatroomWidget* chatWidget =
-        qobject_cast<GenericChatroomWidget*>(layout->itemAt(index)->widget());
-    if (chatWidget != nullptr)
+    QWidget* widget = layout->itemAt(index)->widget();
+    GenericChatroomWidget* chatWidget = qobject_cast<GenericChatroomWidget*>(widget);
+    if (chatWidget != nullptr) {
         emit chatWidget->chatroomWidgetClicked(chatWidget);
+    }
 }
 
 CategoryWidget::CategoryWidget(bool compact, QWidget* parent)

--- a/src/widget/contentdialog.cpp
+++ b/src/widget/contentdialog.cpp
@@ -168,11 +168,11 @@ FriendWidget* ContentDialog::addFriend(int friendId, QString id)
     Friend* frnd = friendWidget->getFriend();
     friendLayout->addFriendWidget(friendWidget, frnd->getStatus());
 
+    ChatForm* form = frnd->getChatForm();
     connect(frnd, &Friend::aliasChanged, this, &ContentDialog::updateFriendWidget);
-    connect(friendWidget, &FriendWidget::chatroomWidgetClicked, this,
-            &ContentDialog::onChatroomWidgetClicked);
-    connect(friendWidget, SIGNAL(chatroomWidgetClicked(GenericChatroomWidget*)),
-            frnd->getChatForm(), SLOT(focusInput()));
+    connect(friendWidget, &FriendWidget::chatroomWidgetClicked, this, &ContentDialog::activate);
+    connect(friendWidget, &FriendWidget::newWindowOpened, this, &ContentDialog::openNewDialog);
+    connect(friendWidget, &FriendWidget::chatroomWidgetClicked, form, &ChatForm::focusInput);
 
     ContentDialog* lastDialog = getFriendDialog(friendId);
     if (lastDialog) {
@@ -181,7 +181,7 @@ FriendWidget* ContentDialog::addFriend(int friendId, QString id)
 
     friendList.insert(friendId, std::make_tuple(this, friendWidget));
     // FIXME: emit should be removed
-    emit friendWidget->chatroomWidgetClicked(friendWidget, false);
+    emit friendWidget->chatroomWidgetClicked(friendWidget);
 
     return friendWidget;
 }
@@ -195,8 +195,8 @@ GroupWidget* ContentDialog::addGroup(int groupId, const QString& name)
     Group* group = groupWidget->getGroup();
     connect(group, &Group::titleChanged, this, &ContentDialog::updateGroupWidget);
     connect(group, &Group::userListChanged, this, &ContentDialog::updateGroupWidget);
-    connect(groupWidget, &GroupWidget::chatroomWidgetClicked, this,
-            &ContentDialog::onChatroomWidgetClicked);
+    connect(groupWidget, &GroupWidget::chatroomWidgetClicked, this, &ContentDialog::activate);
+    connect(groupWidget, &FriendWidget::newWindowOpened, this, &ContentDialog::openNewDialog);
 
     ContentDialog* lastDialog = getGroupDialog(groupId);
 
@@ -206,7 +206,7 @@ GroupWidget* ContentDialog::addGroup(int groupId, const QString& name)
 
     groupList.insert(groupId, std::make_tuple(this, groupWidget));
     // FIXME: emit should be removed
-    emit groupWidget->chatroomWidgetClicked(groupWidget, false);
+    emit groupWidget->chatroomWidgetClicked(groupWidget);
 
     return groupWidget;
 }
@@ -379,7 +379,7 @@ void ContentDialog::cycleContacts(bool forward, bool inverse)
     GenericChatroomWidget* chatWidget = qobject_cast<GenericChatroomWidget*>(widget);
     if (chatWidget && chatWidget != activeChatroomWidget) {
         // FIXME: emit should be removed
-        emit chatWidget->chatroomWidgetClicked(chatWidget, false);
+        emit chatWidget->chatroomWidgetClicked(chatWidget);
     }
 }
 
@@ -691,30 +691,32 @@ void ContentDialog::keyPressEvent(QKeyEvent* event)
 }
 
 /**
- * @brief Show ContentDialog, activate chatroom widget.
- * @param widget Widget which was clicked.
- * @param group Seems always `false`. TODO: Remove
+ * @brief Open a new dialog window associated with widget
+ * @param widget Widget associated with contact.
  */
-void ContentDialog::onChatroomWidgetClicked(GenericChatroomWidget* widget, bool group)
+void ContentDialog::openNewDialog(GenericChatroomWidget* widget)
 {
-    if (group) {
-        ContentDialog* contentDialog = new ContentDialog(settingsWidget);
-        contentDialog->show();
+    ContentDialog* contentDialog = new ContentDialog(settingsWidget);
+    contentDialog->show();
 
-        if (widget->getFriend()) {
-            removeFriend(widget->getFriend()->getFriendId());
-            Widget::getInstance()->addFriendDialog(widget->getFriend(), contentDialog);
-        } else {
-            removeGroup(widget->getGroup()->getGroupId());
-            Widget::getInstance()->addGroupDialog(widget->getGroup(), contentDialog);
-        }
-
-        contentDialog->raise();
-        contentDialog->activateWindow();
-
-        return;
+    if (widget->getFriend()) {
+        removeFriend(widget->getFriend()->getFriendId());
+        Widget::getInstance()->addFriendDialog(widget->getFriend(), contentDialog);
+    } else {
+        removeGroup(widget->getGroup()->getGroupId());
+        Widget::getInstance()->addGroupDialog(widget->getGroup(), contentDialog);
     }
 
+    contentDialog->raise();
+    contentDialog->activateWindow();
+}
+
+/**
+ * @brief Show ContentDialog, activate chatroom widget.
+ * @param widget Widget which should be activated.
+ */
+void ContentDialog::activate(GenericChatroomWidget* widget)
+{
     // If we clicked on the currently active widget, don't reload and relayout everything
     if (activeChatroomWidget == widget) {
         return;
@@ -839,7 +841,7 @@ void ContentDialog::focusDialog(int id, const QHash<int, ContactInfo>& list)
 
     dialog->raise();
     dialog->activateWindow();
-    dialog->onChatroomWidgetClicked(std::get<1>(iter.value()), false);
+    dialog->activate(std::get<1>(iter.value()));
 }
 
 /**

--- a/src/widget/contentdialog.h
+++ b/src/widget/contentdialog.h
@@ -100,7 +100,8 @@ protected:
     void keyPressEvent(QKeyEvent* event) override;
 
 private slots:
-    void onChatroomWidgetClicked(GenericChatroomWidget* widget, bool group);
+    void activate(GenericChatroomWidget* widget);
+    void openNewDialog(GenericChatroomWidget* widget);
     void updateFriendWidget(uint32_t friendId, QString alias);
     void updateGroupWidget(GroupWidget* w);
     void onGroupchatPositionChanged(bool top);

--- a/src/widget/friendlistlayout.cpp
+++ b/src/widget/friendlistlayout.cpp
@@ -81,14 +81,14 @@ void FriendListLayout::moveFriendWidgets(FriendListWidget* listWidget)
 
         FriendWidget* friendWidget = qobject_cast<FriendWidget*>(getWidget);
         Friend* f = FriendList::findFriend(friendWidget->friendId);
-        listWidget->moveWidget(friendWidget, f->getStatus(), false);
+        listWidget->moveWidget(friendWidget, f->getStatus(), true);
     }
     while (!friendOfflineLayout.getLayout()->isEmpty()) {
         QWidget* getWidget = friendOfflineLayout.getLayout()->takeAt(0)->widget();
 
         FriendWidget* friendWidget = qobject_cast<FriendWidget*>(getWidget);
         Friend* f = FriendList::findFriend(friendWidget->friendId);
-        listWidget->moveWidget(friendWidget, f->getStatus(), false);
+        listWidget->moveWidget(friendWidget, f->getStatus(), true);
     }
 }
 

--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -199,18 +199,20 @@ void FriendWidget::onContextMenuCalled(QContextMenuEvent* event)
 
     removeEventFilter(this);
 
-    if (!active)
+    if (!active) {
         setBackgroundRole(QPalette::Window);
+    }
 
-    if (!selectedItem)
+    if (!selectedItem) {
         return;
+    }
 
     if (selectedItem == setAlias) {
         nameLabel->editBegin();
     } else if (selectedItem == removeFriendAction) {
         emit removeFriend(friendId);
     } else if (selectedItem == openChatWindow) {
-        emit chatroomWidgetClicked(this, true);
+        emit newWindowOpened(this);
     } else if (selectedItem == removeChatWindow) {
         ContentDialog* contentDialog = ContentDialog::getFriendDialog(friendId);
         contentDialog->removeFriend(friendId);

--- a/src/widget/genericchatroomwidget.h
+++ b/src/widget/genericchatroomwidget.h
@@ -68,7 +68,8 @@ public slots:
     void compactChange(bool compact);
 
 signals:
-    void chatroomWidgetClicked(GenericChatroomWidget* widget, bool group = false);
+    void chatroomWidgetClicked(GenericChatroomWidget* widget);
+    void newWindowOpened(GenericChatroomWidget* widget);
 
 protected:
     virtual void mouseReleaseEvent(QMouseEvent* event) override;

--- a/src/widget/groupwidget.cpp
+++ b/src/widget/groupwidget.cpp
@@ -101,19 +101,19 @@ void GroupWidget::contextMenuEvent(QContextMenuEvent* event)
     if (!active)
         setBackgroundRole(QPalette::Window);
 
-    if (selectedItem) {
-        if (selectedItem == quitGroup) {
-            emit removeGroup(groupId);
-        } else if (selectedItem == openChatWindow) {
-            emit chatroomWidgetClicked(this, true);
-            return;
-        } else if (selectedItem == removeChatWindow) {
-            ContentDialog* contentDialog = ContentDialog::getGroupDialog(groupId);
-            contentDialog->removeGroup(groupId);
-            return;
-        } else if (selectedItem == setTitle) {
-            editName();
-        }
+    if (!selectedItem) {
+        return;
+    }
+
+    if (selectedItem == quitGroup) {
+        emit removeGroup(groupId);
+    } else if (selectedItem == openChatWindow) {
+        emit newWindowOpened(this);
+    } else if (selectedItem == removeChatWindow) {
+        ContentDialog* contentDialog = ContentDialog::getGroupDialog(groupId);
+        contentDialog->removeGroup(groupId);
+    } else if (selectedItem == setTitle) {
+        editName();
     }
 }
 

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -196,7 +196,8 @@ private slots:
     void onGroupClicked();
     void onTransferClicked();
     void showProfile();
-    void onChatroomWidgetClicked(GenericChatroomWidget*, bool group);
+    void openNewDialog(GenericChatroomWidget* widget);
+    void onChatroomWidgetClicked(GenericChatroomWidget* widget);
     void onStatusMessageChanged(const QString& newStatusMessage);
     void removeFriend(int friendId);
     void copyFriendIdToClipboard(int friendId);
@@ -240,6 +241,7 @@ private:
     static bool filterOffline(FilterCriteria index);
     void retranslateUi();
     void focusChatInput();
+    void openDialog(GenericChatroomWidget* widget, bool newWindow);
 
 private:
     SystemTrayIcon* icon = nullptr;


### PR DESCRIPTION
onChatrootWidgetClicked was used for 2 different actions.
Now it's splitted on 'activate' and 'openNewDialog'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4426)
<!-- Reviewable:end -->
