### PR TITLE
WIP feat(ui): Add global hotkey support, thanks to Mumble

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -494,6 +494,14 @@ if (PLATFORM_EXTENSIONS)
     src/platform/timer_win.cpp
     src/platform/timer_x11.cpp
     src/platform/x11_display.cpp
+    src/platform/GlobalShortcut/GlobalShortcut.cpp
+    src/platform/GlobalShortcut/GlobalShortcut.h
+    src/platform/GlobalShortcut/GlobalShortcut_unix.cpp
+    src/platform/GlobalShortcut/GlobalShortcut_unix.h
+    src/platform/GlobalShortcut/GlobalShortcut_win.cpp
+    src/platform/GlobalShortcut/GlobalShortcut_win.h
+    src/platform/GlobalShortcut/GlobalShortcut_macx.cpp
+    src/platform/GlobalShortcut/GlobalShortcut_macx.h
   )
 endif()
 
@@ -585,6 +593,10 @@ if (MINGW)
   endif()
 endif()
 
+#set(${PROJECT_NAME}_SOURCES ${${PROJECT_NAME}_SOURCES}
+    #src/GlobalShortcut/GlobalShortcut_unix.cpp
+    #src/GlobalShortcut/GlobalShortcut_unix.h
+#)
 # the compiler flags for compiling C sources
 MESSAGE( STATUS "CMAKE_C_FLAGS: " ${CMAKE_C_FLAGS} )
 

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -124,6 +124,7 @@ if (PLATFORM_EXTENSIONS AND UNIX AND NOT APPLE)
   # Automatic auto-away support. (X11 also using for capslock detection)
   search_dependency(X11               PACKAGE x11 OPTIONAL)
   search_dependency(XSS               PACKAGE xscrnsaver OPTIONAL)
+  search_dependency(XI                PACKAGE xi)
 endif()
 
 if(APPLE)

--- a/src/platform/GlobalShortcut/GlobalShortcut.cpp
+++ b/src/platform/GlobalShortcut/GlobalShortcut.cpp
@@ -1,0 +1,138 @@
+/*
+    Copyright © 2014-2015 by The qTox Project Contributors
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+
+    This file incorporates work covered by the following copyright and  
+    permission notice: 
+
+        Copyright 2005-2018 The Mumble Developers. All rights reserved.
+        Use of this source code is governed by a BSD-style license
+        that can be found in the LICENSE file inside the GlobalShortcut
+        directory or at <https://www.mumble.info/LICENSE>.
+*/
+
+#include "GlobalShortcut.h"
+#include <QSet>
+#include <QDebug>
+
+GlobalShortcutEngine::GlobalShortcutEngine(QObject *p) : QThread(p) {
+};
+
+GlobalShortcutEngine::~GlobalShortcutEngine() {
+	QSet<ShortcutKey *> qs;
+	foreach(const QList<ShortcutKey*> &ql, qlShortcutList)
+		qs += ql.toSet();
+
+	foreach(ShortcutKey *sk, qs)
+		delete sk;
+}
+
+/**
+ * This function gets called internally to update the state
+ * of a button.
+ *
+ * @return True if button is suppressed, otherwise false
+*/
+bool GlobalShortcutEngine::handleButton(const QVariant &button, bool down) {
+	bool already = qlDownButtons.contains(button);
+	if (already == down)
+		return qlSuppressed.contains(button);
+	if (down)
+		qlDownButtons << button;
+	else
+		qlDownButtons.removeAll(button);
+
+	int idx = qlButtonList.indexOf(button);
+
+	if (idx == -1)
+		return false;
+
+	bool suppress = false;
+
+	foreach(ShortcutKey *sk, qlShortcutList.at(idx)) {
+		if (down) {
+			sk->iNumUp--;
+			if (sk->iNumUp == 0) {
+				GlobalShortcut *gs = sk->gs;
+				if (sk->s.bSuppress) {
+					suppress = true;
+					qlSuppressed << button;
+				}
+				if (! gs->qlActive.contains(sk->s.qvData)) {
+					gs->qlActive << sk->s.qvData;
+					emit gs->triggered(true, sk->s.qvData);
+					emit gs->down(sk->s.qvData);
+				}
+			} else if (sk->iNumUp < 0) {
+				sk->iNumUp = 0;
+			}
+		} else {
+			if (qlSuppressed.contains(button)) {
+				suppress = true;
+				qlSuppressed.removeAll(button);
+			}
+			sk->iNumUp++;
+			if (sk->iNumUp == 1) {
+				GlobalShortcut *gs = sk->gs;
+				if (gs->qlActive.contains(sk->s.qvData)) {
+					gs->qlActive.removeAll(sk->s.qvData);
+					emit gs->triggered(false, sk->s.qvData);
+				}
+			} else if (sk->iNumUp > sk->s.qlButtons.count()) {
+				sk->iNumUp = sk->s.qlButtons.count();
+			}
+		}
+	}
+	return suppress;
+}
+
+void GlobalShortcutEngine::add(GlobalShortcut *gs) {
+    if (qmShortcuts.contains(gs)) {
+		qWarning() << "Attempted to register the same hotkey (" << gs << ") after it was already registered, ignoring";
+		return;
+	}
+    qmShortcuts.append(gs);
+    Shortcut sc = gs->shortcut;
+    if (gs && ! sc.qlButtons.isEmpty()) {
+        ShortcutKey *sk = new ShortcutKey;
+        sk->s = sc;
+        sk->iNumUp = sc.qlButtons.count();
+        sk->gs = gs;
+
+        foreach(const QVariant &button, sc.qlButtons) {
+            int idx = qlButtonList.indexOf(button);
+            if (idx == -1) {
+                qlButtonList << button;
+                qlShortcutList << QList<ShortcutKey *>();
+                idx = qlButtonList.count() - 1;
+            }
+            qlShortcutList[idx] << sk;
+        }
+    }
+}
+
+void GlobalShortcutEngine::remove(GlobalShortcut *gs) {
+	if (!qmShortcuts.contains(gs)) {
+		qWarning() << "Attempted to remove a hotkey (" << gs << ") that was not registered, ignoring";
+	} else {
+		qmShortcuts.removeOne(gs);
+	}
+}
+
+GlobalShortcut::GlobalShortcut(Shortcut def) : shortcut(def) {}
+
+GlobalShortcut::~GlobalShortcut() {}

--- a/src/platform/GlobalShortcut/GlobalShortcut.h
+++ b/src/platform/GlobalShortcut/GlobalShortcut.h
@@ -1,0 +1,108 @@
+/*
+    Copyright © 2014-2015 by The qTox Project Contributors
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+
+    This file incorporates work covered by the following copyright and  
+    permission notice: 
+
+        Copyright 2005-2018 The Mumble Developers. All rights reserved.
+        Use of this source code is governed by a BSD-style license
+        that can be found in the LICENSE file inside the GlobalShortcut
+        directory or at <https://www.mumble.info/LICENSE>.
+*/
+
+#ifndef MUMBLE_MUMBLE_GLOBALSHORTCUT_H_
+#define MUMBLE_MUMBLE_GLOBALSHORTCUT_H_
+
+#include <QtCore/QtGlobal>
+#include <QtCore/QThread>
+#include <QtWidgets/QToolButton>
+#include <QtWidgets/QStyledItemDelegate>
+
+struct Shortcut {
+    QList<QVariant> qlButtons;
+    QVariant qvData;
+    bool bSuppress;
+    bool operator <(const Shortcut &) const;
+    bool operator ==(const Shortcut &) const;
+};
+
+
+class GlobalShortcut : public QObject {
+		friend class GlobalShortcutEngine;
+	private:
+		Q_OBJECT
+		Q_DISABLE_COPY(GlobalShortcut)
+	protected:
+		QList<QVariant> qlActive;
+	signals:
+		void down(QVariant);
+		void triggered(bool, QVariant);
+	public:
+		GlobalShortcut(Shortcut def);
+		~GlobalShortcut() override;
+		Shortcut shortcut;
+
+		QString toString()	;
+		bool active() const {
+			return ! qlActive.isEmpty();
+		}
+};
+
+struct ShortcutKey {
+    Shortcut s;
+    int iNumUp;
+    GlobalShortcut *gs;
+};
+
+/**
+ * Creates a background thread which handles global shortcut behaviour. This class inherits
+ * a system unspecific interface and basic functionality to the actually used native backend
+ * classes (GlobalShortcutPlatform).
+ *
+ * @see GlobalShortcutX
+ * @see GlobalShortcutMac
+ * @see GlobalShortcutWin
+ */
+class GlobalShortcutEngine : public QThread {
+	private:
+		Q_OBJECT
+		Q_DISABLE_COPY(GlobalShortcutEngine)
+	protected:
+		GlobalShortcutEngine(QObject *p = NULL);
+	public:
+		static GlobalShortcutEngine *platformInit();
+
+		QList<GlobalShortcut*> qmShortcuts; // list of shortcuts
+		QList<QVariant> qlDownButtons; // button currently depressed, needed for multi-key shortcuts
+		QList<QVariant> qlSuppressed; // buttons which block system from seeing them
+
+		QList<QVariant> qlButtonList; // list of buttons that are part of any shortcut?
+		QList<QList<ShortcutKey *> > qlShortcutList; // list of shortcuts?
+
+
+		~GlobalShortcutEngine() override;
+
+		bool handleButton(const QVariant &, bool);
+		void add(GlobalShortcut *);
+		void remove(GlobalShortcut *);
+
+	signals:
+		void buttonPressed(bool last); // should be shortcut pressed? should just call lambda?
+};
+
+#endif

