### PR TITLE
chore(simple_make): use the correct pattern syntax in zypper

### DIFF
--- a/simple_make.sh
+++ b/simple_make.sh
@@ -106,7 +106,7 @@ fedora_locallib() {
 
 zypper_install() {
     local zypper_packages=(
-        automake
+        +pattern:devel_basis
         cmake
         git
         libavcodec-devel
@@ -125,7 +125,6 @@ zypper_install() {
         libvpx-devel
         libXScrnSaver-devel
         openal-soft-devel
-        patterns-openSUSE-devel_basis
         qrencode-devel
         sqlcipher-devel
     )


### PR DESCRIPTION
This fixes different package names for the patterns in OpenSUSE Leap and
Tumbleweed.

Fixes #4751

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4778)
<!-- Reviewable:end -->
