### PR TITLE
feat(settings): add an option to toggle identicons

### DIFF
--- a/src/persistence/profile.cpp
+++ b/src/persistence/profile.cpp
@@ -403,7 +403,7 @@ QPixmap Profile::loadAvatar(const ToxPk& owner)
         } else {
             pic.loadFromData(avataData);
         }
-    
+
     } else {
         pic.loadFromData(loadAvatarData(owner));
     }
@@ -477,10 +477,7 @@ void Profile::setAvatar(QByteArray pic, const ToxPk& owner)
             // with IDENTICON_ROWS=5 this gives a 160x160 image file
             const QImage identicon = Identicon(owner.getKey()).toImage(32);
             pixmap = QPixmap::fromImage(identicon);
-            QBuffer buf(&avatarData);
-            buf.open(QIODevice::WriteOnly);
-            identicon.save(&buf, "png");
-            
+
         } else {
             pixmap.load(":/img/contact_dark.svg");
         }

--- a/src/persistence/profile.cpp
+++ b/src/persistence/profile.cpp
@@ -395,11 +395,17 @@ QPixmap Profile::loadAvatar()
 QPixmap Profile::loadAvatar(const ToxPk& owner)
 {
     QPixmap pic;
-    const QByteArray avataData = loadAvatarData(owner);
-    if(avataData.isEmpty()) {
-        pic = QPixmap::fromImage(Identicon(owner.getKey()).toImage(16));
+    if (Settings::getInstance().getShowIdenticons()) {
+
+        const QByteArray avataData = loadAvatarData(owner);
+        if (avataData.isEmpty()) {
+            pic = QPixmap::fromImage(Identicon(owner.getKey()).toImage(16));
+        } else {
+            pic.loadFromData(avataData);
+        }
+    
     } else {
-        pic.loadFromData(avataData);
+        pic.loadFromData(loadAvatarData(owner));
     }
 
     return pic;
@@ -467,12 +473,18 @@ void Profile::setAvatar(QByteArray pic, const ToxPk& owner)
         pixmap.loadFromData(pic);
         avatarData = pic;
     } else {
-        // with IDENTICON_ROWS=5 this gives a 160x160 image file
-        const QImage identicon = Identicon(owner.getKey()).toImage(32);
-        pixmap = QPixmap::fromImage(identicon);
-        QBuffer buf(&avatarData);
-        buf.open(QIODevice::WriteOnly);
-        identicon.save(&buf, "png");
+        if (Settings::getInstance().getShowIdenticons()) {
+            // with IDENTICON_ROWS=5 this gives a 160x160 image file
+            const QImage identicon = Identicon(owner.getKey()).toImage(32);
+            pixmap = QPixmap::fromImage(identicon);
+            QBuffer buf(&avatarData);
+            buf.open(QIODevice::WriteOnly);
+            identicon.save(&buf, "png");
+            
+        } else {
+            pixmap.load(":/img/contact_dark.svg");
+        }
+
     }
 
     saveAvatar(avatarData, owner);

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -211,6 +211,7 @@ void Settings::loadGlobal()
         groupchatPosition = s.value("groupchatPosition", true).toBool();
         separateWindow = s.value("separateWindow", false).toBool();
         dontGroupWindows = s.value("dontGroupWindows", false).toBool();
+        showIdenticons = s.value("showIdenticons", true).toBool();
 
         const QString DEFAULT_SMILEYS = ":/smileys/emojione/emoticons.xml";
         smileyPack = s.value("smileyPack", DEFAULT_SMILEYS).toString();
@@ -526,6 +527,7 @@ void Settings::saveGlobal()
         s.setValue("separateWindow", separateWindow);
         s.setValue("dontGroupWindows", dontGroupWindows);
         s.setValue("groupchatPosition", groupchatPosition);
+        s.setValue("showIdenticons", showIdenticons);
 
         s.setValue("smileyPack", smileyPack);
         s.setValue("emojiFontPointSize", emojiFontPointSize);
@@ -2188,6 +2190,22 @@ void Settings::setGroupchatPosition(bool value)
     if (value != groupchatPosition) {
         groupchatPosition = value;
         emit groupchatPositionChanged(value);
+    }
+}
+
+bool Settings::getShowIdenticons() const
+{
+    const QMutexLocker locker{&bigLock};
+    return showIdenticons;
+}
+
+void Settings::setShowIdenticons(bool value)
+{
+    const QMutexLocker locker{&bigLock};
+
+    if (value != showIdenticons) {
+        showIdenticons = value;
+        emit showIdenticonsChanged(value);
     }
 }
 

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -75,6 +75,8 @@ class Settings : public QObject, public ICoreSettings, public IAudioSettings, pu
     Q_PROPERTY(QString style READ getStyle WRITE setStyle NOTIFY styleChanged FINAL)
     Q_PROPERTY(bool showSystemTray READ getShowSystemTray WRITE setShowSystemTray NOTIFY
                    showSystemTrayChanged FINAL)