--- a/src/platform/GlobalShortcut/GlobalShortcut_macx.cpp
+++ b/src/platform/GlobalShortcut/GlobalShortcut_macx.cpp
@@ -1,0 +1,488 @@
+/*
+    Copyright © 2014-2015 by The qTox Project Contributors
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+
+    This file incorporates work covered by the following copyright and  
+    permission notice: 
+
+        Copyright 2005-2018 The Mumble Developers. All rights reserved.
+        Use of this source code is governed by a BSD-style license
+        that can be found in the LICENSE file inside the GlobalShortcut
+        directory or at <https://www.mumble.info/LICENSE>.
+*/
+
+#include <QtCore/qsystemdetection.h>
+#if defined(__APPLE__) && defined(__MACH__)
+
+#include "mumble_pch.hpp"
+
+#import <AppKit/AppKit.h>
+#import <Carbon/Carbon.h>
+
+#include "GlobalShortcut_macx.h"
+#include "OverlayClient.h"
+
+#define MOD_OFFSET   0x10000
+#define MOUSE_OFFSET 0x20000
+
+GlobalShortcutEngine *GlobalShortcutEngine::platformInit() {
+	return new GlobalShortcutMac();
+}
+
+CGEventRef GlobalShortcutMac::callback(CGEventTapProxy proxy, CGEventType type,
+                                       CGEventRef event, void *udata) {
+	GlobalShortcutMac *gs = reinterpret_cast<GlobalShortcutMac *>(udata);
+	unsigned int keycode;
+	bool suppress = false;
+	bool forward = false;
+	bool down = false;
+	int64_t repeat = 0;
+
+	Q_UNUSED(proxy);
+
+	switch (type) {
+		case kCGEventLeftMouseDown:
+		case kCGEventRightMouseDown:
+		case kCGEventOtherMouseDown:
+			down = true;
+		case kCGEventLeftMouseUp:
+		case kCGEventRightMouseUp:
+		case kCGEventOtherMouseUp: {
+			keycode = static_cast<unsigned int>(CGEventGetIntegerValueField(event, kCGMouseEventButtonNumber));
+			suppress = gs->handleButton(MOUSE_OFFSET+keycode, down);
+			/* Suppressing "the" mouse button is probably not a good idea :-) */
+			if (keycode == 0)
+				suppress = false;
+			forward = !suppress;
+			break;
+		}
+
+		case kCGEventMouseMoved:
+		case kCGEventLeftMouseDragged:
+		case kCGEventRightMouseDragged:
+		case kCGEventOtherMouseDragged: {
+			if (g.ocIntercept) {
+				int64_t dx = CGEventGetIntegerValueField(event, kCGMouseEventDeltaX);
+				int64_t dy = CGEventGetIntegerValueField(event, kCGMouseEventDeltaY);
+				g.ocIntercept->iMouseX = qBound<int>(0, g.ocIntercept->iMouseX + static_cast<int>(dx), g.ocIntercept->uiWidth - 1);
+				g.ocIntercept->iMouseY = qBound<int>(0, g.ocIntercept->iMouseY + static_cast<int>(dy), g.ocIntercept->uiHeight - 1);
+				QMetaObject::invokeMethod(g.ocIntercept, "updateMouse", Qt::QueuedConnection);
+				forward = true;
+			}
+			break;
+		}
+
+		case kCGEventScrollWheel:
+			forward = true;
+			break;
+
+		case kCGEventKeyDown:
+			down = true;
+		case kCGEventKeyUp:
+			repeat = CGEventGetIntegerValueField(event, kCGKeyboardEventAutorepeat);
+			if (! repeat) {
+				keycode = static_cast<unsigned int>(CGEventGetIntegerValueField(event, kCGKeyboardEventKeycode));
+				suppress = gs->handleButton(keycode, down);
+			}
+			forward = true;
+			break;
+
+		case kCGEventFlagsChanged: {
+			CGEventFlags f = CGEventGetFlags(event);
+
+			// Dump active event taps on Ctrl+Alt+Cmd.
+			CGEventFlags ctrlAltCmd = static_cast<CGEventFlags>(kCGEventFlagMaskControl|kCGEventFlagMaskAlternate|kCGEventFlagMaskCommand);
+			if ((f & ctrlAltCmd) == ctrlAltCmd)
+				gs->dumpEventTaps();
+
+			suppress = gs->handleModButton(f);
+			forward = !suppress;
+			break;
+		}
+
+		case kCGEventTapDisabledByTimeout:
+			qWarning("GlobalShortcutMac: EventTap disabled by timeout. Re-enabling.");
+			/*
+			 * On Snow Leopard, we get this event type quite often. It disables our event
+			 * tap completely. Possible Apple bug.
+			 *
+			 * For now, simply call CGEventTapEnable() to enable our event tap again.
+			 *
+			 * See: http://lists.apple.com/archives/quartz-dev/2009/Sep/msg00007.html
+			 */
+			CGEventTapEnable(gs->port, true);
+			break;
+
+		case kCGEventTapDisabledByUserInput:
+			break;
+
+		default:
+			break;
+	}
+
+		if (forward && g.ocIntercept) {
+			NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+			NSEvent *evt = [[NSEvent eventWithCGEvent:event] retain];
+			QMetaObject::invokeMethod(gs, "forwardEvent", Qt::QueuedConnection, Q_ARG(void *, evt));
+			[pool release];
+			return NULL;
+		}
+
+	return suppress ? NULL : event;
+}
+
+GlobalShortcutMac::GlobalShortcutMac() : modmask(static_cast<CGEventFlags>(0)) {
+#ifndef QT_NO_DEBUG
+	qWarning("GlobalShortcutMac: Debug build detected. Disabling shortcut engine.");
+	return;
+#endif
+
+	CGEventMask evmask = CGEventMaskBit(kCGEventLeftMouseDown) |
+	                     CGEventMaskBit(kCGEventLeftMouseUp) |
+	                     CGEventMaskBit(kCGEventRightMouseDown) |
+	                     CGEventMaskBit(kCGEventRightMouseUp) |
+	                     CGEventMaskBit(kCGEventOtherMouseDown) |
+	                     CGEventMaskBit(kCGEventOtherMouseUp) |
+	                     CGEventMaskBit(kCGEventKeyDown) |
+	                     CGEventMaskBit(kCGEventKeyUp) |
+	                     CGEventMaskBit(kCGEventFlagsChanged) |
+	                     CGEventMaskBit(kCGEventMouseMoved) |
+	                     CGEventMaskBit(kCGEventLeftMouseDragged) |
+	                     CGEventMaskBit(kCGEventRightMouseDragged) |
+	                     CGEventMaskBit(kCGEventOtherMouseDragged) |
+	                     CGEventMaskBit(kCGEventScrollWheel);
+	port = CGEventTapCreate(kCGSessionEventTap,
+	                        kCGTailAppendEventTap,
+	                        kCGEventTapOptionDefault, // active filter (not only a listener)
+	                        evmask,
+	                        GlobalShortcutMac::callback,
+	                        this);
+
+	if (! port) {
+		qWarning("GlobalShortcutMac: Unable to create EventTap. Global Shortcuts will not be available.");
+		return;
+	}
+
+	kbdLayout = NULL;
+
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1050
+# if MAC_OS_X_VERSION_MIN_REQUIRED < 1050
+	if (TISCopyCurrentKeyboardInputSource && TISGetInputSourceProperty)
+# endif
+	{
+		TISInputSourceRef inputSource = TISCopyCurrentKeyboardInputSource();
+		if (inputSource) {
+			CFDataRef data = static_cast<CFDataRef>(TISGetInputSourceProperty(inputSource, kTISPropertyUnicodeKeyLayoutData));
+			if (data)
+				kbdLayout = reinterpret_cast<UCKeyboardLayout *>(const_cast<UInt8 *>(CFDataGetBytePtr(data)));
+		}
+	}
+#endif
+#ifndef __LP64__
+	if (! kbdLayout) {
+		SInt16 currentKeyScript = GetScriptManagerVariable(smKeyScript);
+		SInt16 lastKeyLayoutID = GetScriptVariable(currentKeyScript, smScriptKeys);
+		Handle handle = GetResource('uchr', lastKeyLayoutID);
+		if (handle)
+			kbdLayout = reinterpret_cast<UCKeyboardLayout *>(*handle);
+	}
+#endif
+	if (! kbdLayout)
+		qWarning("GlobalShortcutMac: No keyboard layout mapping available. Unable to perform key translation.");
+
+	start(QThread::TimeCriticalPriority);
+}
+
+GlobalShortcutMac::~GlobalShortcutMac() {
+#ifndef QT_NO_DEBUG
+	return;
+#endif
+	CFRunLoopStop(loop);
+	loop = NULL;
+	wait();
+}
+
+void GlobalShortcutMac::dumpEventTaps() {
+	NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+	uint32_t ntaps = 0;
+	CGEventTapInformation table[64];
+	if (CGGetEventTapList(20, table, &ntaps) == kCGErrorSuccess) {
+		qWarning("--- Installed Event Taps ---");
+		for (uint32_t i = 0; i < ntaps; i++) {
+			CGEventTapInformation *info = &table[i];
+
+			ProcessSerialNumber psn;
+			NSString *processName = nil;
+			OSStatus err = GetProcessForPID(info->tappingProcess, &psn);
+			if (err == noErr) {
+				CFStringRef str = NULL;
+				CopyProcessName(&psn, &str);
+				processName = (NSString *) str;
+				[processName autorelease];
+			}
+
+			qWarning("{");
+			qWarning("  eventTapID: %u", info->eventTapID);
+			qWarning("  tapPoint: 0x%x", info->tapPoint);
+			qWarning("  options = 0x%x", info->options);
+			qWarning("  eventsOfInterest = 0x%llx", info->eventsOfInterest);
+			qWarning("  tappingProcess = %i (%s)", info->tappingProcess, [processName UTF8String]);
+			qWarning("  processBeingTapped = %i", info->processBeingTapped);
+			qWarning("  enabled = %s", info->enabled ? "true":"false");
+			qWarning("  minUsecLatency = %.2f", info->minUsecLatency);
+			qWarning("  avgUsecLatency = %.2f", info->avgUsecLatency);
+			qWarning("  maxUsecLatency = %.2f", info->maxUsecLatency);
+			qWarning("}");
+		}
+		qWarning("--- End of Event Taps ---");
+	}
+	[pool release];
+}
+
+void GlobalShortcutMac::forwardEvent(void *evt) {
+	NSEvent *event = (NSEvent *)evt;
+	SEL sel = nil;
+
+	if (! g.ocIntercept)
+		return;
+
+	QWidget *vp = g.ocIntercept->qgv.viewport();
+	NSView *view = (NSView *) vp->winId();
+
+	switch ([event type]) {
+		case NSLeftMouseDown:
+			sel = @selector(mouseDown:);
+			break;
+		case NSLeftMouseUp:
+			sel = @selector(mouseUp:);
+			break;
+		case NSLeftMouseDragged:
+			sel = @selector(mouseDragged:);
+			break;
+		case NSRightMouseDown:
+			sel = @selector(rightMouseDown:);
+			break;
+		case NSRightMouseUp:
+			sel = @selector(rightMouseUp:);
+			break;
+		case NSRightMouseDragged:
+			sel = @selector(rightMouseDragged:);
+			break;
+		case NSOtherMouseDown:
+			sel = @selector(otherMouseDown:);
+			break;
+		case NSOtherMouseUp:
+			sel = @selector(otherMouseUp:);
+			break;
+		case NSOtherMouseDragged:
+			sel = @selector(otherMouseDragged:);
+			break;
+		case NSMouseEntered:
+			sel = @selector(mouseEntered:);
+			break;
+		case NSMouseExited:
+			sel = @selector(mouseExited:);
+			break;
+		case NSMouseMoved:
+			sel = @selector(mouseMoved:);
+			break;
+		default:
+			// Ignore the rest. We only care about mouse events.
+			break;
+	}
+
+	if (sel) {
+		NSPoint p; p.x = (CGFloat) g.ocIntercept->iMouseX;
+		p.y = (CGFloat) (g.ocIntercept->uiHeight - g.ocIntercept->iMouseY);
+		NSEvent *mouseEvent = [NSEvent mouseEventWithType:[event type] location:p modifierFlags:[event modifierFlags] timestamp:[event timestamp]
+		                               windowNumber:0 context:nil eventNumber:[event eventNumber] clickCount:[event clickCount]
+		                               pressure:[event pressure]];
+		if ([view respondsToSelector:sel])
+				[view performSelector:sel withObject:mouseEvent];
+		[event release];
+		return;
+	}
+
+	switch ([event type]) {
+		case NSKeyDown:
+			sel = @selector(keyDown:);
+			break;
+		case NSKeyUp:
+			sel = @selector(keyUp:);
+			break;
+		case NSFlagsChanged:
+			sel = @selector(flagsChanged:);
+			break;
+		case NSScrollWheel:
+			sel = @selector(scrollWheel:);
+			break;
+		default:
+			break;
+	}
+
+	if (sel) {
+		if ([view respondsToSelector:sel])
+				[view performSelector:sel withObject:event];
+	}
+
+	[event release];
+}
+
+void GlobalShortcutMac::run() {
+	loop = CFRunLoopGetCurrent();
+	CFRunLoopSourceRef src = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, port, 0);
+	CFRunLoopAddSource(loop, src, kCFRunLoopCommonModes);
+	CFRunLoopRun();
+}
+
+void GlobalShortcutMac::needRemap() {
+	remap();
+}
+
+bool GlobalShortcutMac::handleModButton(const CGEventFlags newmask) {
+	bool down;
+	bool suppress = false;
+
+#define MOD_CHANGED(mask, btn) do { \
+	    if ((newmask & mask) != (modmask & mask)) { \
+	        down = newmask & mask; \
+	        suppress = handleButton(MOD_OFFSET+btn, down); \
+	        modmask = newmask; \
+	        return suppress; \
+	    }} while (0)
+
+	MOD_CHANGED(kCGEventFlagMaskAlphaShift, 0);
+	MOD_CHANGED(kCGEventFlagMaskShift, 1);
+	MOD_CHANGED(kCGEventFlagMaskControl, 2);
+	MOD_CHANGED(kCGEventFlagMaskAlternate, 3);
+	MOD_CHANGED(kCGEventFlagMaskCommand, 4);
+	MOD_CHANGED(kCGEventFlagMaskHelp, 5);
+	MOD_CHANGED(kCGEventFlagMaskSecondaryFn, 6);
+	MOD_CHANGED(kCGEventFlagMaskNumericPad, 7);
+
+	return false;
+}
+
+QString GlobalShortcutMac::translateMouseButton(const unsigned int keycode) const {
+	return QString::fromLatin1("Mouse Button %1").arg(keycode-MOUSE_OFFSET+1);
+}
+
+QString GlobalShortcutMac::translateModifierKey(const unsigned int keycode) const {
+	unsigned int key = keycode - MOD_OFFSET;
+	switch (key) {
+		case 0:
+			return QLatin1String("Caps Lock");
+		case 1:
+			return QLatin1String("Shift");
+		case 2:
+			return QLatin1String("Control");
+		case 3:
+			return QLatin1String("Alt/Option");
+		case 4:
+			return QLatin1String("Command");
+		case 5:
+			return QLatin1String("Help");
+		case 6:
+			return QLatin1String("Fn");
+		case 7:
+			return QLatin1String("Num Lock");
+	}
+	return QString::fromLatin1("Modifier %1").arg(key);
+}
+
+QString GlobalShortcutMac::translateKeyName(const unsigned int keycode) const {
+	UInt32 junk = 0;
+	UniCharCount len = 64;
+	UniChar unicodeString[len];
+
+	if (! kbdLayout)
+		return QString();
+
+	OSStatus err = UCKeyTranslate(kbdLayout, static_cast<UInt16>(keycode),
+	                              kUCKeyActionDisplay, 0, LMGetKbdType(),
+	                              kUCKeyTranslateNoDeadKeysBit, &junk,
+	                              len, &len, unicodeString);
+	if (err != noErr)
+		return QString();
+
+	if (len == 1) {
+		switch (unicodeString[0]) {
+			case '\t':
+				return QLatin1String("Tab");
+			case '\r':
+				return QLatin1String("Enter");
+			case '\b':
+				return QLatin1String("Backspace");
+			case '\e':
+				return QLatin1String("Escape");
+			case ' ':
+				return QLatin1String("Space");
+			case 28:
+				return QLatin1String("Left");
+			case 29:
+				return QLatin1String("Right");
+			case 30:
+				return QLatin1String("Up");
+			case 31:
+				return QLatin1String("Down");
+		}
+
+		if (unicodeString[0] < ' ') {
+			qWarning("GlobalShortcutMac: Unknown translation for keycode %u: %u", keycode, unicodeString[0]);
+			return QString();
+		}
+	}
+
+	return QString(reinterpret_cast<const QChar *>(unicodeString), len).toUpper();
+}
+
+QString GlobalShortcutMac::buttonName(const QVariant &v) {
+	bool ok;
+	unsigned int key = v.toUInt(&ok);
+	if (!ok)
+		return QString();
+
+	if (key >= MOUSE_OFFSET)
+		return translateMouseButton(key);
+	else if (key >= MOD_OFFSET)
+		return translateModifierKey(key);
+	else {
+		QString str = translateKeyName(key);
+		if (!str.isEmpty())
+			return str;
+	}
+
+	return QString::fromLatin1("Keycode %1").arg(key);
+}
+
+void GlobalShortcutMac::setEnabled(bool b) {
+	CGEventTapEnable(port, b);
+}
+
+bool GlobalShortcutMac::enabled() {
+	return CGEventTapIsEnabled(port);
+}
+
+bool GlobalShortcutMac::canSuppress() {
+	return true;
+}
+
+bool GlobalShortcutMac::canDisable() {
+	return true;
+}
+
+#endif // defined(__APPLE__) && defined(__MACH__)

