### PR TITLE
fix: Keep open and share X11 connection, create it only on-demand

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -455,6 +455,7 @@ if (PLATFORM_EXTENSIONS)
     src/platform/timer_osx.cpp
     src/platform/timer_win.cpp
     src/platform/timer_x11.cpp
+    src/platform/x11_display.cpp
   )
 endif()
 

--- a/qtox.pro
+++ b/qtox.pro
@@ -123,6 +123,9 @@ contains(DEFINES, QTOX_PLATFORM_EXT) {
     SOURCES += src/platform/capslock_win.cpp \
                src/platform/capslock_x11.cpp \
                src/platform/capslock_osx.cpp
+
+    HEADERS += src/platform/x11_display.h
+    SOURCES += src/platform/x11_display.cpp
 }
 
 # Rules for Windows, Mac OSX, and Linux

--- a/src/platform/timer_x11.cpp
+++ b/src/platform/timer_x11.cpp
@@ -18,6 +18,7 @@
 #include <QtCore/qsystemdetection.h>
 #if defined(Q_OS_UNIX) && !defined(__APPLE__) && !defined(__MACH__)
 #include "src/platform/timer.h"
+#include "src/platform/x11_display.h"
 #include <QDebug>
 #include <X11/extensions/scrnsaver.h>
 
@@ -25,9 +26,10 @@ uint32_t Platform::getIdleTime()
 {
     uint32_t idleTime = 0;
 
-    Display* display = XOpenDisplay(NULL);
+    Display* display = X11Display::lock();
     if (!display) {
-        qDebug() << "XOpenDisplay(NULL) failed";
+        qDebug() << "XOpenDisplay failed";
+        X11Display::unlock();
         return 0;
     }
 
@@ -42,7 +44,7 @@ uint32_t Platform::getIdleTime()
         } else
             qDebug() << "XScreenSaverAllocInfo() failed";
     }
-    XCloseDisplay(display);
+    X11Display::unlock();
     return idleTime;
 }
 

--- a/src/platform/x11_display.cpp
+++ b/src/platform/x11_display.cpp
@@ -1,0 +1,64 @@
+/*
+    Copyright © 2017 by The qTox Project Contributors
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <QtCore/qsystemdetection.h>
+#if defined(Q_OS_UNIX) && !defined(__APPLE__) && !defined(__MACH__)
+#include "src/platform/x11_display.h"
+#include <QMutex>
+#include <X11/Xlib.h>
+
+namespace Platform {
+
+struct X11DisplayPrivate
+{
+    Display* display;
+    QMutex mutex;
+
+    X11DisplayPrivate()
+        : display(XOpenDisplay(nullptr))
+    {
+    }
+    ~X11DisplayPrivate()
+    {
+        if (display) {
+            XCloseDisplay(display);
+        }
+    }
+    static X11DisplayPrivate& getSingleInstance()
+    {
+        // object created on-demand
+        static X11DisplayPrivate singleInstance;
+        return singleInstance;
+    }
+};
+
+Display* X11Display::lock()
+{
+    X11DisplayPrivate& singleInstance = X11DisplayPrivate::getSingleInstance();
+    singleInstance.mutex.lock();
+    return singleInstance.display;
+}
+
+void X11Display::unlock()
+{
+    X11DisplayPrivate::getSingleInstance().mutex.unlock();
+}
+}
+
+#endif // Q_OS_UNIX && !defined(__APPLE__) && !defined(__MACH__)

--- a/src/platform/x11_display.h
+++ b/src/platform/x11_display.h
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2016 by The qTox Project Contributors
+    Copyright © 2017 by The qTox Project Contributors
 
     This file is part of qTox, a Qt-based graphical interface for Tox.
 
@@ -17,28 +17,26 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <QtCore/qsystemdetection.h>
-#if defined(Q_OS_UNIX) && !defined(__APPLE__) && !defined(__MACH__)
-#include "src/platform/capslock.h"
-#include "src/platform/x11_display.h"
-#include <X11/XKBlib.h>
-#undef KeyPress
-#undef KeyRelease
-#undef FocusIn
-#undef FocusOut
+#ifdef QTOX_PLATFORM_EXT
 
-bool Platform::capsLockEnabled()
-{
-    Display* d = X11Display::lock();
-    bool caps_state = false;
-    if (d) {
-        unsigned n;
-        XkbGetIndicatorState(d, XkbUseCoreKbd, &n);
-        caps_state = (n & 0x01) == 1;
-    }
-    X11Display::unlock();
-    return caps_state;
+#ifndef PLATFORM_X11_DISPLAY_H
+#define PLATFORM_X11_DISPLAY_H
+
+#if defined(Q_OS_UNIX) && !defined(__APPLE__) && !defined(__MACH__)
+
+typedef struct _XDisplay Display;
+
+namespace Platform {
+
+namespace X11Display {
+Display* lock();
+void unlock();
 }
 
+}
 
-#endif // defined(Q_OS_UNIX) && !defined(__APPLE__) && !defined(__MACH__)
+#endif // Q_OS_UNIX && !defined(__APPLE__) && !defined(__MACH__)
+
+#endif // PLATFORM_X11_DISPLAY_H
+
+#endif // QTOX_PLATFORM_EXT


### PR DESCRIPTION
This prevents opening and closing of X11 connection and associated files every 1 second.
X11 connection is used for userAutoAway feature and to read CapsLock status.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4525)
<!-- Reviewable:end -->
