### PR TITLE
Refactor name/alias changes

### DIFF
--- a/src/model/friend.cpp
+++ b/src/model/friend.cpp
@@ -39,6 +39,10 @@ Friend::Friend(uint32_t friendId, const ToxPk& friendPk, const QString& userAlia
     }
 }
 
+/**
+ * @brief Friend::setName sets a new username for the friend
+ * @param _name new username, sets the public key if _name is empty
+ */
 void Friend::setName(const QString& _name)
 {
     QString name = _name;
@@ -46,17 +50,36 @@ void Friend::setName(const QString& _name)
         name = friendPk.toString();
     }
 
+    // save old displayed name to be able to compare for changes
+    const auto oldDisplayed = getDisplayedName();
     if (userName != name) {
         userName = name;
         emit nameChanged(friendId, name);
     }
-}
 
+    const auto newDisplayed = getDisplayedName();
+    if (oldDisplayed != newDisplayed) {
+        emit displayedNameChanged(newDisplayed);
+    }
+}
+/**
+ * @brief Friend::setAlias sets the alias for the friend
+ * @param alias new alias, removes it if set to an empty string
+ */
 void Friend::setAlias(const QString& alias)
 {
-    if (userAlias != alias) {
-        userAlias = alias;
-        emit aliasChanged(friendId, alias);
+    if (userAlias == alias) {
+        return;
+    }
+    emit aliasChanged(friendId, alias);
+
+    // save old displayed name to be able to compare for changes
+    const auto oldDisplayed = getDisplayedName();
+    userAlias = alias;
+
+    const auto newDisplayed = getDisplayedName();
+    if (oldDisplayed != newDisplayed) {
+        emit displayedNameChanged(newDisplayed);
     }
 }
 
@@ -73,6 +96,12 @@ QString Friend::getStatusMessage() const
     return statusMessage;
 }
 
+/**
+ * @brief Friend::getDisplayedName Gets the name that should be displayed for a user
+ * @return a QString containing either alias, username or public key
+ * @note This function and corresponding signal should be preferred over getting
+ *       the name or alias directly.
+ */
 QString Friend::getDisplayedName() const
 {
     if (userAlias.isEmpty()) {

--- a/src/model/friend.h
+++ b/src/model/friend.h
@@ -52,6 +52,7 @@ public:
     Status getStatus() const;
 
 signals:
+    void displayedNameChanged(const QString& newName);
     void nameChanged(uint32_t friendId, const QString& name);
     void aliasChanged(uint32_t friendId, QString alias);
     void statusChanged(uint32_t friendId, Status status);

--- a/src/model/group.cpp
+++ b/src/model/group.cpp
@@ -52,7 +52,8 @@ void Group::updatePeer(int peerId, QString name)
     toxids[peerPk] = name;
 
     Friend* f = FriendList::findFriend(peerKey);
-    if (f != nullptr && f->hasAlias()) {
+    if (f != nullptr) {
+        // use the displayed name from the friends list
         peers[peerId] = f->getDisplayedName();
         toxids[peerPk] = f->getDisplayedName();
     } else {

--- a/src/widget/contentdialog.cpp
+++ b/src/widget/contentdialog.cpp
@@ -167,6 +167,7 @@ FriendWidget* ContentDialog::addFriend(const Friend* frnd, GenericChatForm* form
     friendLayout->addFriendWidget(friendWidget, frnd->getStatus());
     friendChatForms[friendId] = form;
 
+    // TODO(sudden6): move this connection to the Friend::displayedNameChanged signal
     connect(frnd, &Friend::aliasChanged, this, &ContentDialog::updateFriendWidget);
     connect(friendWidget, &FriendWidget::chatroomWidgetClicked, this, &ContentDialog::activate);
     connect(friendWidget, &FriendWidget::newWindowOpened, this, &ContentDialog::openNewDialog);
@@ -745,7 +746,6 @@ void ContentDialog::updateFriendWidget(uint32_t friendId, QString alias)
     Friend* f = FriendList::findFriend(friendId);
     GenericChatroomWidget* widget = std::get<1>(friendList.find(friendId).value());
     FriendWidget* friendWidget = static_cast<FriendWidget*>(widget);
-    friendWidget->setName(alias);
 
     Status status = f->getStatus();
     friendLayout->addFriendWidget(friendWidget, status);

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -195,6 +195,9 @@ ChatForm::ChatForm(Friend* chatFriend, History* history)
         isTyping = false;
     });
 
+    // reflect name changes in the header
+    // TODO(sudden6): check if this creates a cycle when the alias is changed
+    connect(f, &Friend::displayedNameChanged, this, &ChatForm::setName);
     connect(headWidget, &ChatFormHeader::nameChanged, this, [=](const QString& newName) {
         f->setAlias(newName);
     });

--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -70,9 +70,12 @@ FriendWidget::FriendWidget(const Friend* f, bool compact)
     avatar->setPixmap(QPixmap(":/img/contact.svg"));
     statusPic.setPixmap(QPixmap(":/img/status/offline.svg"));
     statusPic.setMargin(3);
-    nameLabel->setText(f->getDisplayedName());
+    setName(f->getDisplayedName());
     nameLabel->setTextFormat(Qt::PlainText);
-    connect(nameLabel, &CroppingLabel::editFinished, this, &FriendWidget::setAlias);
+    // update on changes of the displayed name
+    connect(f, &Friend::displayedNameChanged, this, &FriendWidget::setName);
+    // update alias when edited
+    connect(nameLabel, &CroppingLabel::editFinished, f, &Friend::setAlias);
     statusMessageLabel->setTextFormat(Qt::PlainText);
 }
 
@@ -465,12 +468,4 @@ void FriendWidget::mouseMoveEvent(QMouseEvent* ev)
         drag->setPixmap(avatar->getPixmap());
         drag->exec(Qt::CopyAction | Qt::MoveAction);
     }
-}
-
-void FriendWidget::setAlias(const QString& _alias)
-{
-    QString alias = _alias.left(tox_max_name_length());
-    // Hack to avoid edit const Friend. TODO: Repalce on emit
-    Friend* f = FriendList::findFriend(frnd->getId());
-    f->setAlias(alias);
 }

--- a/src/widget/friendwidget.h
+++ b/src/widget/friendwidget.h
@@ -47,7 +47,6 @@ signals:
 public slots:
     void onAvatarChange(uint32_t friendId, const QPixmap& pic);
     void onAvatarRemoved(uint32_t friendId);
-    void setAlias(const QString& alias);
     void onContextMenuCalled(QContextMenuEvent* event);
 
 protected:

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -157,6 +157,7 @@ public slots:
     void addFriendFailed(const ToxPk& userId, const QString& errorInfo = QString());
     void onFriendStatusChanged(int friendId, Status status);
     void onFriendStatusMessageChanged(int friendId, const QString& message);
+    void onFriendDisplayedNameChanged(const QString& displayed);
     void onFriendUsernameChanged(int friendId, const QString& username);
     void onFriendAliasChanged(uint32_t friendId, const QString& alias);
     void onFriendMessageReceived(int friendId, const QString& message, bool isAction);


### PR DESCRIPTION
depends on #4964

This should make updates to the username/alias a lot more safe. All widgets displaying the username/alias are now responsible for connecting to the correct signals themselves.

@Diadlo can you take a look if this doesn't conflict with the ideas from The Plan™?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4970)
<!-- Reviewable:end -->
