### PR TITLE
fix(audio): close the audio device after playing a sound

### DIFF
--- a/src/audio/backend/openal.cpp
+++ b/src/audio/backend/openal.cpp
@@ -521,6 +521,10 @@ void OpenAL::playMono16SoundCleanup()
         alSourcei(alMainSource, AL_BUFFER, AL_NONE);
         alDeleteBuffers(1, &alMainBuffer);
         alMainBuffer = 0;
+        // close the audio device if no other sources active
+        if (peerSources.isEmpty()) {
+            cleanupOutput();
+        }
     } else {
         // the audio didn't finish, try again later
         playMono16Timer.start(10);


### PR DESCRIPTION
This bug was uncovered by 65896e45017f8f748bc5b9db10a4400d7fd418dc
because this sound now happenes after the call is closed, but doesn't
close the audio device.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5122)
<!-- Reviewable:end -->
