### PR TITLE
fix(profile): avoid deadlock with between main and core thread

### DIFF
--- a/src/persistence/profile.cpp
+++ b/src/persistence/profile.cpp
@@ -78,7 +78,7 @@ void Profile::initCore(const QByteArray& toxsave, ICoreSettings& s)
     connect(core.get(), &Core::friendAvatarRemoved, this, &Profile::removeAvatar);
     connect(core.get(), &Core::friendAvatarData, this, &Profile::saveAvatar);
     connect(core.get(), &Core::fileAvatarOfferReceived, this, &Profile::onAvatarOfferReceived,
-            Qt::ConnectionType::BlockingQueuedConnection);
+            Qt::ConnectionType::QueuedConnection);
 }
 
 Profile::Profile(QString name, const QString& password, bool isNewProfile, const QByteArray& toxsave)


### PR DESCRIPTION
The blocking connection was also blocking the callback holding the
coreLock.

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5220)
<!-- Reviewable:end -->
