### PR TITLE
fix(build): when building without XSS extension

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@
 cmake_minimum_required(VERSION 2.8.11)
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
+option(PLATFORM_EXTENSIONS "Enable platform specific extensions, requires extra dependencies" ON)
+
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Debug)
 endif()
@@ -279,18 +281,6 @@ set(${PROJECT_NAME}_SOURCES
   src/persistence/smileypack.h
   src/persistence/toxsave.cpp
   src/persistence/toxsave.h
-  src/platform/autorun.h
-  src/platform/capslock.h
-  src/platform/timer.h
-  src/platform/autorun_osx.cpp
-  src/platform/autorun_win.cpp
-  src/platform/autorun_xdg.cpp
-  src/platform/capslock_osx.cpp
-  src/platform/capslock_win.cpp
-  src/platform/capslock_x11.cpp
-  src/platform/timer_osx.cpp
-  src/platform/timer_win.cpp
-  src/platform/timer_x11.cpp
   src/video/cameradevice.cpp
   src/video/cameradevice.h
   src/video/camerasource.cpp
@@ -448,6 +438,23 @@ elseif (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   set(${PROJECT_NAME}_SOURCES ${${PROJECT_NAME}_SOURCES}
     src/platform/install_osx.cpp
     src/platform/install_osx.h
+  )
+endif()
+
+if (PLATFORM_EXTENSIONS)
+  set(${PROJECT_NAME}_SOURCES ${${PROJECT_NAME}_SOURCES}
+    src/platform/autorun.h
+    src/platform/capslock.h
+    src/platform/timer.h
+    src/platform/autorun_osx.cpp
+    src/platform/autorun_win.cpp
+    src/platform/autorun_xdg.cpp
+    src/platform/capslock_osx.cpp
+    src/platform/capslock_win.cpp
+    src/platform/capslock_x11.cpp
+    src/platform/timer_osx.cpp
+    src/platform/timer_win.cpp
+    src/platform/timer_x11.cpp
   )
 endif()
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -70,6 +70,8 @@ function(search_dependency pkg)
   if(NOT ${pkg}_FOUND)
     if(NOT arg_OPTIONAL)
       message(FATAL_ERROR "${pkg} package, library or framework not found")
+    else()
+      message(STATUS "${pkg} not found")
     endif()
   else()
     link_directories(${${pkg}_LIBRARY_DIRS})
@@ -78,6 +80,7 @@ function(search_dependency pkg)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${flag}" PARENT_SCOPE)
     endforeach()
     set(ALL_LIBRARIES ${ALL_LIBRARIES} ${${pkg}_LIBRARIES} PARENT_SCOPE)
+    message(STATUS "${pkg} found")
   endif()
 
   set(${pkg}_FOUND ${${pkg}_FOUND} PARENT_SCOPE)
@@ -108,9 +111,11 @@ endif()
 
 search_dependency(OPENAL              PACKAGE openal FRAMEWORK OpenAL)
 
-# Automatic auto-away support. (X11 also using for capslock detection)
-search_dependency(X11                 PACKAGE x11 OPTIONAL)
-search_dependency(XSS                 LIBRARY Xss OPTIONAL)
+if (PLATFORM_EXTENSIONS AND UNIX AND NOT APPLE)
+  # Automatic auto-away support. (X11 also using for capslock detection)
+  search_dependency(X11                 PACKAGE x11 OPTIONAL)
+  search_dependency(XSS                 LIBRARY Xss OPTIONAL)
+endif()
 
 if(APPLE)
   search_dependency(AVFOUNDATION      FRAMEWORK AVFoundation)
@@ -178,14 +183,16 @@ if (X11_FOUND AND XSS_FOUND)
   set(X11_EXT True)
 endif()
 
-if (${APPLE_EXT} OR ${X11_EXT})
-  add_definitions(
-    -DQTOX_PLATFORM_EXT=1
-  )
-else()
-  add_definitions(
-    -DQTOX_PLATFORM_EXT=0
-  )
+if (PLATFORM_EXTENSIONS)
+  if (${APPLE_EXT} OR ${X11_EXT})
+    add_definitions(
+      -DQTOX_PLATFORM_EXT
+    )
+    message(STATUS "Using platform extensions")
+  else()
+    message(WARNING "Not using platform extensions, dependencies not found")
+    set(PLATFORM_EXTENSIONS OFF)
+  endif()
 endif()
 
 add_definitions(


### PR DESCRIPTION
previously the build would fail in the `make` stage, now a warning is output during `cmake` and platform extensions are disabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4511)
<!-- Reviewable:end -->
