### PR TITLE
fix: add default return case in Widget::getStatusIconPath to fix warning

### DIFF
--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -2191,7 +2191,9 @@ QString Widget::getStatusIconPath(Status status)
     case Status::Offline:
         return ":/img/status/dot_offline.svg";
     }
+    qWarning() << "Status unknown";
     assert(false);
+    return QString{};
 }
 
 // Preparing needed to set correct size of icons for GTK tray backend


### PR DESCRIPTION
Fixes warning produced with `-Werror=return-type` on GCC 5.4.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4789)
<!-- Reviewable:end -->
