### PR TITLE
fix(receipts): Move sending back to async without double messages

### DIFF
--- a/src/nexus.cpp
+++ b/src/nexus.cpp
@@ -218,7 +218,6 @@ void Nexus::showMainGUI()
     connect(core, &Core::friendStatusMessageChanged, widget, &Widget::onFriendStatusMessageChanged);
     connect(core, &Core::friendRequestReceived, widget, &Widget::onFriendRequestReceived);
     connect(core, &Core::friendMessageReceived, widget, &Widget::onFriendMessageReceived);
-    connect(core, &Core::receiptRecieved, widget, &Widget::onReceiptRecieved);
     connect(core, &Core::groupInviteReceived, widget, &Widget::onGroupInviteReceived);
     connect(core, &Core::groupMessageReceived, widget, &Widget::onGroupMessageReceived);
     connect(core, &Core::groupNamelistChanged, widget, &Widget::onGroupNamelistChanged);

--- a/src/persistence/offlinemsgengine.h
+++ b/src/persistence/offlinemsgengine.h
@@ -41,22 +41,33 @@ public:
     void dischargeReceipt(int receipt);
     void registerReceipt(int receipt, int64_t messageID, ChatMessage::Ptr msg,
                          const QDateTime& timestamp = QDateTime::currentDateTime());
+    void updateTimestamp(int recepitId);
 
 public slots:
     void deliverOfflineMsgs();
     void removeAllReceipts();
 
+signals:
+    void setTimestamp(uint32_t friendId, int receiptId);
+
 private:
+    void processReceipt_(int receipt);
+    struct Receipt
+    {
+        bool bRowValid = false;
+        int64_t rowId;
+        bool bRecepitReceived = false;
+    };
+
     struct MsgPtr
     {
         ChatMessage::Ptr msg;
         QDateTime timestamp;
         int receipt;
     };
-
     QMutex mutex;
     Friend* f;
-    QHash<int, int64_t> receipts;
+    QHash<int, Receipt> receipts;
     QMap<int64_t, MsgPtr> undeliveredMsgs;
 
     static const int offlineTimeout;

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -161,7 +161,7 @@ ChatForm::ChatForm(Friend* chatFriend)
     connect(core, &Core::friendMessageReceived, this, &ChatForm::onFriendMessageReceived);
     connect(core, &Core::friendTypingChanged, this, &ChatForm::onFriendTypingChanged);
     connect(core, &Core::friendStatusChanged, this, &ChatForm::onFriendStatusChanged);
-
+    connect(offlineEngine, &OfflineMsgEngine::setTimestamp, this, &ChatForm::onSentMessageWriteFinished);
 
     const CoreAV* av = core->getAv();
     connect(av, &CoreAV::avInvite, this, &ChatForm::onAvInvite);
@@ -574,6 +574,13 @@ void ChatForm::onReceiptReceived(quint32 friendId, int receipt)
 {
     if (friendId == f->getId()) {
         offlineEngine->dischargeReceipt(receipt);
+    }
+}
+
+void ChatForm::onSentMessageWriteFinished(uint32_t friendId, int receiptId)
+{
+    if (friendId == f->getId()) {
+        offlineEngine->updateTimestamp(receiptId);
     }
 }
 

--- a/src/widget/form/chatform.h
+++ b/src/widget/form/chatform.h
@@ -94,6 +94,7 @@ private slots:
     void onFriendMessageReceived(quint32 friendId, const QString& message, bool isAction);
     void onStatusMessage(const QString& message);
     void onReceiptReceived(quint32 friendId, int receipt);
+    void onSentMessageWriteFinished(uint32_t friendId, int receiptId);
     void onLoadHistory();
     void onUpdateTime();
     void onScreenshotClicked();


### PR DESCRIPTION
Fixes #4608
Move receipt handling back to async write to db, improving performance. Keep safety, resolving duplicate sends by marking a receipt complete only when both the receipt is received and the write to history of the send is finished, otherwise caching the first of the two until the second occurs.

This is based on top of https://github.com/qTox/qTox/pull/4607

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4615)
<!-- Reviewable:end -->
