### PR TITLE
fix: remove unnecessary semicolon to compile with `-pedantic` flag

### DIFF
--- a/src/model/profile/profileinfo.cpp
+++ b/src/model/profile/profileinfo.cpp
@@ -278,7 +278,7 @@ QByteArray picToPng(const QPixmap& pic)
     pic.save(&buffer, "PNG");
     buffer.close();
     return bytes;
-};
+}
 
 /**
  * @brief Set self avatar.


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4771)
<!-- Reviewable:end -->
