### PR TITLE
fix(chatform): check for empty path when exporting profile

### DIFF
--- a/src/chatlog/content/filetransferwidget.cpp
+++ b/src/chatlog/content/filetransferwidget.cpp
@@ -507,8 +507,7 @@ void FileTransferWidget::handleButton(QPushButton* btn)
                 QFileDialog::getSaveFileName(Q_NULLPTR,
                                              tr("Save a file", "Title of the file saving dialog"),
                                              Settings::getInstance().getGlobalAutoAcceptDir() + "/"
-                                                 + fileInfo.fileName,
-                                             0, 0);
+                                                 + fileInfo.fileName);
             acceptTransfer(path);
         }
     }

--- a/src/widget/form/addfriendform.cpp
+++ b/src/widget/form/addfriendform.cpp
@@ -231,7 +231,7 @@ static inline bool checkIsValidId(const QString& id)
 
 void AddFriendForm::onImportOpenClicked()
 {
-    const QString path = QFileDialog::getOpenFileName(tabWidget, tr("Open contact list"));
+    const QString path = QFileDialog::getOpenFileName(Q_NULLPTR, tr("Open contact list"));
     if (path.isEmpty()) {
         return;
     }

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -1067,8 +1067,7 @@ void ChatForm::onExportChat()
     QDateTime now = QDateTime::currentDateTime();
     QList<History::HistMessage> msgs = history->getChatHistoryFromDate(pk, epochStart, now);
 
-    QString path = QFileDialog::getSaveFileName(0, tr("Save chat log"), QString{}, QString{}, 0,
-                                                QFileDialog::DontUseNativeDialog);
+    QString path = QFileDialog::getSaveFileName(Q_NULLPTR, tr("Save chat log"));
     if (path.isEmpty()) {
         return;
     }

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -472,7 +472,7 @@ void GenericChatForm::onEmoteInsertRequested(QString str)
 
 void GenericChatForm::onSaveLogClicked()
 {
-    QString path = QFileDialog::getSaveFileName(0, tr("Save chat log"));
+    QString path = QFileDialog::getSaveFileName(Q_NULLPTR, tr("Save chat log"));
     if (path.isEmpty())
         return;
 

--- a/src/widget/form/profileform.cpp
+++ b/src/widget/form/profileform.cpp
@@ -352,6 +352,10 @@ void ProfileForm::onExportClicked()
                                                       QDir::home().filePath(current),
                                                       //: save dialog filter
                                                       tr("Tox save file (*.tox)"), nullptr);
+    if (path.isEmpty()) {
+        return;
+    }
+
     const IProfileInfo::SaveResult result = profileInfo->exportProfile(path);
     if (result == IProfileInfo::SaveResult::OK) {
         return;
@@ -415,6 +419,9 @@ void ProfileForm::onSaveQrClicked()
     const QString path = QFileDialog::getSaveFileName(
                 Q_NULLPTR, tr("Save", "save qr image"), QDir::home().filePath(current),
                 tr("Save QrCode (*.png)", "save dialog filter"), nullptr);
+    if (path.isEmpty()) {
+        return;
+    }
 
     const IProfileInfo::SaveResult result = profileInfo->saveQr(*qr->getImage(), path);
     if (result == IProfileInfo::SaveResult::OK) {

--- a/src/widget/form/profileform.cpp
+++ b/src/widget/form/profileform.cpp
@@ -348,10 +348,9 @@ void ProfileForm::onExportClicked()
 {
     const QString current = profileInfo->getProfileName() + Core::TOX_EXT;
     //:save dialog title
-    const QString path = QFileDialog::getSaveFileName(Q_NULLPTR, tr("Export profile"),
-                                                      QDir::home().filePath(current),
+    const QString path = QFileDialog::getSaveFileName(Q_NULLPTR, tr("Export profile"), current,
                                                       //: save dialog filter
-                                                      tr("Tox save file (*.tox)"), nullptr);
+                                                      tr("Tox save file (*.tox)"));
     if (path.isEmpty()) {
         return;
     }
@@ -417,8 +416,8 @@ void ProfileForm::onSaveQrClicked()
 {
     const QString current = profileInfo->getProfileName() + ".png";
     const QString path = QFileDialog::getSaveFileName(
-                Q_NULLPTR, tr("Save", "save qr image"), QDir::home().filePath(current),
-                tr("Save QrCode (*.png)", "save dialog filter"), nullptr);
+                Q_NULLPTR, tr("Save", "save qr image"), current,
+                tr("Save QrCode (*.png)", "save dialog filter"));
     if (path.isEmpty()) {
         return;
     }

--- a/src/widget/form/settings/advancedform.cpp
+++ b/src/widget/form/settings/advancedform.cpp
@@ -99,8 +99,7 @@ void AdvancedForm::on_cbMakeToxPortable_stateChanged()
 void AdvancedForm::on_btnExportLog_clicked()
 {
     QString savefile =
-        QFileDialog::getSaveFileName(this, tr("Save File"), QDir::homePath(), tr("Logs (*.log)"), 0,
-                                     QFileDialog::DontUseNativeDialog);
+        QFileDialog::getSaveFileName(Q_NULLPTR, tr("Save File"), QString{}, tr("Logs (*.log)"));
 
     if (savefile.isNull() || savefile.isEmpty()) {
         qDebug() << "Debug log save file was not properly chosen";

--- a/src/widget/tool/profileimporter.cpp
+++ b/src/widget/tool/profileimporter.cpp
@@ -53,7 +53,7 @@ bool ProfileImporter::importProfile()
     // TODO: Change all QFileDialog instances across project to use
     // this instead of Q_NULLPTR. Possibly requires >Qt 5.9 due to:
     // https://bugreports.qt.io/browse/QTBUG-59184
-    QString path = QFileDialog::getOpenFileName(Q_NULLPTR, title, dir, filter, 0);
+    QString path = QFileDialog::getOpenFileName(Q_NULLPTR, title, dir, filter);
 
     return importProfile(path);
 }


### PR DESCRIPTION
Fixes #5146. If the filedialog is cancelled the returned path is empty.
Do not try to export the profile in this case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5158)
<!-- Reviewable:end -->
