### PR TITLE
Fix video

### DIFF
--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -379,6 +379,7 @@ void ChatForm::onAvEnd(uint32_t friendId, bool error)
         return;
     }
 
+    headWidget->removeCallConfirm();
     // Fixes an OS X bug with ending a call while in full screen
     if (netcam && netcam->isFullScreen()) {
         netcam->showNormal();

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -113,6 +113,7 @@ ChatForm::ChatForm(Friend* chatFriend)
     : f(chatFriend)
     , callDuration(new QLabel(this))
     , isTyping(false)
+    , lastCallIsVideo{false}
 {
     setName(f->getDisplayedName());
 
@@ -190,6 +191,10 @@ ChatForm::ChatForm(Friend* chatFriend)
     connect(headWidget, &ChatFormHeader::nameChanged, this, [=](const QString& newName) {
         f->setAlias(newName);
     });
+    connect(headWidget, &ChatFormHeader::callAccepted, this, [this] {
+        onAnswerCallTriggered(lastCallIsVideo);
+    });
+    connect(headWidget, &ChatFormHeader::callRejected, this, &ChatForm::onRejectCallTriggered);
 
     updateCallButtons();
     setAcceptDrops(true);
@@ -345,10 +350,7 @@ void ChatForm::onAvInvite(uint32_t friendId, bool video)
         onAvStart(friendId, video);
     } else {
         headWidget->showCallConfirm(video);
-        connect(headWidget, &ChatFormHeader::callAccepted, this, [this, video] {
-            onAnswerCallTriggered(video);
-        });
-        connect(headWidget, &ChatFormHeader::callRejected, this, &ChatForm::onRejectCallTriggered);
+        lastCallIsVideo = video;
         auto msg = ChatMessage::createChatInfoMessage(tr("%1 calling").arg(displayedName),
                                                       ChatMessage::INFO, QDateTime::currentDateTime());
         insertChatMessage(msg);

--- a/src/widget/form/chatform.h
+++ b/src/widget/form/chatform.h
@@ -134,6 +134,7 @@ private:
 
     QHash<uint, FileTransferInstance*> ftransWidgets;
     bool isTyping;
+    bool lastCallIsVideo;
 };
 
 #endif // CHATFORM_H


### PR DESCRIPTION
Fix #4799
    
For every call was created new connection. First call was success. The second call leaded to double answer: after the second core removes 'friendNum' from 'calls' list and cancels call. The third call leaded to triple answer, where the first two same as before and the last one - tried to answer on call with removed 'friendNum' => assert failed.

And hide call confirm on call end

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4813)
<!-- Reviewable:end -->
