### PR TITLE
fix(build): move Appdata file installation to /usr/share/metainfo

### DIFF
--- a/cmake/Installation.cmake
+++ b/cmake/Installation.cmake
@@ -33,7 +33,7 @@ if(APPLE)
   )
 else()
   install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION "bin")
-  install(FILES "res/qTox.appdata.xml" DESTINATION "share/appdata")
+  install(FILES "res/qTox.appdata.xml" DESTINATION "share/metainfo")
   install(FILES "qtox.desktop" DESTINATION "share/applications")
 
   # Install application icons according to the XDG spec


### PR DESCRIPTION
According to the Appstream specifications, Appdata files must now be installed in /usr/share/metainfo. /usr/share/appdata is a legacy path.

See: https://www.freedesktop.org/software/appstream/docs/sect-Metadata-Application.html
and: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4958)
<!-- Reviewable:end -->