--- a/src/platform/GlobalShortcut/GlobalShortcut_macx.h
+++ b/src/platform/GlobalShortcut/GlobalShortcut_macx.h
@@ -1,0 +1,78 @@
+/*
+    Copyright © 2014-2015 by The qTox Project Contributors
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+
+    This file incorporates work covered by the following copyright and  
+    permission notice: 
+
+        Copyright 2005-2018 The Mumble Developers. All rights reserved.
+        Use of this source code is governed by a BSD-style license
+        that can be found in the LICENSE file inside the GlobalShortcut
+        directory or at <https://www.mumble.info/LICENSE>.
+*/
+
+
+#ifndef MUMBLE_MUMBLE_GLOBALSHORTCUT_MACX_H_
+#define MUMBLE_MUMBLE_GLOBALSHORTCUT_MACX_H_
+
+#include <QtCore/qsystemdetection.h>
+#if defined(__APPLE__) && defined(__MACH__)
+#include <stdlib.h>
+#include <QtCore/QObject>
+
+#include <ApplicationServices/ApplicationServices.h>
+
+#include "GlobalShortcut.h"
+#include "Global.h"
+
+class GlobalShortcutMac : public GlobalShortcutEngine {
+	private:
+		Q_OBJECT
+		Q_DISABLE_COPY(GlobalShortcutMac)
+	public:
+		GlobalShortcutMac();
+		~GlobalShortcutMac() Q_DECL_OVERRIDE;
+		QString buttonName(const QVariant &) Q_DECL_OVERRIDE;
+		void dumpEventTaps();
+		void needRemap() Q_DECL_OVERRIDE;
+		bool handleModButton(CGEventFlags newmask);
+		bool canSuppress() Q_DECL_OVERRIDE;
+
+	void setEnabled(bool) Q_DECL_OVERRIDE;
+	bool enabled() Q_DECL_OVERRIDE;
+	bool canDisable() Q_DECL_OVERRIDE;
+
+	public slots:
+		void forwardEvent(void *evt);
+
+	protected:
+		CFRunLoopRef loop;
+		CFMachPortRef port;
+		CGEventFlags modmask;
+		UCKeyboardLayout *kbdLayout;
+
+		void run() Q_DECL_OVERRIDE;
+
+		static CGEventRef callback(CGEventTapProxy proxy, CGEventType type, CGEventRef event, void *udata);
+		QString translateMouseButton(const unsigned int keycode) const;
+		QString translateModifierKey(const unsigned int keycode) const;
+		QString translateKeyName(const unsigned int keycode) const;
+};
+
+#endif // defined(__APPLE__) && defined(__MACH__)
+#endif
+

--- a/src/platform/GlobalShortcut/GlobalShortcut_macx.mm
+++ b/src/platform/GlobalShortcut/GlobalShortcut_macx.mm
@@ -1,0 +1,483 @@
+/*
+    Copyright © 2014-2015 by The qTox Project Contributors
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+
+    This file incorporates work covered by the following copyright and  
+    permission notice: 
+
+        Copyright 2005-2018 The Mumble Developers. All rights reserved.
+        Use of this source code is governed by a BSD-style license
+        that can be found in the LICENSE file inside the GlobalShortcut
+        directory or at <https://www.mumble.info/LICENSE>.
+*/
+
+#include "mumble_pch.hpp"
+
+#import <AppKit/AppKit.h>
+#import <Carbon/Carbon.h>
+
+#include "GlobalShortcut_macx.h"
+#include "OverlayClient.h"
+
+#define MOD_OFFSET   0x10000
+#define MOUSE_OFFSET 0x20000
+
+GlobalShortcutEngine *GlobalShortcutEngine::platformInit() {
+	return new GlobalShortcutMac();
+}
+
+CGEventRef GlobalShortcutMac::callback(CGEventTapProxy proxy, CGEventType type,
+                                       CGEventRef event, void *udata) {
+	GlobalShortcutMac *gs = reinterpret_cast<GlobalShortcutMac *>(udata);
+	unsigned int keycode;
+	bool suppress = false;
+	bool forward = false;
+	bool down = false;
+	int64_t repeat = 0;
+
+	Q_UNUSED(proxy);
+
+	switch (type) {
+		case kCGEventLeftMouseDown:
+		case kCGEventRightMouseDown:
+		case kCGEventOtherMouseDown:
+			down = true;
+		case kCGEventLeftMouseUp:
+		case kCGEventRightMouseUp:
+		case kCGEventOtherMouseUp: {
+			keycode = static_cast<unsigned int>(CGEventGetIntegerValueField(event, kCGMouseEventButtonNumber));
+			suppress = gs->handleButton(MOUSE_OFFSET+keycode, down);
+			/* Suppressing "the" mouse button is probably not a good idea :-) */
+			if (keycode == 0)
+				suppress = false;
+			forward = !suppress;
+			break;
+		}
+
+		case kCGEventMouseMoved:
+		case kCGEventLeftMouseDragged:
+		case kCGEventRightMouseDragged:
+		case kCGEventOtherMouseDragged: {
+			if (g.ocIntercept) {
+				int64_t dx = CGEventGetIntegerValueField(event, kCGMouseEventDeltaX);
+				int64_t dy = CGEventGetIntegerValueField(event, kCGMouseEventDeltaY);
+				g.ocIntercept->iMouseX = qBound<int>(0, g.ocIntercept->iMouseX + static_cast<int>(dx), g.ocIntercept->uiWidth - 1);
+				g.ocIntercept->iMouseY = qBound<int>(0, g.ocIntercept->iMouseY + static_cast<int>(dy), g.ocIntercept->uiHeight - 1);
+				QMetaObject::invokeMethod(g.ocIntercept, "updateMouse", Qt::QueuedConnection);
+				forward = true;
+			}
+			break;
+		}
+
+		case kCGEventScrollWheel:
+			forward = true;
+			break;
+
+		case kCGEventKeyDown:
+			down = true;
+		case kCGEventKeyUp:
+			repeat = CGEventGetIntegerValueField(event, kCGKeyboardEventAutorepeat);
+			if (! repeat) {
+				keycode = static_cast<unsigned int>(CGEventGetIntegerValueField(event, kCGKeyboardEventKeycode));
+				suppress = gs->handleButton(keycode, down);
+			}
+			forward = true;
+			break;
+
+		case kCGEventFlagsChanged: {
+			CGEventFlags f = CGEventGetFlags(event);
+
+			// Dump active event taps on Ctrl+Alt+Cmd.
+			CGEventFlags ctrlAltCmd = static_cast<CGEventFlags>(kCGEventFlagMaskControl|kCGEventFlagMaskAlternate|kCGEventFlagMaskCommand);
+			if ((f & ctrlAltCmd) == ctrlAltCmd)
+				gs->dumpEventTaps();
+
+			suppress = gs->handleModButton(f);
+			forward = !suppress;
+			break;
+		}
+
+		case kCGEventTapDisabledByTimeout:
+			qWarning("GlobalShortcutMac: EventTap disabled by timeout. Re-enabling.");
+			/*
+			 * On Snow Leopard, we get this event type quite often. It disables our event
+			 * tap completely. Possible Apple bug.
+			 *
+			 * For now, simply call CGEventTapEnable() to enable our event tap again.
+			 *
+			 * See: http://lists.apple.com/archives/quartz-dev/2009/Sep/msg00007.html
+			 */
+			CGEventTapEnable(gs->port, true);
+			break;
+
+		case kCGEventTapDisabledByUserInput:
+			break;
+
+		default:
+			break;
+	}
+
+		if (forward && g.ocIntercept) {
+			NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+			NSEvent *evt = [[NSEvent eventWithCGEvent:event] retain];
+			QMetaObject::invokeMethod(gs, "forwardEvent", Qt::QueuedConnection, Q_ARG(void *, evt));
+			[pool release];
+			return NULL;
+		}
+
+	return suppress ? NULL : event;
+}
+
+GlobalShortcutMac::GlobalShortcutMac() : modmask(static_cast<CGEventFlags>(0)) {
+#ifndef QT_NO_DEBUG
+	qWarning("GlobalShortcutMac: Debug build detected. Disabling shortcut engine.");
+	return;
+#endif
+
+	CGEventMask evmask = CGEventMaskBit(kCGEventLeftMouseDown) |
+	                     CGEventMaskBit(kCGEventLeftMouseUp) |
+	                     CGEventMaskBit(kCGEventRightMouseDown) |
+	                     CGEventMaskBit(kCGEventRightMouseUp) |
+	                     CGEventMaskBit(kCGEventOtherMouseDown) |
+	                     CGEventMaskBit(kCGEventOtherMouseUp) |
+	                     CGEventMaskBit(kCGEventKeyDown) |
+	                     CGEventMaskBit(kCGEventKeyUp) |
+	                     CGEventMaskBit(kCGEventFlagsChanged) |
+	                     CGEventMaskBit(kCGEventMouseMoved) |
+	                     CGEventMaskBit(kCGEventLeftMouseDragged) |
+	                     CGEventMaskBit(kCGEventRightMouseDragged) |
+	                     CGEventMaskBit(kCGEventOtherMouseDragged) |
+	                     CGEventMaskBit(kCGEventScrollWheel);
+	port = CGEventTapCreate(kCGSessionEventTap,
+	                        kCGTailAppendEventTap,
+	                        kCGEventTapOptionDefault, // active filter (not only a listener)
+	                        evmask,
+	                        GlobalShortcutMac::callback,
+	                        this);
+
+	if (! port) {
+		qWarning("GlobalShortcutMac: Unable to create EventTap. Global Shortcuts will not be available.");
+		return;
+	}
+
+	kbdLayout = NULL;
+
+#if MAC_OS_X_VERSION_MAX_ALLOWED >= 1050
+# if MAC_OS_X_VERSION_MIN_REQUIRED < 1050
+	if (TISCopyCurrentKeyboardInputSource && TISGetInputSourceProperty)
+# endif
+	{
+		TISInputSourceRef inputSource = TISCopyCurrentKeyboardInputSource();
+		if (inputSource) {
+			CFDataRef data = static_cast<CFDataRef>(TISGetInputSourceProperty(inputSource, kTISPropertyUnicodeKeyLayoutData));
+			if (data)
+				kbdLayout = reinterpret_cast<UCKeyboardLayout *>(const_cast<UInt8 *>(CFDataGetBytePtr(data)));
+		}
+	}
+#endif
+#ifndef __LP64__
+	if (! kbdLayout) {
+		SInt16 currentKeyScript = GetScriptManagerVariable(smKeyScript);
+		SInt16 lastKeyLayoutID = GetScriptVariable(currentKeyScript, smScriptKeys);
+		Handle handle = GetResource('uchr', lastKeyLayoutID);
+		if (handle)
+			kbdLayout = reinterpret_cast<UCKeyboardLayout *>(*handle);
+	}
+#endif
+	if (! kbdLayout)
+		qWarning("GlobalShortcutMac: No keyboard layout mapping available. Unable to perform key translation.");
+
+	start(QThread::TimeCriticalPriority);
+}
+
+GlobalShortcutMac::~GlobalShortcutMac() {
+#ifndef QT_NO_DEBUG
+	return;
+#endif
+	CFRunLoopStop(loop);
+	loop = NULL;
+	wait();
+}
+
+void GlobalShortcutMac::dumpEventTaps() {
+	NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+	uint32_t ntaps = 0;
+	CGEventTapInformation table[64];
+	if (CGGetEventTapList(20, table, &ntaps) == kCGErrorSuccess) {
+		qWarning("--- Installed Event Taps ---");
+		for (uint32_t i = 0; i < ntaps; i++) {
+			CGEventTapInformation *info = &table[i];
+
+			ProcessSerialNumber psn;
+			NSString *processName = nil;
+			OSStatus err = GetProcessForPID(info->tappingProcess, &psn);
+			if (err == noErr) {
+				CFStringRef str = NULL;
+				CopyProcessName(&psn, &str);
+				processName = (NSString *) str;
+				[processName autorelease];
+			}
+
+			qWarning("{");
+			qWarning("  eventTapID: %u", info->eventTapID);
+			qWarning("  tapPoint: 0x%x", info->tapPoint);
+			qWarning("  options = 0x%x", info->options);
+			qWarning("  eventsOfInterest = 0x%llx", info->eventsOfInterest);
+			qWarning("  tappingProcess = %i (%s)", info->tappingProcess, [processName UTF8String]);
+			qWarning("  processBeingTapped = %i", info->processBeingTapped);
+			qWarning("  enabled = %s", info->enabled ? "true":"false");
+			qWarning("  minUsecLatency = %.2f", info->minUsecLatency);
+			qWarning("  avgUsecLatency = %.2f", info->avgUsecLatency);
+			qWarning("  maxUsecLatency = %.2f", info->maxUsecLatency);
+			qWarning("}");
+		}
+		qWarning("--- End of Event Taps ---");
+	}
+	[pool release];
+}
+
+void GlobalShortcutMac::forwardEvent(void *evt) {
+	NSEvent *event = (NSEvent *)evt;
+	SEL sel = nil;
+
+	if (! g.ocIntercept)
+		return;
+
+	QWidget *vp = g.ocIntercept->qgv.viewport();
+	NSView *view = (NSView *) vp->winId();
+
+	switch ([event type]) {
+		case NSLeftMouseDown:
+			sel = @selector(mouseDown:);
+			break;
+		case NSLeftMouseUp:
+			sel = @selector(mouseUp:);
+			break;
+		case NSLeftMouseDragged:
+			sel = @selector(mouseDragged:);
+			break;
+		case NSRightMouseDown:
+			sel = @selector(rightMouseDown:);
+			break;
+		case NSRightMouseUp:
+			sel = @selector(rightMouseUp:);
+			break;
+		case NSRightMouseDragged:
+			sel = @selector(rightMouseDragged:);
+			break;
+		case NSOtherMouseDown:
+			sel = @selector(otherMouseDown:);
+			break;
+		case NSOtherMouseUp:
+			sel = @selector(otherMouseUp:);
+			break;
+		case NSOtherMouseDragged:
+			sel = @selector(otherMouseDragged:);
+			break;
+		case NSMouseEntered:
+			sel = @selector(mouseEntered:);
+			break;
+		case NSMouseExited:
+			sel = @selector(mouseExited:);
+			break;
+		case NSMouseMoved:
+			sel = @selector(mouseMoved:);
+			break;
+		default:
+			// Ignore the rest. We only care about mouse events.
+			break;
+	}
+
+	if (sel) {
+		NSPoint p; p.x = (CGFloat) g.ocIntercept->iMouseX;
+		p.y = (CGFloat) (g.ocIntercept->uiHeight - g.ocIntercept->iMouseY);
+		NSEvent *mouseEvent = [NSEvent mouseEventWithType:[event type] location:p modifierFlags:[event modifierFlags] timestamp:[event timestamp]
+		                               windowNumber:0 context:nil eventNumber:[event eventNumber] clickCount:[event clickCount]
+		                               pressure:[event pressure]];
+		if ([view respondsToSelector:sel])
+				[view performSelector:sel withObject:mouseEvent];
+		[event release];
+		return;
+	}
+
+	switch ([event type]) {
+		case NSKeyDown:
+			sel = @selector(keyDown:);
+			break;
+		case NSKeyUp:
+			sel = @selector(keyUp:);
+			break;
+		case NSFlagsChanged:
+			sel = @selector(flagsChanged:);
+			break;
+		case NSScrollWheel:
+			sel = @selector(scrollWheel:);
+			break;
+		default:
+			break;
+	}
+
+	if (sel) {
+		if ([view respondsToSelector:sel])
+				[view performSelector:sel withObject:event];
+	}
+
+	[event release];
+}
+
+void GlobalShortcutMac::run() {
+	loop = CFRunLoopGetCurrent();
+	CFRunLoopSourceRef src = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, port, 0);
+	CFRunLoopAddSource(loop, src, kCFRunLoopCommonModes);
+	CFRunLoopRun();
+}
+
+void GlobalShortcutMac::needRemap() {
+	remap();
+}
+
+bool GlobalShortcutMac::handleModButton(const CGEventFlags newmask) {
+	bool down;
+	bool suppress = false;
+
+#define MOD_CHANGED(mask, btn) do { \
+	    if ((newmask & mask) != (modmask & mask)) { \
+	        down = newmask & mask; \
+	        suppress = handleButton(MOD_OFFSET+btn, down); \
+	        modmask = newmask; \
+	        return suppress; \
+	    }} while (0)
+
+	MOD_CHANGED(kCGEventFlagMaskAlphaShift, 0);
+	MOD_CHANGED(kCGEventFlagMaskShift, 1);
+	MOD_CHANGED(kCGEventFlagMaskControl, 2);
+	MOD_CHANGED(kCGEventFlagMaskAlternate, 3);
+	MOD_CHANGED(kCGEventFlagMaskCommand, 4);
+	MOD_CHANGED(kCGEventFlagMaskHelp, 5);
+	MOD_CHANGED(kCGEventFlagMaskSecondaryFn, 6);
+	MOD_CHANGED(kCGEventFlagMaskNumericPad, 7);
+
+	return false;
+}
+
+QString GlobalShortcutMac::translateMouseButton(const unsigned int keycode) const {
+	return QString::fromLatin1("Mouse Button %1").arg(keycode-MOUSE_OFFSET+1);
+}
+
+QString GlobalShortcutMac::translateModifierKey(const unsigned int keycode) const {
+	unsigned int key = keycode - MOD_OFFSET;
+	switch (key) {
+		case 0:
+			return QLatin1String("Caps Lock");
+		case 1:
+			return QLatin1String("Shift");
+		case 2:
+			return QLatin1String("Control");
+		case 3:
+			return QLatin1String("Alt/Option");
+		case 4:
+			return QLatin1String("Command");
+		case 5:
+			return QLatin1String("Help");
+		case 6:
+			return QLatin1String("Fn");
+		case 7:
+			return QLatin1String("Num Lock");
+	}
+	return QString::fromLatin1("Modifier %1").arg(key);
+}
+
+QString GlobalShortcutMac::translateKeyName(const unsigned int keycode) const {
+	UInt32 junk = 0;
+	UniCharCount len = 64;
+	UniChar unicodeString[len];
+
+	if (! kbdLayout)
+		return QString();
+
+	OSStatus err = UCKeyTranslate(kbdLayout, static_cast<UInt16>(keycode),
+	                              kUCKeyActionDisplay, 0, LMGetKbdType(),
+	                              kUCKeyTranslateNoDeadKeysBit, &junk,
+	                              len, &len, unicodeString);
+	if (err != noErr)
+		return QString();
+
+	if (len == 1) {
+		switch (unicodeString[0]) {
+			case '\t':
+				return QLatin1String("Tab");
+			case '\r':
+				return QLatin1String("Enter");
+			case '\b':
+				return QLatin1String("Backspace");
+			case '\e':
+				return QLatin1String("Escape");
+			case ' ':
+				return QLatin1String("Space");
+			case 28:
+				return QLatin1String("Left");
+			case 29:
+				return QLatin1String("Right");
+			case 30:
+				return QLatin1String("Up");
+			case 31:
+				return QLatin1String("Down");
+		}
+
+		if (unicodeString[0] < ' ') {
+			qWarning("GlobalShortcutMac: Unknown translation for keycode %u: %u", keycode, unicodeString[0]);
+			return QString();
+		}
+	}
+
+	return QString(reinterpret_cast<const QChar *>(unicodeString), len).toUpper();
+}
+
+QString GlobalShortcutMac::buttonName(const QVariant &v) {
+	bool ok;
+	unsigned int key = v.toUInt(&ok);
+	if (!ok)
+		return QString();
+
+	if (key >= MOUSE_OFFSET)
+		return translateMouseButton(key);
+	else if (key >= MOD_OFFSET)
+		return translateModifierKey(key);
+	else {
+		QString str = translateKeyName(key);
+		if (!str.isEmpty())
+			return str;
+	}
+
+	return QString::fromLatin1("Keycode %1").arg(key);
+}
+
+void GlobalShortcutMac::setEnabled(bool b) {
+	CGEventTapEnable(port, b);
+}
+
+bool GlobalShortcutMac::enabled() {
+	return CGEventTapIsEnabled(port);
+}
+
+bool GlobalShortcutMac::canSuppress() {
+	return true;
+}
+
+bool GlobalShortcutMac::canDisable() {
+	return true;
+}

