### PR TITLE
fix(ui): avatar highlight on hover in profile

### DIFF
--- a/src/widget/form/profileform.cpp
+++ b/src/widget/form/profileform.cpp
@@ -140,9 +140,11 @@ ProfileForm::ProfileForm(IProfileInfo* profileInfo, QWidget* parent)
     profilePicture->setPixmap(QPixmap(":/img/contact_dark.svg"));
     profilePicture->setContextMenuPolicy(Qt::CustomContextMenu);
     profilePicture->setClickable(true);
+    profilePicture->setObjectName("selfAvatar");
     profilePicture->installEventFilter(this);
     profilePicture->setAccessibleName("Profile avatar");
     profilePicture->setAccessibleDescription("Set a profile avatar shown to all contacts");
+    profilePicture->setStyleSheet(Style::getStylesheet(":ui/window/profile.css"));
     connect(profilePicture, &MaskablePixmapWidget::clicked, this, &ProfileForm::onAvatarClicked);
     connect(profilePicture, &MaskablePixmapWidget::customContextMenuRequested,
             this, &ProfileForm::showProfilePictureContextMenu);


### PR DESCRIPTION
- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

before fix, wiggling mouse over avatar:
![before](https://user-images.githubusercontent.com/10469203/44756132-0188bc00-aade-11e8-9e19-5c83663eb2a8.gif)

after fix, wiggling mouse over avatar:
![border](https://user-images.githubusercontent.com/10469203/44756139-06e60680-aade-11e8-8b1c-ffb3c67753e5.gif)

This makes the behaviour the same as above the friend's list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5312)
<!-- Reviewable:end -->
