### PR TITLE
chore: put download URL for CircleCI artifacts in the build log

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -28,6 +28,7 @@ compile:
     - mkdir -p $CIRCLE_ARTIFACTS/"$BUILD__"/
     - cp -av /home/ubuntu/qTox/workspace/"$BUILD__"/qtox/"$BTYPE__"/qtox.exe $CIRCLE_ARTIFACTS/"$BUILD__"/qtox_"$BTYPE__".exe
     - cd /home/ubuntu/qTox/workspace/"$BUILD__"/qtox/"$BTYPE__"/ ; zip -r $CIRCLE_ARTIFACTS/"$BUILD__"/qtox_"$BUILD__"_"$BTYPE__".zip *
+    - echo "Download Artifacts for this PR at https://circleci.com/api/v1/project/qTox/qTox/latest/artifacts/0/\$CIRCLE_ARTIFACTS/x86_64/qtox_x86_64_release.zip?filter=completed&branch=$CIRCLE_BRANCH"
 test:
   override:
     - "true"


### PR DESCRIPTION
branch protection didn't want to accept  #4976 so here I try again

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5029)
<!-- Reviewable:end -->