--- a/src/platform/GlobalShortcut/GlobalShortcut_unix.cpp
+++ b/src/platform/GlobalShortcut/GlobalShortcut_unix.cpp
@@ -1,0 +1,386 @@
+/*
+    Copyright © 2014-2015 by The qTox Project Contributors
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+
+    This file incorporates work covered by the following copyright and  
+    permission notice: 
+
+        Copyright 2005-2018 The Mumble Developers. All rights reserved.
+        Use of this source code is governed by a BSD-style license
+        that can be found in the LICENSE file inside the GlobalShortcut
+        directory or at <https://www.mumble.info/LICENSE>.
+*/
+
+#include <QtCore/qsystemdetection.h>
+#if defined(Q_OS_UNIX) && !defined(__APPLE__) && !defined(__MACH__)
+#include <QFile>
+#include <QDir>
+#include <QSet>
+#include <QFileSystemWatcher>
+#include <QSocketNotifier>
+
+#include "GlobalShortcut.h"
+#include "GlobalShortcut_unix.h"
+
+// TODO?: guard this whole class with #ifdef PLATFORM_EXTENSIONS
+#include <X11/X.h>
+#include <X11/Xlib.h>
+#include <X11/XKBlib.h>
+#ifndef NO_XINPUT2
+#include <X11/extensions/XI2.h>
+#include <X11/extensions/XInput2.h>
+#endif
+#include <X11/Xutil.h>
+#ifdef Q_OS_LINUX
+#include <linux/input.h>
+#include <fcntl.h>
+#endif
+
+
+/**
+ * Returns a platform specific GlobalShortcutEngine object.
+ *
+ * @see GlobalShortcutX
+ * @see GlobalShortcutMac
+ * @see GlobalShortcutWin
+ */
+GlobalShortcutEngine *GlobalShortcutEngine::platformInit() {
+	return new GlobalShortcutX();
+}
+
+GlobalShortcutX::GlobalShortcutX() {
+	iXIopcode =  -1;
+	bRunning = false;
+
+	display = XOpenDisplay(NULL);
+
+	if (! display) {
+		qWarning("GlobalShortcutX: Unable to open dedicated display connection.");
+		return;
+	}
+
+#ifdef Q_OS_LINUX
+	// TODO: if statement
+	if (/*g.s.bEnableEvdev*/ true) {
+		QString dir = QLatin1String("/dev/input");
+		QFileSystemWatcher *fsw = new QFileSystemWatcher(QStringList(dir), this);
+		connect(fsw, SIGNAL(directoryChanged(const QString &)), this, SLOT(directoryChanged(const QString &)));
+		directoryChanged(dir);
+
+		if (qsKeyboards.isEmpty()) {
+			foreach(QFile *f, qmInputDevices)
+				delete f;
+			qmInputDevices.clear();
+
+			delete fsw;
+			qWarning("GlobalShortcutX: Unable to open any keyboard input devices under /dev/input, falling back to XInput");
+		} else {
+			return;
+		}
+	}
+#endif
+
+	for (int i=0; i < ScreenCount(display); ++i)
+		qsRootWindows.insert(RootWindow(display, i));
+
+#ifndef NO_XINPUT2
+	int evt, error;
+
+	// TODO: g.s.bEnableXInput2?
+	if (/*g.s.bEnableXInput2*/true && XQueryExtension(display, "XInputExtension", &iXIopcode, &evt, &error)) {
+		int major = XI_2_Major;
+		int minor = XI_2_Minor;
+		int rc = XIQueryVersion(display, &major, &minor);
+		if (rc != BadRequest) {
+			qWarning("GlobalShortcutX: Using XI2 %d.%d", major, minor);
+
+			queryXIMasterList();
+
+			XIEventMask evmask;
+			unsigned char mask[(XI_LASTEVENT + 7)/8];
+
+			memset(&evmask, 0, sizeof(evmask));
+			memset(mask, 0, sizeof(mask));
+
+			XISetMask(mask, XI_RawButtonPress);
+			XISetMask(mask, XI_RawButtonRelease);
+			XISetMask(mask, XI_RawKeyPress);
+			XISetMask(mask, XI_RawKeyRelease);
+			XISetMask(mask, XI_HierarchyChanged);
+
+			evmask.deviceid = XIAllDevices;
+			evmask.mask_len = sizeof(mask);
+			evmask.mask = mask;
+
+			foreach(Window w, qsRootWindows)
+				XISelectEvents(display, w, &evmask, 1);
+			XFlush(display);
+
+			connect(new QSocketNotifier(ConnectionNumber(display), QSocketNotifier::Read, this), SIGNAL(activated(int)), this, SLOT(displayReadyRead(int)));
+
+			return;
+		}
+	}
+#endif
+	qWarning("GlobalShortcutX: No XInput support, falling back to polled input. This wastes a lot of CPU resources, so please enable one of the other methods.");
+	bRunning=true;
+	start(QThread::TimeCriticalPriority);
+}
+
+GlobalShortcutX::~GlobalShortcutX() {
+	bRunning = false;
+	wait();
+
+	if (display)
+		XCloseDisplay(display);
+}
+
+// Tight loop polling
+void GlobalShortcutX::run() {
+	Window root = XDefaultRootWindow(display);
+	Window root_ret, child_ret;
+	int root_x, root_y;
+	int win_x, win_y;
+	unsigned int mask[2];
+	int idx = 0;
+	int next = 0;
+	char keys[2][32];
+
+	memset(keys[0], 0, 32);
+	memset(keys[1], 0, 32);
+	mask[0] = mask[1] = 0;
+
+	while (bRunning) {
+		msleep(10);
+
+		idx = next;
+		next = idx ^ 1;
+		if (XQueryPointer(display, root, &root_ret, &child_ret, &root_x, &root_y, &win_x, &win_y, &mask[next]) && XQueryKeymap(display, keys[next])) {
+			for (int i=0;i<256;++i) {
+				int index = i / 8;
+				int keymask = 1 << (i % 8);
+				bool oldstate = (keys[idx][index] & keymask) != 0;
+				bool newstate = (keys[next][index] & keymask) != 0;
+				if (oldstate != newstate) {
+					handleButton(i, newstate);
+				}
+			}
+			for (int i=8;i<=12;++i) {
+				bool oldstate = (mask[idx] & (1 << i)) != 0;
+				bool newstate = (mask[next] & (1 << i)) != 0;
+				if (oldstate != newstate) {
+					handleButton(0x110 + i, newstate);
+				}
+			}
+		}
+	}
+}
+
+// Find XI2 master devices so they can be ignored.
+void GlobalShortcutX::queryXIMasterList() {
+#ifndef NO_XINPUT2
+	XIDeviceInfo *info, *dev;
+	int ndevices;
+
+	qsMasterDevices.clear();
+
+	dev = info = XIQueryDevice(display, XIAllDevices, &ndevices);
+	for (int i=0;i<ndevices;++i) {
+		switch (dev->use) {
+			case XIMasterPointer:
+			case XIMasterKeyboard:
+				qsMasterDevices.insert(dev->deviceid);
+				break;
+			default:
+				break;
+		}
+
+		++dev;
+	}
+	XIFreeDeviceInfo(info);
+#endif
+}
+
+// XInput2 event is ready on socketnotifier.
+void GlobalShortcutX::displayReadyRead(int) {
+#ifndef NO_XINPUT2
+	XEvent evt;
+
+	while (XPending(display)) {
+		XNextEvent(display, &evt);
+		XGenericEventCookie *cookie = & evt.xcookie;
+
+		if ((cookie->type != GenericEvent) || (cookie->extension != iXIopcode) || !XGetEventData(display, cookie))
+			continue;
+
+		XIDeviceEvent *xide = reinterpret_cast<XIDeviceEvent *>(cookie->data);
+		switch (cookie->evtype) {
+			case XI_RawKeyPress:
+			case XI_RawKeyRelease:
+				if (! qsMasterDevices.contains(xide->deviceid))
+					handleButton(xide->detail, cookie->evtype == XI_RawKeyPress);
+				break;
+			case XI_RawButtonPress:
+			case XI_RawButtonRelease:
+				if (! qsMasterDevices.contains(xide->deviceid))
+					handleButton(xide->detail + 0x117, cookie->evtype == XI_RawButtonPress);
+				break;
+			case XI_HierarchyChanged:
+				queryXIMasterList();
+		}
+
+		XFreeEventData(display, cookie);
+	}
+#endif
+}
+
+// One of the raw /dev/input devices has ready input
+void GlobalShortcutX::inputReadyRead(int) {
+#ifdef Q_OS_LINUX
+	// TODO: should this be configurable?
+//	if (!g.s.bEnableEvdev) {
+//		return;
+//	}
+
+	struct input_event ev;
+
+	QFile *f=qobject_cast<QFile *>(sender()->parent());
+	if (!f)
+		return;
+
+	bool found = false;
+
+	while (f->read(reinterpret_cast<char *>(&ev), sizeof(ev)) == sizeof(ev)) {
+		found = true;
+		if (ev.type != EV_KEY)
+			continue;
+		bool down;
+		switch (ev.value) {
+			case 0:
+				down = false;
+				break;
+			case 1:
+				down = true;
+				break;
+			default:
+				continue;
+		}
+		int evtcode = ev.code + 8;
+		handleButton(evtcode, down);
+	}
+
+	if (! found) {
+		int fd = f->handle();
+		int version = 0;
+		if ((ioctl(fd, EVIOCGVERSION, &version) < 0) || (((version >> 16) & 0xFF) < 1)) {
+			qWarning("GlobalShortcutX: Removing dead input device %s", qPrintable(f->fileName()));
+			qmInputDevices.remove(f->fileName());
+			qsKeyboards.remove(f->fileName());
+			delete f;
+		}
+	}
+#endif
+}
+
+#define test_bit(bit, array)    (array[bit/8] & (1<<(bit%8)))
+
+// The /dev/input directory changed
+void GlobalShortcutX::directoryChanged(const QString &dir) {
+#ifdef Q_OS_LINUX
+	// TODO: need this?
+//	if (!g.s.bEnableEvdev) {
+//		return;
+//	}
+
+	QDir d(dir, QLatin1String("event*"), 0, QDir::System);
+	foreach(QFileInfo fi, d.entryInfoList()) {
+		QString path = fi.absoluteFilePath();
+		if (! qmInputDevices.contains(path)) {
+			QFile *f = new QFile(path, this);
+			if (f->open(QIODevice::ReadOnly)) {
+				int fd = f->handle();
+				int version;
+				char name[256];
+				uint8_t events[EV_MAX/8 + 1];
+				memset(events, 0, sizeof(events));
+				if ((ioctl(fd, EVIOCGVERSION, &version) >= 0) && (ioctl(fd, EVIOCGNAME(sizeof(name)), name)>=0) && (ioctl(fd, EVIOCGBIT(0,sizeof(events)), &events) >= 0) && test_bit(EV_KEY, events) && (((version >> 16) & 0xFF) > 0)) {
+					name[255]=0;
+					qWarning("GlobalShortcutX: %s: %s", qPrintable(f->fileName()), name);
+					// Is it grabbed by someone else?
+					if ((ioctl(fd, EVIOCGRAB, 1) < 0)) {
+						qWarning("GlobalShortcutX: Device exclusively grabbed by someone else (X11 using exclusive-mode evdev?)");
+						delete f;
+					} else {
+						ioctl(fd, EVIOCGRAB, 0);
+						uint8_t keys[KEY_MAX/8 + 1];
+						if ((ioctl(fd, EVIOCGBIT(EV_KEY, sizeof(keys)), &keys) >= 0) && test_bit(KEY_SPACE, keys))
+							qsKeyboards.insert(f->fileName());
+
+						fcntl(f->handle(), F_SETFL, O_NONBLOCK);
+						connect(new QSocketNotifier(f->handle(), QSocketNotifier::Read, f), SIGNAL(activated(int)), this, SLOT(inputReadyRead(int)));
+
+						qmInputDevices.insert(f->fileName(), f);
+					}
+				} else {
+					delete f;
+				}
+			} else {
+				delete f;
+			}
+		}
+	}
+#else
+	Q_UNUSED(dir);
+#endif
+}
+
+QString GlobalShortcutX::toString(const QVariant& shortcut) {
+	bool ok;
+	unsigned int key=shortcut.toUInt(&ok);
+	if (!ok)
+		return QString();
+	if ((key < 0x118) || (key >= 0x128)) {
+		// TODO: shift mask broken?
+		KeySym ks=XkbKeycodeToKeysym(display, static_cast<KeyCode>(key), 0, /*event.xkey.state & ShiftMask ? 1 : 0*/0);
+		if (ks == NoSymbol) {
+			return QLatin1String("0x")+QString::number(key,16);
+		} else {
+			const char *str=XKeysymToString(ks);
+			if (*str == '\0') {
+				return QLatin1String("KS0x")+QString::number(ks, 16);
+			} else {
+				return QLatin1String(str);
+			}
+		}
+	} else {
+		return tr("Mouse %1").arg(key-0x118);
+	}
+}
+// these fucking X11 defines break Qt, try to contain them
+#undef Bool
+#undef CursorShape
+#undef Expose
+#undef KeyPress
+#undef KeyRelease
+#undef FocusIn
+#undef FocusOut
+#undef FontChange
+#undef None
+#undef Status
+#undef Unsorted
+
+#endif // defined(Q_OS_UNIX) && !defined(__APPLE__) && !defined(__MACH__)

