### PR TITLE
Automatic deployment of windows builds via TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -122,6 +122,28 @@ deploy:
       tags: true
     skip_cleanup: true
 
+  # Windows Installer 64Bit
+  - provider: releases
+    api_key:
+      secure: "BRbzTWRvadALRQSTihMKruOj64ydxusMUS9FQR//qFlS345ZYfYta43W//4LcWWDKtj6IvA6DRqNdabgWnpbpxpnm9gVftGUdOKlU3niPZhwsMkB2M12QHUnAP6DVOfGPvdciBV+6mu73SSxniEcrYjZ1CrRX7mknmehPpVKxNk="
+    file: "./workspace/x86_64/qtox/release/setup-qtox-x86_64-release.exe"
+    on:
+      condition: $WINDOWS_BUILD_ARCH_CACHE_TRICK_VARIABLE == x86_64 && -f /home/travis/build/qTox/qTox/stage3 && -f /home/travis/build/qTox/qTox/release
+      repo: qTox/qTox
+      tags: true
+    skip_cleanup: true
+
+  # Windows Installer 32Bit
+  - provider: releases
+    api_key:
+      secure: "BRbzTWRvadALRQSTihMKruOj64ydxusMUS9FQR//qFlS345ZYfYta43W//4LcWWDKtj6IvA6DRqNdabgWnpbpxpnm9gVftGUdOKlU3niPZhwsMkB2M12QHUnAP6DVOfGPvdciBV+6mu73SSxniEcrYjZ1CrRX7mknmehPpVKxNk="
+    file: "./workspace/x86_64/qtox/release/setup-qtox-i686-release.exe"
+    on:
+      condition: $WINDOWS_BUILD_ARCH_CACHE_TRICK_VARIABLE == i686 && -f /home/travis/build/qTox/qTox/stage3 && -f /home/travis/build/qTox/qTox/release
+      repo: qTox/qTox
+      tags: true
+    skip_cleanup: true
+
   # branch for windows jenkins build
   - provider: script
     script: .travis/deploy-jenkins-branch.sh

--- a/.travis/build-windows.sh
+++ b/.travis/build-windows.sh
@@ -72,6 +72,14 @@ then
   exit 1
 fi
 
+# make the build stage visible to the deploy process
+touch "$STAGE"
+
+# make the build type visible to the deploy process
+touch "$BUILD_TYPE"
+
+# for debugging of the stage files
+echo $PWD
 
 # Just make sure those exist, makes logic easier
 mkdir -p "$CACHE_DIR"


### PR DESCRIPTION
Tested previously on the `windeploy` branch and it seems to work correctly. Currently there are only release builds, if we want to add debug builds later it's as easy as removing the release condition and adding the generated files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5083)
<!-- Reviewable:end -->
