### PR TITLE
docs: add to CONTRIBUTING.md Git config line for forcing singning tags

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -361,17 +361,19 @@ https://github.com/qTox/qTox/wiki/Testing
 
 *Not a requirement, just a friendly tip. :wink:*
 
-It's nice when commits are being GPG-signed.  Github has a few articles about
-configuring & signing.
+It's nice when commits and tags are being GPG-signed.  Github has a few articles
+about configuring & signing.
 
 https://help.github.com/articles/signing-commits-using-gpg/
 
 And *tl;dr* version:
 
-```
+```sh
 gpg --gen-key
 gpg --send-keys <your generated key ID>
-git config --global commit.gpgsign true
+git config --local commit.gpgsign true
+# also force signing tags
+git config --local tag.forceSignAnnotated true
 ```
 
 


### PR DESCRIPTION
Also change git config from global, to local, specific to repo, since
signing all commits in every project committed to might not be desirable
for some people, as GPG-signing usually involves typing in password,
which is a slowdown.

Partially addresses cause of #5125 and #5274.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5275)
<!-- Reviewable:end -->
