### PR TITLE
fix(travis): make Windows cross-compilation caching work

### DIFF
--- a/.travis/build-windows.sh
+++ b/.travis/build-windows.sh
@@ -80,7 +80,7 @@ mkdir -p workspace/"$ARCH"/dep-cache
 
 # If build.sh has changed, i.e. its hash doesn't match the previously stored one, and it's Stage 1
 # Then we want to rebuild everything from scratch
-if [ "`cat '$CACHE_DIR'/hash`" != "`sha256sum windows/cross-compile/build.sh`" ] && [ "$STAGE" == "stage1" ]
+if [ "`cat $CACHE_DIR/hash`" != "`sha256sum windows/cross-compile/build.sh`" ] && [ "$STAGE" == "stage1" ]
 then
   # Clear the cache, removing all the pre-built dependencies
   rm -rf "$CACHE_DIR"/*


### PR DESCRIPTION
>\<sudden6\> nurupo: the caching for windows dependencies on travis doesn't seem to work, any idea what could be the problem?

@sudden6 this should fix it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4786)
<!-- Reviewable:end -->
