### PR TITLE
Fix desktop file name in Qt properties.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -161,6 +161,9 @@ int main(int argc, char* argv[])
 #endif
 
     a->setApplicationName("qTox");
+#if QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
+    a->setDesktopFileName("io.github.qtox.qTox");
+#endif
     a->setOrganizationName("Tox");
     a->setApplicationVersion("\nGit commit: " + QString(GIT_VERSION));
 


### PR DESCRIPTION
- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)
Fixes issue #5141

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5142)
<!-- Reviewable:end -->
