### PR TITLE
refactor(toxcall): move alSource into ToxFriendCall

### DIFF
--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -506,12 +506,11 @@ void CoreAV::groupCallCallback(void* tox, uint32_t group, uint32_t peer, const i
     }
 
     Audio& audio = Audio::getInstance();
-    if (!call.getPeers()[peer]) {
-        // FIXME: 0 is a valid sourceId, we shouldn't necessarily re-subscribe just because we have 0
-        audio.subscribeOutput(call.getPeers()[peer]);
+    if(!call.havePeer(peer)) {
+        call.addPeer(peer);
     }
 
-    audio.playAudioBuffer(call.getPeers()[peer], data, samples, channels, sample_rate);
+    audio.playAudioBuffer(call.getAlSource(peer), data, samples, channels, sample_rate);
 }
 #else
 void CoreAV::groupCallCallback(void* tox, int group, int peer, const int16_t* data,
@@ -536,9 +535,8 @@ void CoreAV::groupCallCallback(void* tox, int group, int peer, const int16_t* da
     }
 
     Audio& audio = Audio::getInstance();
-    if (!call.getPeers()[peer]) {
-        // FIXME: 0 is a valid sourceId, we shouldn't necessarily re-subscribe just because we have 0
-        audio.subscribeOutput(call.getPeers()[peer]);
+    if(!call.havePeer(peer)) {
+        call.addPeer(peer);
     }
 
     audio.playAudioBuffer(call.getPeers()[peer], data, samples, channels, sample_rate);
@@ -556,9 +554,7 @@ void CoreAV::invalidateGroupCallPeerSource(int group, int peer)
     if (it == groupCalls.end()) {
         return;
     }
-    Audio& audio = Audio::getInstance();
-    audio.unsubscribeOutput(it->second.getPeers()[peer]);
-    it->second.getPeers()[peer] = 0;
+    it->second.removePeer(peer);
 }
 
 /**
@@ -752,7 +748,7 @@ bool CoreAV::isCallOutputMuted(const Friend* f) const
 void CoreAV::invalidateCallSources()
 {
     for (auto& kv : groupCalls) {
-        kv.second.getPeers().clear();
+        kv.second.clearPeers();
     }
 
     for (auto& kv : calls) {

--- a/src/core/toxcall.h
+++ b/src/core/toxcall.h
@@ -97,8 +97,11 @@ public:
     ToxGroupCall& operator=(ToxGroupCall&& other) noexcept;
 
     void removePeer(int peerId);
+    void addPeer(int peerId);
+    bool havePeer(int peerId);
+    void clearPeers();
 
-    QMap<int, quint32>& getPeers();
+    quint32 getAlSource(int peer);
 
 private:
     QMap<int, quint32> peers;

--- a/src/core/toxcall.h
+++ b/src/core/toxcall.h
@@ -18,7 +18,7 @@ class ToxCall
 {
 protected:
     ToxCall() = delete;
-    ToxCall(uint32_t CallId, bool VideoEnabled, CoreAV& av);
+    ToxCall(bool VideoEnabled, CoreAV& av);
     ~ToxCall();
 
 public:

--- a/src/core/toxcall.h
+++ b/src/core/toxcall.h
@@ -45,9 +45,6 @@ public:
 
     CoreVideoSource* getVideoSource() const;
 
-    quint32 getAlSource() const;
-    void setAlSource(const quint32& value);
-
 protected:
     bool active{false};
     CoreAV* av{nullptr};
@@ -55,7 +52,6 @@ protected:
     QMetaObject::Connection audioInConn;
     bool muteMic{false};
     bool muteVol{false};
-    quint32 alSource{0};
     // video
     CoreVideoSource* videoSource{nullptr};
     QMetaObject::Connection videoInConn;
@@ -68,8 +64,9 @@ class ToxFriendCall : public ToxCall
 public:
     ToxFriendCall() = delete;
     ToxFriendCall(uint32_t friendId, bool VideoEnabled, CoreAV& av);
-    ToxFriendCall(ToxFriendCall&& other) noexcept = default;
-    ToxFriendCall& operator=(ToxFriendCall&& other) noexcept = default;
+    ToxFriendCall(ToxFriendCall&& other) noexcept;
+    ToxFriendCall& operator=(ToxFriendCall&& other) noexcept;
+    ~ToxFriendCall();
 
     void startTimeout(uint32_t callId);
     void stopTimeout();
@@ -77,12 +74,16 @@ public:
     TOXAV_FRIEND_CALL_STATE getState() const;
     void setState(const TOXAV_FRIEND_CALL_STATE& value);
 
+    quint32 getAlSource() const;
+    void setAlSource(const quint32& value);
+
 protected:
     std::unique_ptr<QTimer> timeoutTimer;
 
 private:
     TOXAV_FRIEND_CALL_STATE state{TOXAV_FRIEND_CALL_STATE_NONE};
     static constexpr int CALL_TIMEOUT = 45000;
+    quint32 alSource{0};
 };
 
 class ToxGroupCall : public ToxCall

--- a/src/video/corevideosource.h
+++ b/src/video/corevideosource.h
@@ -50,7 +50,7 @@ private:
     std::atomic_bool stopped;
 
     friend class CoreAV;
-    friend class ToxCall;
+    friend class ToxFriendCall;
 };
 
 #endif // COREVIDEOSOURCE_H


### PR DESCRIPTION
- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

Maybe fixes #5128

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5200)
<!-- Reviewable:end -->
