### PR TITLE
fix: add remove history prompt, clear log area after history remove

### DIFF
--- a/src/model/about/aboutfriend.cpp
+++ b/src/model/about/aboutfriend.cpp
@@ -39,6 +39,11 @@ QString AboutFriend::getPublicKey() const
     return f->getPublicKey().toString();
 }
 
+uint32_t AboutFriend::getId() const
+{
+    return f->getId();
+}
+
 QPixmap AboutFriend::getAvatar() const
 {
     const ToxPk pk = f->getPublicKey();
@@ -106,6 +111,17 @@ bool AboutFriend::clearHistory()
     if (history) {
         history->removeFriendHistory(pk.toString());
         return true;
+    }
+
+    return false;
+}
+
+bool AboutFriend::isHistoryExistence()
+{
+    History* const history = Nexus::getProfile()->getHistory();
+    if (history) {
+        const ToxPk pk = f->getPublicKey();
+        return history->isHistoryExistence(pk.toString());
     }
 
     return false;

--- a/src/model/about/aboutfriend.h
+++ b/src/model/about/aboutfriend.h
@@ -20,6 +20,7 @@ public:
     QString getName() const override;
     QString getStatusMessage() const override;
     QString getPublicKey() const override;
+    uint32_t getId() const override;
 
     QPixmap getAvatar() const override;
 
@@ -36,6 +37,9 @@ public:
     void setAutoGroupInvite(bool enabled) override;
 
     bool clearHistory() override;
+    bool isHistoryExistence() override;
+
+    SIGNAL_IMPL(AboutFriend, historyCleared, const QString&)
 
     SIGNAL_IMPL(AboutFriend, nameChanged, const QString&)
     SIGNAL_IMPL(AboutFriend, statusChanged, const QString&)

--- a/src/model/about/iaboutfriend.h
+++ b/src/model/about/iaboutfriend.h
@@ -13,6 +13,7 @@ public:
     virtual QString getName() const = 0;
     virtual QString getStatusMessage() const = 0;
     virtual QString getPublicKey() const = 0;
+    virtual uint32_t getId() const = 0;
 
     virtual QPixmap getAvatar() const = 0;
 
@@ -29,8 +30,11 @@ public:
     virtual void setAutoGroupInvite(bool enabled) = 0;
 
     virtual bool clearHistory() = 0;
+    virtual bool isHistoryExistence() = 0;
 
     /* signals */
+    DECLARE_SIGNAL(historyCleared, const QString&);
+
     DECLARE_SIGNAL(nameChanged, const QString&);
     DECLARE_SIGNAL(statusChanged, const QString&);
     DECLARE_SIGNAL(publicKeyChanged, const QString&);

--- a/src/persistence/history.cpp
+++ b/src/persistence/history.cpp
@@ -86,6 +86,16 @@ bool History::isValid()
 }
 
 /**
+ * @brief Checks if a friend has chat history
+ * @param friendPk
+ * @return True if has, false otherwise.
+ */
+bool History::isHistoryExistence(const QString& friendPk)
+{
+    return !getChatHistoryDefaultNum(friendPk).isEmpty();
+}
+
+/**
  * @brief Erases all the chat history from the database.
  */
 void History::eraseHistory()

--- a/src/persistence/history.h
+++ b/src/persistence/history.h
@@ -73,6 +73,8 @@ public:
     bool isValid();
     void import(const HistoryKeeper& oldHistory);
 
+    bool isHistoryExistence(const QString& friendPk);
+
     void eraseHistory();
     void removeFriendHistory(const QString& friendPk);
     void addNewMessage(const QString& friendPk, const QString& message, const QString& sender,

--- a/src/widget/about/aboutfriendform.h
+++ b/src/widget/about/aboutfriendform.h
@@ -8,6 +8,8 @@
 
 #include <memory>
 
+class Widget;
+
 namespace Ui {
 class AboutFriendForm;
 }
@@ -23,6 +25,9 @@ public:
 private:
     Ui::AboutFriendForm* ui;
     const std::unique_ptr<IAboutFriend> about;
+
+signals:
+    void clearFriendChatLogArea(const uint32_t friendId);
 
 private slots:
     void onAutoAcceptDirChanged(const QString& path);

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -735,12 +735,6 @@ void ChatForm::onAvatarRemoved(const ToxPk& friendPk)
     headWidget->setAvatar(QPixmap(":/img/contact_dark.svg"));
 }
 
