### PR TITLE
docs(build): Add Fedora simple install instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,6 +3,7 @@
 - [Linux](#linux)
   - [Simple install](#simple-install)
     - [Arch](#arch-easy)
+    - [Fedora](#fedora-easy)
     - [Gentoo](#gentoo-easy)
     - [Slackware](#slackware-easy)
     - [FreeBSD](#freebsd-easy)
@@ -116,6 +117,7 @@ To enable: `-DENABLE_APPINDICATOR=True`
 Easy qTox install is provided for variety of distributions:
 
 * [Arch](#arch)
+* [Fedora](#fedora)
 * [Gentoo](#gentoo)
 * [Slackware](#slackware)
 
@@ -129,6 +131,16 @@ PKGBUILD is available in the `community` repo, to install:
 
 ```bash
 pacman -S qtox
+```
+
+<a name="fedora-easy" />
+
+#### Fedora
+
+qTox is available in the [RPMFusion](https://rpmfusion.org/) repo, to install:
+
+```bash
+dnf install qtox
 ```
 
 <a name="gentoo-easy" />

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ while running on all major platforms.
 
 Windows | Linux | OS X | FreeBSD
 --------|-------|------|--------
-**[64 bit release]**| **[Arch]**, **[Gentoo]** | **[Latest release]**  | **[Package & Port]**
+**[64 bit release]**| **[Arch]**, **[Fedora]**, **[Gentoo]** | **[Latest release]**  | **[Package & Port]**
 [32 bit release]| | [Building instructions] |
 [64 bit][64nightly], [32 bit][32nightly] nigthly | [Other] | |
 
@@ -149,6 +149,7 @@ AED3 1134 9C23 A123 E5C4  AA4B 139C A045 3DA2 D773
 [Contributing]: /CONTRIBUTING.md#how-to-start-contributing
 [easy issues]: https://github.com/qTox/qTox/labels/E-easy
 [Latest release]: https://github.com/qTox/qTox/releases/latest
+[Fedora]: /INSTALL.md#fedora
 [Gentoo]: /INSTALL.md#gentoo
 [Install/Build]: /INSTALL.md
 [IRC logs]: https://github.com/qTox/qtox-irc-logs


### PR DESCRIPTION
I've packaged qTox for F27+ on the main Fedora external repo, RPMFusion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5023)
<!-- Reviewable:end -->
