### PR TITLE
fix(settings): save settings early on Windows shutdown

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,6 +59,15 @@ QMutex* logBufferMutex = new QMutex();
 
 void cleanup()
 {
+    // force save early even though destruction saves, because Windows OS will
+    // close qTox before cleanup() is finished if logging out or shutting down,
+    // once the top level window has exited, which occurs in ~Widget within
+    // ~Nexus. Re-ordering Nexus destruction is not trivial.
+    auto& s = Settings::getInstance();
+    s.saveGlobal();
+    s.savePersonal();
+    s.sync();
+
     Nexus::destroyInstance();
     CameraSource::destroyInstance();
     Settings::destroyInstance();


### PR DESCRIPTION
Need to save before top level window is closed.

Fix #1969

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5338)
<!-- Reviewable:end -->
