### PR TITLE
Move platform ifdefs to .cpp files and remove `#error`.

### DIFF
--- a/src/platform/camera/directshow.cpp
+++ b/src/platform/camera/directshow.cpp
@@ -21,6 +21,8 @@
 
 #include "directshow.h"
 
+#ifdef Q_OS_WIN
+
 // Because of replacing to incorrect order, which leads to building failing,
 // this region is ignored for clang-format
 // clang-format off
@@ -255,3 +257,5 @@ QVector<VideoMode> DirectShow::getDeviceModes(QString devName)
 
     return modes;
 }
+
+#endif  // Q_OS_WIN

--- a/src/platform/camera/directshow.h
+++ b/src/platform/camera/directshow.h
@@ -26,10 +26,6 @@
 #include <QString>
 #include <QVector>
 
-#ifndef Q_OS_WIN
-#error "This file is only meant to be compiled for Windows targets"
-#endif
-
 namespace DirectShow {
 QVector<QPair<QString, QString>> getDeviceList();
 QVector<VideoMode> getDeviceModes(QString devName);

--- a/src/platform/camera/v4l2.cpp
+++ b/src/platform/camera/v4l2.cpp
@@ -22,6 +22,8 @@
 
 #include "v4l2.h"
 
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+
 #include <QDebug>
 #include <dirent.h>
 #include <errno.h>
@@ -217,3 +219,5 @@ bool v4l2::betterPixelFormat(uint32_t a, uint32_t b)
     }
     return pixFmtToQuality.at(a) > pixFmtToQuality.at(b);
 }
+
+#endif

--- a/src/platform/camera/v4l2.h
+++ b/src/platform/camera/v4l2.h
@@ -24,10 +24,6 @@
 #include <QString>
 #include <QVector>
 
-#if !(defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD))
-#error "This file is only meant to be compiled for Linux or FreeBSD targets"
-#endif
-
 namespace v4l2 {
 QVector<VideoMode> getDeviceModes(QString devName);
 QVector<QPair<QString, QString>> getDeviceList();

--- a/src/platform/install_osx.cpp
+++ b/src/platform/install_osx.cpp
@@ -19,6 +19,9 @@
 
 
 #include "install_osx.h"
+
+#ifdef Q_OS_OSX
+
 #include <QApplication>
 #include <QDebug>
 #include <QDir>
@@ -120,3 +123,5 @@ void osx::migrateProfiles()
     }
 }
 // End migrateProfiles() compatibility code
+
+#endif  // Q_OS_OSX

--- a/src/platform/install_osx.h
+++ b/src/platform/install_osx.h
@@ -21,10 +21,6 @@
 
 #include <QtCore/qsystemdetection.h>
 
-#ifndef Q_OS_OSX
-#error "This file is only meant to be compiled for Mac OSX targets"
-#endif
-
 namespace osx {
 static constexpr int EXIT_UPDATE_MACX =
     218; // We track our state using unique exit codes when debugging


### PR DESCRIPTION
This allows us to always compile all .cpp files, making the build system
simpler while not increasing complexity in the source, i.e. this is a net
reduction of complexity. I can see some weak arguments for wanting strict
checking, but I don't see what bugs could be prevented by that
strictness.

This PR does not itself simplify the CMake build system, but opens the
door to doing so.

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5261)
<!-- Reviewable:end -->
