### PR TITLE
Allow characters next to formatting characters

### DIFF
--- a/src/chatlog/textformatter.cpp
+++ b/src/chatlog/textformatter.cpp
@@ -23,51 +23,43 @@
 
 // clang-format off
 
-static const QString SINGLE_SIGN_PATTERN = QStringLiteral("(?<=^|[\\s\\n])"
-                                                          "[%1]"
+static const QString SINGLE_SIGN_PATTERN = QStringLiteral("[%1]"
                                                           "(?!\\s)"
                                                           "([^%1\\n]+?)"
                                                           "(?<!\\s)"
-                                                          "[%1]"
-                                                          "(?=$|[\\s\\n])");
+                                                          "[%1]");
 
-static const QString SINGLE_SLASH_PATTERN = QStringLiteral("(?<=^|[\\s\\n])"
-                                                           "/"
+static const QString SINGLE_SLASH_PATTERN = QStringLiteral("/"
                                                            "(?!\\s)"
                                                            "([^/\\n]+?)"
                                                            "(?<!\\s)"
-                                                           "/"
-                                                           "(?=$|[\\s\\n])");
+                                                           "/");
 
-static const QString DOUBLE_SIGN_PATTERN = QStringLiteral("(?<=^|[\\s\\n])"
-                                                          "[%1]{2}"
+static const QString DOUBLE_SIGN_PATTERN = QStringLiteral("[%1]{2}"
                                                           "(?!\\s)"
                                                           "([^\\n]+?)"
                                                           "(?<!\\s)"
-                                                          "[%1]{2}"
-                                                          "(?=$|[\\s\\n])");
+                                                          "[%1]{2}");
 
-static const QString MULTILINE_CODE = QStringLiteral("(?<=^|[\\s\\n])"
-                                                     "```"
+static const QString MULTILINE_CODE = QStringLiteral("```"
                                                      "(?!`)"
                                                      "((.|\\n)+?)"
                                                      "(?<!`)"
-                                                     "```"
-                                                     "(?=$|[\\s\\n])");
+                                                     "```");
 
 #define REGEXP_WRAPPER_PAIR(pattern, wrapper)\
 {QRegularExpression(pattern,QRegularExpression::UseUnicodePropertiesOption),QStringLiteral(wrapper)}
 
 static const QPair<QRegularExpression, QString> REGEX_TO_WRAPPER[] {
     REGEXP_WRAPPER_PAIR(SINGLE_SLASH_PATTERN, "<i>%1</i>"),
-    REGEXP_WRAPPER_PAIR(SINGLE_SIGN_PATTERN.arg('*'), "<b>%1</b>"),
-    REGEXP_WRAPPER_PAIR(SINGLE_SIGN_PATTERN.arg('_'), "<u>%1</u>"),
-    REGEXP_WRAPPER_PAIR(SINGLE_SIGN_PATTERN.arg('~'), "<s>%1</s>"),
-    REGEXP_WRAPPER_PAIR(SINGLE_SIGN_PATTERN.arg('`'), "<font color=#595959><code>%1</code></font>"),
     REGEXP_WRAPPER_PAIR(DOUBLE_SIGN_PATTERN.arg('*'), "<b>%1</b>"),
     REGEXP_WRAPPER_PAIR(DOUBLE_SIGN_PATTERN.arg('/'), "<i>%1</i>"),
     REGEXP_WRAPPER_PAIR(DOUBLE_SIGN_PATTERN.arg('_'), "<u>%1</u>"),
     REGEXP_WRAPPER_PAIR(DOUBLE_SIGN_PATTERN.arg('~'), "<s>%1</s>"),
+    REGEXP_WRAPPER_PAIR(SINGLE_SIGN_PATTERN.arg('*'), "<b>%1</b>"),
+    REGEXP_WRAPPER_PAIR(SINGLE_SIGN_PATTERN.arg('_'), "<u>%1</u>"),
+    REGEXP_WRAPPER_PAIR(SINGLE_SIGN_PATTERN.arg('~'), "<s>%1</s>"),
+    REGEXP_WRAPPER_PAIR(SINGLE_SIGN_PATTERN.arg('`'), "<font color=#595959><code>%1</code></font>"),
     REGEXP_WRAPPER_PAIR(MULTILINE_CODE, "<font color=#595959><code>%1</code></font>"),
 };
 

