### PR TITLE
fix: remove unused variables

### DIFF
--- a/src/audio/backend/openal.cpp
+++ b/src/audio/backend/openal.cpp
@@ -265,7 +265,6 @@ bool OpenAL::initInput(const QString& deviceName, uint32_t channels)
     int stereoFlag = AUDIO_CHANNELS == 1 ? AL_FORMAT_MONO16 : AL_FORMAT_STEREO16;
     const uint32_t sampleRate = AUDIO_SAMPLE_RATE;
     const uint16_t frameDuration = AUDIO_FRAME_DURATION;
-    const uint32_t chnls = AUDIO_CHANNELS;
     const ALCsizei bufSize = (frameDuration * sampleRate * 4) / 1000 * channels;
 
     const QByteArray qDevName = deviceName.toUtf8();

--- a/src/widget/contentdialog.cpp
+++ b/src/widget/contentdialog.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2015 by The qTox Project Contributors
+    Copyright © 2015-2017 by The qTox Project Contributors
 
     This file is part of qTox, a Qt-based graphical interface for Tox.
 
@@ -190,7 +190,6 @@ GroupWidget* ContentDialog::addGroup(int groupId, const QString& name)
     GroupWidget* groupWidget = new GroupWidget(groupId, name, compact);
     groupLayout.addSortedWidget(groupWidget);
 
-    Group* group = groupWidget->getGroup();
     connect(groupWidget, &GroupWidget::chatroomWidgetClicked, this, &ContentDialog::activate);
     connect(groupWidget, &FriendWidget::newWindowOpened, this, &ContentDialog::openNewDialog);
 
@@ -240,8 +239,6 @@ void ContentDialog::removeFriend(int friendId)
 
 void ContentDialog::removeGroup(int groupId)
 {
-    Group* group = GroupList::findGroup(groupId);
-
     auto iter = groupList.find(groupId);
     if (iter == groupList.end()) {
         return;


### PR DESCRIPTION
Fixes some compiler warnings (with `-pedantic`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4709)
<!-- Reviewable:end -->
