### PR TITLE
fix(avatar): Don't invert default avatar colour on connect

### DIFF
--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -390,7 +390,7 @@ void FriendWidget::onAvatarRemoved(int friendId)
 
     isDefaultAvatar = true;
 
-    const QString path = QString(":/img/contact%1.svg").arg(isActive() ? "" : "_dark");
+    const QString path = QString(":/img/contact%1.svg").arg(isActive() ? "_dark" : "");
     avatar->setPixmap(QPixmap(path));
 }
 


### PR DESCRIPTION
Fixes #4629

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4630)
<!-- Reviewable:end -->
