### PR TITLE
fix(install): Fix gzip invalid usage

### DIFF
--- a/cmake/Installation.cmake
+++ b/cmake/Installation.cmake
@@ -47,7 +47,7 @@ else()
   set(SVG_SRC "${CMAKE_SOURCE_DIR}/img/icons/qtox.svg")
   set(SVG_GZIP "${CMAKE_BINARY_DIR}/qtox.svgz")
   install(CODE "
-  execute_process(COMMAND gzip -Sz INPUT_FILE ${SVG_SRC} OUTPUT_FILE ${SVG_GZIP})
+  execute_process(COMMAND gzip -S z INPUT_FILE ${SVG_SRC} OUTPUT_FILE ${SVG_GZIP})
   " COMPONENT Runtime)
   install(FILES "${SVG_GZIP}" DESTINATION "share/icons/hicolor/scalable/apps")
 endif()


### PR DESCRIPTION
I was seeing the following on tip:
```
-- Up-to-date: /usr/local/share/icons/hicolor/512x512/apps/qtox.png
gzip: abort: invalid usage: -s must be followed by space
-- Installing: /usr/local/share/icons/hicolor/scalable/apps/qtox.svgz
```

man page shows that gzip should have `-S .suf` with a space in between.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4847)
<!-- Reviewable:end -->
