### PR TITLE
fix(widget): Fix crash when setIcon is called on settings window when…

### DIFF
--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -858,7 +858,9 @@ void Widget::showProfile() // onAvatarClicked, onUsernameClicked
         }
 
         setActiveToolMenuButton(ActiveToolMenuButton::None);
-        settingsWidget->setWindowIcon(QIcon(":/img/icons/qtox.svg"));
+        if (settingsWidget) {
+            settingsWidget->setWindowIcon(QIcon(":/img/icons/qtox.svg"));
+        }
     } else {
         hideMainForms(nullptr);
         profileForm->show(contentLayout);


### PR DESCRIPTION
… it isn't yet opened

patch by @aasimon
fix #4430

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4431)
<!-- Reviewable:end -->
