### PR TITLE
fix(toxme.io) Remove HTML tags from ID to un-break toxme integration

### DIFF
--- a/src/widget/form/profileform.cpp
+++ b/src/widget/form/profileform.cpp
@@ -512,6 +512,7 @@ void ProfileForm::onRegisterButtonClicked()
     bodyUI->toxmeUpdateButton->setText(tr("Update (processing)"));
 
     QString id = toxId->text();
+    id.remove(QRegularExpression("<[^>]*>"));
     QString bio = bodyUI->toxmeBio->text();
     QString server = bodyUI->toxmeServersList->currentText();
     bool privacy = bodyUI->toxmePrivacy->isChecked();


### PR DESCRIPTION
Same implementation as for copyIdClicked(); someone probably forgot that toxme.io exists :( 
Toxme.io integration works once again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4616)
<!-- Reviewable:end -->
