### PR TITLE
fix(file transfer): Fix misuse of toxcore tox_file_send API

### DIFF
--- a/src/core/corefile.cpp
+++ b/src/core/corefile.cpp
@@ -123,10 +123,11 @@ void CoreFile::sendFile(Core* core, uint32_t friendId, QString filename, QString
     QMutexLocker mlocker(&fileSendMutex);
 
     QByteArray fileName = filename.toUtf8();
+    TOX_ERR_FILE_SEND sendErr;
     uint32_t fileNum = tox_file_send(core->tox.get(), friendId, TOX_FILE_KIND_DATA, filesize,
-                                     nullptr, (uint8_t*)fileName.data(), fileName.size(), nullptr);
-    if (fileNum == std::numeric_limits<uint32_t>::max()) {
-        qWarning() << "sendFile: Can't create the Tox file sender";
+                                     nullptr, (uint8_t*)fileName.data(), fileName.size(), &sendErr);
+    if (sendErr != TOX_ERR_FILE_SEND_OK) {
+        qWarning() << "sendFile: Can't create the Tox file sender (" << sendErr << ")";
         emit core->fileSendFailed(friendId, filename);
         return;
     }


### PR DESCRIPTION
As mentioned in #5350 this is most likely a bug. tox.h indicates that the return value shouldn't indicate whether or not the given function failed and if it does it's by chance. Now we can also log *why* we failed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5352)
<!-- Reviewable:end -->
