### PR TITLE
fix(ui): Display most recent group member's name instead of <Empty>

### DIFF
--- a/src/model/group.cpp
+++ b/src/model/group.cpp
@@ -51,9 +51,8 @@ void Group::updatePeer(int peerId, QString name)
     if (f != nullptr) {
         // use the displayed name from the friends list
         toxpks[peerKey] = f->getDisplayedName();
-    } else {
-        emit userListChanged(groupId, toxpks);
     }
+    emit userListChanged(groupId, toxpks);
 }
 
 void Group::setName(const QString& newTitle)


### PR DESCRIPTION
Fix #5294

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5303)
<!-- Reviewable:end -->
