### PR TITLE
fix(docs): update dependencies for Debian

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -278,9 +278,9 @@ sudo apt-get install \
     build-essential \
     cmake \
     ffmpeg \
+    libavcodec-dev \
     libexif-dev \
     libgdk-pixbuf2.0-dev \
-    libglib2.0-dev \
     libgtk2.0-dev \
     libopenal-dev \
     libqrencode-dev \

--- a/simple_make.sh
+++ b/simple_make.sh
@@ -14,7 +14,6 @@ apt_install() {
         libavdevice-dev
         libexif-dev
         libgdk-pixbuf2.0-dev
-        libglib2.0-dev
         libgtk2.0-dev
         libopenal-dev
         libopus-dev


### PR DESCRIPTION
Add missing libavcodec-dev and remove libglib2.0-dev, which already is a dependency of libgdk-pixbuf2.0-dev.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5031)
<!-- Reviewable:end -->
