### PR TITLE
revert "fix: Replace hardcored roaming path on QStandartPath"

### DIFF
--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -715,35 +715,21 @@ QString Settings::getSettingsDirPath() const
     if (makeToxPortable)
         return qApp->applicationDirPath() + QDir::separator();
 
-    QString path;
-#if (QT_VERSION < QT_VERSION_CHECK(5, 4, 0))
 // workaround for https://bugreports.qt-project.org/browse/QTBUG-38845
-# ifdef Q_OS_WIN
+#ifdef Q_OS_WIN
     return QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::HomeLocation)
                            + QDir::separator() + "AppData" + QDir::separator() + "Roaming"
                            + QDir::separator() + "tox")
            + QDir::separator();
-# elif defined(Q_OS_OSX)
+#elif defined(Q_OS_OSX)
     return QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::HomeLocation)
                            + QDir::separator() + "Library" + QDir::separator()
                            + "Application Support" + QDir::separator() + "Tox")
            + QDir::separator();
-# else
+#else
     return QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::ConfigLocation)
                            + QDir::separator() + "tox")
            + QDir::separator();
-# endif
-#else
-# ifdef Q_OS_WIN
-    return QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)
-                           + QDir::separator() + "tox") + QDir::separator();
-# elif defined(Q_OS_OSX)
-    return QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)
-                           + QDir::separator() + "Tox") + QDir::separator();
-# else
-    return QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::ConfigLocation)
-                           + QDir::separator() + "tox") + QDir::separator();
-# endif
 #endif
 }
 
@@ -757,31 +743,25 @@ QString Settings::getAppDataDirPath() const
     if (makeToxPortable)
         return qApp->applicationDirPath() + QDir::separator();
 
-#if (QT_VERSION < QT_VERSION_CHECK(5, 4, 0))
 // workaround for https://bugreports.qt-project.org/browse/QTBUG-38845
-# ifdef Q_OS_WIN
+#ifdef Q_OS_WIN
     return QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::HomeLocation)
                            + QDir::separator() + "AppData" + QDir::separator() + "Roaming"
                            + QDir::separator() + "tox")
            + QDir::separator();
-# elif defined(Q_OS_OSX)
+#elif defined(Q_OS_OSX)
     return QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::HomeLocation)
                            + QDir::separator() + "Library" + QDir::separator()
                            + "Application Support" + QDir::separator() + "Tox")
            + QDir::separator();
-# else
+#else
+    /*
+     * TODO: Change QStandardPaths::DataLocation to AppDataLocation when upgrate Qt to 5.4+
+     * For now we need support Qt 5.3, so we use deprecated DataLocation
+     * BTW, it's not a big deal since for linux AppDataLocation and DataLocation are equal
+     */
     return QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::DataLocation))
            + QDir::separator();
-# endif
-#else
-# if defined(Q_OS_OSX)
-# elif defined(Q_OS_OSX)
-    return QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)
-                           + QDir::separator() + "Tox") + QDir::separator();
-# else
-    return QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)
-                           + QDir::separator() + "tox") + QDir::separator();
-# endif
 #endif
 }
 
@@ -795,33 +775,20 @@ QString Settings::getAppCacheDirPath() const
     if (makeToxPortable)
         return qApp->applicationDirPath() + QDir::separator();
 
-#if (QT_VERSION < QT_VERSION_CHECK(5, 4, 0))
 // workaround for https://bugreports.qt-project.org/browse/QTBUG-38845
-# ifdef Q_OS_WIN
+#ifdef Q_OS_WIN
     return QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::HomeLocation)
                            + QDir::separator() + "AppData" + QDir::separator() + "Roaming"
                            + QDir::separator() + "tox")
            + QDir::separator();
-# elif defined(Q_OS_OSX)
+#elif defined(Q_OS_OSX)
     return QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::HomeLocation)
                            + QDir::separator() + "Library" + QDir::separator()
                            + "Application Support" + QDir::separator() + "Tox")
            + QDir::separator();
-# else
-    return QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::CacheLocation))
-           + QDir::separator();
-# endif
 #else
-# ifdef Q_OS_WIN
-    return QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)
-                           + QDir::separator() + "tox") + QDir::separator();
-# elif defined(Q_OS_OSX)
-    return QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)
-                           + QDir::separator() + "Tox") + QDir::separator();
-# else
     return QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::CacheLocation))
            + QDir::separator();
-# endif
 #endif
 }
 

--- a/updater/settings.cpp
+++ b/updater/settings.cpp
@@ -108,15 +108,9 @@ QString Settings::getSettingsDirPath() const
     }
 
     if (isOld) {
-#if (QT_VERSION < QT_VERSION_CHECK(5, 4, 0))
         return QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::HomeLocation)
                                + QDir::separator() + "AppData" + QDir::separator() + "Roaming"
                                + QDir::separator() + "tox" + QDir::separator());
-#else
-        return QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)
-                               + QDir::separator() + "tox" + QDir::separator());
-#endif
-
     } else {
         QString pathStr = QString::fromStdWString(path);
         pathStr.replace("\\", "/");


### PR DESCRIPTION
I haven't time now to work with this bug, but regression is too big, so I revert my commit
Fix #4449
This reverts commit f616ff36b6db9142f6e49b2b8bc436b6652aa329.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4452)
<!-- Reviewable:end -->
