### PR TITLE
refactor: Give ChatFormHeader an out-of-line destructor.

### DIFF
--- a/src/widget/chatformheader.cpp
+++ b/src/widget/chatformheader.cpp
@@ -156,6 +156,8 @@ ChatFormHeader::ChatFormHeader(QWidget* parent)
     Translator::registerHandler(std::bind(&ChatFormHeader::retranslateUi, this), this);
 }
 
+ChatFormHeader::~ChatFormHeader() = default;
+
 void ChatFormHeader::setName(const QString& newName)
 {
     nameLabel->setText(newName);

--- a/src/widget/chatformheader.h
+++ b/src/widget/chatformheader.h
@@ -55,6 +55,7 @@ public:
     };
 
     ChatFormHeader(QWidget* parent = nullptr);
+    ~ChatFormHeader();
 
     void setName(const QString& newName);
     void setMode(Mode mode);


### PR DESCRIPTION
This makes the class more widely usable, since deallocating an object of
this class no longer needs to have the `CallConfirmWidget` definition
present. The header file forward-declares `CallConfirmWidget`, so it's
not a complete type if only `chatformheader.h` is included.

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5260)
<!-- Reviewable:end -->
