### PR TITLE
chore(build): fix cmake build when it includes semicolon in CXXFLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -522,5 +522,14 @@ target_link_libraries(${PROJECT_NAME}
   ${PROJECT_NAME}_static
   ${ALL_LIBRARIES})
 
+# Workaround for CMake bug when using it with pkg-config.
+# Workaround from: https://cmake.org/pipermail/cmake/2013-June/055182.html
+# qTox issues: #4175 #4457
+# Upstream issue: https://gitlab.kitware.com/cmake/cmake/issues/16958
+#
+# Remove this workaround when we no longer need to support CMake that does
+# not include the fix.
+string(REPLACE ";" " " CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+
 include(Testing)
 include(Installation)


### PR DESCRIPTION
Systems that are known to be affected are FreeBSD and PCLinuxOS.

Closes #4175, closes #4457.

If there is an actual fix to the issue instead of a workaround, it should be applied instead.

cc @yurivict @marcin-82 mind testing?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4458)
<!-- Reviewable:end -->