--- a/src/widget/emoticonswidget.cpp
+++ b/src/widget/emoticonswidget.cpp
@@ -131,7 +131,7 @@ void EmoticonsWidget::onSmileyClicked()
     if (sender) {
         QString sequence =
             sender->property("sequence").toString().replace("&lt;", "<").replace("&gt;", ">");
-        emit insertEmoticon(' ' + sequence + ' ');
+        emit insertEmoticon(sequence);
     }
 }
 

--- a/test/chatlog/textformatter_test.cpp
+++ b/test/chatlog/textformatter_test.cpp
@@ -99,6 +99,13 @@ static const QVector<StringPair> COMMON_WORK_CASES {
     PAIR_FORMAT("%1a%1", "%2%1a%1%3"),
     PAIR_FORMAT("%1aa%1", "%2%1aa%1%3"),
     PAIR_FORMAT("%1aaa%1", "%2%1aaa%1%3"),
+	PAIR_FORMAT("a%1aa%1a", "a%2%1aa%1%3a"),
+	PAIR_FORMAT("%1aa%1a", "%2%1aa%1%3a"),
+	PAIR_FORMAT("a%1aa%1", "a%2%1aa%1%3"),
+	PAIR_FORMAT("a %1aa%1a", "a %2%1aa%1%3a"),
+	PAIR_FORMAT("a%1aa%1 a", "a%2%1aa%1%3 a"),
+	PAIR_FORMAT("a\n%1aa%1a", "a\n%2%1aa%1%3a"),
+	PAIR_FORMAT("a%1aa%1\na", "a%2%1aa%1%3\na"),
     // Must allow same formatting more than one time
     PAIR_FORMAT("%1aaa%1 %1aaa%1", "%2%1aaa%1%3 %2%1aaa%1%3"),
 };
@@ -140,10 +147,6 @@ static const QVector<StringPair> MULTI_SIGN_WORK_CASES {
 static const QVector<QString> COMMON_EXCEPTIONS {
     // No empty formatting string
     QStringLiteral("%1%1"),
-    // Formatting string must be enclosed by whitespace symbols, newlines or message start/end
-    QStringLiteral("a%1aa%1a"), QStringLiteral("%1aa%1a"), QStringLiteral("a%1aa%1"),
-    QStringLiteral("a %1aa%1a"), QStringLiteral("a%1aa%1 a"),
-    QStringLiteral("a\n%1aa%1a"), QStringLiteral("a%1aa%1\na"),
 };
 
 static const QVector<QString> SINGLE_AND_DOUBLE_SIGN_EXCEPTIONS {
@@ -363,7 +366,8 @@ void TestTextFormatter::commonWorkCasesHideSymbols()
 
 static QString singleSignWorkCasesProcessInput(const QString& str, const MarkdownToTags& mtt)
 {
-    return str.arg(mtt.markdownSequence);
+	const StringPair& tags = mtt.htmlTags;
+    return str.arg(mtt.markdownSequence).arg(tags.first).arg(tags.second);
 }
 
 static QString singleSignWorkCasesProcessOutput(const QString& str,


### PR DESCRIPTION
NOTE: this PR is on top of https://github.com/qTox/qTox/pull/4940.

After https://github.com/qTox/qTox/pull/4940, adding formatting characters next to emoji no longer affects parsing. Because there's no longer a technical restriction on markdown characters next to other characters, and the discussion from https://github.com/qTox/qTox/issues/3047 seemed to lean towards it not being an intentional UX choice, I've enabled markdown next to other characters.
Before :(
![image](https://user-images.githubusercontent.com/10469203/35660831-6036806c-06c3-11e8-8bb0-238a42f81c4f.png)
After :)
![image](https://user-images.githubusercontent.com/10469203/35660844-691f33ea-06c3-11e8-94d3-ddd4fc94a4ea.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4941)
<!-- Reviewable:end -->
