### PR TITLE
fix(friends): Friend request button target location

### DIFF
--- a/src/widget/form/addfriendform.cpp
+++ b/src/widget/form/addfriendform.cpp
@@ -365,9 +365,9 @@ void AddFriendForm::retranslateUi()
 
     onIdChanged(toxId.text());
 
-    tabWidget->setTabText(0, tr("Add a friend"));
-    tabWidget->setTabText(1, tr("Import contacts"));
-    tabWidget->setTabText(2, tr("Friend requests"));
+    tabWidget->setTabText(AddFriend, tr("Add a friend"));
+    tabWidget->setTabText(ImportContacts, tr("Import contacts"));
+    tabWidget->setTabText(FriendRequest, tr("Friend requests"));
 
     for (QPushButton* acceptButton : acceptButtons) {
         retranslateAcceptButton(acceptButton);

--- a/src/widget/form/addfriendform.h
+++ b/src/widget/form/addfriendform.h
@@ -42,8 +42,8 @@ public:
     enum Mode
     {
         AddFriend = 0,
-        FriendRequest = 1,
-        GroupInvite = 2
+        ImportContacts = 1,
+        FriendRequest = 2
     };
 
     AddFriendForm();


### PR DESCRIPTION
Change friendform pane numbering to use existing enum instead of hardcoded values, udpate enum to match current pane layout.
Fixes #4631

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4632)
<!-- Reviewable:end -->
