### PR TITLE
fix: don't use invalid reference after erasing element

### DIFF
--- a/src/persistence/smileypack.cpp
+++ b/src/persistence/smileypack.cpp
@@ -127,7 +127,6 @@ void SmileyPack::cleanupIconsCache()
         std::shared_ptr<QIcon>& icon = it->second;
         if (icon.use_count() == 1) {
             it = cachedIcon.erase(it);
-            icon.reset();
         } else {
             ++it;
         }


### PR DESCRIPTION
Fix #5002

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5010)
<!-- Reviewable:end -->
