### PR TITLE
fix(history): don't save own messages when history is disabled

### DIFF
--- a/src/persistence/history.cpp
+++ b/src/persistence/history.cpp
@@ -230,6 +230,10 @@ void History::addNewMessage(const QString& friendPk, const QString& message, con
                             const QDateTime& time, bool isSent, QString dispName,
                             const std::function<void(int64_t)>& insertIdCallback)
 {
+    if (!Settings::getInstance().getEnableLogging()) {
+        qWarning() << "Blocked a message from being added to database while history is disabled";
+        return;
+    }
     if (!isValid()) {
         return;
     }

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -984,7 +984,7 @@ void ChatForm::SendMessageStr(QString msg)
         uint32_t friendId = f->getId();
         int rec = isAction ? core->sendAction(friendId, part) : core->sendMessage(friendId, part);
 
-        if (history) {
+        if (history && Settings::getInstance().getEnableLogging()) {
             auto* offMsgEngine = getOfflineMsgEngine();
             QString selfPk = Core::getInstance()->getSelfId().toString();
             QString pk = f->getPublicKey().toString();


### PR DESCRIPTION
Fix #5036

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5038)
<!-- Reviewable:end -->
