### PR TITLE
feat(audio): Added the configuration variable to enable/disable audio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ cmake_minimum_required(VERSION 2.8.11)
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 option(PLATFORM_EXTENSIONS "Enable platform specific extensions, requires extra dependencies" ON)
+option(ENABLE_AUDIO "Enable audio conversations" ON)
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Debug)
@@ -181,10 +182,6 @@ execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different
   ${CMAKE_CURRENT_BINARY_DIR}/translations.qrc)
 
 set(${PROJECT_NAME}_SOURCES
-  src/audio/audio.cpp
-  src/audio/audio.h
-  src/audio/backend/openal.cpp
-  src/audio/backend/openal.h
   src/chatlog/chatlinecontent.cpp
   src/chatlog/chatlinecontent.h
   src/chatlog/chatlinecontentproxy.cpp
@@ -455,6 +452,15 @@ if (PLATFORM_EXTENSIONS)
     src/platform/timer_osx.cpp
     src/platform/timer_win.cpp
     src/platform/timer_x11.cpp
+  )
+endif()
+
+if (ENABLE_AUDIO)
+  set(${PROJECT_NAME}_SOURCES ${${PROJECT_NAME}_SOURCES}
+    src/audio/audio.cpp
+    src/audio/audio.h
+    src/audio/backend/openal.cpp
+    src/audio/backend/openal.h
   )
 endif()
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -116,7 +116,9 @@ if (NOT TOXCORE_FOUND OR
     search_dependency(TOXAV           PACKAGE libtoxav)
 endif()
 
-search_dependency(OPENAL              PACKAGE openal FRAMEWORK OpenAL)
+if (ENABLE_AUDIO)
+  search_dependency(OPENAL              PACKAGE openal FRAMEWORK OpenAL)
+endif()
 
 if (PLATFORM_EXTENSIONS AND UNIX AND NOT APPLE)
   # Automatic auto-away support. (X11 also using for capslock detection)
@@ -202,6 +204,12 @@ if (PLATFORM_EXTENSIONS)
     message(WARNING "Not using platform extensions, dependencies not found")
     set(PLATFORM_EXTENSIONS OFF)
   endif()
+endif()
+
+if (ENABLE_AUDIO)
+  add_definitions(
+    -DQTOX_ENABLE_AUDIO
+  )
 endif()
 
 add_definitions(

--- a/qtox.pro
+++ b/qtox.pro
@@ -101,6 +101,12 @@ contains(DISABLE_PLATFORM_EXT, YES) {
     DEFINES += QTOX_PLATFORM_EXT
 }
 
+contains(DISABLE_AUDIO, YES) {
+
+} else {
+    DEFINES += QTOX_ENABLE_AUDIO
+}
+
 contains(JENKINS,YES) {
     INCLUDEPATH += ./libs/include/
     TOX_CMAKE = YES
@@ -123,6 +129,13 @@ contains(DEFINES, QTOX_PLATFORM_EXT) {
     SOURCES += src/platform/capslock_win.cpp \
                src/platform/capslock_x11.cpp \
                src/platform/capslock_osx.cpp
+}
+
+contains(DEFINES, QTOX_ENABLE_AUDIO) {
+    HEADERS += src/audio/audio.h \
+               src/audio/backend/openal.h
+    SOURCES += src/audio/audio.cpp \
+               src/audio/backend/openal.cpp
 }
 
 # Rules for Windows, Mac OSX, and Linux
@@ -242,7 +255,6 @@ win32 {
                 -ltoxencryptsave \
                 -lvpx \
                 -lsodium \
-                -lopenal \
                 -lavformat \
                 -lavdevice \
                 -lavcodec \
@@ -253,6 +265,10 @@ win32 {
     }
 
     contains(DEFINES, QTOX_PLATFORM_EXT) {
+        LIBS += -lopenal
+    }
+
+    contains(DEFINES, QTOX_ENABLE_AUDIO) {
         LIBS += -lX11 \
                 -lXss
     }
@@ -332,8 +348,6 @@ RESOURCES += res.qrc \
 }
 
 HEADERS  += \
-    src/audio/audio.h \
-    src/audio/backend/openal.h \
     src/chatlog/chatline.h \
     src/chatlog/chatlinecontent.h \
     src/chatlog/chatlinecontentproxy.h \
@@ -453,8 +467,6 @@ HEADERS  += \
     src/widget/widget.h
 
 SOURCES += \
-    src/audio/audio.cpp \
-    src/audio/backend/openal.cpp \
     src/chatlog/chatline.cpp \
     src/chatlog/chatlinecontent.cpp \
     src/chatlog/chatlinecontentproxy.cpp \

--- a/src/core/coreav.h
+++ b/src/core/coreav.h
@@ -54,12 +54,13 @@ public:
     bool isCallActive(const Friend* f) const;
     bool isCallActive(const Group* g) const;
     bool isCallVideoEnabled(const Friend* f) const;
+#ifdef QTOX_ENABLE_AUDIO
     bool sendCallAudio(uint32_t friendNum, const int16_t* pcm, size_t samples, uint8_t chans,
                        uint32_t rate);
-    void sendCallVideo(uint32_t friendNum, std::shared_ptr<VideoFrame> frame);
     bool sendGroupCallAudio(int groupNum, const int16_t* pcm, size_t samples, uint8_t chans,
                             uint32_t rate);
-
+#endif
+    void sendCallVideo(uint32_t friendNum, std::shared_ptr<VideoFrame> frame);
     VideoSource* getVideoSourceFromCall(int callNumber);
     void invalidateCallSources();
     void sendNoVideo();
@@ -103,15 +104,21 @@ private slots:
 
 private:
     void process();
+#ifdef QTOX_ENABLE_AUDIO
     static void audioFrameCallback(ToxAV* toxAV, uint32_t friendNum, const int16_t* pcm,
                                    size_t sampleCount, uint8_t channels, uint32_t samplingRate,
                                    void* self);
+#endif
     static void videoFrameCallback(ToxAV* toxAV, uint32_t friendNum, uint16_t w, uint16_t h,
                                    const uint8_t* y, const uint8_t* u, const uint8_t* v,
                                    int32_t ystride, int32_t ustride, int32_t vstride, void* self);
 
 private:
+#ifdef QTOX_ENABLE_AUDIO
     static constexpr uint32_t AUDIO_DEFAULT_BITRATE = 64;
+#else
+    static constexpr uint32_t AUDIO_DEFAULT_BITRATE = 0;
+#endif
     static constexpr uint32_t VIDEO_DEFAULT_BITRATE = 6144;
 
 private:
@@ -122,7 +129,9 @@ private:
     static IndexedList<ToxGroupCall> groupCalls;
     std::atomic_flag threadSwitchLock;
 
+#ifdef QTOX_ENABLE_AUDIO
     friend class Audio;
+#endif
 };
 
 #endif // COREAV_H

--- a/src/video/groupnetcamview.cpp
+++ b/src/video/groupnetcamview.cpp
@@ -18,7 +18,9 @@
 */
 
 #include "groupnetcamview.h"
+#ifdef QTOX_ENABLE_AUDIO
 #include "src/audio/audio.h"
+#endif
 #include "src/core/core.h"
 #include "src/friend.h"
 #include "src/friendlist.h"

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -19,7 +19,9 @@
 
 #include "chatform.h"
 
+#ifdef QTOX_ENABLE_AUDIO
 #include "src/audio/audio.h"
+#endif
 #include "src/chatlog/chatlinecontentproxy.h"
 #include "src/chatlog/chatlog.h"
 #include "src/chatlog/chatmessage.h"
@@ -373,7 +375,9 @@ void ChatForm::onAvStart(uint32_t friendId, bool video)
         hideNetcam();
     }
 
+#ifdef QTOX_ENABLE_AUDIO
     Audio::getInstance().stopLoop();
+#endif
     updateCallButtons();
     startCounter();
 }
