### PR TITLE
Spelling: Pluralized singular fixed

### DIFF
--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -2367,7 +2367,7 @@ void Widget::friendRequestsUpdate()
     }
 
     if (friendRequestsButton) {
-        friendRequestsButton->setText(tr("%n New Friend Request(s)", "", unreadFriendRequests));
+        friendRequestsButton->setText(tr("%n New Friend Request", "", unreadFriendRequests));
     }
 }
 


### PR DESCRIPTION
The plural of this string is (as it should be,) "requests", whereas this is still (s).

Seems to have been pluralized, but not corrected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4664)
<!-- Reviewable:end -->
