### PR TITLE
fix(ui): Use native file picker dialog

### DIFF
--- a/src/chatlog/content/filetransferwidget.cpp
+++ b/src/chatlog/content/filetransferwidget.cpp
@@ -502,11 +502,11 @@ void FileTransferWidget::handleButton(QPushButton* btn)
             Core::getInstance()->pauseResumeFileRecv(fileInfo.friendId, fileInfo.fileNum);
         else if (btn->objectName() == "accept") {
             QString path =
-                QFileDialog::getSaveFileName(parentWidget(),
+                QFileDialog::getSaveFileName(Q_NULLPTR,
                                              tr("Save a file", "Title of the file saving dialog"),
                                              Settings::getInstance().getGlobalAutoAcceptDir() + "/"
                                                  + fileInfo.fileName,
-                                             0, 0, QFileDialog::DontUseNativeDialog);
+                                             0, 0);
             acceptTransfer(path);
         }
     }

--- a/src/widget/about/aboutuser.cpp
+++ b/src/widget/about/aboutuser.cpp
@@ -64,9 +64,8 @@ void AboutUser::onAutoAcceptDirClicked()
         Settings::getInstance().setAutoAcceptDir(this->friendPk, "");
         ui->selectSaveDir->setText(tr("Auto accept for this contact is disabled"));
     } else if (ui->autoacceptfile->isChecked()) {
-        dir = QFileDialog::getExistingDirectory(this, tr("Choose an auto accept directory",
-                                                         "popup title"),
-                                                dir, QFileDialog::DontUseNativeDialog);
+        dir = QFileDialog::getExistingDirectory(Q_NULLPTR, tr("Choose an auto accept directory",
+                                                         "popup title"), dir);
         if (dir.isEmpty()) {
             ui->autoacceptfile->setChecked(false);
             return; // user canellced
@@ -98,9 +97,9 @@ void AboutUser::onAutoGroupInvite()
 void AboutUser::onSelectDirClicked()
 {
     QString dir;
-    dir = QFileDialog::getExistingDirectory(this,
+    dir = QFileDialog::getExistingDirectory(Q_NULLPTR,
                                             tr("Choose an auto accept directory", "popup title"),
-                                            dir, QFileDialog::DontUseNativeDialog);
+                                            dir);
     ui->autoacceptfile->setChecked(true);
     Settings::getInstance().setAutoAcceptDir(this->friendPk, dir);
     Settings::getInstance().savePersonal();

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -245,8 +245,8 @@ void ChatForm::onTextEditChanged()
 
 void ChatForm::onAttachClicked()
 {
-    QStringList paths = QFileDialog::getOpenFileNames(this, tr("Send a file"), QDir::homePath(), 0,
-                                                      0, QFileDialog::DontUseNativeDialog);
+    QStringList paths = QFileDialog::getOpenFileNames(Q_NULLPTR, tr("Send a file"), QDir::homePath(), 0, 0);
+
     if (paths.isEmpty()) {
         return;
     }

--- a/src/widget/form/profileform.cpp
+++ b/src/widget/form/profileform.cpp
@@ -265,13 +265,12 @@ void ProfileForm::onAvatarClicked()
         return bytes;
     };
 
-    QString filename = QFileDialog::getOpenFileName(this, tr("Choose a profile picture"),
-                                                    QDir::homePath(), Nexus::getSupportedImageFilter(),
-                                                    0, QFileDialog::DontUseNativeDialog);
-    if (filename.isEmpty())
+    QString path = QFileDialog::getOpenFileName(Q_NULLPTR, tr("Choose a profile picture"),
+                                                QDir::homePath(), Nexus::getSupportedImageFilter(), 0);
+    if (path.isEmpty())
         return;
 
-    QFile file(filename);
+    QFile file(path);
     file.open(QIODevice::ReadOnly);
     if (!file.isOpen()) {
         GUI::showError(tr("Error"), tr("Unable to open this file."));
@@ -335,10 +334,9 @@ void ProfileForm::onRenameClicked()
 void ProfileForm::onExportClicked()
 {
     QString current = Nexus::getProfile()->getName() + Core::TOX_EXT;
-    QString path = QFileDialog::getSaveFileName(this, tr("Export profile", "save dialog title"),
+    QString path = QFileDialog::getSaveFileName(Q_NULLPTR, tr("Export profile", "save dialog title"),
                                                 QDir::home().filePath(current),
-                                                tr("Tox save file (*.tox)", "save dialog filter"),
-                                                0, QFileDialog::DontUseNativeDialog);
+                                                tr("Tox save file (*.tox)", "save dialog filter"), 0);
     if (!path.isEmpty()) {
         if (!Nexus::tryRemoveFile(path)) {
             GUI::showWarning(tr("Location not writable", "Title of permissions popup"),
@@ -406,10 +404,9 @@ void ProfileForm::onCopyQrClicked()
 void ProfileForm::onSaveQrClicked()
 {
     QString current = Nexus::getProfile()->getName() + ".png";
-    QString path = QFileDialog::getSaveFileName(this, tr("Save", "save qr image"),
+    QString path = QFileDialog::getSaveFileName(Q_NULLPTR, tr("Save", "save qr image"),
                                                 QDir::home().filePath(current),
-                                                tr("Save QrCode (*.png)", "save dialog filter"), 0,
-                                                QFileDialog::DontUseNativeDialog);
+                                                tr("Save QrCode (*.png)", "save dialog filter"), 0);
     if (!path.isEmpty()) {
         if (!Nexus::tryRemoveFile(path)) {
             GUI::showWarning(tr("Location not writable", "Title of permissions popup"),

--- a/src/widget/form/settings/generalform.cpp
+++ b/src/widget/form/settings/generalform.cpp
@@ -258,10 +258,9 @@ void GeneralForm::on_autoSaveFilesDir_clicked()
 {
     QString previousDir = Settings::getInstance().getGlobalAutoAcceptDir();
     QString directory =
-        QFileDialog::getExistingDirectory(0, tr("Choose an auto accept directory",
-                                                "popup title"), // opens in home directory
-                                          QDir::homePath(),
-                                          QFileDialog::DontUseNativeDialog);
+        QFileDialog::getExistingDirectory(Q_NULLPTR,
+                                          tr("Choose an auto accept directory", "popup title"),
+                                          QDir::homePath());
     if (directory.isEmpty()) // cancel was pressed
         directory = previousDir;
 

--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -223,9 +223,9 @@ void FriendWidget::onContextMenuCalled(QContextMenuEvent* event)
             autoAccept->setChecked(false);
             Settings::getInstance().setAutoAcceptDir(id, "");
         } else if (autoAccept->isChecked()) {
-            dir = QFileDialog::getExistingDirectory(0, tr("Choose an auto accept directory",
-                                                          "popup title"),
-                                                    dir, QFileDialog::DontUseNativeDialog);
+            dir = QFileDialog::getExistingDirectory(Q_NULLPTR,
+                                                    tr("Choose an auto accept directory", "popup title"),
+                                                    dir);
 
             autoAccept->setChecked(true);
             qDebug() << "Setting auto accept dir for" << friendId << "to" << dir;

--- a/src/widget/tool/profileimporter.cpp
+++ b/src/widget/tool/profileimporter.cpp
@@ -49,8 +49,11 @@ bool ProfileImporter::importProfile()
     QString title = tr("Import profile", "import dialog title");
     QString filter = tr("Tox save file (*.tox)", "import dialog filter");
     QString dir = QDir::homePath();
-    QString path =
-        QFileDialog::getOpenFileName(this, title, dir, filter, 0, QFileDialog::DontUseNativeDialog);
+
+    // TODO: Change all QFileDialog instances across project to use
+    // this instead of Q_NULLPTR. Possibly requires >Qt 5.9 due to:
+    // https://bugreports.qt.io/browse/QTBUG-59184
+    QString path = QFileDialog::getOpenFileName(Q_NULLPTR, title, dir, filter, 0);
 
     return importProfile(path);
 }


### PR DESCRIPTION
The original reason that the Qt picker was used instead of the native
picker was that the native option would cause Nautilus/GNOME-based
pickers to hang.

This turned out to be due with a Qt bug with parenting Gtk windows. As a
result the parent of each file dialog window has been set to NULL,
eliminating the crash. As far as tests have shown, this produces no
adverse effects on either floating or tiling wms.

Fixes #3494 

---

~~**NOTE:** I've tested this on Arch/KDE, Arch/GNOME, Ubuntu/GNOME and all performs as expected. If someone with a **non-gnome** DE with **nautilus** as the default file manager would like to test this patch and see if a crash still occurs that would be most appreciated.~~

~~Otherwise everything should work as expected with normal distros, as well as on Windows/Mac.~~

Should work on all distros now. Testing is appreciated, so far only i3/Nautilus and KDE/Dolphin configurations have been tested.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4507)
<!-- Reviewable:end -->