-void ChatForm::clearChatArea(bool notInForm)
-{
-    GenericChatForm::clearChatArea(notInForm);
-    offlineEngine->removeAllReceipts();
-}
-
 QString getMsgAuthorDispName(const ToxPk& authorPk, const QString& dispName)
 {
     QString authorStr;
@@ -765,6 +759,12 @@ void ChatForm::loadHistoryDefaultNum(bool processUndelivered)
         earliestMessage = msgs.first().timestamp;
     }
     handleLoadedMessages(msgs, processUndelivered);
+}
+
+void ChatForm::clearFriendChatLog()
+{
+    GenericChatForm::clearChatArea(false, true);
+    offlineEngine->removeAllReceipts();
 }
 
 void ChatForm::loadHistoryByDateRange(const QDateTime& since, bool processUndelivered)

--- a/src/widget/form/chatform.h
+++ b/src/widget/form/chatform.h
@@ -49,6 +49,8 @@ public:
     void loadHistoryByDateRange(const QDateTime& since, bool processUndelivered = false);
     void loadHistoryDefaultNum(bool processUndelivered = false);
 
+    void clearFriendChatLog();
+
     void dischargeReceipt(int receipt);
     void setFriendTyping(bool isTyping);
     OfflineMsgEngine* getOfflineMsgEngine();
@@ -82,7 +84,6 @@ protected slots:
     void onSearchDown(const QString& phrase, const ParameterSearch& parameter) override;
 
 private slots:
-    void clearChatArea(bool notInForm) override final;
     void onSendTriggered() override;
     void onAttachClicked() override;
     void onScreenshotClicked() override;

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -220,7 +220,7 @@ GenericChatForm::GenericChatForm(const Contact* contact, QWidget* parent)
     saveChatAction = menu.addAction(QIcon::fromTheme("document-save"), QString(),
                                     this, SLOT(onSaveLogClicked()));
     clearAction = menu.addAction(QIcon::fromTheme("edit-clear"), QString(),
-                                 this, SLOT(clearChatArea(bool)),
+                                 this, SLOT(clearChatArea()),
                                  QKeySequence(Qt::CTRL + Qt::SHIFT + Qt::Key_L));
     addAction(clearAction);
 
@@ -816,22 +816,25 @@ std::pair<int, int> GenericChatForm::indexForSearchInLine(const QString& txt, co
 
 void GenericChatForm::clearChatArea()
 {
-    clearChatArea(true);
+    clearChatArea(true, true);
 }
 
-void GenericChatForm::clearChatArea(bool notinform)
+void GenericChatForm::clearChatArea(bool confirm, bool inform)
 {
-    QMessageBox::StandardButton mboxResult =
-        QMessageBox::question(this, tr("Confirmation"),
-                              tr("You are sure that you want to clear all displayed messages?"),
-                              QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
-    if (mboxResult == QMessageBox::No) {
-        return;
+    if (confirm) {
+        QMessageBox::StandardButton mboxResult =
+                QMessageBox::question(this, tr("Confirmation"),
+                                      tr("You are sure that you want to clear all displayed messages?"),
+                                      QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+        if (mboxResult == QMessageBox::No) {
+            return;
+        }
     }
+
     chatWidget->clear();
     previousId = ToxPk();
 
-    if (!notinform)
+    if (inform)
         addSystemInfoMessage(tr("Cleared"), ChatMessage::INFO, QDateTime::currentDateTime());
 
     earliestMessage = QDateTime(); // null

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -104,7 +104,7 @@ protected slots:
     void onEmoteInsertRequested(QString str);
     void onSaveLogClicked();
     void onCopyLogClicked();
-    virtual void clearChatArea(bool);
+    void clearChatArea(bool confirm, bool inform);
     void clearChatArea();
     void onSelectAllClicked();
     void showFileMenu();

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -943,6 +943,11 @@ void Widget::reloadHistory()
     }
 }
 
+void Widget::onFriendChatAreaCleared(const uint32_t friendId)
+{
+    chatForms[friendId]->clearFriendChatLog();
+}
+
 void Widget::incomingNotification(uint32_t friendId)
 {
     newFriendMessageAlert(friendId, false);
@@ -1631,7 +1636,7 @@ ContentLayout* Widget::createContentDialog(DialogType type) const
             connect(Core::getInstance(), &Core::usernameSet, this, &Dialog::retranslateUi);
         }
 
-        ~Dialog()
+        ~Dialog() override
         {
             Translator::unregister(this);
         }

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -142,6 +142,7 @@ public:
     void resetIcon();
 
 public slots:
+    void onFriendChatAreaCleared(const uint32_t friendId);
     void onShowSettings();
     void onSeparateWindowClicked(bool separate);
     void onSeparateWindowChanged(bool separate, bool clicked);


### PR DESCRIPTION
 fix(chatform): add prompt while remove chat history. clear chat log area after history removed. 

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5333)
<!-- Reviewable:end -->
