### PR TITLE
fix(chatform): include pressed key(s) when changing focus

### DIFF
--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -311,13 +311,15 @@ void GenericChatForm::showEvent(QShowEvent*)
 bool GenericChatForm::event(QEvent* e)
 {
     // If the user accidentally starts typing outside of the msgEdit, focus it automatically
-    if (e->type() == QEvent::KeyRelease && !msgEdit->hasFocus()) {
+    if (e->type() == QEvent::KeyPress) {
         QKeyEvent* ke = static_cast<QKeyEvent*>(e);
         if ((ke->modifiers() == Qt::NoModifier || ke->modifiers() == Qt::ShiftModifier)
                 && !ke->text().isEmpty()) {
             if (searchForm->isHidden()) {
+                msgEdit->sendKeyEvent(ke);
                 msgEdit->setFocus();
             } else {
+                searchForm->insertEditor(ke->text());
                 searchForm->setFocusEditor();
             }
         }

--- a/src/widget/searchform.cpp
+++ b/src/widget/searchform.cpp
@@ -65,6 +65,11 @@ void SearchForm::setFocusEditor()
     searchLine->setFocus();
 }
 
+void SearchForm::insertEditor(const QString &text)
+{
+    searchLine->insert(text);
+}
+
 void SearchForm::showEvent(QShowEvent* event)
 {
     QWidget::showEvent(event);

--- a/src/widget/searchform.h
+++ b/src/widget/searchform.h
@@ -34,6 +34,7 @@ public:
     void removeSearchPhrase();
     QString getSearchPhrase() const;
     void setFocusEditor();
+    void insertEditor(const QString &text);
 
 protected:
     virtual void showEvent(QShowEvent* event) final override;


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5054)
<!-- Reviewable:end -->
