### PR TITLE
fix(offlinemsg): make faux offline messages purely event based

### DIFF
--- a/src/persistence/offlinemsgengine.h
+++ b/src/persistence/offlinemsgengine.h
@@ -28,22 +28,19 @@
 #include <QSet>
 
 class Friend;
-class QTimer;
 
 class OfflineMsgEngine : public QObject
 {
     Q_OBJECT
 public:
     explicit OfflineMsgEngine(Friend*);
-    virtual ~OfflineMsgEngine();
-    static QMutex globalMutex;
+    virtual ~OfflineMsgEngine() = default;
 
     void dischargeReceipt(int receipt);
-    void registerReceipt(int receipt, int64_t messageID, ChatMessage::Ptr msg,
-                         const QDateTime& timestamp = QDateTime::currentDateTime());
+    void registerReceipt(int receipt, int64_t messageID, ChatMessage::Ptr msg);
+    void deliverOfflineMsgs();
 
 public slots:
-    void deliverOfflineMsgs();
     void removeAllReceipts();
     void updateTimestamp(int receiptId);
 
@@ -59,7 +56,6 @@ private:
     struct MsgPtr
     {
         ChatMessage::Ptr msg;
-        QDateTime timestamp;
         int receipt;
     };
     QMutex mutex;

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -64,7 +64,6 @@
  */
 
 static const int CHAT_WIDGET_MIN_HEIGHT = 50;
-static const int DELIVER_OFFLINE_MESSAGES_DELAY = 250;
 static const int SCREENSHOT_GRABBER_OPENING_DELAY = 500;
 static const int TYPING_NOTIFICATION_DURATION = 3000;
 
@@ -559,7 +558,7 @@ void ChatForm::onFriendStatusChanged(uint32_t friendId, Status status)
         // Hide the "is typing" message when a friend goes offline
         setFriendTyping(false);
     } else {
-        QTimer::singleShot(DELIVER_OFFLINE_MESSAGES_DELAY, this, SLOT(onDeliverOfflineMessages()));
+        offlineEngine->deliverOfflineMsgs();
     }
 
     updateCallButtons();
@@ -693,11 +692,6 @@ void ChatForm::clearChatArea(bool notInForm)
 {
     GenericChatForm::clearChatArea(notInForm);
     offlineEngine->removeAllReceipts();
-}
-
-void ChatForm::onDeliverOfflineMessages()
-{
-    offlineEngine->deliverOfflineMsgs();
 }
 
 void ChatForm::onLoadChatHistory()

--- a/src/widget/form/chatform.h
+++ b/src/widget/form/chatform.h
@@ -82,7 +82,6 @@ private slots:
     void onAttachClicked() override;
     void onScreenshotClicked() override;
 
-    void onDeliverOfflineMessages();
     void onLoadChatHistory();
     void onTextEditChanged();
     void onCallTriggered();

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -112,9 +112,6 @@ void Widget::init()
 
     timer = new QTimer();
     timer->start(1000);
-    offlineMsgTimer = new QTimer();
-    // FIXME: ↓ make a proper fix instead of increasing timeout into ∞
-    offlineMsgTimer->start(2 * 60 * 1000);
 
     icon_size = 15;
 
@@ -259,7 +256,6 @@ void Widget::init()
     connect(timer, &QTimer::timeout, this, &Widget::onUserAwayCheck);
     connect(timer, &QTimer::timeout, this, &Widget::onEventIconTick);
     connect(timer, &QTimer::timeout, this, &Widget::onTryCreateTrayIcon);
-    connect(offlineMsgTimer, &QTimer::timeout, this, &Widget::processOfflineMsgs);
     connect(ui->searchContactText, &QLineEdit::textChanged, this, &Widget::searchContacts);
     connect(filterGroup, &QActionGroup::triggered, this, &Widget::searchContacts);
     connect(filterDisplayGroup, &QActionGroup::triggered, this, &Widget::changeDisplayMode);
@@ -537,7 +533,6 @@ Widget::~Widget()
     delete groupInviteForm;
     delete filesForm;
     delete timer;
-    delete offlineMsgTimer;
     delete contentLayout;
 
     FriendList::clear();
@@ -2177,18 +2172,6 @@ bool Widget::filterOnline(FilterCriteria index)
         return true;
     default:
         return false;
-    }
-}
-
-void Widget::processOfflineMsgs()
-{
-    if (OfflineMsgEngine::globalMutex.tryLock()) {
-        QList<Friend*> frnds = FriendList::getAllFriends();
-        for (Friend* f : frnds) {
-            chatForms[f->getId()]->getOfflineMsgEngine()->deliverOfflineMsgs();
-        }
-
-        OfflineMsgEngine::globalMutex.unlock();
     }
 }
 

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -212,7 +212,6 @@ private slots:
     void onTryCreateTrayIcon();
     void onSetShowSystemTray(bool newValue);
     void onSplitterMoved(int pos, int index);
-    void processOfflineMsgs();
     void friendListContextMenu(const QPoint& pos);
     void friendRequestsUpdate();
     void groupInvitesUpdate();
@@ -293,7 +292,7 @@ private:
     MaskablePixmapWidget* profilePicture;
     bool notify(QObject* receiver, QEvent* event);
     bool autoAwayActive = false;
-    QTimer *timer, *offlineMsgTimer;
+    QTimer *timer;
     QRegExp nameMention, sanitizedNameMention;
     bool eventFlag;
     bool eventIcon;


### PR DESCRIPTION
Offline messages are now sent as soon as we see our friend come online, and at no other time. Fixes 2 minute wait time before attempting to send if message is entered while you or friend is offline, removes 2 minute constant retry timer, removes 250ms delay between seeing friend come online and sending offline messages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/4975)
<!-- Reviewable:end -->