@@ -462,6 +466,11 @@ void ChatForm::updateCallButtons()
     CoreAV* av = Core::getInstance()->getAv();
     bool audio = av->isCallActive(f);
     bool video = av->isCallVideoEnabled(f);
+#ifdef QTOX_ENABLE_AUDIO
+    bool audioSupported = true;
+#else
+    bool audioSupported = false;
+#endif
     callButton->setEnabled(audio && !video);
     videoButton->setEnabled(video);
     if (audio) {
@@ -473,14 +482,13 @@ void ChatForm::updateCallButtons()
     } else {
         const Status fs = f->getStatus();
         bool online = fs != Status::Offline;
-        callButton->setEnabled(online);
+        callButton->setEnabled(audioSupported && online);
         videoButton->setEnabled(online);
 
-        QString color = online ? "green" : "";
-        callButton->setObjectName(color);
-        callButton->setToolTip(online ? tr("Start audio call") : tr("Can't start audio call"));
+        callButton->setObjectName(audioSupported && online ? "green" : "");
+        callButton->setToolTip(audioSupported ? (online ? tr("Start audio call") : tr("Can't start audio call")) : tr("Audio calls are disabled"));
 
-        videoButton->setObjectName(color);
+        videoButton->setObjectName(online ? "green" : "");
         videoButton->setToolTip(online ? tr("Start video call") : tr("Can't start video call"));
     }
 

