### PR TITLE
fix(group): Add second signal for title changed

### DIFF
--- a/src/grouplist.cpp
+++ b/src/grouplist.cpp
@@ -24,13 +24,14 @@
 
 QHash<int, Group*> GroupList::groupList;
 
-Group* GroupList::addGroup(int groupId, const QString& name, bool isAvGroupchat)
+Group* GroupList::addGroup(int groupId, const QString& name, bool isAvGroupchat,
+                           const QString& selfName)
 {
     auto checker = groupList.find(groupId);
     if (checker != groupList.end())
         qWarning() << "addGroup: groupId already taken";
 
-    Group* newGroup = new Group(groupId, name, isAvGroupchat);
+    Group* newGroup = new Group(groupId, name, isAvGroupchat, selfName);
     groupList[groupId] = newGroup;
 
     return newGroup;

--- a/src/grouplist.h
+++ b/src/grouplist.h
@@ -30,7 +30,7 @@ class QString;
 class GroupList
 {
 public:
-    static Group* addGroup(int groupId, const QString& name, bool isAvGroupchat);
+    static Group* addGroup(int groupId, const QString& name, bool isAvGroupchat, const QString& selfName);
     static Group* findGroup(int groupId);
     static void removeGroup(int groupId, bool fake = false);
     static QList<Group*> getAllGroups();

--- a/src/model/group.cpp
+++ b/src/model/group.cpp
@@ -30,8 +30,9 @@
 
 static const int MAX_GROUP_TITLE_LENGTH = 128;
 
-Group::Group(int groupId, const QString& name, bool isAvGroupchat)
+Group::Group(int groupId, const QString& name, bool isAvGroupchat, const QString& selfName)
     : title{name}
+    , selfName{selfName}
     , groupId(groupId)
     , nPeers{0}
     , avGroupchat{isAvGroupchat}
@@ -66,11 +67,20 @@ void Group::updatePeer(int peerId, QString name)
     }
 }
 
-void Group::setName(const QString& name)
+void Group::setName(const QString& newTitle)
 {
-    if (!name.isEmpty() && title != name) {
-        title = name.left(MAX_GROUP_TITLE_LENGTH);
-        emit titleChanged(groupId, title);
+    if (!newTitle.isEmpty() && title != newTitle) {
+        title = newTitle.left(MAX_GROUP_TITLE_LENGTH);
+        emit titleChangedByUser(groupId, title);
+        emit titleChanged(groupId, selfName, title);
+    }
+}
+
+void Group::onTitleChanged(const QString& author, const QString& newTitle)
+{
+    if (!newTitle.isEmpty() && title != newTitle) {
+        title = newTitle.left(MAX_GROUP_TITLE_LENGTH);
+        emit titleChanged(groupId, author, title);
     }
 }
 
@@ -171,4 +181,9 @@ QString Group::resolveToxId(const ToxPk& id) const
         return *it;
 
     return QString();
+}
+
+void Group::setSelfName(const QString& name)
+{
+    selfName = name;
 }

--- a/src/model/group.h
+++ b/src/model/group.h
@@ -35,7 +35,7 @@ class Group : public Contact
 {
     Q_OBJECT
 public:
-    Group(int groupId, const QString& name, bool isAvGroupchat);
+    Group(int groupId, const QString& name, bool isAvGroupchat, const QString& selfName);
     ~Group() override;
 
     bool isAvGroupchat() const;
@@ -54,17 +54,21 @@ public:
     bool getMentionedFlag() const;
 
     void updatePeer(int peerId, QString newName);
-    void setName(const QString& name) override;
+    void setName(const QString& newTitle) override;
+    void onTitleChanged(const QString& author, const QString& newTitle);
     QString getName() const;
     QString getDisplayedName() const override;
 
     QString resolveToxId(const ToxPk& id) const;
+    void setSelfName(const QString& name);
 
 signals:
-    void titleChanged(uint32_t groupId, const QString& title);
+    void titleChangedByUser(uint32_t groupId, const QString& title);
+    void titleChanged(uint32_t groupId, const QString& author, const QString& title);
     void userListChanged(uint32_t groupId, const QMap<QByteArray, QString>& toxids);
 
 private:
+    QString selfName;
     QString title;
     GroupChatForm* chatForm;
     QStringList peers;

--- a/src/widget/form/groupchatform.cpp
+++ b/src/widget/form/groupchatform.cpp
@@ -114,6 +114,7 @@ GroupChatForm::GroupChatForm(Group* chatGroup)
         chatGroup->setName(newName);
     });
     connect(group, &Group::userListChanged, this, &GroupChatForm::onUserListChanged);
+    connect(group, &Group::titleChanged, this, &GroupChatForm::onTitleChanged);
 
     setAcceptDrops(true);
     Translator::registerHandler(std::bind(&GroupChatForm::retranslateUi, this), this);
@@ -170,6 +171,19 @@ void GroupChatForm::onUserListChanged()
         Core::getInstance()->getAv()->leaveGroupCall(group->getId());
         hideNetcam();
     }
