### PR TITLE
refactor(core): cleanup thread and timer destruction in Core and CoreAV

### DIFF
--- a/src/core/core.h
+++ b/src/core/core.h
@@ -257,7 +257,6 @@ private:
     static void registerCallbacks(Tox* tox);
 
 private slots:
-    void killTimers();
     void process();
     void onStarted();
 

--- a/src/core/coreav.h
+++ b/src/core/coreav.h
@@ -108,7 +108,6 @@ private slots:
                                 void* self);
     static void audioBitrateCallback(ToxAV* toxAV, uint32_t friendNum, uint32_t rate, void* self);
     static void videoBitrateCallback(ToxAV* toxAV, uint32_t friendNum, uint32_t rate, void* self);
-    void killTimerFromThread();
 
 private:
     void process();


### PR DESCRIPTION
- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

@hkarel can you test?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5270)
<!-- Reviewable:end -->