--- a/src/widget/form/settings/avform.h
+++ b/src/widget/form/settings/avform.h
@@ -44,8 +44,10 @@ public:
     }
 
 private:
+#ifdef QTOX_ENABLE_AUDIO
     void getAudioInDevices();
     void getAudioOutDevices();
+#endif
     void getVideoDevices();
 
     static int getModeSize(VideoMode mode);
@@ -60,12 +62,14 @@ private:
     void retranslateUi();
 
 private slots:
+#ifdef QTOX_ENABLE_AUDIO
     // audio
     void on_inDevCombobox_currentIndexChanged(int deviceIndex);
     void on_outDevCombobox_currentIndexChanged(int deviceIndex);
     void on_playbackSlider_valueChanged(int value);
     void on_cbEnableTestSound_stateChanged();
     void on_microphoneSlider_valueChanged(int value);
+#endif
 
     // camera
     void on_videoDevCombobox_currentIndexChanged(int index);

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -48,7 +48,9 @@
 #include "splitterrestorer.h"
 #include "systemtrayicon.h"
 #include "form/groupchatform.h"
+#ifdef QTOX_ENABLE_AUDIO
 #include "src/audio/audio.h"
+#endif
 #include "src/core/core.h"
 #include "src/core/coreav.h"
 #include "src/friend.h"
@@ -929,33 +931,43 @@ void Widget::incomingNotification(uint32_t friendId)
 {
     newFriendMessageAlert(friendId, false);
 
+#ifdef QTOX_ENABLE_AUDIO
     Audio& audio = Audio::getInstance();
     audio.startLoop();
     audio.playMono16Sound(Audio::getSound(Audio::Sound::IncomingCall));
+#endif
 }
 
 void Widget::outgoingNotification()
 {
+#ifdef QTOX_ENABLE_AUDIO
     Audio& audio = Audio::getInstance();
     audio.startLoop();
     audio.playMono16Sound(Audio::getSound(Audio::Sound::OutgoingCall));
+#endif
 }
 
 void Widget::onRejectCall(uint32_t friendId)
 {
+#ifdef QTOX_ENABLE_AUDIO
     Audio::getInstance().stopLoop();
+#endif
     CoreAV* av = Core::getInstance()->getAv();
     av->cancelCall(friendId);
 }
 
 void Widget::onAcceptCall(uint32_t friendId)
 {
+#ifdef QTOX_ENABLE_AUDIO
     Audio::getInstance().stopLoop();
+#endif
 }
 
 void Widget::onCallEnd(uint32_t friendId)
 {
+#ifdef QTOX_ENABLE_AUDIO
     Audio::getInstance().stopLoop();
+#endif
 }
 
 void Widget::addFriend(int friendId, const ToxPk& friendPk)
@@ -1408,10 +1420,12 @@ bool Widget::newMessageAlert(QWidget* currentWindow, bool isActive, bool sound, 
         bool busySound = Settings::getInstance().getBusySound();
         bool notifySound = Settings::getInstance().getNotifySound();
 
+#ifdef QTOX_ENABLE_AUDIO
         if (notifySound && sound && (!isBusy || busySound)) {
             QString soundPath = Audio::getSound(Audio::Sound::NewMessage);
             Audio::getInstance().playMono16Sound(soundPath);
         }
+#endif
     }
 
     return true;


### PR DESCRIPTION
The new configuration variable ENABLE_AUDIO with the default ON allows to disable audio.

The reasons:
1. [security] People who want to only use text and are afraid that their sound will accidentally get transmitted should be able to disable linking with audio library.
2. [debugging] It is better to have a way to disable various libraries to be able to isolate potential problems.
3. [flexibility] Users have another option to choose what they want.

Caveat:
* It looks like toxcore still doesn't support capability flags, so callers can always initiate audio calls, regardless of the peer ability/willingness to accept them. Currently choosing audio devices "None" also doesn't prevent callers from initiating audio calls.

Future:
* Same should be done with video, there should be ENABLE_VIDEO_OUT that will disable camera.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4532)
<!-- Reviewable:end -->