+}
+
+void GroupChatForm::onTitleChanged(uint32_t groupId, const QString& author, const QString& title)
+{
+    Q_UNUSED(groupId);
+    setName(title);
+    if (author.isEmpty()) {
+        return;
+    }
+
+    const QString message = tr("%1 has set the title to %2").arg(author, title);
+    const QDateTime curTime = QDateTime::currentDateTime();
+    addSystemInfoMessage(message, ChatMessage::INFO, curTime);
 }
 
 /**

--- a/src/widget/form/groupchatform.h
+++ b/src/widget/form/groupchatform.h
@@ -46,6 +46,7 @@ private slots:
     void onVolMuteToggle();
     void onCallClicked();
     void onUserListChanged();
+    void onTitleChanged(uint32_t groupId, const QString& author, const QString& title);
 
 protected:
     virtual GenericNetCamView* createNetcam() final override;

--- a/src/widget/friendlistwidget.cpp
+++ b/src/widget/friendlistwidget.cpp
@@ -281,8 +281,10 @@ void FriendListWidget::addGroupWidget(GroupWidget* widget)
 {
     groupLayout.addSortedWidget(widget);
     Group* g = widget->getGroup();
-    connect(g, &Group::titleChanged, [=](uint32_t groupId, const QString& name) {
+    connect(g, &Group::titleChanged,
+            [=](uint32_t groupId, const QString& author, const QString& name) {
         Q_UNUSED(groupId);
+        Q_UNUSED(author);
         renameGroupWidget(widget, name);
     });
 }

--- a/src/widget/groupwidget.cpp
+++ b/src/widget/groupwidget.cpp
@@ -70,9 +70,10 @@ void GroupWidget::setTitle(const QString& newName)
     g->setName(newName);
 }
 
-void GroupWidget::updateTitle(uint32_t groupId, const QString& newName)
+void GroupWidget::updateTitle(uint32_t groupId, const QString& author, const QString& newName)
 {
     Q_UNUSED(groupId);
+    Q_UNUSED(author);
     nameLabel->setText(newName);
 }
 

--- a/src/widget/groupwidget.h
+++ b/src/widget/groupwidget.h
@@ -53,7 +53,7 @@ protected:
 private slots:
     void retranslateUi();
     void setTitle(const QString& newName);
-    void updateTitle(uint32_t groupId, const QString& newName);
+    void updateTitle(uint32_t groupId, const QString& author, const QString& newName);
     void updateUserCount();
 
 public:

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1756,21 +1756,12 @@ void Widget::onGroupTitleChanged(int groupnumber, const QString& author, const Q
         return;
     }
 
-    if (!author.isEmpty()) {
-        QString message = tr("%1 has set the title to %2").arg(author, title);
-        QDateTime curTime = QDateTime::currentDateTime();
-        g->getChatForm()->addSystemInfoMessage(message, ChatMessage::INFO, curTime);
-    }
-
     GroupWidget* widget = groupWidgets[groupnumber];
-    contactListWidget->renameGroupWidget(widget, title);
-    g->getChatForm()->setName(title);
-
     if (widget->isActive()) {
         GUI::setWindowTitle(title);
     }
 
-    g->setName(title);
+    g->onTitleChanged(author, title);
     FilterCriteria filter = getFilterCriteria();
     widget->searchName(ui->searchContactText->text(), filterGroups(filter));
 }
@@ -1843,7 +1834,7 @@ Group* Widget::createGroup(int groupId)
     }
 
     bool enabled = coreAv->isGroupAvEnabled(groupId);
-    Group* newgroup = GroupList::addGroup(groupId, groupName, enabled);
+    Group* newgroup = GroupList::addGroup(groupId, groupName, enabled, core->getUsername());
     bool compact = Settings::getInstance().getCompactLayout();
     GroupWidget* widget = new GroupWidget(groupId, groupName, compact);
     groupWidgets[groupId] = widget;
@@ -1859,7 +1850,8 @@ Group* Widget::createGroup(int groupId)
     connect(widget, &GroupWidget::chatroomWidgetClicked, form, &ChatForm::focusInput);
     connect(form, &GroupChatForm::sendMessage, core, &Core::sendGroupMessage);
     connect(form, &GroupChatForm::sendAction, core, &Core::sendGroupAction);
-    connect(newgroup, &Group::titleChanged, core, &Core::changeGroupTitle);
+    connect(newgroup, &Group::titleChangedByUser, core, &Core::changeGroupTitle);
+    connect(core, &Core::usernameSet, newgroup, &Group::setSelfName);
 
     FilterCriteria filter = getFilterCriteria();
     widget->searchName(ui->searchContactText->text(), filterGroups(filter));


### PR DESCRIPTION
Fix #4800.

In old implementation after Core title change notification, Group
updates self name and emit signal, core as subscribed on this signal and try to
change title twice.

In new implementation was added new signal to Group:
  1. To notify core about user changes.
  2. To notify views about core changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4801)
<!-- Reviewable:end -->
