### PR TITLE
fix(ui): by default, don't grab focus on new message

### DIFF
--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -207,7 +207,7 @@ void Settings::loadGlobal()
     s.beginGroup("GUI");
     {
         showWindow = s.value("showWindow", true).toBool();
-        showInFront = s.value("showInFront", true).toBool();
+        showInFront = s.value("showInFront", false).toBool();
         notify = s.value("notify", true).toBool();
         groupAlwaysNotify = s.value("groupAlwaysNotify", true).toBool();
         groupchatPosition = s.value("groupchatPosition", true).toBool();


### PR DESCRIPTION
Fix #5284

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5315)
<!-- Reviewable:end -->
