### PR TITLE
chore(build): don't update version numbers via cmake

### DIFF
--- a/cmake/Installation.cmake
+++ b/cmake/Installation.cmake
@@ -4,11 +4,6 @@
 #
 ################################################################################
 
-# set correct version to update files
-set(QTOX_VERSION "1.10.1")
-execute_process(COMMAND ${CMAKE_SOURCE_DIR}/tools/update-versions.sh
-    ${QTOX_VERSION})
-
 if(APPLE)
   set_target_properties(${PROJECT_NAME} PROPERTIES
     MACOSX_BUNDLE_INFO_PLIST "${CMAKE_SOURCE_DIR}/osx/info.plist")


### PR DESCRIPTION
Scripts updating versions in source depend on GNU sed which is sometimes
not set as the default on some OSes.

With the change, one will need to manually call the update script before
releases.

Fixes #4439.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4441)
<!-- Reviewable:end -->
