### PR TITLE
fix bug .when the source code not at user home

### DIFF
--- a/osx/qTox-Mac-Deployer-ULTIMATE.sh
+++ b/osx/qTox-Mac-Deployer-ULTIMATE.sh
@@ -32,7 +32,7 @@ then
     MAIN_DIR="${TRAVIS_BUILD_DIR}"
     QTOX_DIR="${MAIN_DIR}"
 else
-    MAIN_DIR="/Users/${USER}"
+    MAIN_DIR="$(pwd)"
     QTOX_DIR="${MAIN_DIR}/qTox${SUBGIT}"
 fi
 QT_DIR="/usr/local/Cellar/qt5" # Folder name of QT install


### PR DESCRIPTION
- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)
when i pull the source into /path/custom/qTox ,execute 'qTox-Mac-Deployer-ULTIMATE.sh -b' .
can not compile successful

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5170)
<!-- Reviewable:end -->
