### PR TITLE
fix #4777 using current setting in autoaccept dialog

### DIFF
--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -178,7 +178,7 @@ void FriendWidget::onContextMenuCalled(QContextMenuEvent* event)
     QAction* autoAccept = menu.addAction(tr("Auto accept files from this friend",
                                             "context menu entry"));
     const ToxPk id = frnd->getPublicKey();
-    const QString dir = s.getAutoAcceptDir(id);
+    QString dir = s.getAutoAcceptDir(id);
     autoAccept->setCheckable(true);
     autoAccept->setChecked(!dir.isEmpty());
     menu.addSeparator();
@@ -221,8 +221,8 @@ void FriendWidget::onContextMenuCalled(QContextMenuEvent* event)
             autoAccept->setChecked(false);
             Settings::getInstance().setAutoAcceptDir(id, "");
         } else if (autoAccept->isChecked()) {
-            const QString dir = QFileDialog::getExistingDirectory(
-                        Q_NULLPTR, tr("Choose an auto accept directory", "popup title"), dir);
+            dir = QFileDialog::getExistingDirectory(
+                Q_NULLPTR, tr("Choose an auto accept directory", "popup title"), dir);
 
             autoAccept->setChecked(true);
             qDebug() << "Setting auto accept dir for" << friendId << "to" << dir;


### PR DESCRIPTION
Trying to fix #4777.
The code was passing an object to a function that is creating this object. This didn't seem correct.
Fix it by passing current setting value.
Tested on Arch Linux.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4779)
<!-- Reviewable:end -->
