### PR TITLE
fix(chatlog): parse multi-length emoji properly

### DIFF
--- a/src/widget/emoticonswidget.cpp
+++ b/src/widget/emoticonswidget.cpp
@@ -131,7 +131,7 @@ void EmoticonsWidget::onSmileyClicked()
     if (sender) {
         QString sequence =
             sender->property("sequence").toString().replace("&lt;", "<").replace("&gt;", ">");
-        emit insertEmoticon(' ' + sequence + ' ');
+        emit insertEmoticon(sequence);
     }
 }
 


### PR DESCRIPTION
Before, when multi-length emoji were next to any other character, they would not be transformed into images. With this change, emoji are replaced with images no matter where they are in the string. Parsing is now done by checking to see if two-character blocks are valid as a single UTF-32 character, or if they are truly two distinct characters. Because we no longer need white space before emoji, I also removed our addition of spaces on either side of an emoji when a user sends them.

[Before](https://imgur.com/a/kUaoU):  :(
[After](https://imgur.com/a/A1BHO):  :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4940)
<!-- Reviewable:end -->
