### PR TITLE
fix(receipts): Prevent double message send for received receipt

### DIFF
--- a/src/nexus.cpp
+++ b/src/nexus.cpp
@@ -218,7 +218,6 @@ void Nexus::showMainGUI()
     connect(core, &Core::friendStatusMessageChanged, widget, &Widget::onFriendStatusMessageChanged);
     connect(core, &Core::friendRequestReceived, widget, &Widget::onFriendRequestReceived);
     connect(core, &Core::friendMessageReceived, widget, &Widget::onFriendMessageReceived);
-    connect(core, &Core::receiptRecieved, widget, &Widget::onReceiptRecieved);
     connect(core, &Core::groupInviteReceived, widget, &Widget::onGroupInviteReceived);
     connect(core, &Core::groupMessageReceived, widget, &Widget::onGroupMessageReceived);
     connect(core, &Core::groupNamelistChanged, widget, &Widget::onGroupNamelistChanged);

--- a/src/persistence/offlinemsgengine.h
+++ b/src/persistence/offlinemsgengine.h
@@ -45,18 +45,26 @@ public:
 public slots:
     void deliverOfflineMsgs();
     void removeAllReceipts();
+    void updateTimestamp(int receiptId);
 
 private:
+    void processReceipt(int receiptId);
+    struct Receipt
+    {
+        bool bRowValid{false};
+        int64_t rowId{0};
+        bool bRecepitReceived{false};
+    };
+
     struct MsgPtr
     {
         ChatMessage::Ptr msg;
         QDateTime timestamp;
         int receipt;
     };
-
     QMutex mutex;
     Friend* f;
-    QHash<int, int64_t> receipts;
+    QHash<int, Receipt> receipts;
     QMap<int64_t, MsgPtr> undeliveredMsgs;
 
     static const int offlineTimeout;


### PR DESCRIPTION
Fixes #2726
Register for receipt handling only once, log if receipt is received that is unexpected, synchronously add receipt of a sent message to map so that the peer can't answer before we are expecting the receipt.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4607)
<!-- Reviewable:end -->