--- a/src/platform/GlobalShortcut/GlobalShortcut_unix.h
+++ b/src/platform/GlobalShortcut/GlobalShortcut_unix.h
@@ -1,0 +1,66 @@
+/*
+    Copyright © 2014-2015 by The qTox Project Contributors
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+
+    This file incorporates work covered by the following copyright and  
+    permission notice: 
+
+        Copyright 2005-2018 The Mumble Developers. All rights reserved.
+        Use of this source code is governed by a BSD-style license
+        that can be found in the LICENSE file inside the GlobalShortcut
+        directory or at <https://www.mumble.info/LICENSE>.
+*/
+
+#ifndef MUMBLE_MUMBLE_GLOBALSHORTCUT_UNIX_H_
+#define MUMBLE_MUMBLE_GLOBALSHORTCUT_UNIX_H_
+
+#include <QFile>
+#include <QSet>
+#include <ostream>
+#include "GlobalShortcut.h"
+
+//#include <X11/Xlib.h>
+// These should be coming from Xlib.h, but with conflicting types and unity build, this is easier..
+typedef struct _XDisplay Display;
+typedef unsigned long Window;
+
+class GlobalShortcutX : public GlobalShortcutEngine {
+	private:
+		Q_OBJECT
+		Q_DISABLE_COPY(GlobalShortcutX)
+	public:
+		Display *display;
+		QSet<Window> qsRootWindows;
+		int iXIopcode;
+		QSet<int> qsMasterDevices;
+
+		volatile bool bRunning;
+		QSet<QString> qsKeyboards;
+		QMap<QString, QFile *> qmInputDevices;
+
+		GlobalShortcutX();
+		~GlobalShortcutX() override;
+		void run() override;
+		QString toString(const QVariant& shortcut);
+
+		void queryXIMasterList();
+	public slots:
+		void displayReadyRead(int);
+		void inputReadyRead(int);
+		void directoryChanged(const QString &);
+};
+#endif

