### PR TITLE
fix(build): install libexif-dev on apt-based systems

### DIFF
--- a/simple_make.sh
+++ b/simple_make.sh
@@ -12,6 +12,7 @@ apt_install() {
         cmake
         git
         libavdevice-dev
+        libexif-dev
         libgdk-pixbuf2.0-dev
         libglib2.0-dev
         libgtk2.0-dev


### PR DESCRIPTION
Add libexif-dev into dependency list.

Fixes #4749

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4750)
<!-- Reviewable:end -->
