### PR TITLE
docs(maint): Change patch release commit strategy to reduce duplication

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -199,10 +199,11 @@ Follow steps for adding translations from Weblate up to step 5. Next:
 - Generate changelog with `clog`.
   - In a `MAJOR`/`MINOR` release tag should include information that changelog
     is located in the `CHANGELOG.md` file, e.g. `For details see CHANGELOG.md`
-- To release a `PATCH` version after non-fix changes have landed on `master`
-  branch, checkout latest `MAJOR`/`MINOR` version and `git cherry-pick -x`
-  commits from `master` that you want `PATCH` release to include. Once
-  cherry-picking has been done, tag HEAD of the branch.
+- To release a `PATCH` version, checkout the latest `MAJOR`/`MINOR`/`PATCH` release tag
+  and merge or commit the changes that you want the `PATCH` release to include. Once the
+  required changes have been made, tag HEAD of the branch, then merge back to master `HEAD`
+    - If the required changes have already landed on `master` branch, checkout latest
+      `MAJOR`/`MINOR`/`PATCH` version and `git cherry-pick -x` the required commits from `master`.
   - When making a `PATCH` tag, include in tag message short summary of what the
     tag release fixes, and to whom it's interesting (often only some
     OSes/distributions would find given `PATCH` release interesting).


### PR DESCRIPTION
Prefer committing patch commits on previous patch and merging up to master head, instead of previously committing on master and cherry picking required changes back to patch head, duplicating each commit in history.

before, with commits duplicated and cherry picked back from master to make a patch release:
![before](https://user-images.githubusercontent.com/10469203/37503474-ecd55f54-2895-11e8-94b4-6d68f7c60593.png)
after this change, with commits made on patch and merged up to master:
![after](https://user-images.githubusercontent.com/10469203/37503480-f0f99ad2-2895-11e8-80ff-7df2719feb1c.png)

I'm not very proficient with git, so let me know if I'm using the wrong terminology, or if this is a bad idea in general.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5009)
<!-- Reviewable:end -->
