### PR TITLE
docs(INSTALL.md): correct compiling instructions for some 64-bit distros

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -510,6 +510,10 @@ git checkout v0.2.7
 cmake .
 make -j$(nproc)
 sudo make install
+
+# we don't know what whether user runs 64 or 32 bits, and on some distros
+# (Fedora, openSUSE) lib/ doesn't link to lib64/, so add both
+echo '/usr/local/lib64/' | sudo tee -a /etc/ld.so.conf.d/locallib.conf
 echo '/usr/local/lib/' | sudo tee -a /etc/ld.so.conf.d/locallib.conf
 sudo ldconfig
 ```
@@ -524,6 +528,9 @@ If you are compiling on Fedora 25, you must add libtoxcore to the
 `PKG_CONFIG_PATH` environment variable manually:
 
 ```
+# we don't know what whether user runs 64 or 32 bits, and on some distros
+# (Fedora, openSUSE) lib/ doesn't link to lib64/, so add both
+export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/lib64/pkgconfig"
 export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/lib/pkgconfig"
 ```
 


### PR DESCRIPTION
Figured out by @Marty665 and @ezavod in #5155.

Closes #5155.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5357)
<!-- Reviewable:end -->
