### PR TITLE
Add missing build dependency for openSUSE

### DIFF
--- a/simple_make.sh
+++ b/simple_make.sh
@@ -112,6 +112,7 @@ zypper_install() {
         libavcodec-devel
         libavdevice-devel
         libopus-devel
+        libexif-devel
         libQt5Concurrent-devel
         libqt5-linguist
         libqt5-linguist-devel


### PR DESCRIPTION
Build failed without `libexif-devel`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4875)
<!-- Reviewable:end -->
