### PR TITLE
feat(core): Disk usage control

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,6 +259,8 @@ set(${PROJECT_NAME}_SOURCES
   src/net/toxuri.h
   src/nexus.cpp
   src/nexus.h
+  src/persistence/checkdisk.cpp
+  src/persistence/checkdisk.h
   src/persistence/db/rawdatabase.cpp
   src/persistence/db/rawdatabase.h
   src/persistence/history.cpp

--- a/qtox.pro
+++ b/qtox.pro
@@ -371,6 +371,7 @@ HEADERS  += \
     src/net/toxme.h \
     src/net/toxuri.h \
     src/nexus.h \
+    src/persistence/checkdisk.h \
     src/persistence/db/rawdatabase.h \
     src/persistence/history.h \
     src/persistence/offlinemsgengine.h \
@@ -492,6 +493,7 @@ SOURCES += \
     src/net/toxme.cpp \
     src/net/toxuri.cpp \
     src/nexus.cpp \
+    src/persistence/checkdisk.cpp \
     src/persistence/db/rawdatabase.cpp \
     src/persistence/history.cpp \
     src/persistence/offlinemsgengine.cpp \

--- a/src/persistence/checkdisk.cpp
+++ b/src/persistence/checkdisk.cpp
@@ -1,0 +1,111 @@
+
+#include "checkdisk.h"
+#include <QDebug>
+#include <QMessageBox>
+#include <QString>
+#include <QWidget>
+#include <stdint.h>
+
+
+#ifdef Q_OS_LINUX
+#include <errno.h>
+#include <sys/vfs.h>
+#endif
+
+#ifdef Q_OS_FREEBSD
+#include <errno.h>
+#include <sys/mount.h>
+#include <sys/param.h>
+#endif
+
+#ifdef Q_OS_OSX
+#include <errno.h>
+#include <sys/mount.h>
+#include <sys/param.h>
+#endif
+
+
+/** Reserve size differ because of API provided by OS.
+ * Windows returns bytes while POSIX systems use blocks.
+ */
+#ifdef Q_OS_WIN
+#include <windows.h>
+#define RESERVE_SIZE 102400
+#else
+#define RESERVE_SIZE 100
+#endif
+
+
+#define ERRC -1
+#define OK 0
+
+
+/**
+ * @brief Fetches disk usage info. Windows uses bytes. Other OS blocks.
+ * @param path Path to file in filesystem.
+ * @param available Pointer to store available size.
+ * @param total Pointer to store total size.
+ * @param free Pointer to store free size.
+ * @return OK on succes, ERRC on error.
+ */
+static int diskInfo(const QString& path, uint64_t* available, uint64_t* total, uint64_t* free)
+{
+#ifdef Q_OS_WIN
+    char_t* c_path = path.toStdString().c_str();
+    bool ret = GetDiskFreeSpaceEx(c_path, (PULARGE_INTEGER)available, (PULARGE_INTEGER)total,
+                                  (PULARGE_INTEGER)free);
+    if (!ret) {
+        qCritical() << "Error reading disk size at :" << path << ":" << GetLastError();
+        return ERRC;
+    }
+#else
+    struct statfs info;
+    if (statfs(path.toStdString().c_str(), &info) != 0) {
+        qCritical() << "Error reading disk size at :" << path << ":" << strerror(errno);
+        return ERRC;
+    }
+    *available = info.f_bavail;
+    *total = info.f_blocks;
+    *free = info.f_bfree;
+#endif
+    return OK;
+
+}
+
+/**
+ * @brief Check is disk full.
+ * @param path Path to file in filesystem.
+ * @param ok Stores success status.
+ * @return True if disk is full or error occured, else false.
+ */
+bool CheckDisk::diskFull(const QString& path)
+{
+    uint64_t available, total, free;
+    if (diskInfo(path, &available, &total, &free) == OK) {
+        return available < RESERVE_SIZE;
+    }
+    return true;
+}
+
+/**
+ * @brief Checks disk usage.
+ * @param path Path to file in filesystem.
+ * @return Return usage in percentage. On error returns -1.
+ */
+int CheckDisk::diskUsage(const QString& path)
+{
+    uint64_t available, total, free;
+    if (diskInfo(path, &available, &total, &free) == OK) {
+        return (100 - ((available * 100) / total));
+    }
+    return -1;
+}
+
+/**
+ * @brief Shows error message for full disk.
+ * @param parent Parent widget
+ */
+void CheckDisk::errorDialog(QWidget* parent)
+{
+    qCritical() << "Disk full";
+}

--- a/src/persistence/checkdisk.h
+++ b/src/persistence/checkdisk.h
@@ -1,0 +1,20 @@
+#ifndef CHECKDISK_H
+#define CHECKDISK_H
+
+#include <QString>
+#include <QWidget>
+
+// Warn user if disk usage is above threshold
+#define DISK_WARN_THRESHOLD 95
+
+namespace CheckDisk {
+
+int diskUsage(const QString& path);
+
+bool diskFull(const QString& path);
+
+void errorDialog(QWidget* parent = 0);
+}
+
+
+#endif // CHECKDISK_H

--- a/src/persistence/db/rawdatabase.cpp
+++ b/src/persistence/db/rawdatabase.cpp
@@ -19,6 +19,7 @@
 
 #include "rawdatabase.h"
 
+#include "src/persistence/checkdisk.h"
 #include <cassert>
 #include <tox/toxencryptsave.h>
 
@@ -628,7 +629,11 @@ void RawDatabase::process()
                     qWarning() << "Constraint error executing query" << anonQuery;
                     goto cleanupStatements;
                 default:
-                    qWarning() << "Unknown error" << result << "executing query" << anonQuery;
+                    if (CheckDisk::diskFull(this->path)) {
+                        CheckDisk::errorDialog();
+                        qWarning() << "Disk full error, executing query" << anonQuery;
+                    } else
+                        qWarning() << "Unknown error" << result << "executing query" << anonQuery;
                     goto cleanupStatements;
                 }
             }