--- a/src/platform/GlobalShortcut/GlobalShortcut_win.cpp
+++ b/src/platform/GlobalShortcut/GlobalShortcut_win.cpp
@@ -1,0 +1,916 @@
+/*
+    Copyright © 2014-2015 by The qTox Project Contributors
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+
+    This file incorporates work covered by the following copyright and  
+    permission notice: 
+
+        Copyright 2005-2018 The Mumble Developers. All rights reserved.
+        Use of this source code is governed by a BSD-style license
+        that can be found in the LICENSE file inside the GlobalShortcut
+        directory or at <https://www.mumble.info/LICENSE>.
+*/
+
+#include <QtCore/qsystemdetection.h>
+#ifdef Q_OS_WIN32
+// MinGW does not support std::future/std::promise
+// at present. Use Boost's implementation for now.
+
+#define BOOST_THREAD_VERSION 4
+#include <boost/thread.hpp>
+#include <boost/thread/future.hpp>
+
+#include "GlobalShortcut_win.h"
+
+// 3rdparty/xinputcheck-src.
+#include <xinputcheck.h>
+
+#undef FAILED
+#define FAILED(Status) (static_cast<HRESULT>(Status)<0)
+
+#define DX_SAMPLE_BUFFER_SIZE 512
+
+// from os_win.cpp
+extern HWND mumble_mw_hwnd;
+
+/// The QEvent::Type value to use for InjectKeyboardMessageEvent.
+#define INJECTKEYBOARDMESSAGE_QEVENT (QEvent::User + 200)
+/// The QEvent::Type value to use for InjectKeyboardMouseEvent.
+#define INJECTMOUSEMESSAGE_QEVENT (QEvent::User + 201)
+
+/// InjectKeyboardMessageEvent is an event that can be sent to
+/// the GlobalShortcutWin engine to inject a native Windows keyboard
+/// event into GlobalShortcutWin's event stream.
+class InjectKeyboardMessageEvent : public QEvent {
+		Q_DISABLE_COPY(InjectKeyboardMessageEvent);
+
+	public:
+		boost::promise<bool> m_suppressionPromise;
+		DWORD m_scancode;
+		DWORD m_vkcode;
+		bool m_extended;
+		bool m_down;
+
+		/// Construct a new InjectKeyboardMessageEvent.
+		///
+		/// @param  scancode            The Windows scancode of the button.
+		/// @param  vkcode              The Windows virtual keycode of the button.
+		/// @param  extended            Indicates whether the button is an extended key in
+		///                             Windows nomenclature. ("[...] such as the right-hand ALT
+		///                             and CTRL keys that appear on an enhanced 101- or 102-key
+		///                             keyboard")
+		/// @param  down                The down/pressed status of the keyboard button.
+		InjectKeyboardMessageEvent(DWORD scancode, DWORD vkcode, bool extended, bool down)
+			: QEvent(static_cast<QEvent::Type>(INJECTKEYBOARDMESSAGE_QEVENT))
+			, m_scancode(scancode)
+			, m_vkcode(vkcode)
+			, m_extended(extended)
+			, m_down(down) {}
+
+		inline boost::future<bool> shouldSuppress() {
+			return m_suppressionPromise.get_future();
+		}
+};
+
+/// InjectMouseMessageEvent is an event that can be sent to
+/// the GlobalShortcutWin engine to inject a native Windows mouse
+/// event into GlobalShortcutWin's event stream.
+class InjectMouseMessageEvent : public QEvent {
+		Q_DISABLE_COPY(InjectMouseMessageEvent);
+
+	public:
+		boost::promise<bool> m_suppressionPromise;
+		unsigned int m_btn;
+		bool m_down;
+
+		/// Construct a new InjectMouseMessageEvent.
+		///
+		/// @param  btn                 The DirectInput button index of the mouse event.
+		/// @param  down                The down/pressed status of the mouse button.
+		InjectMouseMessageEvent(unsigned int btn, bool down)
+			: QEvent(static_cast<QEvent::Type>(INJECTMOUSEMESSAGE_QEVENT))
+			, m_btn(btn)
+			, m_down(down) {}
+
+		inline boost::future<bool> shouldSuppress() {
+			return m_suppressionPromise.get_future();
+		}
+};
+
+uint qHash(const GUID &a) {
+	uint val = a.Data1 ^ a.Data2 ^ a.Data3;
+	for (int i=0;i<8;i++)
+		val += a.Data4[i];
+	return val;
+}
+
+/**
+ * Returns a platform specific GlobalShortcutEngine object.
+ *
+ * @see GlobalShortcutX
+ * @see GlobalShortcutMac
+ * @see GlobalShortcutWin
+ */
+GlobalShortcutEngine *GlobalShortcutEngine::platformInit() {
+	return new GlobalShortcutWin();
+}
+
+
+GlobalShortcutWin::GlobalShortcutWin()
+	: pDI(NULL)
+	, hhMouse(NULL)
+	, hhKeyboard(NULL)
+	, uiHardwareDevices(0)
+#ifdef USE_GKEY
+	, gkey(NULL)
+#endif
+#ifdef USE_XBOXINPUT
+	, xboxinput(NULL)
+	, nxboxinput(0)
+#endif
+{
+	// Hidden setting to disable hooking
+	bHook = g.qs->value(QLatin1String("winhooks"), true).toBool();
+
+	moveToThread(this);
+	start(QThread::LowestPriority);
+}
+
+GlobalShortcutWin::~GlobalShortcutWin() {
+	quit();
+	wait();
+}
+
+void GlobalShortcutWin::run() {
+	if (FAILED(DirectInput8Create(GetModuleHandle(NULL), DIRECTINPUT_VERSION, IID_IDirectInput8, reinterpret_cast<void **>(&pDI), NULL))) {
+		qFatal("GlobalShortcutWin: Failed to create d8input");
+		return;
+	}
+
+	// Print the user's LowLevelHooksTimeout registry key for debugging purposes.
+	// On Windows 7 and greater, Windows will silently remove badly behaving hooks
+	// without telling the application. Users can tweak the timeout themselves
+	// with this registry key.
+	HKEY key = NULL;
+	DWORD type = 0;
+	DWORD value = 0;
+	DWORD len = sizeof(DWORD);
+	if (RegOpenKeyExA(HKEY_CURRENT_USER, "Control Panel\\Desktop", 0, KEY_READ, &key) == ERROR_SUCCESS) {
+		LONG err = RegQueryValueExA(key, "LowLevelHooksTimeout", NULL, &type, reinterpret_cast<LPBYTE>(&value), &len);
+		if (err == ERROR_SUCCESS && type == REG_DWORD) {
+			qWarning("GlobalShortcutWin: Found LowLevelHooksTimeout with value = 0x%lx", static_cast<unsigned long>(value));
+		} else if (err == ERROR_FILE_NOT_FOUND) {
+			qWarning("GlobalShortcutWin: No LowLevelHooksTimeout registry key found.");
+		} else {
+			qWarning("GlobalShortcutWin: Error looking up LowLevelHooksTimeout. (Error: 0x%lx, Type: 0x%lx, Value: 0x%lx)", static_cast<unsigned long>(err), static_cast<unsigned long>(type), static_cast<unsigned long>(value));
+		}
+	}
+
+	// Wait for MainWindow's constructor to finish before we enumerate DirectInput devices.
+	// We need to do this because adding a new device requires a Window handle. (SetCooperativeLevel())
+	while (! g.mw)
+		this->yieldCurrentThread();
+
+#ifdef USE_GKEY
+	if (g.s.bEnableGKey) {
+		gkey = new GKeyLibrary();
+		qWarning("GlobalShortcutWin: GKeys initialized, isValid: %d", gkey->isValid());
+	}
+#endif
+
+#ifdef USE_XBOXINPUT
+	if (g.s.bEnableXboxInput) {
+		xboxinput = new XboxInput();
+		ZeroMemory(&xboxinputLastPacket, sizeof(xboxinputLastPacket));
+		qWarning("GlobalShortcutWin: XboxInput initialized, isValid: %d", xboxinput->isValid());
+	}
+#endif
+
+	QTimer *timer = new QTimer;
+	connect(timer, SIGNAL(timeout()), this, SLOT(timeTicked()));
+	timer->start(20);
+
+	setPriority(QThread::TimeCriticalPriority);
+
+	exec();
+
+	delete timer;
+
+#ifdef USE_GKEY
+	delete gkey;
+#endif
+
+#ifdef USE_XBOXINPUT
+	delete xboxinput;
+#endif
+
+	if (bHook) {
+		if (hhMouse != NULL) {
+			UnhookWindowsHookEx(hhMouse);
+		}
+		if (hhKeyboard != NULL) {
+			UnhookWindowsHookEx(hhKeyboard);
+		}
+	}
+
+	foreach(InputDevice *id, qhInputDevices) {
+		if (id->pDID) {
+			id->pDID->Unacquire();
+			id->pDID->Release();
+		}
+		delete id;
+	}
+	pDI->Release();
+}
+
+bool GlobalShortcutWin::event(QEvent *event) {
+	QEvent::Type type = event->type();
+	if (type == INJECTKEYBOARDMESSAGE_QEVENT) {
+		InjectKeyboardMessageEvent *ikme = static_cast<InjectKeyboardMessageEvent *>(event);
+		bool suppress = handleKeyboardMessage(ikme->m_scancode, ikme->m_vkcode, ikme->m_extended, ikme->m_down);
+		ikme->m_suppressionPromise.set_value(suppress);
+		return true;
+	} else if (type == INJECTMOUSEMESSAGE_QEVENT) {
+		InjectMouseMessageEvent *imme = static_cast<InjectMouseMessageEvent *>(event);
+		bool suppress = handleMouseMessage(imme->m_btn, imme->m_down);
+		imme->m_suppressionPromise.set_value(suppress);
+		return true;
+	}
+	return GlobalShortcutEngine::event(event);
+}
+
+bool GlobalShortcutWin::injectKeyboardMessage(MSG *msg) {
+	if (!bHook) {
+		return false;
+	}
+
+	// Only allow keyboard messages.
+	switch (msg->message) {
+		case WM_KEYDOWN:
+		case WM_KEYUP:
+		case WM_SYSKEYDOWN:
+		case WM_SYSKEYUP:
+			break;
+		default:
+			return false;
+	}
+
+	DWORD scancode = (msg->lParam >> 16) & 0xff;
+	DWORD vkcode = msg->wParam;
+	bool extended = !!(msg->lParam & 0x01000000);
+	bool up = !!(msg->lParam & 0x80000000);
+
+	InjectKeyboardMessageEvent *ikme = new InjectKeyboardMessageEvent(scancode, vkcode, extended, !up);
+	boost::future<bool> suppress = ikme->shouldSuppress();
+	qApp->postEvent(this, ikme);
+	return suppress.get();
+}
+
+bool GlobalShortcutWin::injectMouseMessage(MSG *msg) {
+	if (!bHook) {
+		return false;
+	}
+
+	bool down = false;
+	unsigned int btn = 0;
+
+	// Convert the Windows mouse message into a DirectInput
+	// button index, and store the pressed state of the button.
+	switch (msg->message) {
+		case WM_LBUTTONDOWN:
+			down = true;
+		case WM_LBUTTONUP:
+			btn = 3;
+			break;
+		case WM_RBUTTONDOWN:
+			down = true;
+		case WM_RBUTTONUP:
+			btn = 4;
+			break;
+		case WM_MBUTTONDOWN:
+			down = true;
+		case WM_MBUTTONUP:
+			btn = 5;
+			break;
+		case WM_XBUTTONDOWN:
+			down = true;
+		case WM_XBUTTONUP: {
+			unsigned int offset = (msg->wParam >> 16) & 0xffff;
+			btn = 5 + offset;
+		}
+		default:
+			// Non-mouse event. Return early.
+			return false;
+	}
+
+	InjectMouseMessageEvent *imme = new InjectMouseMessageEvent(btn, down);
+	boost::future<bool> suppress = imme->shouldSuppress();
+	qApp->postEvent(this, imme);
+	return suppress.get();
+}
+
+bool GlobalShortcutWin::handleKeyboardMessage(DWORD scancode, DWORD vkcode, bool extended, bool down) {
+	GlobalShortcutWin *gsw = static_cast<GlobalShortcutWin *>(engine);
+
+	QList<QVariant> ql;
+
+	// Convert the low-level key event to
+	// a DirectInput key ID.
+	unsigned int keyid = static_cast<unsigned int>((scancode << 8) | 0x4);
+	if (extended) {
+		keyid |= 0x8000U;
+	}
+
+	// NumLock and Pause need special handling.
+	// For those keys, the method above of setting
+	// bit 15 high when the LLKHF_EXTENDED flag is
+	// set on the low-level key event does not work.
+	//
+	// When we receive a low-level Windows
+	// Pause key event, the extended flag isn't
+	// set, but DirectInput expects it to be.
+	//
+	// The opposite is true for NumLock key,
+	// where the extended flag for the low-level
+	// Windows event is set, but DirectInput expects
+	// it not to be.
+	//
+	// Without this fix-up, we would emit Pause as
+	// NumLock, and NumLock as pause. That was
+	// problematic, because at the same time,
+	// DirectInput would emit the correct key.
+	// This meant that when pressing one of Pause
+	// and NumLock, shortcut actions for both keys
+	// would be triggered.
+	//
+	// Originally reported in mumble-voip/mumble#1353
+	if (vkcode == VK_PAUSE) {
+		// Always set the extended bit for Pause.
+		keyid |= 0x8000U;
+	} else if (vkcode == VK_NUMLOCK) {
+		// Never set the extended bit for NumLock.
+		keyid &= ~0x8000U;
+	}
+
+	ql << keyid;
+	ql << QVariant(QUuid(GUID_SysKeyboard));
+	bool suppress = gsw->handleButton(ql, down);
+
+	return suppress;
+}
+
+bool GlobalShortcutWin::handleMouseMessage(unsigned int btn, bool down) {
+	GlobalShortcutWin *gsw = static_cast<GlobalShortcutWin *>(engine);
+
+	bool suppress = false;
+
+	if (btn > 0) {
+		QList<QVariant> ql;
+		ql << static_cast<unsigned int>((btn << 8) | 0x4);
+		ql << QVariant(QUuid(GUID_SysMouse));
+
+		// Do not suppress LBUTTONUP though (so suppression can be deactivated via mouse).
+		bool wantsuppress = gsw->handleButton(ql, down);
+		suppress = wantsuppress && (btn != 3);
+	}
+
+	return suppress;
+}
+
+LRESULT CALLBACK GlobalShortcutWin::HookKeyboard(int nCode, WPARAM wParam, LPARAM lParam) {
+	GlobalShortcutWin *gsw=static_cast<GlobalShortcutWin *>(engine);
+	KBDLLHOOKSTRUCT *key=reinterpret_cast<KBDLLHOOKSTRUCT *>(lParam);
+
+#ifndef QT_NO_DEBUG
+	static int safety = 0;
+
+	if ((++safety < 100) && (nCode >= 0)) {
+#else
+	if (nCode >= 0) {
+#endif
+		DWORD scancode = key->scanCode;
+		DWORD vkcode = key->vkCode;
+		bool extended = !!(key->flags & LLKHF_EXTENDED);
+		bool up = !!(key->flags & LLKHF_UP);
+		bool suppress = handleKeyboardMessage(scancode, vkcode, extended, !up);
+		if (suppress) {
+			return 1;
+		}
+	}
+	return CallNextHookEx(gsw->hhKeyboard, nCode, wParam, lParam);
+}
+
+LRESULT CALLBACK GlobalShortcutWin::HookMouse(int nCode, WPARAM wParam, LPARAM lParam) {
+	GlobalShortcutWin *gsw=static_cast<GlobalShortcutWin *>(engine);
+	MSLLHOOKSTRUCT *mouse=reinterpret_cast<MSLLHOOKSTRUCT *>(lParam);
+
+	if (nCode >= 0) {
+		bool suppress = false;
+		UINT msg = wParam;
+		// Convert the hooked Windows mouse message into a DirectInput
+		// button index, and store the pressed state of the button.
+		bool down = false;
+		unsigned int btn = 0;
+		switch (msg) {
+			case WM_LBUTTONDOWN:
+				down = true;
+			case WM_LBUTTONUP:
+				btn = 3;
+				break;
+			case WM_RBUTTONDOWN:
+				down = true;
+			case WM_RBUTTONUP:
+				btn = 4;
+				break;
+			case WM_MBUTTONDOWN:
+				down = true;
+			case WM_MBUTTONUP:
+				btn = 5;
+				break;
+			case WM_XBUTTONDOWN:
+				down = true;
+			case WM_XBUTTONUP:
+				btn = 5 + (mouse->mouseData >> 16);
+			default:
+				break;
+		}
+		if (btn > 0) {
+			suppress = handleMouseMessage(btn, down);
+			if (suppress) {
+				return 1;
+			}
+		}
+	}
+	return CallNextHookEx(gsw->hhMouse, nCode, wParam, lParam);
+}
+
+BOOL CALLBACK GlobalShortcutWin::EnumDeviceObjectsCallback(LPCDIDEVICEOBJECTINSTANCE lpddoi, LPVOID pvRef) {
+	InputDevice *id=static_cast<InputDevice *>(pvRef);
+	QString name = QString::fromUtf16(reinterpret_cast<const ushort *>(lpddoi->tszName));
+	id->qhNames[lpddoi->dwType] = name;
+
+	if (g.s.bDirectInputVerboseLogging) {
+		qWarning("GlobalShortcutWin: EnumObjects: device %s %s object 0x%.8lx %s",
+		         qPrintable(QUuid(id->guid).toString()),
+		         qPrintable(id->name),
+		         static_cast<unsigned long>(lpddoi->dwType),
+		         qPrintable(name));
+	}
+
+	return DIENUM_CONTINUE;
+}
+
+BOOL GlobalShortcutWin::EnumDevicesCB(LPCDIDEVICEINSTANCE pdidi, LPVOID pContext) {
+	GlobalShortcutWin *cbgsw=static_cast<GlobalShortcutWin *>(pContext);
+	HRESULT hr;
+
+	QString name = QString::fromUtf16(reinterpret_cast<const ushort *>(pdidi->tszProductName));
+	QString sname = QString::fromUtf16(reinterpret_cast<const ushort *>(pdidi->tszInstanceName));
+
+	InputDevice *id = new InputDevice;
+
+	id->pDID = NULL;
+
+	id->name = name;
+
+	id->guid = pdidi->guidInstance;
+	id->vguid = QVariant(QUuid(id->guid).toString());
+
+	id->guidproduct = pdidi->guidProduct;
+	id->vguidproduct = QVariant(QUuid(id->guidproduct).toString());
+
+	// Is it an XInput device? Skip it.
+	//
+	// This check is not restricted to USE_XBOXINPUT because
+	// Windows 10 (10586.122, ~March 2016) has issues with
+	// using XInput devices via DirectInput.
+	//
+	// See issues mumble-voip/mumble#2104 and mumble-voip/mumble#2147
+	// for more information.
+	if (XInputCheck_IsGuidProductXInputDevice(&id->guidproduct)) {
+		cbgsw->nxboxinput += 1;
+
+		qWarning("GlobalShortcutWin: excluded XInput device '%s' (guid %s guid product %s) from DirectInput",
+		         qPrintable(id->name),
+		         qPrintable(id->vguid.toString()),
+		         qPrintable(id->vguidproduct.toString()));
+		delete id;
+		return DIENUM_CONTINUE;
+	}
+
+	// Check for PIDVID at the end of the GUID, as
+	// per http://stackoverflow.com/q/25622780.
+	BYTE pidvid[8] = { 0, 0, 'P', 'I', 'D', 'V', 'I', 'D' };
+	if (memcmp(id->guidproduct.Data4, pidvid, 8) == 0) {
+		uint16_t vendor_id = id->guidproduct.Data1 & 0xffff;
+		uint16_t product_id = (id->guidproduct.Data1 >> 16) & 0xffff;
+
+		id->vendor_id = vendor_id;
+		id->product_id = product_id;
+	} else {
+		id->vendor_id = 0x00;
+		id->product_id = 0x00;
+	}
+
+	// Reject devices if they are blacklisted.
+	//
+	// Device Name: ODAC-revB
+	// Vendor/Product ID: 0x262A, 0x1048
+	// https://github.com/mumble-voip/mumble/issues/1977
+	//
+	// Device Name: Aune T1 MK2 - HID-compliant consumer control device
+	// Vendor/Product ID: 0x262A, 0x1168
+	// https://github.com/mumble-voip/mumble/issues/1880
+	//
+	// For now, we simply disable the 0x262A vendor ID.
+	//
+	// 0x26A is SAVITECH Corp.
+	// http://www.savitech-ic.com/, or
+	// http://www.saviaudio.com/product.html
+	// (via https://usb-ids.gowdy.us/read/UD/262a)
+	//
+	// In the future, if there are more devices in the
+	// blacklist, we need a more structured aproach.
+	{
+		if (id->vendor_id == 0x262A) {
+			qWarning("GlobalShortcutWin: rejected blacklisted device %s (GUID: %s, PGUID: %s, VID: 0x%.4x, PID: 0x%.4x, TYPE: 0x%.8lx)",
+			         qPrintable(id->name),
+			         qPrintable(id->vguid.toString()),
+			         qPrintable(id->vguidproduct.toString()),
+			         id->vendor_id,
+			         id->product_id,
+			         static_cast<unsigned long>(pdidi->dwDevType));
+			delete id;
+			return DIENUM_CONTINUE;
+		}
+	}
+
+	foreach(InputDevice *dev, cbgsw->qhInputDevices) {
+		if (dev->guid == id->guid) {
+			delete id;
+			return DIENUM_CONTINUE;
+		}
+	}
+
+	if (FAILED(hr = cbgsw->pDI->CreateDevice(pdidi->guidInstance, &id->pDID, NULL)))
+		qFatal("GlobalShortcutWin: CreateDevice: %lx", hr);
+
+	if (FAILED(hr = id->pDID->EnumObjects(EnumDeviceObjectsCallback, static_cast<void *>(id), DIDFT_BUTTON)))
+		qFatal("GlobalShortcutWin: EnumObjects: %lx", hr);
+
+	if (id->qhNames.count() > 0) {
+		QList<DWORD> types = id->qhNames.keys();
+		qSort(types);
+
+		int nbuttons = types.count();
+		STACKVAR(DIOBJECTDATAFORMAT, rgodf, nbuttons);
+		DIDATAFORMAT df;
+		ZeroMemory(&df, sizeof(df));
+		df.dwSize = sizeof(df);
+		df.dwObjSize = sizeof(DIOBJECTDATAFORMAT);
+		df.dwFlags=DIDF_ABSAXIS;
+		df.dwDataSize = (nbuttons + 3) & (~0x3);
+		df.dwNumObjs = nbuttons;
+		df.rgodf = rgodf;
+		for (int i=0;i<nbuttons;i++) {
+			ZeroMemory(& rgodf[i], sizeof(DIOBJECTDATAFORMAT));
+			DWORD dwType = types[i];
+			DWORD dwOfs = i;
+			rgodf[i].dwOfs = dwOfs;
+			rgodf[i].dwType = dwType;
+			id->qhOfsToType[dwOfs] = dwType;
+			id->qhTypeToOfs[dwType] = dwOfs;
+		}
+
+		if (FAILED(hr = id->pDID->SetCooperativeLevel(mumble_mw_hwnd, DISCL_NONEXCLUSIVE|DISCL_BACKGROUND)))
+			qFatal("GlobalShortcutWin: SetCooperativeLevel: %lx", hr);
+
+		if (FAILED(hr = id->pDID->SetDataFormat(&df)))
+			qFatal("GlobalShortcutWin: SetDataFormat: %lx", hr);
+
+		DIPROPDWORD dipdw;
+
+		dipdw.diph.dwSize       = sizeof(DIPROPDWORD);
+		dipdw.diph.dwHeaderSize = sizeof(DIPROPHEADER);
+		dipdw.diph.dwObj        = 0;
+		dipdw.diph.dwHow        = DIPH_DEVICE;
+		dipdw.dwData            = DX_SAMPLE_BUFFER_SIZE;
+
+		if (FAILED(hr = id->pDID->SetProperty(DIPROP_BUFFERSIZE, &dipdw.diph)))
+			qFatal("GlobalShortcutWin: SetProperty: %lx", hr);
+
+		qWarning("Adding device %s %s %s:%d type 0x%.8lx guid product %s",
+		         qPrintable(QUuid(id->guid).toString()),
+		         qPrintable(name),
+		         qPrintable(sname),
+		         id->qhNames.count(),
+		         static_cast<unsigned long>(pdidi->dwDevType),
+		         qPrintable(id->vguidproduct.toString()));
+
+		cbgsw->qhInputDevices[id->guid] = id;
+	} else {
+		id->pDID->Release();
+		delete id;
+	}
+
+	return DIENUM_CONTINUE;
+}
+
+void GlobalShortcutWin::timeTicked() {
+	if (g.mw->uiNewHardware != uiHardwareDevices) {
+		uiHardwareDevices = g.mw->uiNewHardware;
+
+		XInputCheck_ClearDeviceCache();
+		nxboxinput = 0;
+
+		pDI->EnumDevices(DI8DEVCLASS_ALL, EnumDevicesCB, static_cast<void *>(this), DIEDFL_ATTACHEDONLY);
+	}
+
+	if (bNeedRemap)
+		remap();
+
+	foreach(InputDevice *id, qhInputDevices) {
+		DIDEVICEOBJECTDATA rgdod[DX_SAMPLE_BUFFER_SIZE];
+		DWORD   dwItems = DX_SAMPLE_BUFFER_SIZE;
+		HRESULT hr;
+
+		hr = id->pDID->Acquire();
+
+		switch (hr) {
+			case DI_OK:
+			case S_FALSE:
+				break;
+			case DIERR_UNPLUGGED:
+			case DIERR_GENERIC:
+				qWarning("Removing device %s", qPrintable(QUuid(id->guid).toString()));
+				id->pDID->Release();
+				qhInputDevices.remove(id->guid);
+				delete id;
+				return;
+			case DIERR_OTHERAPPHASPRIO:
+				continue;
+			default:
+				break;
+		}
+
+		{
+			QElapsedTimer timer;
+			timer.start();
+
+			id->pDID->Poll();
+
+			// If a call to Poll takes more than
+			// a second, warn the user that they
+			// might have a misbehaving device.
+			if (timer.elapsed() > 1000) {
+				qWarning("GlobalShortcut_win: Poll() for device %s took %li msec. This is abnormal, the device is possibly misbehaving...", qPrintable(QUuid(id->guid).toString()), static_cast<long>(timer.elapsed()));
+			}
+		}
+
+		hr = id->pDID->GetDeviceData(sizeof(DIDEVICEOBJECTDATA), rgdod, &dwItems, 0);
+		if (FAILED(hr))
+			continue;
+
+		if (dwItems <= 0)
+			continue;
+
+		for (DWORD j=0; j<dwItems; j++) {
+			QList<QVariant> ql;
+
+			quint32 uiType = id->qhOfsToType.value(rgdod[j].dwOfs);
+			ql << uiType;
+			ql << id->vguid;
+			handleButton(ql, rgdod[j].dwData & 0x80);
+		}
+	}
+
+#ifdef USE_GKEY
+	if (g.s.bEnableGKey && gkey != NULL && gkey->isValid()) {
+		for (int button = GKEY_MIN_MOUSE_BUTTON; button <= GKEY_MAX_MOUSE_BUTTON; button++) {
+			QList<QVariant> ql;
+			ql << button;
+			ql << GKeyLibrary::quMouse;
+			handleButton(ql, gkey->isMouseButtonPressed(button));
+		}
+		for (int mode = GKEY_MIN_KEYBOARD_MODE; mode <= GKEY_MAX_KEYBOARD_MODE; mode++) {
+			for (int key = GKEY_MIN_KEYBOARD_BUTTON; key <= GKEY_MAX_KEYBOARD_BUTTON; key++) {
+				QList<QVariant> ql;
+				// Store the key and mode in one int
+				// bit 0..15: mode, bit 16..31: key
+				ql << (key | (mode << 16));
+				ql << GKeyLibrary::quKeyboard;
+				handleButton(ql, gkey->isKeyboardGkeyPressed(key, mode));
+			}
+		}
+	}
+#endif
+
+#ifdef USE_XBOXINPUT
+	if (g.s.bEnableXboxInput && xboxinput != NULL && xboxinput->isValid() && nxboxinput > 0) {
+		XboxInputState state;
+		for (uint32_t i = 0; i < XBOXINPUT_MAX_DEVICES; i++) {
+			if (xboxinput->GetState(i, &state) == 0) {
+				// Skip the result of GetState() if the packet number hasn't changed,
+				// or if we're at the first packet.
+				if (xboxinputLastPacket[i] != 0 && state.packetNumber == xboxinputLastPacket[i]) {
+					continue;
+				}
+
+				// The buttons field of XboxInputState contains a bit
+				// for each button on the Xbox controller. The official
+				// headers enumerate the bits via XINPUT_GAMEPAD_*.
+				// The official mapping uses all 16-bits, but leaves
+				// bit 10 and 11 (counting from 0) undocumented.
+				//
+				// It turns out that bit 10 is the guide button,
+				// which can be queried using the non-public
+				// XInputGetStateEx() function.
+				//
+				// Our mapping uses the bit number as a button index.
+				// So 0x1 -> 0, 0x2 -> 1, 0x4 -> 2, and so on...
+				//
+				// However, since the buttons field is only a 16-bit value,
+				// and we also want to use the left and right triggers as
+				// buttons, we assign them the button indexes 16 and 17.
+				uint32_t buttonMask = state.buttons;
+				for (uint32_t j = 0; j < 18; j++) {
+					QList<QVariant> ql;
+
+					bool pressed = false;
+					if (j >= 16) {
+						if (j == 16) { // LeftTrigger
+							pressed = state.leftTrigger > XBOXINPUT_TRIGGER_THRESHOLD;
+						} else if (j == 17) { // RightTrigger
+							pressed = state.rightTrigger > XBOXINPUT_TRIGGER_THRESHOLD;
+						}
+					} else {
+						uint32_t currentButtonMask = (1 << j);
+						pressed = (buttonMask & currentButtonMask) != 0;
+					}
+
+					uint32_t type = (i << 24) | j;
+					ql << static_cast<uint>(type);
+					ql << XboxInput::s_XboxInputGuid;
+					handleButton(ql, pressed);
+				}
+
+				xboxinputLastPacket[i] = state.packetNumber;
+			}
+		}
+	}
+#endif
+
+	// Initialize winhooks.
+	//
+	// We do this here, because at this point, we've just run our
+	// first timeTicked() slot. The GlobalShortcut_win thread's event
+	// loop has nothing else to do at this point, so there is nothing
+	// that blocks the callbacks of the hooks.
+	//
+	// That is, if we initialize here, our callbacks *can* be called
+	// immediately after initialization, which gives the best results
+	// as far as interactivity and user experience goes. The initialization
+	// cannot be "felt".
+	//
+	// Let me explain...
+	//
+	// Originally, this code lived in the body of run, ::run(), just
+	// before exec() was called.
+	//
+	// It turns out that if our hooks are initialized there, it can take
+	// a short while before the mouse and keyboard callbacks can be processed.
+	//
+	// During this time, where the mouse callback is not able to be called,
+	// the mouse in Windows becomes laggy. It makes the whole computer feel
+	// like it has locked up -- because input "stops".
+	//
+	// As explained above, initializing the hooks here yields a much superior
+	// experience, where this initialization has no observable effect on the
+	// behavior of the system's mouse input.
+	if (bHook && hhMouse == NULL && hhKeyboard == NULL) {
+		HMODULE hSelf;
+		GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, reinterpret_cast<LPCTSTR>(&HookKeyboard), &hSelf);
+		hhMouse = SetWindowsHookEx(WH_MOUSE_LL, HookMouse, hSelf, 0);
+		hhKeyboard = SetWindowsHookEx(WH_KEYBOARD_LL, HookKeyboard, hSelf, 0);
+	}
+}
+
+QString GlobalShortcutWin::buttonName(const QVariant &v) {
+	GlobalShortcutWin *gsw = static_cast<GlobalShortcutWin *>(GlobalShortcutEngine::engine);
+
+	const QList<QVariant> &sublist = v.toList();
+	if (sublist.count() != 2)
+		return QString();
+
+	bool ok = false;
+	DWORD type = sublist.at(0).toUInt(&ok);
+	QUuid guid(sublist.at(1).toString());
+
+	if (guid.isNull() || (!ok))
+		return QString();
+
+	QString device=guid.toString();
+	QString name=QLatin1String("Unknown");
+
+#ifdef USE_GKEY
+	if (g.s.bEnableGKey && gkey != NULL && gkey->isValid()) {
+		bool isGKey = false;
+		if (guid == GKeyLibrary::quMouse) {
+			isGKey = true;
+			name = gkey->getMouseButtonString(type);
+		} else if (guid == GKeyLibrary::quKeyboard) {
+			isGKey = true;
+			name = gkey->getKeyboardGkeyString(type & 0xFFFF, type >> 16);
+		}
+		if (isGKey) {
+			device = QLatin1String("GKey:");
+			return device + name; // Example output: "Gkey:G6/M1"
+		}
+	}
+#endif
+
+#ifdef USE_XBOXINPUT
+	if (g.s.bEnableXboxInput && xboxinput != NULL && xboxinput->isValid() && guid == XboxInput::s_XboxInputGuid) {
+		uint32_t idx = (type >> 24) & 0xff;
+		uint32_t button = (type & 0x00ffffff);
+
+		// Translate from our own button index mapping to
+		// the actual Xbox controller button names.
+		// For a description of the mapping, see the state
+		// querying code in GlobalShortcutWin::timeTicked().
+		switch (button) {
+			case 0:
+				return QString::fromLatin1("Xbox%1:Up").arg(idx + 1);
+			case 1:
+				return QString::fromLatin1("Xbox%1:Down").arg(idx + 1);
+			case 2:
+				return QString::fromLatin1("Xbox%1:Left").arg(idx + 1);
+			case 3:
+				return QString::fromLatin1("Xbox%1:Right").arg(idx + 1);
+			case 4:
+				return QString::fromLatin1("Xbox%1:Start").arg(idx + 1);
+			case 5:
+				return QString::fromLatin1("Xbox%1:Back").arg(idx + 1);
+			case 6:
+				return QString::fromLatin1("Xbox%1:LeftThumb").arg(idx + 1);
+			case 7:
+				return QString::fromLatin1("Xbox%1:RightThumb").arg(idx + 1);
+			case 8:
+				return QString::fromLatin1("Xbox%1:LeftShoulder").arg(idx + 1);
+			case 9:
+				return QString::fromLatin1("Xbox%1:RightShoulder").arg(idx + 1);
+			case 10:
+				return QString::fromLatin1("Xbox%1:Guide").arg(idx + 1);
+			case 11:
+				return QString::fromLatin1("Xbox%1:11").arg(idx + 1);
+			case 12:
+				return QString::fromLatin1("Xbox%1:A").arg(idx + 1);
+			case 13:
+				return QString::fromLatin1("Xbox%1:B").arg(idx + 1);
+			case 14:
+				return QString::fromLatin1("Xbox%1:X").arg(idx + 1);
+			case 15:
+				return QString::fromLatin1("Xbox%1:Y").arg(idx + 1);
+			case 16:
+				return QString::fromLatin1("Xbox%1:LeftTrigger").arg(idx + 1);
+			case 17:
+				return QString::fromLatin1("Xbox%1:RightTrigger").arg(idx + 1);
+		}
+	}
+#endif
+
+	InputDevice *id = gsw->qhInputDevices.value(guid);
+	if (guid == GUID_SysMouse)
+		device=QLatin1String("M:");
+	else if (guid == GUID_SysKeyboard)
+		device=QLatin1String("K:");
+	else if (id)
+		device=id->name+QLatin1String(":");
+	if (id) {
+		QString result = id->qhNames.value(type);
+		if (!result.isEmpty()) {
+			name = result;
+		}
+	}
+	return device+name;
+}
+
+bool GlobalShortcutWin::canSuppress() {
+	return bHook;
+}
+
+#endif // Q_OS_WIN32

