### PR TITLE
fix(audio): Moved volume and gain defaults from OpenAL to the calling code

### DIFF
--- a/src/audio/backend/openal.cpp
+++ b/src/audio/backend/openal.cpp
@@ -266,8 +266,6 @@ bool OpenAL::initInput(const QString& deviceName)
         return false;
     }
 
-    setInputGain(Settings::getInstance().getAudioInGainDecibel());
-
     qDebug() << "Opened audio input" << deviceName;
     alcCaptureStart(alInDev);
 
@@ -307,10 +305,6 @@ bool OpenAL::initOutput(const QString& deviceName)
     }
 
     alGenSources(1, &alMainSource);
-    checkAlError();
-
-    // init master volume
-    alListenerf(AL_GAIN, Settings::getInstance().getOutVolume() * 0.01f);
     checkAlError();
 
     Core* core = Core::getInstance();

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -471,6 +471,7 @@ void AVForm::on_inDevCombobox_currentIndexChanged(int deviceIndex)
 
     Audio& audio = Audio::getInstance();
     audio.reinitInput(deviceName);
+    audio.setInputGain(Settings::getInstance().getAudioInGainDecibel());
     microphoneSlider->setEnabled(deviceIndex > 0);
     microphoneSlider->setSliderPosition(qRound(audio.inputGain() * 10.0));
 }
@@ -487,6 +488,7 @@ void AVForm::on_outDevCombobox_currentIndexChanged(int deviceIndex)
 
     Audio& audio = Audio::getInstance();
     audio.reinitOutput(deviceName);
+    audio.setOutputVolume(Settings::getInstance().getOutVolume() * 0.01f);
     playbackSlider->setEnabled(deviceIndex > 0);
     playbackSlider->setSliderPosition(qRound(audio.outputVolume() * 100.0));
 }


### PR DESCRIPTION
There is no need for all backends to reset their default volume and gain.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4545)
<!-- Reviewable:end -->