--- a/src/persistence/profile.cpp
+++ b/src/persistence/profile.cpp
@@ -34,6 +34,7 @@
 #include "src/core/core.h"
 #include "src/net/avatarbroadcaster.h"
 #include "src/nexus.h"
+#include "src/persistence/checkdisk.h"
 #include "src/widget/gui.h"
 #include "src/widget/widget.h"
 
@@ -343,6 +344,9 @@ void Profile::saveToxSave(QByteArray data)
         newProfile = false;
     } else {
         saveFile.cancelWriting();
+        if (CheckDisk::diskFull(path)) {
+            CheckDisk::errorDialog();
+        }
         qCritical() << "Failed to write, can't save!";
     }
 }
@@ -505,7 +509,9 @@ void Profile::saveAvatar(QByteArray pic, const QString& ownerId)
             qWarning() << "Tox avatar " << path << " couldn't be saved";
             return;
         }
-        file.write(pic);
+        if (file.write(pic) == -1 && CheckDisk::diskFull(path)) {
+            CheckDisk::errorDialog();
+        }
         file.commit();
     }
 }

--- a/src/persistence/settingsserializer.cpp
+++ b/src/persistence/settingsserializer.cpp
@@ -21,6 +21,7 @@
 #include "serialize.h"
 
 #include "src/core/toxencrypt.h"
+#include "src/persistence/checkdisk.h"
 #include "src/persistence/profile.h"
 
 #include <QDebug>
@@ -311,6 +312,9 @@ void SettingsSerializer::save()
         f.commit();
     } else {
         f.cancelWriting();
+        if (CheckDisk::diskFull(path)) {
+            CheckDisk::errorDialog();
+        }
         qCritical() << "Failed to write, can't save!";
     }
 }


### PR DESCRIPTION
Fixes #3946

Needs testing!

Upon start disk usage is controlled. If usage exceeds threshold user is warned.
If disk is full program notifies user and exits.

On write operation error disk usage is checked.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4498)
<!-- Reviewable:end -->
