### PR TITLE
chore(travis): fix deployment of jenkins branch for bugfix tags

### DIFF
--- a/.travis/deploy-jenkins-branch.sh
+++ b/.travis/deploy-jenkins-branch.sh
@@ -31,7 +31,7 @@ main() {
     fi
 
     cd qTox
-    git checkout $(git describe --abbrev=0) -b for-jenkins-release
+    git checkout "$TRAVIS_BRANCH" -b for-jenkins-release
     git push --force "https://${GH_DEPLOY_JENKINS}@github.com/qTox/qTox.git"
 }
 main


### PR DESCRIPTION
Bugfix tags contain backported patches, and thus they aren't shown by
the `git describe`. Thus trust that Travis provides correct branch name
for the tag to push to `for-jenkins-release` branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4450)
<!-- Reviewable:end -->
