### PR TITLE
fix(cmake): add missing dependency

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -39,18 +39,18 @@
 
 ## Dependencies
 
-| Name          | Version     | Modules                                      |
-|---------------|-------------|----------------------------------------------|
-| [Qt]          | >= 5.5.0    | core, gui, network, opengl, svg, widget, xml |
-| [GCC]/[MinGW] | >= 4.8      | C++11 enabled                                |
-| [toxcore]     | = 0.1.\*    | core, av                                     |
-| [FFmpeg]      | >= 2.6.0    | avformat, avdevice, avcodec, avutil, swscale |
-| [CMake]       | >= 2.8.11   |                                              |
-| [OpenAL Soft] | >= 1.16.0   |                                              |
-| [qrencode]    | >= 3.0.3    |                                              |
-| [sqlcipher]   | >= 3.2.0    |                                              |
-| [pkg-config]  | >= 0.28     |                                              |
-| [filteraudio] | >= 0.0.1    | optional dependency                          |
+| Name          | Version     | Modules                                                  |
+|---------------|-------------|----------------------------------------------------------|
+| [Qt]          | >= 5.5.0    | concurrent, core, gui, network, opengl, svg, widget, xml |
+| [GCC]/[MinGW] | >= 4.8      | C++11 enabled                                            |
+| [toxcore]     | = 0.1.\*    | core, av                                                 |
+| [FFmpeg]      | >= 2.6.0    | avformat, avdevice, avcodec, avutil, swscale             |
+| [CMake]       | >= 2.8.11   |                                                          |
+| [OpenAL Soft] | >= 1.16.0   |                                                          |
+| [qrencode]    | >= 3.0.3    |                                                          |
+| [sqlcipher]   | >= 3.2.0    |                                                          |
+| [pkg-config]  | >= 0.28     |                                                          |
+| [filteraudio] | >= 0.0.1    | optional dependency                                      |
 
 ## Optional dependencies
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -6,6 +6,7 @@
 
 # This should go into subdirectories later.
 find_package(PkgConfig        REQUIRED)
+find_package(Qt5Concurrent    REQUIRED)
 find_package(Qt5Core          REQUIRED)
 find_package(Qt5Gui           REQUIRED)
 find_package(Qt5LinguistTools REQUIRED)


### PR DESCRIPTION
Requires `Qt5Concurrent` to be installed when running cmake.
This is needed by `coreav.cpp`.

Before this if `Qt5Concurrent` development package is not installed, cmake works without error but make dies because of missing dependencies in `coreav.cpp`.
Now cmake hints at missing package, so such errors while compiling are avoided.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4820)
<!-- Reviewable:end -->
