### PR TITLE
fix(popup): Don't create two error popups for friend requests

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -592,6 +592,7 @@ void Core::requestFriendship(const ToxId& friendId, const QString& message)
     if (!errorMessage.isNull()) {
         emit failedToAddFriend(friendPk, errorMessage);
         profile.saveToxSave();
+        return;
     }
 
     ToxString cMessage(message);


### PR DESCRIPTION
Fixes #4633

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4634)
<!-- Reviewable:end -->
