### PR TITLE
fix(build): remove newline from timestamp

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -179,6 +179,7 @@ if (NOT TIMESTAMP)
   execute_process(
     COMMAND date +%s
     OUTPUT_VARIABLE TIMESTAMP
+    OUTPUT_STRIP_TRAILING_WHITESPACE
   )
 endif()
 


### PR DESCRIPTION
If this newline makes it into the build flags, following flags are ignored

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4553)
<!-- Reviewable:end -->
