### PR TITLE
chore: Fix warnings: remove unused variables

### DIFF
--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -133,7 +133,6 @@ void FriendWidget::onContextMenuCalled(QContextMenuEvent* event)
         });
     }
 
-    const auto& s = Settings::getInstance();
     const auto circleId = chatroom->getCircleId();
     auto circleMenu =
         menu.addMenu(tr("Move to circle...", "Menu to move a friend into a different circle"));
@@ -280,9 +279,6 @@ void FriendWidget::moveToCircle(int newCircleId)
 
 void FriendWidget::changeAutoAccept(bool enable)
 {
-    const auto frnd = chatroom->getFriend();
-    const auto pk = frnd->getPublicKey();
-    auto& s = Settings::getInstance();
     if (enable) {
         const auto oldDir = chatroom->getAutoAcceptDir();
         const auto newDir = QFileDialog::getExistingDirectory(


### PR DESCRIPTION
- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5249)
<!-- Reviewable:end -->
