### PR TITLE
feat(build): update docs and tools to provide signed tar.gz

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -183,12 +183,13 @@ Follow steps for adding translations from Weblate up to step 5. Next:
 
 ### After tagging
 
-- Create and GPG-sign tarball using [`./tools/create-tarball.sh`] script, and
-  upload the tarball to the github release that was created by a Travis OSX
+- Create and GPG-sign the tar.lz and tar.gz archives using
+  [`./tools/create-tarballs.sh`] script, and upload both archives plus both
+  signature files to the github release that was created by a Travis OSX
   release job.
 - Update download links on https://tox.chat to point to the new release.
-- Write a short blog post for https://github.com/qTox/blog/ and advertise the post
-  on Tox IRC channels, popular Tox groups, reddit, or whatever other platforms.
+- Write a short blog post for https://github.com/qTox/blog/ and advertise the
+  post on Tox IRC channels, popular Tox groups, reddit, or whatever other platforms.
 - Open a PR to update the Flatpak manifest of our [Flathub repository] with the 
   changes from [`./flatpak/io.github.qtox.qTox.json`].
 - Comment to the PR with `bot, build` to execute a test build

--- a/tools/create-tarballs.sh
+++ b/tools/create-tarballs.sh
@@ -15,7 +15,7 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# Create a `lzip` archive and make a detached GPG signature for it.
+# Create a `lzip` and a `gzip` archive and make a detached GPG signature for them.
 #
 # When tag name is supplied, it's used to create archive. If there is no tag
 # name supplied, latest tag is used.
@@ -24,6 +24,7 @@
 #   * GPG
 #   * git
 #   * lzip
+#   * gzip
 
 # usage:
 #   ./$script [$tag_name]
@@ -33,24 +34,33 @@
 set -eu -o pipefail
 
 
-archive_from_tag() {
+archives_from_tag() {
     git archive --format=tar "$@" \
     | lzip --best \
     > "$@".tar.lz
     echo "$@.tar.lz archive has been created."
+    git archive --format=tar "$@" \
+    | gzip --best \
+    > "$@".tar.gz
+    echo "$@.tar.gz archive has been created."
 }
 
-sign_archive() {
+sign_archives() {
     gpg \
         --armor \
         --detach-sign \
         "$@".tar.lz
     echo "$@.tar.lz.asc signature has been created."
+    gpg \
+        --armor \
+        --detach-sign \
+        "$@".tar.gz
+    echo "$@.tar.gz.asc signature has been created."
 }
 
 create_and_sign() {
-    archive_from_tag "$@"
-    sign_archive "$@"
+    archives_from_tag "$@"
+    sign_archives "$@"
 }
 
 get_tag() {


### PR DESCRIPTION
To support openSUSE package creation.

Fix #5278

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

Upon merge, I will add signed gz for v1.16.3 release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5310)
<!-- Reviewable:end -->