--- a/src/platform/GlobalShortcut/GlobalShortcut_win.h
+++ b/src/platform/GlobalShortcut/GlobalShortcut_win.h
@@ -1,0 +1,162 @@
+/*
+    Copyright © 2014-2015 by The qTox Project Contributors
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+
+    This file incorporates work covered by the following copyright and  
+    permission notice: 
+
+        Copyright 2005-2018 The Mumble Developers. All rights reserved.
+        Use of this source code is governed by a BSD-style license
+        that can be found in the LICENSE file inside the GlobalShortcut
+        directory or at <https://www.mumble.info/LICENSE>.
+*/
+
+#ifndef MUMBLE_MUMBLE_GLOBALSHORTCUT_WIN_H_
+#define MUMBLE_MUMBLE_GLOBALSHORTCUT_WIN_H_
+
+#include <QtCore/qsystemdetection.h>
+#ifdef Q_OS_WIN32
+
+#include "GlobalShortcut.h"
+//#include "Timer.h"
+
+#ifdef USE_GKEY
+#include "GKey.h"
+#endif
+
+#ifdef USE_XBOXINPUT
+#include "XboxInput.h"
+#endif
+
+#define DIRECTINPUT_VERSION 0x0800
+#include <dinput.h>
+
+typedef QPair<GUID, DWORD> qpButton;
+
+struct InputDevice {
+	LPDIRECTINPUTDEVICE8 pDID;
+
+	QString name;
+
+	GUID guid;
+	QVariant vguid;
+
+	GUID guidproduct;
+	QVariant vguidproduct;
+
+	uint16_t vendor_id;
+	uint16_t product_id;
+
+	// dwType to name
+	QHash<DWORD, QString> qhNames;
+
+	// Map dwType to dwOfs in our structure
+	QHash<DWORD, DWORD> qhTypeToOfs;
+
+	// Map dwOfs in our structure to dwType
+	QHash<DWORD, DWORD> qhOfsToType;
+
+	// Buttons active since last reset
+	QSet<DWORD> activeMap;
+};
+
+class GlobalShortcutWin : public GlobalShortcutEngine {
+	private:
+		Q_OBJECT
+		Q_DISABLE_COPY(GlobalShortcutWin)
+	public:
+		LPDIRECTINPUT8 pDI;
+		QHash<GUID, InputDevice *> qhInputDevices;
+		HHOOK hhMouse, hhKeyboard;
+		unsigned int uiHardwareDevices;
+		Timer tDoubleClick;
+		bool bHook;
+#ifdef USE_GKEY
+		GKeyLibrary *gkey;
+#endif
+#ifdef USE_XBOXINPUT
+		/// xboxinputLastPacket holds the last packet number
+		/// that was processed. Any new data queried for a
+		/// device is only valid if the packet number is
+		/// different than last time we queried it.
+		uint32_t   xboxinputLastPacket[XBOXINPUT_MAX_DEVICES];
+		XboxInput *xboxinput;
+		/// nxboxinput holds the number of XInput devices
+		/// available on the system. It is filled out by
+		/// our EnumDevices callback.
+		int nxboxinput;
+#endif
+
+		static BOOL CALLBACK EnumSuitableDevicesCB(LPCDIDEVICEINSTANCE, LPDIRECTINPUTDEVICE8, DWORD, DWORD, LPVOID);
+		static BOOL CALLBACK EnumDevicesCB(LPCDIDEVICEINSTANCE, LPVOID);
+		static BOOL CALLBACK EnumDeviceObjectsCallback(LPCDIDEVICEOBJECTINSTANCE lpddoi, LPVOID pvRef);
+		static LRESULT CALLBACK HookKeyboard(int, WPARAM, LPARAM);
+		static LRESULT CALLBACK HookMouse(int, WPARAM, LPARAM);
+
+		/// Handle an incoming Windows keyboard message.
+		///
+		/// Returns true if the GlobalShortcut engine signals that the
+		/// button should be suppressed. Returns false otherwise.
+		static bool handleKeyboardMessage(DWORD scancode, DWORD vkcode, bool extended, bool down);
+
+		/// Handle an incoming Windows mouse message.
+		///
+		/// Returns true if the GlobalShortcut engine signals that the
+		/// button should be suppressed. Returns false otherwise.
+		static bool handleMouseMessage(unsigned int btn, bool down);
+
+		virtual bool canSuppress() Q_DECL_OVERRIDE;
+		void run() Q_DECL_OVERRIDE;
+		bool event(QEvent *e) Q_DECL_OVERRIDE;
+	public slots:
+		void timeTicked();
+	public:
+		GlobalShortcutWin();
+		~GlobalShortcutWin() Q_DECL_OVERRIDE;
+		void unacquire();
+		QString buttonName(const QVariant &) Q_DECL_OVERRIDE;
+
+		/// Inject a native Windows keyboard message into GlobalShortcutWin's
+		/// event stream. This method is meant to be called from the main thread
+		/// to pass native Windows keyboard messages to GlobalShortcutWin.
+		///
+		/// @param  msg  The keyboard message to inject into GlobalShortcutWin.
+		///              Must be WM_KEYDOWN, WM_KEYUP, WM_SYSKEYDOWN or WM_SYSKEYUP.
+		///              Otherwise the message will be ignored.
+		///
+		/// @return      Returns true if the GlobalShortcut engine signalled that
+		///              the button should be suppressed. Returns false otherwise.
+		bool injectKeyboardMessage(MSG *msg);
+
+		/// Inject a native Windows mouse message into GlobalShortcutWin's
+		/// event stream. This method is meant to be called from the main thread
+		/// to pass native Windows mouse messages to GlobalShortcutWin.
+		///
+		/// @param  msg  The keyboard message to inject into GlobalShortcutWin.
+		///              Must be WM_LBUTTONDOWN, WM_LBUTTONUP, WM_RBUTTONDOWN,
+		///              WM_RBUTTONUP, WM_MBUTTONDOWN, WM_MBUTTONUP, WM_XBUTTONDOWN
+		///              or WM_XBUTTONUP. Otherwise the message will be ignored.
+		///
+		/// @return      Returns true if the GlobalShortcut engine signalled that
+		///              the button should be suppressed. Returns false otherwise.
+		bool injectMouseMessage(MSG *msg);
+};
+
+uint qHash(const GUID &);
+
+#endif // Q_OS_WIN32
+#endif

