### PR TITLE
fix(ui): increase number of low res camera options

### DIFF
--- a/src/video/videomode.cpp
+++ b/src/video/videomode.cpp
@@ -69,8 +69,9 @@ uint32_t VideoMode::norm(const VideoMode& other) const
 
 uint32_t VideoMode::tolerance() const
 {
+    constexpr uint32_t minTolerance = 300; // keep wider tolerance for low res cameras
     constexpr uint32_t toleranceFactor = 10; // video mode must be within 10% to be "close enough" to ideal
-    return (width + height)/toleranceFactor;
+    return std::max((width + height)/toleranceFactor, minTolerance);
 }
 
 /**


### PR DESCRIPTION
partially revert behaviour of 04ecfe3f344c29d9c598d38aaad46f2da8a17728 to show any options that were shown before. Mentioned in comments of #5097.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5102)
<!-- Reviewable:end -->
