### PR TITLE
perf(widget): don't save on setExpanded if categorywidget is unchanged

### DIFF
--- a/src/widget/categorywidget.cpp
+++ b/src/widget/categorywidget.cpp
@@ -81,6 +81,9 @@ bool CategoryWidget::isExpanded() const
 
 void CategoryWidget::setExpanded(bool isExpanded, bool save)
 {
+    if (expanded == isExpanded) {
+        return;
+    }
     expanded = isExpanded;
     setMouseTracking(true);
     listWidget->setVisible(isExpanded);


### PR DESCRIPTION
fixes #4932

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4933)
<!-- Reviewable:end -->
