### PR TITLE
fix(ui): don't scale avatar to point of cropping in chat form header

### DIFF
--- a/src/widget/maskablepixmapwidget.cpp
+++ b/src/widget/maskablepixmapwidget.cpp
@@ -58,8 +58,8 @@ void MaskablePixmapWidget::setPixmap(const QPixmap& pmap)
     }
 
     unscaled = pmap;
-    pixmap = pmap.scaled(width() - 2, height() - 2,
-                         Qt::KeepAspectRatioByExpanding,
+    pixmap = pmap.scaled(width(), height(),
+                         Qt::KeepAspectRatio,
                          Qt::SmoothTransformation);
     updatePixmap();
     update();
@@ -82,8 +82,8 @@ void MaskablePixmapWidget::setSize(QSize size)
     }
 
     if (!unscaled.isNull()) {
-        pixmap = unscaled.scaled(width() - 2, height() - 2,
-                                 Qt::KeepAspectRatioByExpanding,
+        pixmap = unscaled.scaled(width(), height(),
+                                 Qt::KeepAspectRatio,
                                  Qt::SmoothTransformation);
         updatePixmap();
         update();


### PR DESCRIPTION
- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

Before on left, after on right for both comparisons. 
![image](https://user-images.githubusercontent.com/10469203/44626095-b8611e00-a8cb-11e8-92ea-c09a1368424a.png)

It looks like this accidentally improved the quality of the friends list avatars by making them slightly larger and avoiding downsampling artefacts, as well as having the rounded corners apply as intended.
![list](https://user-images.githubusercontent.com/10469203/44626117-0f66f300-a8cc-11e8-8e57-f83132865a64.png)
![image](https://user-images.githubusercontent.com/10469203/44626118-1b52b500-a8cc-11e8-86e0-abc4a89455ea.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5306)
<!-- Reviewable:end -->
