### PR TITLE
fix(chatform): mark message with triple click

### DIFF
--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -197,8 +197,14 @@ void ChatLog::mousePressEvent(QMouseEvent* ev)
         clearSelection();
     }
 
-    // Counts only single clicks and first click of doule click
-    clickCount++;
+    if (lastClickButton == ev->button()) {
+        // Counts only single clicks and first click of doule click
+        clickCount++;
+    }
+    else {
+        clickCount = 1; // restarting counter
+        lastClickButton = ev->button();
+    }
     lastClickPos = ev->pos();
 
     // Triggers on odd click counts
@@ -477,8 +483,14 @@ void ChatLog::mouseDoubleClickEvent(QMouseEvent* ev)
         emit selectionChanged();
     }
 
-    // Counts the second click of double click
-    clickCount++;
+    if (lastClickButton == ev->button()) {
+        // Counts the second click of double click
+        clickCount++;
+    }
+    else {
+        clickCount = 1; // restarting counter
+        lastClickButton = ev->button();
+    }
     lastClickPos = ev->pos();
 
     // Triggers on even click counts

--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -154,6 +154,7 @@ private:
     AutoScrollDirection selectionScrollDir = NoDirection;
     int clickCount = 0;
     QPoint lastClickPos;
+    Qt::MouseButton lastClickButton;
 
     // worker vars
     int workerLastIndex = 0;


### PR DESCRIPTION
Fixes #5211.
Only trigger on triple clicks that are caused by the same mouse button clicked successively.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5222)
<!-- Reviewable:end -->
