### PR TITLE
fix: simple_make.sh script

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -93,23 +93,7 @@ install_toxcore() {
             "${BASE_DIR}/${TOXCORE_DIR}"
 
         pushd ${BASE_DIR}/${TOXCORE_DIR}
-        ./autogen.sh
-
-        # configure
-        if [[ $SYSTEM_WIDE = "false" ]]
-        then
-            ./configure --prefix=${BASE_DIR}
-        else
-            ./configure
-        fi
-
-        # ensure A/V support is enabled
-        if ! grep -Fxq "BUILD_AV_TRUE=''" config.log
-        then
-            echo "A/V support of libtoxcore is disabled but required by qTox.  Aborting."
-            echo "Maybe the dev-packages of libopus and libvpx are not installed?"
-            exit 1
-        fi
+        cmake .
 
         # compile
         make -j $(nproc)

--- a/simple_make.sh
+++ b/simple_make.sh
@@ -3,8 +3,8 @@
 set -eu -o pipefail
 
 # additional flags for apt-get, used for CI
-readonly APT_FLAGS=$1
-readonly WITHOUT_SQLCIPHER=$2
+readonly APT_FLAGS='$1'
+readonly WITHOUT_SQLCIPHER='$2'
 
 apt_install() {
     local apt_packages=(


### PR DESCRIPTION
- fix crash when run without parameters
- use cmake instad of automake for building toxcore

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5192)
<!-- Reviewable:end -->
