### PR TITLE
Add join and leave messages

### DIFF
--- a/src/model/group.h
+++ b/src/model/group.h
@@ -63,6 +63,9 @@ signals:
     void titleChangedByUser(uint32_t groupId, const QString& title);
     void titleChanged(uint32_t groupId, const QString& author, const QString& title);
     void userListChanged(uint32_t groupId, const QMap<QByteArray, QString>& toxids);
+    void peerJoined(int peerId, QString username);
+    void peerLeft(int peerId, QString username);
+    void peerNameChanged(int peerId, QString oldName, QString newName);
 
 private:
     QString selfName;

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1833,6 +1833,48 @@ void Widget::onGroupPeerAudioPlaying(int groupnumber, int peernumber)
     form->peerAudioPlaying(peernumber);
 }
 
+void Widget::groupShowPeerJoinMessage(int groupnumber, QString username)
+{
+    const QDateTime curTime = QDateTime::currentDateTime();
+    const QString message = tr("%1 has joined the chat");
+
+    Group* g = GroupList::findGroup(groupnumber);
+    if (!g) {
+        return;
+    }
+
+    auto form = groupChatForms[g->getId()];
+    form->addSystemInfoMessage(message.arg(username), ChatMessage::INFO, curTime);
+}
+
+void Widget::groupShowPeerLeaveMessage(int groupnumber, QString username)
+{
+    const QDateTime curTime = QDateTime::currentDateTime();
+    const QString message = tr("%1 has left the chat");
+
+    Group* g = GroupList::findGroup(groupnumber);
+    if (!g) {
+        return;
+    }
+
+    auto form = groupChatForms[g->getId()];
+    form->addSystemInfoMessage(message.arg(username), ChatMessage::INFO, curTime);
+}
+
+void Widget::groupShowPeerNameChangeMessage(int groupnumber, QString oldName, QString newName)
+{
+    const QDateTime curTime = QDateTime::currentDateTime();
+    const QString message = tr("%1 is now known as %2");
+
+    Group* g = GroupList::findGroup(groupnumber);
+    if (!g) {
+        return;
+    }
+
+    auto form = groupChatForms[g->getId()];
+    form->addSystemInfoMessage(message.arg(oldName, newName), ChatMessage::INFO, curTime);
+}
+
 void Widget::removeGroup(Group* g, bool fake)
 {
     GroupWidget* widget = groupWidgets[g->getId()];
@@ -1900,6 +1942,9 @@ Group* Widget::createGroup(int groupId)
     connect(form, &GroupChatForm::sendAction, core, &Core::sendGroupAction);
     connect(newgroup, &Group::titleChangedByUser, core, &Core::changeGroupTitle);
     connect(core, &Core::usernameSet, newgroup, &Group::setSelfName);
+    connect(newgroup, &Group::peerJoined, this, &Widget::groupShowPeerJoinMessage);
+    connect(newgroup, &Group::peerLeft, this, &Widget::groupShowPeerLeaveMessage);
+    connect(newgroup, &Group::peerNameChanged, this, &Widget::groupShowPeerNameChangeMessage);
 
     FilterCriteria filter = getFilterCriteria();
     widget->searchName(ui->searchContactText->text(), filterGroups(filter));

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -113,10 +113,13 @@ public:
     void addGroupDialog(Group* group, ContentDialog* dialog);
     bool newFriendMessageAlert(int friendId, bool sound = true);
     bool newGroupMessageAlert(int groupId, bool notify);
+    void groupShowPeerJoinMessage(int groupnumber, QString username);
+    void groupShowPeerLeaveMessage(int groupnumber, QString username);
+    void groupShowPeerNameChangeMessage(int groupnumber, QString oldName, QString newName);
+
     bool getIsWindowMinimized();
     void updateIcons();
     void clearContactsList();
-
     static QString fromDialogType(DialogType type);
     ContentDialog* createContentDialog() const;
     ContentLayout* createContentDialog(DialogType type) const;


### PR DESCRIPTION
Adds messages that notify when user joins or leaves group chat or changes their name. Implements #4128.

Current issues:
- ~~when user joins a non empty group chat they will always get a join message for every participant at once~~
- ~~every time someone joins a group that we are in, we don't see their user name at first. Instead we see "Tox User" as their name. A few seconds later the name changes to their real name, which creates additional message~~

~~I am not sure how to fix them yet.~~

Depends on https://github.com/TokTok/c-toxcore/pull/819

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4923)
<!-- Reviewable:end -->
