### PR TITLE
fix(ui): wrong size of svg images on buttons

### DIFF
--- a/ui/callButton/callButton.svg
+++ b/ui/callButton/callButton.svg
@@ -8,8 +8,8 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    version="1.1"
-   width="100%"
-   height="100%"
+   width="25"
+   height="23"
    viewBox="0 0 25 23"
    id="Layer_1"
    xml:space="preserve"><metadata

--- a/ui/emoteButton/emoteButton.svg
+++ b/ui/emoteButton/emoteButton.svg
@@ -8,8 +8,8 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    version="1.1"
-   width="100%"
-   height="100%"
+   width="17"
+   height="17"
    viewBox="0 0 17 17"
    id="Layer_1"
    xml:space="preserve"><metadata

--- a/ui/micButton/micButton.svg
+++ b/ui/micButton/micButton.svg
@@ -1,21 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    id="svg4867"
    version="1.1"
-   inkscape:version="0.91 r13725"
-   width="27.5"
-   height="22.5"
-   viewBox="0 0 27.5 22.5"
-   sodipodi:docname="micButton.svg">
+   width="30"
+   height="28"
+   viewBox="0 0 28.124999 26.25">
   <metadata
      id="metadata4873">
     <rdf:RDF>
@@ -30,29 +24,9 @@
   </metadata>
   <defs
      id="defs4871" />
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="965"
-     id="namedview4869"
-     showgrid="false"
-     inkscape:zoom="22.627418"
-     inkscape:cx="11.743876"
-     inkscape:cy="5.7111464"
-     inkscape:window-x="0"
-     inkscape:window-y="96"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg4867" />
   <g
      id="g4144"
-     transform="matrix(1.1244169,0,0,1.1264917,-1.7361911,-1.4498809)">
+     transform="matrix(1.1279459,0,0,1.1264917,-1.4773586,0.42511766)">
     <rect
        ry="2.6881006"
        y="1.2870765"
@@ -80,8 +54,6 @@
        id="rect5427"
        style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.70899999;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <path
-       sodipodi:nodetypes="csc"
-       inkscape:connector-curvature="0"
        id="path5431"
        d="m 7.0765239,9.8278885 c 0,0 -0.9033248,7.8098235 6.4139421,7.8098235 7.317267,0 7.022576,-7.8534036 7.022576,-7.8534036"
        style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1.89999998;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />

--- a/ui/volButton/volButton.svg
+++ b/ui/volButton/volButton.svg
@@ -1,21 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-
 <svg
    xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   id="svg5872"
+   viewBox="0 0 20.625 20.625"
+   height="22"
+   width="22"
    version="1.1"
-   inkscape:version="0.91 r13725"
-   width="20.625"
-   height="16.875"
-   viewBox="0 0 20.625 16.875"
-   sodipodi:docname="volButton.svg">
+   id="svg5872">
   <metadata
      id="metadata5878">
     <rdf:RDF>
@@ -24,60 +18,35 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <defs
      id="defs5876" />
-  <sodipodi:namedview
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="965"
-     id="namedview5874"
-     showgrid="false"
-     inkscape:zoom="22.627417"
-     inkscape:cx="11.342775"
-     inkscape:cy="5.7587929"
-     inkscape:window-x="0"
-     inkscape:window-y="96"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg5872" />
   <g
-     id="g3465"
-     transform="matrix(1.1540409,0,0,1.1540409,-0.84812976,-1.3955943)">
+     transform="matrix(1.1540409,0,0,1.1540409,-0.84812976,0.4794057)"
+     id="g3465">
     <rect
-       rx="1.281631"
-       ry="1.4363106"
-       y="5.6757092"
-       x="1.8454813"
-       height="5.5364447"
-       width="5.2330775"
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.89999998;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        id="rect6422"
-       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.89999998;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+       width="5.2330775"
+       height="5.5364447"
+       x="1.8454813"
+       y="5.6757092"
+       ry="1.4363106"
+       rx="1.281631" />
     <path
-       inkscape:connector-curvature="0"
-       id="path6434"
+       style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:bevel;stroke-opacity:1"
        d="m 13.014741,4.9931342 c 0,0 2.696002,3.0409607 0,7.7105728"
-       style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:bevel;stroke-opacity:1" />
+       id="path6434" />
     <path
-       sodipodi:nodetypes="cc"
-       inkscape:connector-curvature="0"
-       id="path6438"
+       style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1"
        d="m 15.269462,2.9706889 c 0,0 4.044848,4.3654114 0,10.8453631"
-       style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1" />
+       id="path6438" />
     <path
-       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="M 6.337401,6.1307596 10.26,2.246 l 0,12.586 -4.0174011,-4.384584 z"
        id="path4750"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccc" />
+       d="M 6.337401,6.1307596 10.26,2.246 V 14.832 L 6.2425989,10.447416 Z"
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>


### PR DESCRIPTION
Replaced size in percentage with size in pixels in call and emote buttons.
Added margin to mic and volume buttons.

After updating to Qt 5.9.0 some buttons were broken (I am not sure which Qt version was the first to break, but maybe merge this before #4493 to avoid this issue).
Seems to be because setting size in percent is no longer working.
Current state and fixed:
![buttons_top](https://user-images.githubusercontent.com/16089150/27541380-054d1558-5a84-11e7-9abe-6f8e702441b9.png)   ![buttons_top_fixed](https://user-images.githubusercontent.com/16089150/27541394-0fbc0c60-5a84-11e7-99fc-e80913d386da.png)
![button_bottom](https://user-images.githubusercontent.com/16089150/27541450-428b97e6-5a84-11e7-8940-45a94f272702.png)   ![buttons_bottom_fixed](https://user-images.githubusercontent.com/16089150/27541462-487c76fc-5a84-11e7-9b47-c5be890ba106.png)

~~Did also some cleanup of SVG code,~~ but this should be better done systematically with all images (I am very busy at the moment, but maybe I could have a look at this in future).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4494)
<!-- Reviewable:end -->
