### PR TITLE
fix(video): workaround for webcams that provide no fps value

### DIFF
--- a/src/video/cameradevice.cpp
+++ b/src/video/cameradevice.cpp
@@ -191,8 +191,9 @@ CameraDevice* CameraDevice::open(QString devName, VideoMode mode)
         av_dict_set(&options, "video_size", videoSize.c_str(), 0);
         av_dict_set(&options, "framerate", framerate.c_str(), 0);
         const std::string pixelFormatStr = v4l2::getPixelFormatString(mode.pixel_format).toStdString();
-        const char* pixel_format = pixelFormatStr.c_str();
-        if (strncmp(pixel_format, "unknown", 7) != 0) {
+        // don't try to set a format string that doesn't exist
+        if (pixelFormatStr != "unknown" && pixelFormatStr != "invalid") {
+            const char* pixel_format = pixelFormatStr.c_str();
             av_dict_set(&options, "pixel_format", pixel_format, 0);
         }
     }

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -222,6 +222,11 @@ void AVForm::on_videoModescomboBox_currentIndexChanged(int index)
 
 void AVForm::selectBestModes(QVector<VideoMode>& allVideoModes)
 {
+    if (allVideoModes.isEmpty()) {
+        qCritical() << "Trying to select best mode from empty modes list";
+        return;
+    }
+
     // Identify the best resolutions available for the supposed XXXXp resolutions.
     std::map<int, VideoMode> idealModes;
     idealModes[120] = VideoMode(160, 120);


### PR DESCRIPTION
fixes #5082

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5355)
<!-- Reviewable:end -->