--- a/src/platform/GlobalShortcut/LICENSE
+++ b/src/platform/GlobalShortcut/LICENSE
@@ -1,0 +1,35 @@
+Copyright (C) 2005-2018 The Mumble Developers
+
+A list of The Mumble Developers can be found in the
+AUTHORS file at the root of the Mumble source tree
+or at <https://www.mumble.info/AUTHORS>.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+- Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
+- Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+- Neither the name of The Mumble Developers nor the names of its
+  contributors may be used to endorse or promote products derived from this
+  software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+`AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+For questions and inquiries about Mumble's license,
+please contact <license@mumble.info>.

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -168,6 +168,8 @@ ChatForm::ChatForm(Friend* chatFriend, History* history)
     connect(headWidget, &ChatFormHeader::videoCallTriggered, this, &ChatForm::onVideoCallTriggered);
     connect(headWidget, &ChatFormHeader::micMuteToggle, this, &ChatForm::onMicMuteToggle);
     connect(headWidget, &ChatFormHeader::volMuteToggle, this, &ChatForm::onVolMuteToggle);
+    const Widget* widget = Widget::getInstance();
+    connect(widget, &Widget::pttMute, this, &ChatForm::onMicMuteToggle);
 
     connect(msgEdit, &ChatTextEdit::enterPressed, this, &ChatForm::onSendTriggered);
     connect(msgEdit, &ChatTextEdit::textChanged, this, &ChatForm::onTextEditChanged);

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -62,6 +62,7 @@
 #include "src/persistence/offlinemsgengine.h"
 #include "src/persistence/profile.h"
 #include "src/persistence/settings.h"
+#include "src/platform/GlobalShortcut/GlobalShortcut.h"
 #include "src/platform/timer.h"
 #include "src/widget/form/addfriendform.h"
 #include "src/widget/form/chatform.h"
@@ -272,7 +273,17 @@ void Widget::init()
     new QShortcut(Qt::CTRL + Qt::Key_Tab, this, SLOT(nextContact()));
     new QShortcut(Qt::CTRL + Qt::Key_PageUp, this, SLOT(previousContact()));
     new QShortcut(Qt::CTRL + Qt::Key_PageDown, this, SLOT(nextContact()));
-    new QShortcut(Qt::Key_F11, this, SLOT(toggleFullscreen()));
+    auto tmp = new QShortcut(Qt::Key_F11, this, SLOT(toggleFullscreen()));
+
+    // global shortcuts
+    globalShortcutEngine = std::unique_ptr<GlobalShortcutEngine>(GlobalShortcutEngine::platformInit());
+    Shortcut pttShortcut;
+    pttShortcut.bSuppress = false;
+    // TODO: where do these button values come from? not ascii or utf8, related to keyboard mapping? system independent?
+    pttShortcut.qlButtons = QList<QVariant>{QVariant{49}, QVariant{37}};  // 49 == '`', 37 == ctrl
+	gsPushTalk = std::unique_ptr<GlobalShortcut>(new GlobalShortcut(pttShortcut));
+	globalShortcutEngine->add(gsPushTalk.get());
+	connect(gsPushTalk.get(), &GlobalShortcut::triggered, this, &Widget::pttMute);
 
 #ifdef Q_OS_MAC
     QMenuBar* globalMenu = Nexus::getInstance().globalMenuBar;

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -66,6 +66,8 @@ class QTimer;
 class SettingsWidget;
 class SystemTrayIcon;
 class VideoSurface;
+class GlobalShortcutEngine;
+class GlobalShortcut;
 
 class Widget final : public QMainWindow
 {
@@ -187,6 +189,7 @@ signals:
     void statusMessageChanged(const QString& statusMessage);
     void resized();
     void windowStateChanged(Qt::WindowStates states);
+    void pttMute();
 
 private slots:
     void onAddClicked();
@@ -299,6 +302,9 @@ private:
     QPushButton* groupInvitesButton;
     unsigned int unreadGroupInvites;
     int icon_size;
+
+    std::unique_ptr<GlobalShortcutEngine> globalShortcutEngine;
+    std::unique_ptr<GlobalShortcut> gsPushTalk;
 
     QMap<uint32_t, GroupWidget*> groupWidgets;
     QMap<uint32_t, FriendWidget*> friendWidgets;


### PR DESCRIPTION
once complete, will fix #4929 
complete so far:
- imported from mumble, added licensing.
- removed the majority of GlobalHotkey leaving only the bare minimum to support the API of adding or removing a hotkey, and linking that hotkey's keydown and keyup events.
- change GlobalHotkeyEngine from a static instance to a normal class
- change architecture by removing remap() logic, adding keys to map on add() call, and other confusing architectural decisions
- *nix implementation seems to be working pretty well, currently " ctrl + ` " toggles mute on calls on both key down and key up. Works to either "push to talk" or "push to mute" which can be toggled by just clicking the mute button in call

TODO:
- code full of TODO's added by me for parts of code hacked out
- win and macx implementations not yet worked on
- no UI to set shortcuts (@tox-user mentioned he may want to help out with this). Mumble had an implementation for this that used to be part of GlobalShortcut that I removed. We may want to pull that back in and re-use part of it.
- I don't understand the mapping from read-back keycodes to actual keys, making it tricky to set shortcuts. i.e. keycode values read are not ascii or UTF8. Maybe these key codes with align with our UI input so this won't be an issue.

Looking for input:
- API of GlobalShortcutEngine and GlobalShortcut
- Architecture of the classes
- Handling the cross-platform compilation, i.e. having a static platformInit() defined in GlobalShortcut.h which is implemented in whichever GlobalShortcut_(platform).cpp is compiled
- Testing on *nix

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4936)
<!-- Reviewable:end -->
