### PR TITLE
Fix crash on friend remove

### DIFF
--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -195,7 +195,8 @@ void FriendWidget::onContextMenuCalled(QContextMenuEvent* event)
     if (!contentDialog || !contentDialog->hasFriendWidget(friendId, this)) {
         const auto removeAction = menu.addAction(
                     tr("Remove friend", "Menu to remove the friend from our friendlist"));
-        connect(removeAction, &QAction::triggered, [=]() { emit removeFriend(friendId); });
+        connect(removeAction, &QAction::triggered, this, [=]() { emit removeFriend(friendId); },
+            Qt::QueuedConnection);
     }
 
     menu.addSeparator();


### PR DESCRIPTION
Fix #4966

Since 'removeAction' can remove friend (who would have thought?) it must be
connectd queued to avoid use after free.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4967)
<!-- Reviewable:end -->
