### PR TITLE
Fix sqlcipher header inclusion

### DIFF
--- a/src/persistence/db/rawdatabase.cpp
+++ b/src/persistence/db/rawdatabase.cpp
@@ -34,7 +34,7 @@
 #define SQLITE_HAS_CODEC
 #define SQLITE_TEMP_STORE 2
 
-#include <sqlcipher/sqlite3.h>
+#include <sqlite3.h>
 
 
 /**


### PR DESCRIPTION
SQLCipher sets include path to `-I${includedir}/sqlcipher` https://github.com/sqlcipher/sqlcipher/blob/master/sqlcipher.pc.in#L13 , which you can see in cmake

```sh
-- Checking for one of the modules 'sqlcipher'
-- SQLCIPHER LIBRARY_DIRS: /workdir/x86_64/build/../deps/libsqlcipher/lib
-- SQLCIPHER INCLUDE_DIRS: /workdir/x86_64/build/../deps/libsqlcipher/include/sqlcipher
```

while the header inclusion in `rawdatabase.cpp` assumes that it's set to `-I${includedir}`. This might accidentally work as long as you have libsqlcipher-dev installed system-wide, as gcc will look for header `sqlcipher/sqlite3.h` in default system include directory and will accidentally find it there, but if you don't have it installed system-wide, which is pretty common when cross-compiling, it will look into `sqlcipher-prefix/include/sqlcipher/sqlcipher/sqlite3.h` and not find it, as it's actually one level below, at `sqlcipher-prefix/include/sqlcipher/sqlite3.h`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4533)
<!-- Reviewable:end -->
