### PR TITLE
Improve toxcore-originated log messages.

### DIFF
--- a/src/core/toxlogger.cpp
+++ b/src/core/toxlogger.cpp
@@ -7,54 +7,45 @@
 #include <QString>
 #include <QStringBuilder>
 
-/**
- * @brief Map TOX_LOG_LEVEL to a string
- * @param level log level
- * @return Descriptive string for the log level
- */
-QString getToxLogLevel(TOX_LOG_LEVEL level) {
-    switch (level) {
-    case TOX_LOG_LEVEL_TRACE:
-        return QLatin1Literal("TRACE");
-    case TOX_LOG_LEVEL_DEBUG:
-        return QLatin1Literal("DEBUG");
-    case TOX_LOG_LEVEL_INFO:
-        return QLatin1Literal("INFO ");
-    case TOX_LOG_LEVEL_WARNING:
-        return QLatin1Literal("WARN ");
-    case TOX_LOG_LEVEL_ERROR:
-        return QLatin1Literal("ERROR");
-    default:
-        // Invalid log level
-        return QLatin1Literal("INVAL");
-    }
+namespace ToxLogger {
+namespace {
+
+QByteArray cleanPath(const char *file)
+{
+    // for privacy, make the path relative to the c-toxcore source directory
+    const QRegularExpression pathCleaner(QLatin1Literal{"[\\s|\\S]*c-toxcore."});
+    QByteArray cleanedPath = QString{file}.remove(pathCleaner).toUtf8();
+    cleanedPath.append('\0');
+    return cleanedPath;
 }
+
+}  // namespace
 
 /**
  * @brief Log message handler for toxcore log messages
  * @note See tox.h for the parameter definitions
  */
-void ToxLogger::onLogMessage(Tox *tox, TOX_LOG_LEVEL level, const char *file, uint32_t line,
-                                    const char *func, const char *message, void *user_data)
+void onLogMessage(Tox *tox, TOX_LOG_LEVEL level, const char *file, uint32_t line,
+                  const char *func, const char *message, void *user_data)
 {
-    // for privacy, make the path relative to the c-toxcore source directory
-    const QRegularExpression pathCleaner(QLatin1Literal{"[\\s|\\S]*c-toxcore."});
-    const QString cleanPath = QString{file}.remove(pathCleaner);
-
-    const QString logMsg = getToxLogLevel(level) % QLatin1Literal{":"} % cleanPath
-                           % QLatin1Literal{":"} % func % QStringLiteral(":%1: ").arg(line)
-                           % message;
+    const QByteArray cleanedPath = cleanPath(file);
 
     switch (level) {
     case TOX_LOG_LEVEL_TRACE:
         return; // trace level generates too much noise to enable by default
     case TOX_LOG_LEVEL_DEBUG:
+        QMessageLogger(cleanedPath.data(), line, func).debug() << message;
+        break;
     case TOX_LOG_LEVEL_INFO:
-        qDebug() << logMsg;
+        QMessageLogger(cleanedPath.data(), line, func).info() << message;
         break;
     case TOX_LOG_LEVEL_WARNING:
+        QMessageLogger(cleanedPath.data(), line, func).warning() << message;
+        break;
     case TOX_LOG_LEVEL_ERROR:
-        qWarning() << logMsg;
+        QMessageLogger(cleanedPath.data(), line, func).critical() << message;
+        break;
     }
 }
 
+}  // namespace ToxLogger


### PR DESCRIPTION
This changes ToxLogger to behave as if `qDebug()` were used inside
toxcore itself, i.e. with the correct file/line/func.

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5307)
<!-- Reviewable:end -->
