### PR TITLE
fix(tooltip): Set font colour to black for beige tooltip background

### DIFF
--- a/ui/settings/mainContent.css
+++ b/ui/settings/mainContent.css
@@ -49,6 +49,12 @@ QPushButton
     background: white;
 }
 
+QToolTip
+{
+    color: black;
+    background: #ffffdc;
+}
+
 QGroupBox
 {
     color: black;


### PR DESCRIPTION
Fixes #4641

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4642)
<!-- Reviewable:end -->
