### PR TITLE
fix(widget): Fix status pic alignment

### DIFF
--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -377,7 +377,7 @@ void FriendWidget::updateStatusLight()
         Widget::getInstance()->updateFriendActivity(frnd);
     }
 
-    statusPic.setMargin(event ? 0 : 3);
+    statusPic.setMargin(event ? 1 : 3);
 }
 
 QString FriendWidget::getStatusString() const

--- a/src/widget/groupwidget.cpp
+++ b/src/widget/groupwidget.cpp
@@ -183,7 +183,7 @@ void GroupWidget::updateStatusLight()
         statusPic.setMargin(3);
     } else {
         statusPic.setPixmap(QPixmap(":img/status/online_notification.svg"));
-        statusPic.setMargin(0);
+        statusPic.setMargin(1);
     }
 }
 


### PR DESCRIPTION
The notification icon was 1px offset to the right of being centered with the normal status icons.
before:
![before](https://user-images.githubusercontent.com/10469203/36467456-b35d77c0-1693-11e8-987b-98b8d1d74ae9.png)
after:
![after](https://user-images.githubusercontent.com/10469203/36467507-e8b2b778-1693-11e8-84f1-2242c97505db.png)
This doesn't use CSS which would scale better with increasing numbers of status i.e. for calls/video calls in the future, and probably would be better design, but just doing this for now as a minimal change. Sorry @tox-user :(

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4965)
<!-- Reviewable:end -->