+    Q_PROPERTY(bool showIdenticons READ getShowIdenticons WRITE setShowIdenticons NOTIFY
+                   showIdenticonsChanged FINAL)
 
     // ChatView
     Q_PROPERTY(bool groupchatPosition READ getGroupchatPosition WRITE setGroupchatPosition NOTIFY
@@ -209,6 +211,7 @@ signals:
     void styleChanged(const QString& style);
     void themeColorChanged(int color);
     void compactLayoutChanged(bool enabled);
+    void showIdenticonsChanged(bool enabled);
 
     // ChatView
     void useEmoticonsChanged(bool enabled);
@@ -499,9 +502,12 @@ public:
 
     bool getDontGroupWindows() const;
     void setDontGroupWindows(bool value);
-
+    
     bool getGroupchatPosition() const;
     void setGroupchatPosition(bool value);
+    
+    bool getShowIdenticons() const;
+    void setShowIdenticons(bool value);
 
     bool getAutoLogin() const;
     void setAutoLogin(bool state);
@@ -566,6 +572,7 @@ private:
     bool groupchatPosition;
     bool separateWindow;
     bool dontGroupWindows;
+    bool showIdenticons;
     bool enableIPv6;
     QString translation;
     bool makeToxPortable;

--- a/src/widget/form/settings/userinterfaceform.cpp
+++ b/src/widget/form/settings/userinterfaceform.cpp
@@ -87,6 +87,7 @@ UserInterfaceForm::UserInterfaceForm(SettingsWidget* myParent)
     bodyUI->cbSeparateWindow->setChecked(s.getSeparateWindow());
     bodyUI->cbDontGroupWindows->setChecked(s.getDontGroupWindows());
     bodyUI->cbDontGroupWindows->setEnabled(s.getSeparateWindow());
+    bodyUI->cbShowIdenticons->setChecked(s.getShowIdenticons());
 
     bodyUI->useEmoticons->setChecked(s.getUseEmoticons());
     for (auto entry : SmileyPack::listSmileyPacks())
@@ -296,6 +297,11 @@ void UserInterfaceForm::on_cbDontGroupWindows_stateChanged()
 void UserInterfaceForm::on_cbGroupchatPosition_stateChanged()
 {
     Settings::getInstance().setGroupchatPosition(bodyUI->cbGroupchatPosition->isChecked());
+}
+
+void UserInterfaceForm::on_cbShowIdenticons_stateChanged()
+{
+    Settings::getInstance().setShowIdenticons(bodyUI->cbShowIdenticons->isChecked());
 }
 
 void UserInterfaceForm::on_themeColorCBox_currentIndexChanged(int)

--- a/src/widget/form/settings/userinterfaceform.h
+++ b/src/widget/form/settings/userinterfaceform.h
@@ -56,6 +56,7 @@ private slots:
     void on_cbDontGroupWindows_stateChanged();
     void on_cbGroupchatPosition_stateChanged();
     void on_themeColorCBox_currentIndexChanged(int);
+    void on_cbShowIdenticons_stateChanged();
 
     void on_txtChatFont_currentFontChanged(const QFont& f);
     void on_txtChatFontSize_valueChanged(int arg1);

--- a/src/widget/form/settings/userinterfacesettings.ui
+++ b/src/widget/form/settings/userinterfacesettings.ui
@@ -257,6 +257,16 @@
             </item>
            </layout>
           </item>
+          <item>
+           <widget class="QCheckBox" name="cbShowIdenticons">
+            <property name="toolTip">
+             <string comment="toolTip for show identicons">If enabled every contact without an avatar set will have a generated avatar based on their Tox ID instead of a default picture. Requires restart to apply.</string>
+            </property>
+            <property name="text">
+             <string>Use identicons instead of empty avatars</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>


### PR DESCRIPTION
Solves #4741

Adds a setting to User Interface tab that allows to toggle displaying
identicons instead of default avatar picture.

This toggles identicons for all of user's contacts, not just for the 
user's own profile.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4818)
<!-- Reviewable:end -->
