### PR TITLE
Declare signal only under Mac OS

### DIFF
--- a/src/widget/contentdialog.h
+++ b/src/widget/contentdialog.h
@@ -82,7 +82,9 @@ public:
 signals:
     void friendDialogShown(const Friend* f);
     void groupDialogShown(Group* g);
+#ifdef Q_OS_MAC
     void activated();
+#endif
 
 public slots:
     void reorderLayouts(bool newGroupOnTop);


### PR DESCRIPTION
Since activated used only if Q_OS_MAC is defined, it should be declared accordingly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4599)
<!-- Reviewable:end -->
