### PR TITLE
Autoaccept file limit

### DIFF
--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -272,9 +272,9 @@ void Settings::loadGlobal()
         enableTestSound = s.value("enableTestSound", true).toBool();
         audioBitrate = s.value("audioBitrate", 64).toInt();
         enableBackend2 = false;
-        #ifdef USE_FILTERAUDIO
+#ifdef USE_FILTERAUDIO
         enableBackend2 = s.value("enableBackend2", false).toBool();
-        #endif
+#endif
     }
     s.endGroup();
 

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -183,6 +183,8 @@ void Settings::loadGlobal()
                                       QStandardPaths::locate(QStandardPaths::HomeLocation, QString(),
                                                              QStandardPaths::LocateDirectory))
                                   .toString();
+        autoAcceptMaxSize =
+            static_cast<size_t>(s.value("autoAcceptMaxSize", 20 << 20 /*20 MB*/).toLongLong());
         stylePreference = static_cast<StyleType>(s.value("stylePreference", 1).toInt());
     }
     s.endGroup();
@@ -499,6 +501,7 @@ void Settings::saveGlobal()
         s.setValue("busySound", busySound);
         s.setValue("fauxOfflineMessaging", fauxOfflineMessaging);
         s.setValue("autoSaveEnabled", autoSaveEnabled);
+        s.setValue("autoAcceptMaxSize", static_cast<qlonglong>(autoAcceptMaxSize));
         s.setValue("globalAutoAcceptDir", globalAutoAcceptDir);
         s.setValue("stylePreference", static_cast<int>(stylePreference));
     }
@@ -1506,6 +1509,22 @@ void Settings::setGlobalAutoAcceptDir(const QString& newValue)
     if (newValue != globalAutoAcceptDir) {
         globalAutoAcceptDir = newValue;
         emit globalAutoAcceptDirChanged(globalAutoAcceptDir);
+    }
+}
+
+size_t Settings::getMaxAutoAcceptSize() const
+{
+    QMutexLocker locker{&bigLock};
+    return autoAcceptMaxSize;
+}
+
+void Settings::setMaxAutoAcceptSize(size_t size)
+{
+    QMutexLocker locker{&bigLock};
+
+    if (size != autoAcceptMaxSize) {
+        autoAcceptMaxSize = size;
+        emit autoAcceptMaxSizeChanged(autoAcceptMaxSize);
     }
 }
 

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -43,8 +43,11 @@ namespace Db {
 enum class syncType;
 }
 
