### PR TITLE
fix: remove full screen btn from audio group chat

### DIFF
--- a/src/video/genericnetcamview.h
+++ b/src/video/genericnetcamview.h
@@ -50,11 +50,11 @@ public slots:
 protected:
     QVBoxLayout* verLayout;
     VideoSurface* videoSurface;
+    QPushButton* enterFullScreenButton = nullptr;
 
 private:
     QHBoxLayout* buttonLayout = nullptr;
     QPushButton* toggleMessagesButton = nullptr;
-    QPushButton* enterFullScreenButton = nullptr;
     QFrame* buttonPanel = nullptr;
     QPushButton* videoPreviewButton = nullptr;
     QPushButton* volumeButton = nullptr;

--- a/src/video/groupnetcamview.cpp
+++ b/src/video/groupnetcamview.cpp
@@ -117,6 +117,9 @@ GroupNetCamView::GroupNetCamView(int group, QWidget* parent)
     videoLabelSurface->layout()->setMargin(0);
     videoLabelSurface->setStyleSheet("QFrame { background-color: black; }");
 
+    // remove full screen button in audio group chat since it's useless there
+    enterFullScreenButton->hide();
+
     QSplitter* splitter = new QSplitter(Qt::Vertical, this);
     splitter->setChildrenCollapsible(false);
     verLayout->insertWidget(0, splitter, 1);


### PR DESCRIPTION
Fixes: #5202

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5209)
<!-- Reviewable:end -->
