### PR TITLE
feat(core): Disk usage control

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,6 +259,8 @@ set(${PROJECT_NAME}_SOURCES
   src/net/toxuri.h
   src/nexus.cpp
   src/nexus.h
+  src/persistence/checkdisk.cpp
+  src/persistence/checkdisk.h
   src/persistence/db/rawdatabase.cpp
   src/persistence/db/rawdatabase.h
   src/persistence/history.cpp

--- a/qtox.pro
+++ b/qtox.pro
@@ -371,6 +371,7 @@ HEADERS  += \
     src/net/toxme.h \
     src/net/toxuri.h \
     src/nexus.h \
+    src/persistence/checkdisk.h \
     src/persistence/db/rawdatabase.h \
     src/persistence/history.h \
     src/persistence/offlinemsgengine.h \
@@ -492,6 +493,7 @@ SOURCES += \
     src/net/toxme.cpp \
     src/net/toxuri.cpp \
     src/nexus.cpp \
+    src/persistence/checkdisk.cpp \
     src/persistence/db/rawdatabase.cpp \
     src/persistence/history.cpp \
     src/persistence/offlinemsgengine.cpp \

--- a/src/persistence/checkdisk.cpp
+++ b/src/persistence/checkdisk.cpp
@@ -1,0 +1,64 @@
+/*
+    Copyright © 2017 by The qTox Project Contributors
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "checkdisk.h"
+#include <QDebug>
+#include <QSaveFile>
+#include <QStorageInfo>
+#include <QString>
+
+// Consider less bytes available as full disk
+#define RESERVE_SIZE (10 * 1024 * 1024)
+
+/**
+ * @brief Check if disk is full.
+ * @param path Path to file in filesystem.
+ * @param ok Contains false if error occurs.
+ * @return True if disk is full or error occured, else false.
+ */
+bool CheckDisk::diskFull(const QString& path, bool& noErr)
+{
+    QStorageInfo info(path);
+    noErr = info.isValid();
+    return info.bytesAvailable() < RESERVE_SIZE;
+}
+
+/**
+ * @brief Checks disk usage.
+ * @param path Path to file in filesystem.
+ * @param ok Contains false if error occurs.
+ * @return Return usage in percentage.
+ */
+int CheckDisk::diskUsage(const QString& path, bool& noErr)
+{
+    QStorageInfo info(path);
+    noErr = info.isValid();
+    return (100 - ((info.bytesAvailable() * 100) / info.bytesTotal()));
+}
+
+/**
+ * @brief Checks if file can be written to disk.
+ * @param path Path to any file/dir in filesystem.
+ * @param file File to write.
+ */
+bool CheckDisk::canWrite(const QString& path, const QSaveFile& file)
+{
+    QStorageInfo info(path);
+    return (info.bytesAvailable() != -1 && file.size() < info.bytesAvailable());
+}

--- a/src/persistence/checkdisk.h
+++ b/src/persistence/checkdisk.h
@@ -1,0 +1,38 @@
+/*
+    Copyright © 2017 by The qTox Project Contributors
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef CHECKDISK_H
+#define CHECKDISK_H
+
+class QString;
+class QSaveFile;
+
+// Warn user if disk usage is above threshold
+#define DISK_WARN_THRESHOLD 95
+
+namespace CheckDisk {
+
+int diskUsage(const QString& path, bool& noErr);
+
+bool diskFull(const QString& path, bool& noErr);
+
+bool canWrite(const QString& path, const QSaveFile& file);
+}
+
+#endif // CHECKDISK_H

--- a/src/persistence/db/rawdatabase.cpp
+++ b/src/persistence/db/rawdatabase.cpp
@@ -19,6 +19,8 @@
 
 #include "rawdatabase.h"
 
+#include "src/persistence/checkdisk.h"
+#include "src/widget/gui.h"
 #include <cassert>
 #include <tox/toxencryptsave.h>
 
@@ -628,7 +630,14 @@ void RawDatabase::process()
                     qWarning() << "Constraint error executing query" << anonQuery;
                     goto cleanupStatements;
                 default:
-                    qWarning() << "Unknown error" << result << "executing query" << anonQuery;
+                    bool ok;
+                    if (CheckDisk::diskFull(this->path, ok)) {
+                        QString message = (ok) ? "Disk full error" : "Disk write error";
+                        qCritical() << message << "while executing query" << anonQuery;
+                        GUI::showError(tr("Disk error"), tr(message.toStdString().c_str()));
+                    } else {
+                        qWarning() << "Unknown error" << result << "executing query" << anonQuery;
+                    }
                     goto cleanupStatements;
                 }
             }

--- a/src/persistence/settingsserializer.cpp
+++ b/src/persistence/settingsserializer.cpp
@@ -21,7 +21,9 @@
 #include "serialize.h"
 
 #include "src/core/toxencrypt.h"
+#include "src/persistence/checkdisk.h"
 #include "src/persistence/profile.h"
+#include "src/widget/gui.h"
 
 #include <QDebug>
 #include <QFile>
@@ -311,6 +313,10 @@ void SettingsSerializer::save()
         f.commit();
     } else {
         f.cancelWriting();
+        if (!CheckDisk::canWrite(path, f)) {
+            GUI::showError(QObject::tr("Disk full"), QObject::tr("Operation failed due to full disk. Clear some space!"));
+            qCritical() << "Disk full!";
+        }
         qCritical() << "Failed to write, can't save!";
     }
 }


### PR DESCRIPTION
Fixes #3946

Upon start disk usage is controlled. If usage exceeds threshold user is warned.
If disk is full program notifies user and exits.

On write operation error disk usage is checked.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4500)
<!-- Reviewable:end -->
