### PR TITLE
fix(chatform): Broaden URL matching to any string following scheme

### DIFF
--- a/src/chatlog/chatmessage.cpp
+++ b/src/chatlog/chatmessage.cpp
@@ -56,7 +56,7 @@ ChatMessage::Ptr ChatMessage::createChatMessage(const QString& sender, const QSt
 
     // quotes (green text)
     text = detectQuotes(text, type);
-    text = highlightURL(text);
+    text = highlightURI(text);
 
     // text styling
     Settings::StyleType styleType = Settings::getInstance().getStylePreference();

--- a/src/chatlog/textformatter.h
+++ b/src/chatlog/textformatter.h
@@ -22,7 +22,7 @@
 
 #include <QString>
 
-QString highlightURL(const QString& message);
+QString highlightURI(const QString& message);
 
 QString applyMarkdown(const QString& message, bool showFormattingSymbols);
 

--- a/test/chatlog/textformatter_test.cpp
+++ b/test/chatlog/textformatter_test.cpp
@@ -168,11 +168,12 @@ static const QVector<StringPair> MIXED_FORMATTING_SPECIAL_CASES {
 };
 
 #define MAKE_LINK(url) "<a href=\"" url "\">" url "</a>"
+#define MAKE_WWW_LINK(url) "<a href=\"http://" url "\">" url "</a>"
 
 static const QVector<QPair<QString, QString>> URL_CASES {
     PAIR_FORMAT("https://github.com/qTox/qTox/issues/4233",
                 MAKE_LINK("https://github.com/qTox/qTox/issues/4233")),
-    PAIR_FORMAT("www.youtube.com", MAKE_LINK("www.youtube.com")),
+    PAIR_FORMAT("www.youtube.com", MAKE_WWW_LINK("www.youtube.com")),
     PAIR_FORMAT("https://url.com/some*url/some*more*url/",
                 MAKE_LINK("https://url.com/some*url/some*more*url/")),
     PAIR_FORMAT("https://url.com/some_url/some_more_url/",
@@ -191,7 +192,7 @@ static const QVector<QPair<QString, QString>> URL_CASES {
                 "www.site.com/part1/part2",
                 MAKE_LINK("http://site.com/part1/part2") " "
                 MAKE_LINK("http://site.com/part3") " and one more time "
-                MAKE_LINK("www.site.com/part1/part2")),
+                MAKE_WWW_LINK("www.site.com/part1/part2")),
     PAIR_FORMAT("https://127.0.0.1/asd\n"
                 "https://ABCD:EF01:2345:6789:ABCD:EF01:2345:6789/\n"
                 "ftp://2001:DB8::8:800:200C:417A/\n"
@@ -213,6 +214,26 @@ static const QVector<QPair<QString, QString>> URL_CASES {
                 MAKE_LINK("http://[::1]:22/") " "
                 MAKE_LINK("http://[::]:20/") " "
                 ),
+    // Test case from issue #4853 (include unicode, ending brackets that are part of URL)
+    PAIR_FORMAT("https://ja.wikipedia.org/wiki/印章",
+                MAKE_LINK("https://ja.wikipedia.org/wiki/印章")),
+    PAIR_FORMAT("https://en.wikipedia.org/wiki/Seal_(East_Asia)",
+                MAKE_LINK("https://en.wikipedia.org/wiki/Seal_(East_Asia)")),
+    // Test cases from issue #4295 (exclude surrounding quotes, brackets, ending punctuation)
+    PAIR_FORMAT("(http://www.google.com)",
+                "(" MAKE_LINK("http://www.google.com") ")"),
+    PAIR_FORMAT("&quot;http://www.google.com&quot;",
+                "&quot;" MAKE_LINK("http://www.google.com") "&quot;"),
+    PAIR_FORMAT("http://www.google.com.",
+                MAKE_LINK("http://www.google.com") "."),
+    PAIR_FORMAT("http://www.google.com,",
+                MAKE_LINK("http://www.google.com") ","),
+    PAIR_FORMAT("http://www.google.com?",
+                MAKE_LINK("http://www.google.com") "?"),
+    PAIR_FORMAT("https://google.com?gfe_rd=cr",
+                MAKE_LINK("https://google.com?gfe_rd=cr")),
+    PAIR_FORMAT("[&quot;https://en.wikipedia.org/wiki/Seal_(East_Asia)&quot;]?",
+                "[&quot;" MAKE_LINK("https://en.wikipedia.org/wiki/Seal_(East_Asia)") "&quot;]?")
 };
 
 #undef PAIR_FORMAT
@@ -325,7 +346,7 @@ private slots:
     void urlTest();
 private:
     const MarkdownFunction markdownFunction = applyMarkdown;
-    UrlHighlightFunction urlHighlightFunction = highlightURL;
+    UrlHighlightFunction urlHighlightFunction = highlightURI;
 };
 
 static QString commonWorkCasesProcessInput(const QString& str, const MarkdownToTags& mtt)


### PR DESCRIPTION
Fix #4853

Instead of searching strictly valid URLs, allow anything characters following scheme. This allows for UTF-8 characters used in other lanagues, as well as parentheses and other ASCII encoding. This will over-match some invalid URLs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4951)
<!-- Reviewable:end -->
