### PR TITLE
fix(name): Clear alias on name change so that name changes are visible

### DIFF
--- a/src/model/friend.cpp
+++ b/src/model/friend.cpp
@@ -52,6 +52,11 @@ void Friend::setName(const QString& _name)
 
     // save old displayed name to be able to compare for changes
     const auto oldDisplayed = getDisplayedName();
+    if (userName == userAlias) {
+        userAlias.clear(); // Because userAlias was set on name change before (issue #5013)
+                           // we clear alias if equal to old name so that name change is visible.
+                           // TODO: We should not modify alias on setName.
+    }
     if (userName != name) {
         userName = name;
         emit nameChanged(friendId, name);


### PR DESCRIPTION
Temporary work around for #5013

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5015)
<!-- Reviewable:end -->
