### PR TITLE
fix: remove build date and time from main.cpp

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -185,8 +185,7 @@ int main(int argc, char* argv[])
 
     // Process arguments
     QCommandLineParser parser;
-    parser.setApplicationDescription("qTox, version: " + QString(GIT_VERSION) + "\nBuilt: "
-                                     + __TIME__ + " " + __DATE__);
+    parser.setApplicationDescription("qTox, version: " + QString(GIT_VERSION));
     parser.addHelpOption();
     parser.addVersionOption();
     parser.addPositionalArgument("uri", QObject::tr("Tox URI to parse"));
@@ -253,7 +252,6 @@ int main(int argc, char* argv[])
     QCoreApplication::addLibraryPath(QCoreApplication::applicationDirPath());
     a->addLibraryPath("platforms");
 
-    qDebug() << "built on: " << __TIME__ << __DATE__ << "(" << TIMESTAMP << ")";
     qDebug() << "commit: " << GIT_VERSION;
 
 


### PR DESCRIPTION
This is the first step to having reproducible builds. It should allow to make an identical build in the same environment and increase privacy when sharing logs, because the build time was not in UTC.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5028)
<!-- Reviewable:end -->
