### PR TITLE
Fix displaying own username on detached windows.

### DIFF
--- a/src/widget/contentdialog.cpp
+++ b/src/widget/contentdialog.cpp
@@ -485,6 +485,8 @@ void ContentDialog::updateTitleAndStatusIcon()
         return;
     }
 
+    username = Core::getInstance()->getUsername();
+
     setWindowTitle(activeChatroomWidget->getTitle() + QStringLiteral(" - ") + username);
 
     bool isGroupchat = activeChatroomWidget->getGroup() != nullptr;


### PR DESCRIPTION
After the changes in commit 'https://github.com/qTox/qTox/commit/add8d51a2913fa6979674247696da9d397d252b5', the name of the "local" user is empty, and as such, it is not displayed in the window title any longer in multiple windows mode.  This commit adds a change that brings it back.

There might be a better way, or/and a better place for this fix, but this is what I came up with.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4738)
<!-- Reviewable:end -->
