### PR TITLE
chore: make {merge,test}-pr.sh scripts accept hash-preceded PR number

### DIFF
--- a/merge-pr.sh
+++ b/merge-pr.sh
@@ -31,7 +31,7 @@
 
 set -e -o pipefail
 
-readonly PR=$1
+readonly PR="${1###}"
 
 # make sure to add newlines to the message, otherwise merge message
 # will not look well

--- a/test-pr.sh
+++ b/test-pr.sh
@@ -30,7 +30,7 @@
 
 set -e -o pipefail
 
-readonly PR=$1
+readonly PR="${1###}"
 
 # make sure to add newlines to the message, otherwise merge message
 # will not look well


### PR DESCRIPTION
Previously one needed to provide only digits, (e.g. `123`), otherwise
scripts would fail to recognise supplied argument as an issue number.

Github almost everywhere precedes PR numbers with hash sign, so it might
be easier/faster to copypaste PR number with along with preceding hash.

With the change scripts will ignore the first preceding hash in the
supplied PR number.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

---
Although, shell will just treat the characters preceded with a hash as a comment, unless enclosed in quotes. Which makes me wonder if this is an actual improvement, or whether I'm adding a pitfall here..

```bash
# pitfall
./test-pr.sh #123
# works
./test-pr.sh '#123'
```

Merge only if you think that this is an actual improvement.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5356)
<!-- Reviewable:end -->
