### PR TITLE
fix(video): Set toxav video bitrate to 0 if answering audio-only call

### DIFF
--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -214,7 +214,7 @@ bool CoreAV::isCallVideoEnabled(const Friend* f) const
     return isCallStarted(f) ? calls[f->getId()].videoEnabled : false;
 }
 
-bool CoreAV::answerCall(uint32_t friendNum)
+bool CoreAV::answerCall(uint32_t friendNum, bool video)
 {
     if (QThread::currentThread() != coreavThread.get()) {
         if (threadSwitchLock.test_and_set(std::memory_order_acquire)) {
@@ -224,7 +224,7 @@ bool CoreAV::answerCall(uint32_t friendNum)
 
         bool ret;
         QMetaObject::invokeMethod(this, "answerCall", Qt::BlockingQueuedConnection,
-                                  Q_RETURN_ARG(bool, ret), Q_ARG(uint32_t, friendNum));
+                                  Q_RETURN_ARG(bool, ret), Q_ARG(uint32_t, friendNum), Q_ARG(bool, video));
 
         threadSwitchLock.clear(std::memory_order_release);
         return ret;
@@ -233,7 +233,9 @@ bool CoreAV::answerCall(uint32_t friendNum)
     qDebug() << QString("answering call %1").arg(friendNum);
     assert(calls.contains(friendNum));
     TOXAV_ERR_ANSWER err;
-    if (toxav_answer(toxav, friendNum, Settings::getInstance().getAudioBitrate(), VIDEO_DEFAULT_BITRATE, &err)) {
+
+    const uint32_t videoBitrate = video ? VIDEO_DEFAULT_BITRATE : 0;
+    if (toxav_answer(toxav, friendNum, Settings::getInstance().getAudioBitrate(), videoBitrate, &err)) {
         calls[friendNum].inactive = false;
         return true;
     } else {

--- a/src/core/coreav.h
+++ b/src/core/coreav.h
@@ -82,8 +82,8 @@ public:
     static void invalidateGroupCallPeerSource(int group, int peer);
 
 public slots:
-    bool startCall(uint32_t friendNum, bool video = false);
-    bool answerCall(uint32_t friendNum);
+    bool startCall(uint32_t friendNum, bool video);
+    bool answerCall(uint32_t friendNum, bool video);
     bool cancelCall(uint32_t friendNum);
     void timeoutCall(uint32_t friendNum);
     void start();

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -348,12 +348,12 @@ void ChatForm::onAvInvite(uint32_t friendId, bool video)
         qDebug() << "automatic call answer";
         CoreAV* coreav = Core::getInstance()->getAv();
         QMetaObject::invokeMethod(coreav, "answerCall", Qt::QueuedConnection,
-                                  Q_ARG(uint32_t, friendId));
+                                  Q_ARG(uint32_t, friendId), Q_ARG(bool, video));
         onAvStart(friendId, video);
     } else {
         callConfirm->show();
         CallConfirmWidget* confirmData = callConfirm.data();
-        connect(confirmData, &CallConfirmWidget::accepted, this, &ChatForm::onAnswerCallTriggered);
+        connect(confirmData, &CallConfirmWidget::accepted, this, [this, video]{ onAnswerCallTriggered(video); });
         connect(confirmData, &CallConfirmWidget::rejected, this, &ChatForm::onRejectCallTriggered);
         auto msg = ChatMessage::createChatInfoMessage(tr("%1 calling").arg(displayedName),
                                                       ChatMessage::INFO, QDateTime::currentDateTime());
@@ -409,7 +409,7 @@ void ChatForm::showOutgoingCall(bool video)
     Widget::getInstance()->updateFriendActivity(f);
 }
 
-void ChatForm::onAnswerCallTriggered()
+void ChatForm::onAnswerCallTriggered(bool video)
 {
     delete callConfirm;
     uint32_t friendId = f->getId();
@@ -417,7 +417,7 @@ void ChatForm::onAnswerCallTriggered()
 
     updateCallButtons();
     CoreAV* av = Core::getInstance()->getAv();
-    if (!av->answerCall(friendId)) {
+    if (!av->answerCall(friendId, video)) {
         updateCallButtons();
         stopCounter();
         hideNetcam();

--- a/src/widget/form/chatform.h
+++ b/src/widget/form/chatform.h
@@ -82,7 +82,7 @@ private slots:
     void onAttachClicked();
     void onCallTriggered();
     void onVideoCallTriggered();
-    void onAnswerCallTriggered();
+    void onAnswerCallTriggered(bool video);
     void onRejectCallTriggered();
     void onMicMuteToggle();
     void onVolMuteToggle();


### PR DESCRIPTION
Before we would set the video bitrate to 0 if sending an audio-only call, but we would still set the video bitrate to default when receiving an audio only call. In bad network conditions, this caused tox to ask us to decrease video bitrate in audio-only calls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4747)
<!-- Reviewable:end -->
