### PR TITLE
fix(chatform): Update member info when group created

### DIFF
--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1865,6 +1865,8 @@ void Widget::onEmptyGroupCreated(int groupId)
     if (Widget::getInstance()->groupsVisible()) {
         groupWidgets[groupId]->editName();
     }
+
+    group->regeneratePeerList();
 }
 
 /**


### PR DESCRIPTION
this should be fix issue https://github.com/qTox/qTox/issues/4503

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4621)
<!-- Reviewable:end -->
