### PR TITLE
docs(CONTRIBUTING):add a step within 'How to open a pull request'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,6 +122,9 @@ git clone git@github.com:<YOUR_USER>/qTox.git
 # Add the "upstream" remote to be able to fetch from the qTox upstream repository:
 git remote add upstream https://github.com/qTox/qTox.git
 
+# Fetch from the "upstream" repository
+git fetch upstream
+
 # Point the local "master" branch to the "upstream" repository
 git branch master --set-upstream-to=upstream/master
 ```


### PR DESCRIPTION
- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)
#### Guiding with the instructions step by step,when set the upstream I got following errors. It bewildered me for a long time because I am a github newcomer.At last found the answer:it firstly need to fetch upstream to find 'upstream/master'.
$ git branch master --set-upstream-to=upstream/master
error: the requested upstream branch 'upstream/master' does not exist
hint: 
hint: If you are planning on basing your work on an upstream
hint: branch that already exists at the remote, you may need to
hint: run "git fetch" to retrieve it.
hint: 
hint: If you are planning to push out a new local branch that
hint: will track its remote counterpart, you may want to use
hint: "git push -u" to set the upstream config as you push.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5238)
<!-- Reviewable:end -->
