### PR TITLE
Update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -281,7 +281,8 @@ sudo apt-get install \
     qt5-default \
     qttools5-dev \
     qttools5-dev-tools \
-    yasm
+    yasm \
+    sqlcipher
 ```
 
 <a name="fedora-other-deps" />


### PR DESCRIPTION
The version of sqlcipher in Debian 9 is now 3.2.0-2 => 3.2.0
Added it to the list of installed packages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4805)
<!-- Reviewable:end -->
