### PR TITLE
fix(emojis): Add text variants for the blush emoji

### DIFF
--- a/smileys/ASCII+Universe/emoticons.xml
+++ b/smileys/ASCII+Universe/emoticons.xml
@@ -170,6 +170,8 @@
     </emoticon>
     <emoticon file="../Universe/1f633">
         <string>😳</string>
+        <string>:$</string>
+        <string>:blush:</string>
     </emoticon>
     <emoticon file="../Universe/1f634">
         <string>😴</string>

--- a/smileys/ASCII+emojione/emoticons.xml
+++ b/smileys/ASCII+emojione/emoticons.xml
@@ -170,11 +170,13 @@
     </emoticon>
     <emoticon file="../emojione/1f633">
         <string>😳</string>
+        <string>:$</string>
+        <string>:blush:</string>
     </emoticon>
     <emoticon file="../emojione/1f634">
         <string>😴</string>
-	<string>:sleep:</string>
-	<string>:sleeping:</string>
+        <string>:sleep:</string>
+        <string>:sleeping:</string>
     </emoticon>
     <emoticon file="../emojione/1f635">
         <string>😵</string>

--- a/smileys/Universe/emoticons.xml
+++ b/smileys/Universe/emoticons.xml
@@ -213,6 +213,8 @@
     </emoticon>
     <emoticon file="1f633">
         <string>😳</string>
+        <string>:$</string>
+        <string>:blush:</string>
     </emoticon>
     <emoticon file="1f634">
         <string>😴</string>

--- a/smileys/emojione/emoticons.xml
+++ b/smileys/emojione/emoticons.xml
@@ -213,6 +213,8 @@
     </emoticon>
     <emoticon file="1f633">
         <string>😳</string>
+        <string>:$</string>
+        <string>:blush:</string>
     </emoticon>
     <emoticon file="1f634">
         <string>😴</string>


### PR DESCRIPTION
The `:$` emoji seems to be heavily used in Skype, some Skype users were upset/confused when it didn't translate in qTox.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4480)
<!-- Reviewable:end -->
