### PR TITLE
Update INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -403,7 +403,8 @@ sudo apt-get install \
     libxss-dev \
     qrencode \
     qt5-default \
-    qttools5-dev-tools
+    qttools5-dev-tools \
+    qttools5-dev
 ```
 
 ### toxcore dependencies


### PR DESCRIPTION
docs : add qttools5-dev to the dependencies list for Ubuntu

qttools5-dev is required to build properly qTox on Ubuntu. `Fix #4963`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4968)
<!-- Reviewable:end -->
