### PR TITLE
docs: remove mention of manual translation without Weblate

### DIFF
--- a/translations/README.md
+++ b/translations/README.md
@@ -3,10 +3,6 @@
 Translating qTox should be easy & straightforward for anyone using
 [**Weblate**](https://hosted.weblate.org/projects/tox/qtox/).
 
-Though if you're interested in doing it manually, there's a [wiki page]
-(https://github.com/qTox/qTox/wiki/Translating) for it.
-
-
 Overall translation: [![Translation status](https://hosted.weblate.org/widgets/tox/-/svg-badge.svg)](https://hosted.weblate.org/engage/tox/?utm_source=widget)
 
 Language | Status


### PR DESCRIPTION
In the past year or so none of the translation pull requests that were
made directly without using Weblate were merged, since either they
didn't conform to the commit message format, or they conflicted with
translations pulled from Weblate.  This clearly shows that potential
translators should not be pointed out that it's possible to translate
without using Weblate, as it would only lead to wasting their time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4797)
<!-- Reviewable:end -->
