### PR TITLE
fix: Correct display the call confirm window (CallConfirmWidget)

### DIFF
--- a/src/widget/chatformheader.cpp
+++ b/src/widget/chatformheader.cpp
@@ -199,13 +199,18 @@ void ChatFormHeader::showOutgoingCall(bool video)
     updateButtonsView();
 }
 
-void ChatFormHeader::showCallConfirm(bool video)
+void ChatFormHeader::createCallConfirm(bool video)
 {
     QWidget* btn = video ? videoButton : callButton;
     callConfirm = std::unique_ptr<CallConfirmWidget>(new CallConfirmWidget(btn));
-    callConfirm->show();
     connect(callConfirm.get(), &CallConfirmWidget::accepted, this, &ChatFormHeader::callAccepted);
     connect(callConfirm.get(), &CallConfirmWidget::rejected, this, &ChatFormHeader::callRejected);
+}
+
+void ChatFormHeader::showCallConfirm()
+{
+    if (callConfirm && !callConfirm->isVisible())
+        callConfirm->show();
 }
 
 void ChatFormHeader::removeCallConfirm()

--- a/src/widget/chatformheader.h
+++ b/src/widget/chatformheader.h
@@ -60,7 +60,8 @@ public:
     void setMode(Mode mode);
 
     void showOutgoingCall(bool video);
-    void showCallConfirm(bool video);
+    void createCallConfirm(bool video);
+    void showCallConfirm();
     void removeCallConfirm();
 
     void updateCallButtons(bool online, bool audio, bool video = false);

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -346,7 +346,8 @@ void ChatForm::onAvInvite(uint32_t friendId, bool video)
                                   Q_ARG(uint32_t, friendId), Q_ARG(bool, video));
         onAvStart(friendId, video);
     } else {
-        headWidget->showCallConfirm(video);
+        headWidget->createCallConfirm(video);
+        headWidget->showCallConfirm();
         lastCallIsVideo = video;
         auto msg = ChatMessage::createChatInfoMessage(tr("%1 calling").arg(displayedName),
                                                       ChatMessage::INFO, QDateTime::currentDateTime());

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -285,6 +285,7 @@ void GenericChatForm::show(ContentLayout* contentLayout)
 void GenericChatForm::showEvent(QShowEvent*)
 {
     msgEdit->setFocus();
+    headWidget->showCallConfirm();
 }
 
 bool GenericChatForm::event(QEvent* e)


### PR DESCRIPTION
With an incoming call, the confirmation window (CallConfirmWidget) is only displayed
when the caller is on the active tab. In other cases, the call confirmation window
is not displayed, as a result, the call cannot be answered.
The problem is manifested in Kubuntu 14.04 and Ubuntu 16.04 MATE (Qt 5.6.3/5.9.3)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4886)
<!-- Reviewable:end -->
