### PR TITLE
refactor: use ToxPk as identifier

### DIFF
--- a/src/core/toxpk.cpp
+++ b/src/core/toxpk.cpp
@@ -72,6 +72,16 @@ bool ToxPk::operator!=(const ToxPk& other) const
 }
 
 /**
+ * @brief Compares two ToxPks
+ * @param other ToxPk to compare.
+ * @return True if this ToxPks is less than the other ToxPk, false otherwise.
+ */
+bool ToxPk::operator<(const ToxPk& other) const
+{
+    return key < other.key;
+}
+
+/**
  * @brief Converts the ToxPk to a uppercase hex string.
  * @return QString containing the hex representation of the key
  */

--- a/src/core/toxpk.h
+++ b/src/core/toxpk.h
@@ -17,6 +17,7 @@ public:
 
     bool operator==(const ToxPk& other) const;
     bool operator!=(const ToxPk& other) const;
+    bool operator<(const ToxPk& other) const;
     QString toString() const;
     QByteArray getKey() const;
     const uint8_t* getBytes() const;

--- a/src/model/group.cpp
+++ b/src/model/group.cpp
@@ -32,7 +32,6 @@ Group::Group(int groupId, const QString& name, bool isAvGroupchat, const QString
     : selfName{selfName}
     , title{name}
     , groupId(groupId)
-    , nPeers{0}
     , avGroupchat{isAvGroupchat}
 {
     // in groupchats, we only notify on messages containing your name <-- dumb
@@ -46,15 +45,14 @@ Group::Group(int groupId, const QString& name, bool isAvGroupchat, const QString
 void Group::updatePeer(int peerId, QString name)
 {
     ToxPk peerKey = Core::getInstance()->getGroupPeerPk(groupId, peerId);
-    QByteArray peerPk = peerKey.getKey();
-    toxids[peerPk] = name;
+    toxpks[peerKey] = name;
 
     Friend* f = FriendList::findFriend(peerKey);
     if (f != nullptr) {
         // use the displayed name from the friends list
-        toxids[peerPk] = f->getDisplayedName();
+        toxpks[peerKey] = f->getDisplayedName();
     } else {
-        emit userListChanged(groupId, toxids);
+        emit userListChanged(groupId, toxpks);
     }
 }
 
@@ -89,34 +87,42 @@ QString Group::getDisplayedName() const
     return getName();
 }
 
+/**
+ * @brief performs a peerId to ToxPk lookup
+ * @param peerId peerId to lookup
+ * @return ToxPk if peerId found
+ * @note should not be used, reference peers by their ToxPk instead
+ * @todo remove this function
+ */
+const ToxPk Group::resolvePeerId(int peerId) const
+{
+    const Core* core = Core::getInstance();
+    return core->getGroupPeerPk(groupId, peerId);
+}
+
 void Group::regeneratePeerList()
 {
     const Core* core = Core::getInstance();
-    const ToxPk self = core->getSelfId().getPublicKey();
 
     QStringList peers = core->getGroupPeerNames(groupId);
-    toxids.clear();
-    nPeers = peers.size();
+    toxpks.clear();
+    const int nPeers = peers.size();
     for (int i = 0; i < nPeers; ++i) {
-        ToxPk id = core->getGroupPeerPk(groupId, i);
-        if (id == self) {
-            selfPeerNum = i;
-        }
+        const auto pk = core->getGroupPeerPk(groupId, i);
 
-        QByteArray peerPk = id.getKey();
-        toxids[peerPk] = peers[i];
-        if (toxids[peerPk].isEmpty()) {
-            toxids[peerPk] =
+        toxpks[pk] = peers[i];
+        if (toxpks[pk].isEmpty()) {
+            toxpks[pk] =
                 tr("<Empty>", "Placeholder when someone's name in a group chat is empty");
         }
 
-        Friend* f = FriendList::findFriend(id);
+        Friend* f = FriendList::findFriend(pk);
         if (f != nullptr && f->hasAlias()) {
-            toxids[peerPk] = f->getDisplayedName();
+            toxpks[pk] = f->getDisplayedName();
         }
     }
 
-    emit userListChanged(groupId, toxids);
+    emit userListChanged(groupId, toxpks);
 }
 
 bool Group::isAvGroupchat() const
@@ -131,17 +137,16 @@ uint32_t Group::getId() const
 
 int Group::getPeersCount() const
 {
-    return nPeers;
+    return toxpks.size();
 }
 
-QStringList Group::getPeerList() const
+/**
+ * @brief Gets the PKs and names of all peers
+ * @return PKs and names of all peers, including our own PK and name
+ */
+const QMap<ToxPk, QString>& Group::getPeerList() const
 {
-    return toxids.values();
-}
-
-bool Group::isSelfPeerNumber(int num) const
-{
-    return num == selfPeerNum;
+    return toxpks;
 }
 
 void Group::setEventFlag(bool f)
@@ -166,10 +171,9 @@ bool Group::getMentionedFlag() const
 
 QString Group::resolveToxId(const ToxPk& id) const
 {
-    QByteArray key = id.getKey();
-    auto it = toxids.find(key);
+    auto it = toxpks.find(id);
 
-    if (it != toxids.end()) {
+    if (it != toxpks.end()) {
         return *it;
     }
 

--- a/src/model/group.h
+++ b/src/model/group.h
@@ -21,13 +21,12 @@
 #define GROUP_H
 
 #include "contact.h"
+
+#include "src/core/toxpk.h"
+
 #include <QMap>
 #include <QObject>
 #include <QStringList>
-
-#define RETRY_PEER_INFO_INTERVAL 500
-
-class ToxPk;
 
 class Group : public Contact
 {
@@ -39,8 +38,7 @@ public:
     uint32_t getId() const override;
     int getPeersCount() const;
     void regeneratePeerList();
-    QStringList getPeerList() const;
-    bool isSelfPeerNumber(int peernumber) const;
+    const QMap<ToxPk, QString>& getPeerList() const;
 
     void setEventFlag(bool f) override;
     bool getEventFlag() const override;
@@ -54,23 +52,22 @@ public:
     QString getName() const;
     QString getDisplayedName() const override;
 
+    const ToxPk resolvePeerId(int peerId) const;
     QString resolveToxId(const ToxPk& id) const;
     void setSelfName(const QString& name);
 
 signals:
     void titleChangedByUser(uint32_t groupId, const QString& title);
     void titleChanged(uint32_t groupId, const QString& author, const QString& title);
-    void userListChanged(uint32_t groupId, const QMap<QByteArray, QString>& toxids);
+    void userListChanged(uint32_t groupId, const QMap<ToxPk, QString>& toxpks);
 
 private:
     QString selfName;
     QString title;
-    QMap<QByteArray, QString> toxids;
+    QMap<ToxPk, QString> toxpks;
     bool hasNewMessages;
     bool userWasMentioned;
     int groupId;
-    int nPeers;
-    int selfPeerNum = -1;
     bool avGroupchat;
 };
 

--- a/src/video/groupnetcamview.h
+++ b/src/video/groupnetcamview.h
@@ -21,6 +21,9 @@
 #define GROUPNETCAMVIEW_H
 
 #include "genericnetcamview.h"
+
+#include "src/core/toxpk.h"
+
 #include <QMap>
 
 class LabeledVideo;
@@ -31,15 +34,12 @@ class GroupNetCamView : public GenericNetCamView
 public:
     GroupNetCamView(int group, QWidget* parent = 0);
     void clearPeers();
-    void addPeer(int peer, const QString& name);
-    void removePeer(int peer);
-
-public slots:
-    void groupAudioPlayed(int group, int peer, unsigned short volume);
+    void addPeer(const ToxPk& peer, const QString& name);
+    void removePeer(const ToxPk& peer);
 
 private slots:
     void onUpdateActivePeer();
-    void friendAvatarChanged(int FriendId, const QPixmap& pixmap);
+    void friendAvatarChanged(int friendId, const QPixmap& pixmap);
 
 private:
     struct PeerVideo
@@ -47,10 +47,10 @@ private:
         LabeledVideo* video;
     };
 
-    void setActive(int peer = -1);
+    void setActive(const ToxPk& peer = ToxPk{});
 
     QHBoxLayout* horLayout;
-    QMap<int, PeerVideo> videoList;
+    QMap<ToxPk, PeerVideo> videoList;
     LabeledVideo* videoLabelSurface;
     LabeledVideo* selfVideoSurface;
     int activePeer;

--- a/src/widget/form/groupchatform.h
+++ b/src/widget/form/groupchatform.h
@@ -21,6 +21,7 @@
 #define GROUPCHATFORM_H
 
 #include "genericchatform.h"
+#include "src/core/toxpk.h"
 #include <QMap>
 
 namespace Ui {
@@ -38,7 +39,7 @@ public:
     explicit GroupChatForm(Group* chatGroup);
     ~GroupChatForm();
 
-    void peerAudioPlaying(int peer);
+    void peerAudioPlaying(ToxPk peerPk);
 
 private slots:
     void onSendTriggered() override;
@@ -67,8 +68,8 @@ private:
 
 private:
     Group* group;
-    QVector<QLabel*> peerLabels;
-    QMap<int, QTimer*> peerAudioTimers;
+    QMap<ToxPk, QLabel*> peerLabels;
+    QMap<ToxPk, QTimer*> peerAudioTimers;
     FlowLayout* namesListLayout;
     QLabel* nusersLabel;
     TabCompleter* tabber;

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1835,7 +1835,8 @@ void Widget::onGroupPeerAudioPlaying(int groupnumber, int peernumber)
     }
 
     auto form = groupChatForms[g->getId()];
-    form->peerAudioPlaying(peernumber);
+    // TODO(sudden6): switch to ToxPk here
+    form->peerAudioPlaying(g->resolvePeerId(peernumber));
 }
 
 void Widget::removeGroup(Group* g, bool fake)


### PR DESCRIPTION
fixes #5116 and #5117

This started as a fix, but then "escalated" a bit. As I already told some of you, I want to replace all these friend/group/peerIds with something better and more persistent. For friendId and peerId the obvious replacement is `ToxPk`, for groupId I haven't found something good yet, but maybe the group key once persistent groups are merged.

In this PR I wanted to move a small part of qTox over to this idea, so there are some changes that are maybe unrelated to each other, but to make working easier I kept it in one commit. If we agree on this design, I can split it up afterwards for proper review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5120)
<!-- Reviewable:end -->