-class Settings : public QObject, public ICoreSettings, public IFriendSettings, 
-    public IAudioSettings, public IVideoSettings
+class Settings : public QObject,
+                 public ICoreSettings,
+                 public IFriendSettings,
+                 public IAudioSettings,
+                 public IVideoSettings
 {
     Q_OBJECT
 
@@ -91,8 +94,8 @@ class Settings : public QObject, public ICoreSettings, public IFriendSettings,
     Q_PROPERTY(QString dateFormat READ getDateFormat WRITE setDateFormat NOTIFY dateFormatChanged FINAL)
     Q_PROPERTY(bool statusChangeNotificationEnabled READ getStatusChangeNotificationEnabled WRITE
                    setStatusChangeNotificationEnabled NOTIFY statusChangeNotificationEnabledChanged FINAL)
-    Q_PROPERTY(bool spellCheckingEnabled READ getSpellCheckingEnabled WRITE
-                   setSpellCheckingEnabled NOTIFY spellCheckingEnabledChanged FINAL)
+    Q_PROPERTY(bool spellCheckingEnabled READ getSpellCheckingEnabled WRITE setSpellCheckingEnabled
+                   NOTIFY spellCheckingEnabledChanged FINAL)
 
     // Privacy
     Q_PROPERTY(bool typingNotification READ getTypingNotification WRITE setTypingNotification NOTIFY
@@ -105,8 +108,8 @@ class Settings : public QObject, public ICoreSettings, public IFriendSettings,
                    audioInDevEnabledChanged FINAL)
     Q_PROPERTY(qreal audioInGainDecibel READ getAudioInGainDecibel WRITE setAudioInGainDecibel
                    NOTIFY audioInGainDecibelChanged FINAL)
-    Q_PROPERTY(qreal audioThreshold READ getAudioThreshold WRITE setAudioThreshold
-                   NOTIFY audioThresholdChanged FINAL)
+    Q_PROPERTY(qreal audioThreshold READ getAudioThreshold WRITE setAudioThreshold NOTIFY
+                   audioThresholdChanged FINAL)
     Q_PROPERTY(QString outDev READ getOutDev WRITE setOutDev NOTIFY outDevChanged FINAL)
     Q_PROPERTY(bool audioOutDevEnabled READ getAudioOutDevEnabled WRITE setAudioOutDevEnabled NOTIFY
                    audioOutDevEnabledChanged FINAL)
@@ -352,8 +355,14 @@ public:
     void setAudioThreshold(qreal percent) override;
 
     int getOutVolume() const override;
-    int getOutVolumeMin() const override { return 0; }
-    int getOutVolumeMax() const override { return 100; }
+    int getOutVolumeMin() const override
+    {
+        return 0;
+    }
+    int getOutVolumeMax() const override
+    {
+        return 100;
+    }
     void setOutVolume(int volume) override;
 
     int getAudioBitrate() const override;
@@ -491,8 +500,8 @@ public:
     void saveFriendSettings(const ToxPk& id) override;
     void removeFriendSettings(const ToxPk& id) override;
 
-    SIGNAL_IMPL(Settings, autoAcceptCallChanged,
-                const ToxPk& id, IFriendSettings::AutoAcceptCallFlags accept)
+    SIGNAL_IMPL(Settings, autoAcceptCallChanged, const ToxPk& id,
+                IFriendSettings::AutoAcceptCallFlags accept)
     SIGNAL_IMPL(Settings, autoGroupInviteChanged, const ToxPk& id, bool accept)
     SIGNAL_IMPL(Settings, autoAcceptDirChanged, const ToxPk& id, const QString& dir)
     SIGNAL_IMPL(Settings, contactNoteChanged, const ToxPk& id, const QString& note)
@@ -508,10 +517,10 @@ public:
 
     bool getDontGroupWindows() const;
     void setDontGroupWindows(bool value);
-    
+
     bool getGroupchatPosition() const;
     void setGroupchatPosition(bool value);
-    
+
     bool getShowIdenticons() const;
     void setShowIdenticons(bool value);
 

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -186,6 +186,7 @@ signals:
     void enableLoggingChanged(bool enabled);
     void autoAwayTimeChanged(int minutes);
     void globalAutoAcceptDirChanged(const QString& path);
+    void autoAcceptMaxSizeChanged(size_t size);
     void checkUpdatesChanged(bool enabled);
     void widgetDataChanged(const QString& key);
 
@@ -438,6 +439,9 @@ public:
     QString getGlobalAutoAcceptDir() const;
     void setGlobalAutoAcceptDir(const QString& dir);
 
+    size_t getMaxAutoAcceptSize() const;
+    void setMaxAutoAcceptSize(size_t size);
+
     bool getAutoGroupInvite(const ToxPk& id) const override;
     void setAutoGroupInvite(const ToxPk& id, bool accept) override;
 
@@ -627,6 +631,7 @@ private:
     QHash<QString, QString> autoAccept;
     bool autoSaveEnabled;
     QString globalAutoAcceptDir;
+    size_t autoAcceptMaxSize;
 
     QList<Request> friendRequests;
 

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -234,7 +234,7 @@ void ChatForm::onSendTriggered()
 }
 void ChatForm::onFileNameChanged(const ToxPk& friendPk)
 {
-    if(friendPk != f->getPublicKey()) {
+    if (friendPk != f->getPublicKey()) {
         return;
     }
 
@@ -266,8 +266,8 @@ void ChatForm::onTextEditChanged()
 
 void ChatForm::onAttachClicked()
 {
-    QStringList paths =
-        QFileDialog::getOpenFileNames(Q_NULLPTR, tr("Send a file"), QDir::homePath(), nullptr, nullptr);
+    QStringList paths = QFileDialog::getOpenFileNames(Q_NULLPTR, tr("Send a file"),
+                                                      QDir::homePath(), nullptr, nullptr);
 
     if (paths.isEmpty()) {
         return;
@@ -512,8 +512,8 @@ void ChatForm::searchInBegin(const QString& phrase, const ParameterSearch& param
     if (isFirst || isAfter) {
         if (isFirst || (isAfter && parameter.date < getFirstDate())) {
             const QString pk = f->getPublicKey().toString();
-            if ((isFirst || parameter.date >= history->getStartDateChatHistory(pk).date()) &&
-                    loadHistory(phrase, parameter)) {
+            if ((isFirst || parameter.date >= history->getStartDateChatHistory(pk).date())
+                && loadHistory(phrase, parameter)) {
 
                 return;
             }
@@ -523,7 +523,8 @@ void ChatForm::searchInBegin(const QString& phrase, const ParameterSearch& param
     } else {
         if (parameter.period == PeriodSearch::BeforeDate && parameter.date < getFirstDate()) {
             const QString pk = f->getPublicKey().toString();
-            if (parameter.date >= history->getStartDateChatHistory(pk).date() && loadHistory(phrase, parameter)) {
+            if (parameter.date >= history->getStartDateChatHistory(pk).date()
+                && loadHistory(phrase, parameter)) {
                 return;
             }
         }
@@ -558,7 +559,8 @@ void ChatForm::onSearchUp(const QString& phrase, const ParameterSearch& paramete
 
     if (!isSearch) {
         const QString pk = f->getPublicKey().toString();
-        const QDateTime newBaseDate = history->getDateWhereFindPhrase(pk, earliestMessage, phrase, parameter);
+        const QDateTime newBaseDate =
+            history->getDateWhereFindPhrase(pk, earliestMessage, phrase, parameter);
 
         if (!newBaseDate.isValid()) {
             emit messageNotFoundShow(SearchDirection::Up);
@@ -651,7 +653,7 @@ void ChatForm::onReceiptReceived(quint32 friendId, int receipt)
     }
 }
 
-void ChatForm::onAvatarChanged(const ToxPk &friendPk, const QPixmap& pic)
+void ChatForm::onAvatarChanged(const ToxPk& friendPk, const QPixmap& pic)
 {
     if (friendPk != f->getPublicKey()) {
         return;
@@ -1061,7 +1063,7 @@ void ChatForm::SendMessageStr(QString msg)
         }
 
         ChatMessage::Ptr ma = createSelfMessage(part, timestamp, isAction, false);
-        
+
         if (history && Settings::getInstance().getEnableLogging()) {
             auto* offMsgEngine = getOfflineMsgEngine();
             QString selfPk = Core::getInstance()->getSelfId().toString();
@@ -1086,7 +1088,8 @@ void ChatForm::SendMessageStr(QString msg)
 bool ChatForm::loadHistory(const QString& phrase, const ParameterSearch& parameter)
 {
     const QString pk = f->getPublicKey().toString();
-    const QDateTime newBaseDate = history->getDateWhereFindPhrase(pk, earliestMessage, phrase, parameter);
+    const QDateTime newBaseDate =
+        history->getDateWhereFindPhrase(pk, earliestMessage, phrase, parameter);
 
     if (newBaseDate.isValid() && getFirstDate().isValid() && newBaseDate.date() < getFirstDate()) {
         searchAfterLoadHistory = true;
@@ -1136,7 +1139,8 @@ void ChatForm::onExportChat()
         ToxPk authorPk(ToxId(it.sender).getPublicKey());
         QString author = getMsgAuthorDispName(authorPk, it.dispName);
 
-        buffer = buffer % QString{datestamp % '\t' % timestamp % '\t' % author % '\t' % it.message % '\n'};
+        buffer = buffer
+                 % QString{datestamp % '\t' % timestamp % '\t' % author % '\t' % it.message % '\n'};
     }
     file.write(buffer.toUtf8());
     file.close();

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -339,12 +339,16 @@ void ChatForm::onFileRecvRequest(ToxFile file)
 
     const Settings& settings = Settings::getInstance();
     QString autoAcceptDir = settings.getAutoAcceptDir(f->getPublicKey());
-    // there is auto-accept for that contact
-    if (!autoAcceptDir.isEmpty()) {
+
+    if (autoAcceptDir.isEmpty() && settings.getAutoSaveEnabled()) {
+        autoAcceptDir = settings.getGlobalAutoAcceptDir();
+    }
+
+    auto maxAutoAcceptSize = settings.getMaxAutoAcceptSize();
+    bool autoAcceptSizeCheckPassed = maxAutoAcceptSize == 0 || maxAutoAcceptSize >= file.filesize;
+
+    if (!autoAcceptDir.isEmpty() && autoAcceptSizeCheckPassed) {
         tfWidget->autoAcceptTransfer(autoAcceptDir);
-        // global autosave to global directory
-    } else if (settings.getAutoSaveEnabled()) {
-        tfWidget->autoAcceptTransfer(settings.getGlobalAutoAcceptDir());
     }
 
     Widget::getInstance()->updateFriendActivity(f);

--- a/src/widget/form/settings/generalform.cpp
+++ b/src/widget/form/settings/generalform.cpp
@@ -21,6 +21,7 @@
 #include "ui_generalsettings.h"
 
 #include <QFileDialog>
+#include <cmath>
 
 #include "src/core/core.h"
 #include "src/core/coreav.h"
@@ -148,7 +149,9 @@ GeneralForm::GeneralForm(SettingsWidget* myParent)
 
     bodyUI->autoAwaySpinBox->setValue(s.getAutoAwayTime());
     bodyUI->autoSaveFilesDir->setText(s.getGlobalAutoAcceptDir());
+    bodyUI->maxAutoAcceptSizeMB->setValue(static_cast<double>(s.getMaxAutoAcceptSize()) / 1024 / 1024);
     bodyUI->autoacceptFiles->setChecked(s.getAutoSaveEnabled());
+
 
 #ifndef QTOX_PLATFORM_EXT
     bodyUI->autoAwayLabel->setEnabled(false); // these don't seem to change the appearance of the widgets,
@@ -242,6 +245,14 @@ void GeneralForm::on_autoSaveFilesDir_clicked()
 
     Settings::getInstance().setGlobalAutoAcceptDir(directory);
     bodyUI->autoSaveFilesDir->setText(directory);
+}
+
+void GeneralForm::on_maxAutoAcceptSizeMB_editingFinished()
+{
+    auto newMaxSizeMB = bodyUI->maxAutoAcceptSizeMB->value();
+    auto newMaxSizeB = std::lround(newMaxSizeMB * 1024 * 1024);
+
+    Settings::getInstance().setMaxAutoAcceptSize(newMaxSizeB);
 }
 
 void GeneralForm::on_checkUpdates_stateChanged()

--- a/src/widget/form/settings/generalform.cpp
+++ b/src/widget/form/settings/generalform.cpp
@@ -151,8 +151,7 @@ GeneralForm::GeneralForm(SettingsWidget* myParent)
     bodyUI->autoacceptFiles->setChecked(s.getAutoSaveEnabled());
 
 #ifndef QTOX_PLATFORM_EXT
-    bodyUI->autoAwayLabel->setEnabled(
-        false); // these don't seem to change the appearance of the widgets,
+    bodyUI->autoAwayLabel->setEnabled(false); // these don't seem to change the appearance of the widgets,
     bodyUI->autoAwaySpinBox->setEnabled(false); // though they are unusable
 #endif
 

--- a/src/widget/form/settings/generalform.h
+++ b/src/widget/form/settings/generalform.h
@@ -53,6 +53,7 @@ private slots:
     void on_cbFauxOfflineMessaging_stateChanged();
 
     void on_autoacceptFiles_stateChanged();
+    void on_maxAutoAcceptSizeMB_editingFinished();
     void on_autoSaveFilesDir_clicked();
     void on_checkUpdates_stateChanged();
 

--- a/src/widget/form/settings/generalsettings.ui
+++ b/src/widget/form/settings/generalsettings.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1312</width>
-    <height>580</height>
+    <height>511</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -39,8 +39,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>1276</width>
-        <height>587</height>
+        <width>1298</width>
+        <height>497</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,0">
@@ -278,6 +278,13 @@ instead of closing itself.</string>
             <property name="leftMargin">
              <number>0</number>
             </property>
+            <item row="2" column="0">
+             <widget class="QLabel" name="label">
+              <property name="text">
+               <string>Default directory to save files:</string>
+              </property>
+             </widget>
+            </item>
             <item row="2" column="1">
              <widget class="QPushButton" name="autoSaveFilesDir">
               <property name="sizePolicy">
@@ -288,13 +295,6 @@ instead of closing itself.</string>
               </property>
               <property name="toolTip">
                <string>Set where files will be saved.</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="label">
-              <property name="text">
-               <string>Default directory to save files:</string>
               </property>
              </widget>
             </item>
@@ -311,6 +311,20 @@ instead of closing itself.</string>
               </property>
               <property name="text">
                <string>Autoaccept files</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="0">
+             <widget class="QLabel" name="maxAutoAcceptSizeLabel">
+              <property name="text">
+               <string>Max autoaccept file size (0 to disable):</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="1">
+             <widget class="QDoubleSpinBox" name="maxAutoAcceptSizeMB">
+              <property name="suffix">
+               <string> MB</string>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
- [x ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

As discussed in #5348 it would be desirable to have a way to limit autoaccept to files under a certain size. This PR implements that.

No UI changes to the chatlog, just an extra item in the general settings pane
![image](https://user-images.githubusercontent.com/1069811/46568222-1a169e00-c8f6-11e8-934b-b543c8c56929.png)

Ran the following tests
* Ensure default value is 20MB (up for discussion, just seemed like a sane limit to me)
* Send file above 20M and below 20M, only below 20M should be auto accepted
* Change value to 5
* Send file above 5M and below 5M, only file below 5M should be auto accepted
* restart qtox
* Send file above 5M and below 5M, only file below 5M should be auto accepted
* Set value to 0
* Send a really large file, should be auto accepted

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5373)
<!-- Reviewable:end -->
