### PR TITLE
fix(chatform): name in window title and close detached chats

### DIFF
--- a/src/widget/contentdialog.cpp
+++ b/src/widget/contentdialog.cpp
@@ -109,6 +109,7 @@ ContentDialog::ContentDialog(QWidget* parent)
 
     setMinimumSize(minSize);
     setAttribute(Qt::WA_DeleteOnClose);
+    setObjectName("detached");
 
     QByteArray geometry = s.getDialogGeometry();
 
@@ -120,6 +121,8 @@ ContentDialog::ContentDialog(QWidget* parent)
 
     SplitterRestorer restorer(splitter);
     restorer.restore(s.getDialogSplitterState(), size());
+
+    username = Core::getInstance()->getUsername();
 
     currentDialog = this;
     setAcceptDrops(true);


### PR DESCRIPTION
This displays the name of the currently used account in the window title of detached chats. The name is persistent even if one changes the name while having open chats.

Also closes all open chats when switching back to one window. The content of the input field is saved as draft so no loss of written texts that aren't send yet.

Note: Closes #4738. Don't want to steal anybodies opportunity to have their own PR merged, but this has not been worked on for over half a year now (for one line of change).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5167)
<!-- Reviewable:end -->
