### PR TITLE
refactor(chatform): Use QStringList instead of QVector<QString>

### DIFF
--- a/src/model/profile/iprofileinfo.h
+++ b/src/model/profile/iprofileinfo.h
@@ -49,7 +49,7 @@ public:
     virtual QString getProfileName() const = 0;
     virtual RenameResult renameProfile(const QString& name) = 0;
     virtual SaveResult exportProfile(const QString& path) const = 0;
-    virtual QVector<QString> removeProfile() = 0;
+    virtual QStringList removeProfile() = 0;
     virtual void logout() = 0;
 
     virtual void copyQr(const QImage& image) const = 0;

--- a/src/model/profile/profileinfo.cpp
+++ b/src/model/profile/profileinfo.cpp
@@ -213,10 +213,9 @@ IProfileInfo::SaveResult ProfileInfo::exportProfile(const QString &path) const
  * @brief Remove profile.
  * @return List of files, which couldn't be removed automaticaly.
  */
-// TODO: Use QStringList
-QVector<QString> ProfileInfo::removeProfile()
+QStringList ProfileInfo::removeProfile()
 {
-    QVector<QString> manualDeleteFiles = profile->remove();
+    QStringList manualDeleteFiles = profile->remove();
     QMetaObject::invokeMethod(&Nexus::getInstance(), "showLogin");
     return manualDeleteFiles;
 }

--- a/src/model/profile/profileinfo.h
+++ b/src/model/profile/profileinfo.h
@@ -40,7 +40,7 @@ public:
     QString getProfileName() const override;
     RenameResult renameProfile(const QString& name) override;
     SaveResult exportProfile(const QString& path) const override;
-    QVector<QString> removeProfile() override;
+    QStringList removeProfile() override;
     void logout() override;
 
     void copyQr(const QImage& image) const override;

--- a/src/persistence/profile.cpp
+++ b/src/persistence/profile.cpp
@@ -49,7 +49,7 @@
  * @brief True if the profile has been removed by remove().
  */
 
-QVector<QString> Profile::profiles;
+QStringList Profile::profiles;
 
 Profile::Profile(QString name, const QString& password, bool isNewProfile, const QByteArray& toxsave)
     : name{name}
@@ -236,10 +236,10 @@ Profile::~Profile()
  * @param extension Raw extension, e.g. "jpeg" not ".jpeg".
  * @return Vector of filenames.
  */
-QVector<QString> Profile::getFilesByExt(QString extension)
+QStringList Profile::getFilesByExt(QString extension)
 {
     QDir dir(Settings::getInstance().getSettingsDirPath());
-    QVector<QString> out;
+    QStringList out;
     dir.setFilter(QDir::Files | QDir::NoDotAndDotDot);
     dir.setNameFilters(QStringList("*." + extension));
     QFileInfoList list = dir.entryInfoList();
@@ -258,7 +258,7 @@ QVector<QString> Profile::getFilesByExt(QString extension)
 void Profile::scanProfiles()
 {
     profiles.clear();
-    QVector<QString> toxfiles = getFilesByExt("tox"), inifiles = getFilesByExt("ini");
+    QStringList toxfiles = getFilesByExt("tox"), inifiles = getFilesByExt("ini");
     for (QString toxfile : toxfiles) {
         if (!inifiles.contains(toxfile)) {
             Settings::getInstance().createPersonal(toxfile);
@@ -268,7 +268,7 @@ void Profile::scanProfiles()
     }
 }
 
-QVector<QString> Profile::getProfiles()
+QStringList Profile::getProfiles()
 {
     return profiles;
 }
@@ -630,7 +630,7 @@ bool Profile::isEncrypted(QString name)
  * @return Vector of filenames that could not be removed.
  * @warning It is invalid to call loadToxSave or saveToxSave on a deleted profile.
  */
-QVector<QString> Profile::remove()
+QStringList Profile::remove()
 {
     if (isRemoved) {
         qWarning() << "Profile " << name << " is already removed!";
@@ -651,7 +651,7 @@ QVector<QString> Profile::remove()
     QFile profileMain{path + ".tox"};
     QFile profileConfig{path + ".ini"};
 
-    QVector<QString> ret;
+    QStringList ret;
 
     if (!profileMain.remove() && profileMain.exists()) {
         ret.push_back(profileMain.fileName());

--- a/src/persistence/profile.h
+++ b/src/persistence/profile.h
@@ -70,12 +70,12 @@ public:
     bool isHistoryEnabled();
     History* getHistory();
 
-    QVector<QString> remove();
+    QStringList remove();
 
     bool rename(QString newName);
 
     static void scanProfiles();
-    static QVector<QString> getProfiles();
+    static QStringList getProfiles();
 
     static bool exists(QString name);
     static bool isEncrypted(QString name);
@@ -92,7 +92,7 @@ private slots:
 
 private:
     Profile(QString name, const QString& password, bool newProfile, const QByteArray& toxsave);
-    static QVector<QString> getFilesByExt(QString extension);
+    static QStringList getFilesByExt(QString extension);
     QString avatarPath(const ToxPk& owner, bool forceUnencrypted = false);
 
 private:
@@ -105,7 +105,7 @@ private:
     bool newProfile;
     bool isRemoved;
     bool encrypted = false;
-    static QVector<QString> profiles;
+    static QStringList profiles;
 };
 
 #endif // PROFILE_H

--- a/src/persistence/settingsserializer.h
+++ b/src/persistence/settingsserializer.h
@@ -106,7 +106,7 @@ private:
     QString path;
     const ToxEncrypt* passKey;
     int group, array, arrayIndex;
-    QVector<QString> groups;
+    QStringList groups;
     QVector<Array> arrays;
     QVector<Value> values;
     static const char magic[];

--- a/src/platform/camera/v4l2.cpp
+++ b/src/platform/camera/v4l2.cpp
@@ -171,7 +171,7 @@ QVector<VideoMode> v4l2::getDeviceModes(QString devName)
 QVector<QPair<QString, QString>> v4l2::getDeviceList()
 {
     QVector<QPair<QString, QString>> devices;
-    QVector<QString> deviceFiles;
+    QStringList deviceFiles;
 
     DIR* dir = opendir("/dev");
     if (!dir)

--- a/src/widget/form/profileform.cpp
+++ b/src/widget/form/profileform.cpp
@@ -373,8 +373,7 @@ void ProfileForm::onDeleteClicked()
         return;
     }
 
-    // TODO: Use QStringList
-    const QVector<QString> manualDeleteFiles = profileInfo->removeProfile();
+    const QStringList manualDeleteFiles = profileInfo->removeProfile();
     if (manualDeleteFiles.empty()) {
         return;
     }

--- a/src/widget/loginscreen.cpp
+++ b/src/widget/loginscreen.cpp
@@ -87,7 +87,7 @@ void LoginScreen::reset(QString initialProfile)
     if (initialProfile.isEmpty()) {
         initialProfile = Settings::getInstance().getCurrentProfile();
     }
-    QVector<QString> profiles = Profile::getProfiles();
+    QStringList profiles = Profile::getProfiles();
     for (QString profile : profiles) {
         ui->loginUsernames->addItem(profile);
         if (profile == initialProfile) {


### PR DESCRIPTION
I have seen some TODOs while working on something else, this replaces QVector<QString> with QStringList consistently across all files. The [documentation](https://doc.qt.io/qt-5/qstringlist.html) promises _fast and safe_ access.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5159)
<!-- Reviewable:end -->
