### PR TITLE
fix(ui): add date message before info messages

### DIFF
--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -402,9 +402,7 @@ ChatMessage::Ptr GenericChatForm::createMessage(const ToxPk& author, const QStri
     bool isSelf = author == core->getSelfId().getPublicKey();
     QString authorStr = isSelf ? core->getUsername() : resolveToxPk(author);
     if (getLatestDate() != QDate::currentDate()) {
-        const Settings& s = Settings::getInstance();
-        QString dateText = QDate::currentDate().toString(s.getDateFormat());
-        addSystemInfoMessage(dateText, ChatMessage::INFO, QDateTime());
+        addSystemDateMessage();
     }
 
     ChatMessage::Ptr msg;
@@ -553,8 +551,21 @@ void GenericChatForm::onChatMessageFontChanged(const QFont& font)
 void GenericChatForm::addSystemInfoMessage(const QString& message, ChatMessage::SystemMessageType type,
                                            const QDateTime& datetime)
 {
+    if (getLatestDate() != QDate::currentDate()) {
+        addSystemDateMessage();
+    }
+
     previousId = ToxPk();
     insertChatMessage(ChatMessage::createChatInfoMessage(message, type, datetime));
+}
+
+void GenericChatForm::addSystemDateMessage()
+{
+    const Settings& s = Settings::getInstance();
+    QString dateText = QDate::currentDate().toString(s.getDateFormat());
+
+    previousId = ToxPk();
+    insertChatMessage(ChatMessage::createChatInfoMessage(dateText, ChatMessage::INFO, QDateTime()));
 }
 
 void GenericChatForm::clearChatArea()

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -101,6 +101,7 @@ protected slots:
 
 private:
     void retranslateUi();
+    void addSystemDateMessage();
 
 protected:
     ChatMessage::Ptr createMessage(const ToxPk& author, const QString& message,


### PR DESCRIPTION
Fixes #4388.
Separated date message in its own function.
Also added date message before info messages like it is already done with normal chat messages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4440)
<!-- Reviewable:end -->
