### PR TITLE
Pause state fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,6 +268,7 @@ set(${PROJECT_NAME}_SOURCES
   src/core/toxencrypt.h
   src/core/toxfile.cpp
   src/core/toxfile.h
+  src/core/toxfilepause.h
   src/core/toxid.cpp
   src/core/toxid.h
   src/core/toxlogger.cpp

--- a/src/chatlog/content/filetransferwidget.cpp
+++ b/src/chatlog/content/filetransferwidget.cpp
@@ -557,18 +557,18 @@ void FileTransferWidget::handleButton(QPushButton* btn)
         if (btn->objectName() == "cancel") {
             Core::getInstance()->cancelFileSend(fileInfo.friendId, fileInfo.fileNum);
         } else if (btn->objectName() == "pause") {
-            Core::getInstance()->pauseResumeFileSend(fileInfo.friendId, fileInfo.fileNum);
+            Core::getInstance()->pauseResumeFile(fileInfo.friendId, fileInfo.fileNum);
         } else if (btn->objectName() == "resume") {
-            Core::getInstance()->pauseResumeFileSend(fileInfo.friendId, fileInfo.fileNum);
+            Core::getInstance()->pauseResumeFile(fileInfo.friendId, fileInfo.fileNum);
         }
     } else // receiving or paused
     {
         if (btn->objectName() == "cancel") {
             Core::getInstance()->cancelFileRecv(fileInfo.friendId, fileInfo.fileNum);
         } else if (btn->objectName() == "pause") {
-            Core::getInstance()->pauseResumeFileRecv(fileInfo.friendId, fileInfo.fileNum);
+            Core::getInstance()->pauseResumeFile(fileInfo.friendId, fileInfo.fileNum);
         } else if (btn->objectName() == "resume") {
-            Core::getInstance()->pauseResumeFileRecv(fileInfo.friendId, fileInfo.fileNum);
+            Core::getInstance()->pauseResumeFile(fileInfo.friendId, fileInfo.fileNum);
         } else if (btn->objectName() == "accept") {
             QString path =
                 QFileDialog::getSaveFileName(Q_NULLPTR,

--- a/src/chatlog/content/filetransferwidget.cpp
+++ b/src/chatlog/content/filetransferwidget.cpp
@@ -346,7 +346,7 @@ void FileTransferWidget::updateWidgetColor(ToxFile const& file)
 
 void FileTransferWidget::updateWidgetText(ToxFile const& file)
 {
-    if (lastStatus == file.status) {
+    if (lastStatus == file.status && file.status != ToxFile::PAUSED) {
         return;
     }
 
@@ -360,7 +360,11 @@ void FileTransferWidget::updateWidgetText(ToxFile const& file)
         break;
     case ToxFile::PAUSED:
         ui->etaLabel->setText("");
-        ui->progressLabel->setText(tr("Paused", "file transfer widget"));
+        if (file.pauseStatus.localPaused()) {
+            ui->progressLabel->setText(tr("Paused", "file transfer widget"));
+        } else {
+            ui->progressLabel->setText(tr("Remote Paused", "file transfer widget"));
+        }
         break;
     case ToxFile::TRANSMITTING:
         ui->etaLabel->setText("");
@@ -474,7 +478,7 @@ void FileTransferWidget::updateSignals(ToxFile const& file)
 
 void FileTransferWidget::setupButtons(ToxFile const& file)
 {
-    if (lastStatus == file.status) {
+    if (lastStatus == file.status && file.status != ToxFile::PAUSED) {
         return;
     }
 
@@ -492,9 +496,15 @@ void FileTransferWidget::setupButtons(ToxFile const& file)
         break;
 
     case ToxFile::PAUSED:
-        ui->leftButton->setIcon(QIcon(Style::getImagePath("fileTransferInstance/arrow_white.svg")));
-        ui->leftButton->setObjectName("resume");
-        ui->leftButton->setToolTip(tr("Resume transfer"));
+        if (file.pauseStatus.localPaused()) {
+            ui->leftButton->setIcon(QIcon(Style::getImagePath("fileTransferInstance/arrow_white.svg")));
+            ui->leftButton->setObjectName("resume");
+            ui->leftButton->setToolTip(tr("Resume transfer"));
+        } else {
+            ui->leftButton->setIcon(QIcon(Style::getImagePath("fileTransferInstance/pause.svg")));
+            ui->leftButton->setObjectName("pause");
+            ui->leftButton->setToolTip(tr("Pause transfer"));
+        }
 
         ui->rightButton->setIcon(QIcon(Style::getImagePath("fileTransferInstance/no.svg")));
         ui->rightButton->setObjectName("cancel");

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -715,18 +715,11 @@ void Core::sendAvatarFile(uint32_t friendId, const QByteArray& data)
     CoreFile::sendAvatarFile(this, friendId, data);
 }
 
-void Core::pauseResumeFileSend(uint32_t friendId, uint32_t fileNum)
+void Core::pauseResumeFile(uint32_t friendId, uint32_t fileNum)
 {
     QMutexLocker ml{coreLoopLock.get()};
 
-    CoreFile::pauseResumeFileSend(this, friendId, fileNum);
-}
-
-void Core::pauseResumeFileRecv(uint32_t friendId, uint32_t fileNum)
-{
-    QMutexLocker ml{coreLoopLock.get()};
-
-    CoreFile::pauseResumeFileRecv(this, friendId, fileNum);
+    CoreFile::pauseResumeFile(this, friendId, fileNum);
 }
 
 void Core::cancelFileSend(uint32_t friendId, uint32_t fileNum)

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -130,8 +130,7 @@ public slots:
     void cancelFileRecv(uint32_t friendId, uint32_t fileNum);
     void rejectFileRecvRequest(uint32_t friendId, uint32_t fileNum);
     void acceptFileRecvRequest(uint32_t friendId, uint32_t fileNum, QString path);
-    void pauseResumeFileSend(uint32_t friendId, uint32_t fileNum);
-    void pauseResumeFileRecv(uint32_t friendId, uint32_t fileNum);
+    void pauseResumeFile(uint32_t friendId, uint32_t fileNum);
 
     void setNospam(uint32_t nospam);
 

--- a/src/core/corefile.cpp
+++ b/src/core/corefile.cpp
@@ -152,41 +152,34 @@ void CoreFile::pauseResumeFileSend(Core* core, uint32_t friendId, uint32_t fileI
         qWarning("pauseResumeFileSend: No such file in queue");
         return;
     }
-    if (file->status == ToxFile::TRANSMITTING) {
+
+    if (file->status != ToxFile::TRANSMITTING && file->status != ToxFile::PAUSED) {
+        qWarning() << "pauseResumeFileSend: File is stopped";
+        return;
+    }
+
+    file->pauseStatus.localPauseToggle();
+
+    if (file->pauseStatus.paused()) {
         file->status = ToxFile::PAUSED;
         emit core->fileTransferPaused(*file);
-        tox_file_control(core->tox.get(), file->friendId, file->fileNum, TOX_FILE_CONTROL_PAUSE,
-                         nullptr);
-    } else if (file->status == ToxFile::PAUSED) {
+    } else {
         file->status = ToxFile::TRANSMITTING;
         emit core->fileTransferAccepted(*file);
-        tox_file_control(core->tox.get(), file->friendId, file->fileNum, TOX_FILE_CONTROL_RESUME,
+    }
+
+    if (file->pauseStatus.localPaused()) {
+        tox_file_control(core->tox.get(), file->friendId, file->fileNum, TOX_FILE_CONTROL_PAUSE,
                          nullptr);
     } else {
-        qWarning() << "pauseResumeFileSend: File is stopped";
+        tox_file_control(core->tox.get(), file->friendId, file->fileNum, TOX_FILE_CONTROL_RESUME,
+                         nullptr);
     }
 }
 
 void CoreFile::pauseResumeFileRecv(Core* core, uint32_t friendId, uint32_t fileId)
 {
-    ToxFile* file = findFile(friendId, fileId);
-    if (!file) {
-        qWarning("cancelFileRecv: No such file in queue");
-        return;
-    }
-    if (file->status == ToxFile::TRANSMITTING) {
-        file->status = ToxFile::PAUSED;
-        emit core->fileTransferPaused(*file);
-        tox_file_control(core->tox.get(), file->friendId, file->fileNum, TOX_FILE_CONTROL_PAUSE,
-                         nullptr);
-    } else if (file->status == ToxFile::PAUSED) {
-        file->status = ToxFile::TRANSMITTING;
-        emit core->fileTransferAccepted(*file);
-        tox_file_control(core->tox.get(), file->friendId, file->fileNum, TOX_FILE_CONTROL_RESUME,
-                         nullptr);
-    } else {
-        qWarning() << "pauseResumeFileRecv: File is stopped or broken";
-    }
+    pauseResumeFileSend(core, friendId, fileId);
 }
 
 void CoreFile::cancelFileSend(Core* core, uint32_t friendId, uint32_t fileId)
@@ -382,6 +375,7 @@ void CoreFile::onFileControlCallback(Tox*, uint32_t friendId, uint32_t fileId,
         removeFile(friendId, fileId);
     } else if (control == TOX_FILE_CONTROL_PAUSE) {
         qDebug() << "onFileControlCallback: Received pause for file " << friendId << ":" << fileId;
+        file->pauseStatus.remotePause();
         file->status = ToxFile::PAUSED;
         emit static_cast<Core*>(core)->fileTransferRemotePausedUnpaused(*file, true);
     } else if (control == TOX_FILE_CONTROL_RESUME) {
@@ -389,7 +383,8 @@ void CoreFile::onFileControlCallback(Tox*, uint32_t friendId, uint32_t fileId,
             qDebug() << "Avatar transfer" << fileId << "to friend" << friendId << "accepted";
         else
             qDebug() << "onFileControlCallback: Received resume for file " << friendId << ":" << fileId;
-        file->status = ToxFile::TRANSMITTING;
+        file->pauseStatus.remoteResume();
+        file->status = file->pauseStatus.paused() ? ToxFile::PAUSED : ToxFile::TRANSMITTING;
         emit static_cast<Core*>(core)->fileTransferRemotePausedUnpaused(*file, false);
     } else {
         qWarning() << "Unhandled file control " << control << " for file " << friendId << ':' << fileId;

--- a/src/core/corefile.cpp
+++ b/src/core/corefile.cpp
@@ -145,7 +145,7 @@ void CoreFile::sendFile(Core* core, uint32_t friendId, QString filename, QString
     emit core->fileSendStarted(file);
 }
 
-void CoreFile::pauseResumeFileSend(Core* core, uint32_t friendId, uint32_t fileId)
+void CoreFile::pauseResumeFile(Core* core, uint32_t friendId, uint32_t fileId)
 {
     ToxFile* file = findFile(friendId, fileId);
     if (!file) {
@@ -175,11 +175,6 @@ void CoreFile::pauseResumeFileSend(Core* core, uint32_t friendId, uint32_t fileI
         tox_file_control(core->tox.get(), file->friendId, file->fileNum, TOX_FILE_CONTROL_RESUME,
                          nullptr);
     }
-}
-
-void CoreFile::pauseResumeFileRecv(Core* core, uint32_t friendId, uint32_t fileId)
-{
-    pauseResumeFileSend(core, friendId, fileId);
 }
 
 void CoreFile::cancelFileSend(Core* core, uint32_t friendId, uint32_t fileId)

--- a/src/core/corefile.h
+++ b/src/core/corefile.h
@@ -51,8 +51,7 @@ private:
     static void sendFile(Core* core, uint32_t friendId, QString filename, QString filePath,
                          long long filesize);
     static void sendAvatarFile(Core* core, uint32_t friendId, const QByteArray& data);
-    static void pauseResumeFileSend(Core* core, uint32_t friendId, uint32_t fileId);
-    static void pauseResumeFileRecv(Core* core, uint32_t friendId, uint32_t fileId);
+    static void pauseResumeFile(Core* core, uint32_t friendId, uint32_t fileId);
     static void cancelFileSend(Core* core, uint32_t friendId, uint32_t fileId);
     static void cancelFileRecv(Core* core, uint32_t friendId, uint32_t fileId);
     static void rejectFileRecvRequest(Core* core, uint32_t friendId, uint32_t fileId);

--- a/src/core/toxfile.h
+++ b/src/core/toxfile.h
@@ -1,6 +1,8 @@
 #ifndef CORESTRUCTS_H
 #define CORESTRUCTS_H
 
+#include "src/core/toxfilepause.h"
+
 #include <QString>
 #include <memory>
 #include <QCryptographicHash>
@@ -53,6 +55,7 @@ struct ToxFile
     QByteArray avatarData;
     QByteArray resumeFileId;
     std::shared_ptr<QCryptographicHash> hashGenerator = std::make_shared<QCryptographicHash>(QCryptographicHash::Sha256);
+    ToxFilePause pauseStatus;
 };
 
 #endif // CORESTRUCTS_H

--- a/src/core/toxfilepause.h
+++ b/src/core/toxfilepause.h
@@ -1,0 +1,76 @@
+/*
+    Copyright © 2018 by The qTox Project Contributors
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef TOX_FILE_PAUSE_H
+#define TOX_FILE_PAUSE_H
+
+class ToxFilePause
+{
+public:
+    void localPause()
+    {
+        localPauseState = true;
+    }
+
+    void localResume()
+    {
+        localPauseState = false;
+    }
+
+    void localPauseToggle()
+    {
+        localPauseState = !localPauseState;
+    }
+
+    void remotePause()
+    {
+        remotePauseState = true;
+    }
+
+    void remoteResume()
+    {
+        remotePauseState = false;
+    }
+
+    void remotePauseToggle()
+    {
+        remotePauseState = !remotePauseState;
+    }
+
+    bool localPaused() const
+    {
+        return localPauseState;
+    }
+
+    bool remotePaused() const
+    {
+        return remotePauseState;
+    }
+
+    bool paused() const
+    {
+        return localPauseState || remotePauseState;
+    }
+
+private:
+    bool localPauseState = false;
+    bool remotePauseState = false;
+};
+
+#endif // TOX_FILE_PAUSE_H


### PR DESCRIPTION
Toxcore has a 3 state pause, us, them, or both. Currently our UI messes up if both parties pause. This changeset changes our UI behavior to show whether we're paused, or if we are waiting on the remote to
unpause.

*Note*: This fix is on top of my other PR #5354. This is because I touched this area pretty heavily and don't want to have to fix the UI twice.

Demo of post-fix behavior.

![tox_file_transfer](https://user-images.githubusercontent.com/1069811/46457760-574d2580-c768-11e8-8ad2-bb6e60c087df.gif)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5366)
<!-- Reviewable:end -->
