### PR TITLE
fix(toxme): Remove HTML tags from ID to un-break toxme integration

### DIFF
--- a/src/widget/form/profileform.cpp
+++ b/src/widget/form/profileform.cpp
@@ -512,6 +512,7 @@ void ProfileForm::onRegisterButtonClicked()
     bodyUI->toxmeUpdateButton->setText(tr("Update (processing)"));
 
     QString id = toxId->text();
+    id.remove(QRegularExpression("<[^>]*>"));
     QString bio = bodyUI->toxmeBio->text();
     QString server = bodyUI->toxmeServersList->currentText();
     bool privacy = bodyUI->toxmePrivacy->isChecked();


### PR DESCRIPTION
Due to the colours, the current implementation sends a bunch of html tags along with the ID, which obviously isn't desirable.
To remove these tags, I am using the same implementation as in copyIdClicked .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4617)
<!-- Reviewable:end -->
