### PR TITLE
fix(theme): clear stylesheet cache on theme colour change

### DIFF
--- a/src/widget/style.cpp
+++ b/src/widget/style.cpp
@@ -196,6 +196,7 @@ void Style::repolish(QWidget* w)
 
 void Style::setThemeColor(int color)
 {
+    stylesheetsCache.clear(); // clear stylesheet cache which includes color info
     if (color < 0 || color >= themeColorColors.size())
         setThemeColor(QColor());
     else


### PR DESCRIPTION
Fix #5092

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5104)
<!-- Reviewable:end -->
