### PR TITLE
fix(core): ensure QTimers are moved with the objects they belong to

### DIFF
--- a/src/core/core.h
+++ b/src/core/core.h
@@ -273,7 +273,7 @@ private:
     ToxPtr tox;
 
     std::unique_ptr<CoreAV> av;
-    QTimer toxTimer;
+    QTimer* toxTimer = nullptr;
     // recursive, since we might call our own functions
     // pointer so we can circumvent const functions
     std::unique_ptr<QMutex> coreLoopLock = nullptr;

--- a/src/core/coreav.h
+++ b/src/core/coreav.h
@@ -30,8 +30,8 @@
 
 class Friend;
 class Group;
-class QTimer;
 class QThread;
+class QTimer;
 class CoreVideoSource;
 class CameraSource;
 class VideoSource;
@@ -94,7 +94,6 @@ public slots:
     bool cancelCall(uint32_t friendNum);
     void timeoutCall(uint32_t friendNum);
     void start();
-    void stop();
 
 signals:
     void avInvite(uint32_t friendId, bool video);
@@ -124,7 +123,7 @@ private:
 private:
     ToxAV* toxav;
     std::unique_ptr<QThread> coreavThread;
-    std::unique_ptr<QTimer> iterateTimer;
+    QTimer* iterateTimer = nullptr;
     static std::map<uint32_t, ToxFriendCall> calls;
     static std::map<int, ToxGroupCall> groupCalls;
     std::atomic_flag threadSwitchLock;


### PR DESCRIPTION
We use the Qt parent/child model instead of unique_ptr to achieve this.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

@sphaerophoria can you please review this?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5378)
<!-- Reviewable:end -->
