### PR TITLE
Move default autoaccept dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,6 +333,8 @@ set(${PROJECT_NAME}_SOURCES
   src/persistence/smileypack.h
   src/persistence/toxsave.cpp
   src/persistence/toxsave.h
+  src/persistence/upgradablesetting.cpp
+  src/persistence/upgradablesetting.h
   src/video/cameradevice.cpp
   src/video/cameradevice.h
   src/video/camerasource.cpp

--- a/src/model/about/aboutfriend.cpp
+++ b/src/model/about/aboutfriend.cpp
@@ -2,26 +2,22 @@
 
 #include "src/model/friend.h"
 #include "src/nexus.h"
-#include "src/persistence/profile.h"
 #include "src/persistence/ifriendsettings.h"
+#include "src/persistence/profile.h"
 
 AboutFriend::AboutFriend(const Friend* f, IFriendSettings* const s)
     : f{f}
     , settings{s}
 {
-    s->connectTo_contactNoteChanged([=](const ToxPk& pk, const QString& note) {
-        emit noteChanged(note);
-    });
-    s->connectTo_autoAcceptCallChanged(
-            [=](const ToxPk& pk, IFriendSettings::AutoAcceptCallFlags flag) {
+    s->connectTo_contactNoteChanged(
+        [=](const ToxPk& pk, const QString& note) { emit noteChanged(note); });
+    s->connectTo_autoAcceptCallChanged([=](const ToxPk& pk, IFriendSettings::AutoAcceptCallFlags flag) {
         emit autoAcceptCallChanged(flag);
     });
-    s->connectTo_autoAcceptDirChanged([=](const ToxPk& pk, const QString& dir) {
-        emit autoAcceptDirChanged(dir);
-    });
-    s->connectTo_autoGroupInviteChanged([=](const ToxPk& pk, bool enable) {
-        emit autoGroupInviteChanged(enable);
-    });
+    s->connectTo_autoAcceptDirChanged(
+        [=](const ToxPk& pk, const QString& dir) { emit autoAcceptDirChanged(dir); });
+    s->connectTo_autoGroupInviteChanged(
+        [=](const ToxPk& pk, bool enable) { emit autoGroupInviteChanged(enable); });
 }
 
 QString AboutFriend::getName() const
@@ -43,8 +39,7 @@ QPixmap AboutFriend::getAvatar() const
 {
     const ToxPk pk = f->getPublicKey();
     const QPixmap avatar = Nexus::getProfile()->loadAvatar(pk);
-    return avatar.isNull() ? QPixmap(QStringLiteral(":/img/contact_dark.svg"))
-                           : avatar;
+    return avatar.isNull() ? QPixmap(QStringLiteral(":/img/contact_dark.svg")) : avatar;
 }
 
 QString AboutFriend::getNote() const

--- a/src/model/about/aboutfriend.cpp
+++ b/src/model/about/aboutfriend.cpp
@@ -55,6 +55,19 @@ void AboutFriend::setNote(const QString& note)
     settings->saveFriendSettings(pk);
 }
 
+bool AboutFriend::getAutoAcceptEnable() const
+{
+    const ToxPk pk = f->getPublicKey();
+    return settings->getAutoAcceptEnable(pk);
+}
+
+void AboutFriend::setAutoAcceptEnable(bool enable)
+{
+    const ToxPk pk = f->getPublicKey();
+    settings->setAutoAcceptEnable(pk, enable);
+    settings->saveFriendSettings(pk);
+}
+
 QString AboutFriend::getAutoAcceptDir() const
 {
     const ToxPk pk = f->getPublicKey();

--- a/src/model/about/aboutfriend.h
+++ b/src/model/about/aboutfriend.h
@@ -26,6 +26,9 @@ public:
     QString getNote() const override;
     void setNote(const QString& note) override;
 
+    bool getAutoAcceptEnable() const override;
+    void setAutoAcceptEnable(bool enable) override;
+
     QString getAutoAcceptDir() const override;
     void setAutoAcceptDir(const QString& path) override;
 

--- a/src/model/about/iaboutfriend.h
+++ b/src/model/about/iaboutfriend.h
@@ -19,6 +19,9 @@ public:
     virtual QString getNote() const = 0;
     virtual void setNote(const QString& note) = 0;
 
+    virtual bool getAutoAcceptEnable() const = 0;
+    virtual void setAutoAcceptEnable(bool enable) = 0;
+
     virtual QString getAutoAcceptDir() const = 0;
     virtual void setAutoAcceptDir(const QString& path) = 0;
 

--- a/src/model/chatroom/friendchatroom.cpp
+++ b/src/model/chatroom/friendchatroom.cpp
@@ -1,5 +1,5 @@
-#include "src/grouplist.h"
 #include "src/model/chatroom/friendchatroom.h"
+#include "src/grouplist.h"
 #include "src/model/friend.h"
 #include "src/model/group.h"
 #include "src/persistence/settings.h"
@@ -19,12 +19,11 @@ QString getShortName(const QString& name)
     return name.left(MAX_NAME_LENGTH).trimmed() + "…";
 }
 
-}
+} // namespace
 
 FriendChatroom::FriendChatroom(Friend* frnd)
     : frnd{frnd}
-{
-}
+{}
 
 Friend* FriendChatroom::getFriend()
 {
@@ -102,7 +101,7 @@ QVector<GroupToDisplay> FriendChatroom::getGroups() const
     QVector<GroupToDisplay> groups;
     for (const auto group : GroupList::getAllGroups()) {
         const auto name = getShortName(group->getName());
-        const GroupToDisplay groupToDisplay = { name, group };
+        const GroupToDisplay groupToDisplay = {name, group};
         groups.push_back(groupToDisplay);
     }
 
@@ -123,7 +122,7 @@ QVector<CircleToDisplay> FriendChatroom::getOtherCircles() const
         }
 
         const auto name = getShortName(s.getCircleName(i));
-        const CircleToDisplay circle = { name, i };
+        const CircleToDisplay circle = {name, i};
         circles.push_back(circle);
     }
 

--- a/src/model/chatroom/friendchatroom.cpp
+++ b/src/model/chatroom/friendchatroom.cpp
@@ -79,14 +79,16 @@ void FriendChatroom::setAutoAcceptDir(const QString& dir)
     Settings::getInstance().setAutoAcceptDir(pk, dir);
 }
 
-void FriendChatroom::disableAutoAccept()
+void FriendChatroom::setAutoAccept(bool enable)
 {
-    setAutoAcceptDir(QString{});
+    const auto pk = frnd->getPublicKey();
+    Settings::getInstance().setAutoAcceptEnable(pk, enable);
 }
 
 bool FriendChatroom::autoAcceptEnabled() const
 {
-    return getAutoAcceptDir().isEmpty();
+    const auto pk = frnd->getPublicKey();
+    return Settings::getInstance().getAutoAcceptEnable(pk);
 }
 
 void FriendChatroom::inviteFriend(const Group* group)

--- a/src/model/chatroom/friendchatroom.h
+++ b/src/model/chatroom/friendchatroom.h
@@ -65,7 +65,7 @@ public slots:
 
     bool autoAcceptEnabled() const;
     QString getAutoAcceptDir() const;
-    void disableAutoAccept();
+    void setAutoAccept(bool enable);
     void setAutoAcceptDir(const QString& dir);
 
     QVector<GroupToDisplay> getGroups() const;

--- a/src/persistence/ifriendsettings.h
+++ b/src/persistence/ifriendsettings.h
@@ -3,8 +3,8 @@
 
 #include "src/model/interface.h"
 
-#include <QObject>
 #include <QFlag>
+#include <QObject>
 
 class ToxPk;
 

--- a/src/persistence/ifriendsettings.h
+++ b/src/persistence/ifriendsettings.h
@@ -26,6 +26,9 @@ public:
     virtual QString getAutoAcceptDir(const ToxPk& pk) const = 0;
     virtual void setAutoAcceptDir(const ToxPk& pk, const QString& dir) = 0;
 
+    virtual bool getAutoAcceptEnable(const ToxPk& id) const = 0;
+    virtual void setAutoAcceptEnable(const ToxPk& id, bool enable) = 0;
+
     virtual AutoAcceptCallFlags getAutoAcceptCall(const ToxPk& pk) const = 0;
     virtual void setAutoAcceptCall(const ToxPk& pk, AutoAcceptCallFlags accept) = 0;
 
@@ -47,6 +50,7 @@ public:
 signals:
     DECLARE_SIGNAL(autoAcceptCallChanged, const ToxPk& pk, AutoAcceptCallFlags accept);
     DECLARE_SIGNAL(autoGroupInviteChanged, const ToxPk& pk, bool accept);
+    DECLARE_SIGNAL(autoAcceptEnableChanged, const ToxPk& pk, bool enable);
     DECLARE_SIGNAL(autoAcceptDirChanged, const ToxPk& pk, const QString& dir);
     DECLARE_SIGNAL(contactNoteChanged, const ToxPk& pk, const QString& note);
 };

--- a/src/persistence/profile.cpp
+++ b/src/persistence/profile.cpp
@@ -395,18 +395,8 @@ QString Profile::avatarPath(const ToxPk& owner, bool forceUnencrypted)
         return Settings::getInstance().getSettingsDirPath() + "avatars/" + ownerStr + ".png";
     }
 
-    QByteArray idData = ownerStr.toUtf8();
-    QByteArray pubkeyData = core->getSelfId().getPublicKey().getKey();
-    constexpr int hashSize = TOX_PUBLIC_KEY_SIZE;
-    static_assert(hashSize >= crypto_generichash_BYTES_MIN && hashSize <= crypto_generichash_BYTES_MAX,
-                  "Hash size not supported by libsodium");
-    static_assert(hashSize >= crypto_generichash_KEYBYTES_MIN
-                      && hashSize <= crypto_generichash_KEYBYTES_MAX,
-                  "Key size not supported by libsodium");
-    QByteArray hash(hashSize, 0);
-    crypto_generichash((uint8_t*)hash.data(), hashSize, (uint8_t*)idData.data(), idData.size(),
-                       (uint8_t*)pubkeyData.data(), pubkeyData.size());
-    return Settings::getInstance().getSettingsDirPath() + "avatars/" + hash.toHex().toUpper() + ".png";
+    auto hashedId = hashedFriendId(ownerStr);
+    return Settings::getInstance().getSettingsDirPath() + "avatars/" + hashedId + ".png";
 }
 
 /**
@@ -772,6 +762,22 @@ bool Profile::rename(QString newName)
 
     name = newName;
     return true;
+}
+
+QString Profile::hashedFriendId(const QString& ownerStr) const
+{
+    QByteArray idData = ownerStr.toUtf8();
+    QByteArray pubkeyData = core->getSelfId().getPublicKey().getKey();
+    constexpr int hashSize = TOX_PUBLIC_KEY_SIZE;
+    static_assert(hashSize >= crypto_generichash_BYTES_MIN && hashSize <= crypto_generichash_BYTES_MAX,
+                  "Hash size not supported by libsodium");
+    static_assert(hashSize >= crypto_generichash_KEYBYTES_MIN
+                      && hashSize <= crypto_generichash_KEYBYTES_MAX,
+                  "Key size not supported by libsodium");
+    QByteArray hash(hashSize, 0);
+    crypto_generichash((uint8_t*)hash.data(), hashSize, (uint8_t*)idData.data(), idData.size(),
+                       (uint8_t*)pubkeyData.data(), pubkeyData.size());
+    return hash.toHex().toUpper();
 }
 
 const ToxEncrypt* Profile::getPasskey() const

--- a/src/persistence/profile.h
+++ b/src/persistence/profile.h
@@ -68,6 +68,12 @@ public:
 
     bool rename(QString newName);
 
+    /**
+     * @brief Hashes a friend Id (ownerStr) using our own public key as the hash key
+     * @param[in] ownerStr A stringized public key of a friend (pk.toHex().toUppercase())
+     */
+    QString hashedFriendId(const QString& ownerStr) const;
+
     static void scanProfiles();
     static QStringList getProfiles();
 

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -175,8 +175,12 @@ void Settings::loadGlobal()
         }
         autoAwayTime = s.value("autoAwayTime", 10).toInt();
         checkUpdates = s.value("checkUpdates", true).toBool();
-        notifySound = s.value("notifySound", true).toBool(); // note: notifySound and busySound UI elements are now under UI settings
-        busySound = s.value("busySound", false).toBool();    // page, but kept under General in settings file to be backwards compatible
+        notifySound =
+            s.value("notifySound", true)
+                .toBool(); // note: notifySound and busySound UI elements are now under UI settings
+        busySound =
+            s.value("busySound", false)
+                .toBool(); // page, but kept under General in settings file to be backwards compatible
         fauxOfflineMessaging = s.value("fauxOfflineMessaging", true).toBool();
         autoSaveEnabled = s.value("autoSaveEnabled", false).toBool();
         globalAutoAcceptDir = s.value("globalAutoAcceptDir",

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -433,6 +433,9 @@ public:
     QString getAutoAcceptDir(const ToxPk& id) const override;
     void setAutoAcceptDir(const ToxPk& id, const QString& dir) override;
 
+    bool getAutoAcceptEnable(const ToxPk& id) const override;
+    void setAutoAcceptEnable(const ToxPk& id, bool enable) override;
+
     AutoAcceptCallFlags getAutoAcceptCall(const ToxPk& id) const override;
     void setAutoAcceptCall(const ToxPk& id, AutoAcceptCallFlags accept) override;
 
@@ -507,6 +510,7 @@ public:
     SIGNAL_IMPL(Settings, autoAcceptCallChanged, const ToxPk& id,
                 IFriendSettings::AutoAcceptCallFlags accept)
     SIGNAL_IMPL(Settings, autoGroupInviteChanged, const ToxPk& id, bool accept)
+    SIGNAL_IMPL(Settings, autoAcceptEnableChanged, const ToxPk& id, bool enable)
     SIGNAL_IMPL(Settings, autoAcceptDirChanged, const ToxPk& id, const QString& dir)
     SIGNAL_IMPL(Settings, contactNoteChanged, const ToxPk& id, const QString& note)
 
@@ -568,11 +572,15 @@ public:
     static uint32_t makeProfileId(const QString& profile);
 
 private:
+    struct friendProp;
+
     Settings();
     ~Settings();
     Settings(Settings& settings) = delete;
     Settings& operator=(const Settings&) = delete;
     void savePersonal(QString profileName, const ToxEncrypt* passkey);
+    QString getDefaultTransfersDir() const;
+    QString defaultAutoAcceptDir(friendProp const& friendProp) const;
 
 public slots:
     void savePersonal(Profile* profile);
@@ -618,6 +626,10 @@ private:
     uint32_t currentProfileId;
 
     // Toxme Info
+    /**
+     * @var QString Settings::toxmeInfo
+     * @brief Toxme info like name@server
+     */
     QString toxmeInfo;
     QString toxmeBio;
     bool toxmePriv;
@@ -628,8 +640,8 @@ private:
     int autoAwayTime;
 
     QHash<QString, QByteArray> widgetSettings;
-    QHash<QString, QString> autoAccept;
     bool autoSaveEnabled;
+    bool defaultAutoAcceptDirV2Initialized;
     QString globalAutoAcceptDir;
     size_t autoAcceptMaxSize;
 
@@ -686,6 +698,7 @@ private:
     {
         QString alias;
         QString addr;
+        bool autoAcceptEnabled;
         QString autoAcceptDir;
         QString note;
         int circleID = -1;
@@ -705,11 +718,6 @@ private:
     QVector<circleProp> circleLst;
 
     int themeColor;
-
-    static QMutex bigLock;
-    static Settings* settings;
-    static const QString globalSettingsFile;
-    static QThread* settingsThread;
 };
 
 #endif // SETTINGS_HPP

--- a/src/persistence/upgradablesetting.cpp
+++ b/src/persistence/upgradablesetting.cpp
@@ -1,0 +1,137 @@
+/*
+    Copyright © 2018 by The qTox Project Contributors
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "upgradablesetting.h"
+
+#include <QCheckBox>
+#include <QDialog>
+#include <QDialogButtonBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QScrollArea>
+#include <QScrollBar>
+#include <QVBoxLayout>
+
+std::vector<bool> UpgradableSettingDetail::doUpgradeRequest(QString const& message,
+                                                            std::vector<MessageItem> messageItems)
+{
+    if (messageItems.size() == 0) {
+        return {};
+    } else if (messageItems.size() == 1) {
+        QString fullMessage = message;
+        fullMessage += "\nOld value: %1\nNew default: %2";
+        fullMessage = fullMessage.arg(messageItems[0].oldValue).arg(messageItems[0].newDefault);
+        auto response = QMessageBox::question(nullptr, QObject::tr("Upgrade Request"), fullMessage);
+        return {response == QMessageBox::StandardButton::Yes};
+    } else {
+        QDialog upgradeDialog;
+        upgradeDialog.setWindowTitle(QObject::tr("Upgrade Request"));
+        upgradeDialog.setWindowFlags(Qt::Window | Qt::WindowTitleHint | Qt::CustomizeWindowHint);
+        QVBoxLayout layout(&upgradeDialog);
+
+        QLabel messageLabel(message);
+        messageLabel.setWordWrap(true);
+        layout.addWidget(&messageLabel);
+
+        QScrollArea scrollArea;
+        QWidget itemsWidget;
+        QGridLayout itemsLayout(&itemsWidget);
+        layout.addWidget(&scrollArea);
+        scrollArea.setWidget(&itemsWidget);
+        scrollArea.setWidgetResizable(true);
+        scrollArea.horizontalScrollBar()->setEnabled(false);
+        scrollArea.setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+
+        auto nameHeader = new QLabel(QObject::tr("Name"));
+        itemsLayout.addWidget(nameHeader, 0, 0);
+
+        auto oldHeader = new QLabel(QObject::tr("Old Value"));
+        itemsLayout.addWidget(oldHeader, 0, 1);
+
+        auto newHeader = new QLabel(QObject::tr("New Default"));
+        itemsLayout.addWidget(newHeader, 0, 2);
+
+        auto acceptHeader = new QLabel(QObject::tr("Accept"));
+        itemsLayout.addWidget(acceptHeader, 0, 3);
+
+        int rowIdx = 1;
+
+        std::vector<QCheckBox*> checkboxes;
+
+        for (auto const& messageItem : messageItems) {
+            auto nameLabel = new QLabel(messageItem.name);
+            itemsLayout.addWidget(nameLabel, rowIdx, 0);
+
+            auto oldValueLabel = new QLabel(messageItem.oldValue);
+            oldValueLabel->setWordWrap(true);
+            itemsLayout.addWidget(oldValueLabel, rowIdx, 1);
+
+            auto newValueLabel = new QLabel(messageItem.newDefault);
+            newValueLabel->setWordWrap(true);
+            itemsLayout.addWidget(newValueLabel, rowIdx, 2);
+
+            auto checkbox = new QCheckBox();
+            checkbox->setCheckState(Qt::CheckState::Checked);
+            checkboxes.push_back(checkbox);
+            itemsLayout.addWidget(checkbox, rowIdx, 3);
+
+            rowIdx++;
+        }
+
+        scrollArea.setMinimumWidth(itemsLayout.sizeHint().width());
+
+        QHBoxLayout upgradeAllHbox;
+        layout.addLayout(&upgradeAllHbox);
+
+        QLabel upgradeAllLabel(QObject::tr("Upgrade all: "));
+        upgradeAllHbox.addWidget(&upgradeAllLabel);
+
+        QSizePolicy upgradeAllLabelSizePolicy;
+        upgradeAllLabelSizePolicy.setHorizontalPolicy(QSizePolicy::Policy::Expanding);
+        upgradeAllLabel.setSizePolicy(upgradeAllLabelSizePolicy);
+
+        auto upgradeAllCheckbox = new QCheckBox();
+        upgradeAllHbox.addWidget(upgradeAllCheckbox);
+
+        upgradeAllCheckbox->setChecked(true);
+        QCheckBox::connect(upgradeAllCheckbox, &QCheckBox::stateChanged, [&](int state) {
+            for (auto& checkbox : checkboxes) {
+                checkbox->setCheckState(static_cast<Qt::CheckState>(state));
+            }
+        });
+
+        QDialogButtonBox buttonBox;
+        QPushButton okButton;
+        okButton.setText(QObject::tr("OK"));
+        QObject::connect(&okButton, &QPushButton::clicked, &upgradeDialog, &QDialog::close);
+        buttonBox.addButton(&okButton, QDialogButtonBox::AcceptRole);
+        layout.addWidget(&buttonBox);
+
+        upgradeDialog.exec();
+
+        std::vector<bool> successes;
+        successes.reserve(checkboxes.size());
+        std::transform(checkboxes.begin(), checkboxes.end(), std::back_inserter(successes),
+                       [](QCheckBox* checkbox) { return checkbox->isChecked(); });
+
+        return successes;
+    }
+}

--- a/src/persistence/upgradablesetting.h
+++ b/src/persistence/upgradablesetting.h
@@ -1,0 +1,355 @@
+/*
+    Copyright © 2018 by The qTox Project Contributors
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef UPGRADABLESETTING_H
+#define UPGRADABLESETTING_H
+
+#include <QSettings>
+#include <QString>
+#include <QVariant>
+
+#include <algorithm>
+#include <bitset>
+#include <cassert>
+#include <memory>
+
+/**
+ * Respose handle for caller after upgrade request has completed
+ */
+template <typename OldType, typename NewType>
+class UpgradableSettingResponse
+{
+private:
+    const bool upgraded;
+    void* value;
+
+public:
+    UpgradableSettingResponse(NewType* newType, bool upgraded)
+        : upgraded(upgraded)
+        , value(newType)
+    {}
+
+    // we can only instantiate this if OldType != NewType or we'll have a duplicate declaration
+    template <bool OldIsNewType = std::is_same<OldType, NewType>::value>
+    UpgradableSettingResponse(OldType* oldType, bool upgraded,
+                              typename std::enable_if<OldIsNewType, int>::type = 0)
+        : upgraded(upgraded)
+        , value(oldType)
+    {}
+
+    /**
+     * @brief Indicates if inner data is upgraded to NewType
+     * @return true if upgraded
+     */
+    bool isUpgraded() const
+    {
+        return upgraded;
+    }
+
+    OldType& asOldType() const
+    {
+        assert(!upgraded);
+        return *static_cast<OldType*>(value);
+    }
+
+    OldType& asNewType() const
+    {
+        assert(upgraded);
+        return *static_cast<NewType*>(value);
+    }
+};
+
+/**
+ * Assists with settings value upgrades. Will ask the user if an upgrade is okay
+ */
+template <typename OldType, typename NewType>
+class UpgradableSetting
+{
+public:
+    /**
+     * Helps construct our UpgradableSetting without a lengthy constructor
+     */
+    class Builder
+    {
+    public:
+        Builder() = default;
+
+        /**
+         * @param[in] name name of old settings field
+         * @note Mandatory parameter
+         */
+        Builder& oldSettingsName(QString name);
+
+        /**
+         * @param[in] name name of new settings field
+         * @note Mandatory parameter
+         */
+        Builder& newSettingsName(QString name);
+
+        /**
+         * @param[in] name name of setting indicating that we have already done this upgrade
+         * @note Mandatory parameter
+         */
+        Builder& upgradeHasHappenedName(QString name);
+
+        /**
+         * @param[in] message Message to use when requesting an upgrade from the
+         * user. Should be in the form of a question
+         * @note Mandatory parameter
+         */
+        Builder& upgradeMessage(QString message);
+
+        /**
+         * @brief Indicates that if the saved value exists but is the same as a default constructed
+         * value of OldType we can treat the item as if it's never been set
+         * @note Optional parameter
+         */
+        Builder& defaultConstructedIsNull();
+
+        /**
+         * @brief Constructs our upgradable setting. Assumes all mandatory fields have been set
+         * @return UpgradableSetting
+         */
+        UpgradableSetting build();
+
+    private:
+        enum class MandatoryFields
+        {
+            oldSettings,
+            newSettings,
+            upgradeHasHappened,
+            upgradeMessage,
+            numElems,
+        };
+
+        /**
+         * @brief Helper function to cast the MandatoryFields enum back to something useable to index a bitset at compile time
+         */
+        static constexpr size_t mandatoryFieldsIdx(MandatoryFields field)
+        {
+            return static_cast<typename std::underlying_type<MandatoryFields>::type>(field);
+        }
+
+        UpgradableSetting setting;
+        /// Tracking variable to ensure that the caller has set all mandatory fields before building
+        /// the UpgradableSetting. Only use at time of writing is to assert on the build() function
+        std::bitset<mandatoryFieldsIdx(MandatoryFields::numElems)> setMandatoryFields{0};
+    };
+
+    /**
+     * @brief Requests upgrade of setting to the user. This will only be
+     * prompted once per setting and only if the previous value has already
+     * been set
+     * @param[in] message Message to display
+     */
+    void requestUpgrade();
+
+    /**
+     * @brief Adds an upgrade request. We re-use the names assuming that all fields are related,
+     * but it's expected that you may have a different default for each contact. On completion
+     * of the request we callback to the above layer to decide what to do with the upgrade of this item.
+     * Note that fields from the settings struct are resolved on call of addItem, so if they change between
+     * the call of addItem and requestUpgrade you may end up with out of date state. This is done to help
+     * with the parsing of arrays of data.
+     * @param name Name to associate with this item
+     * @param settings Settings struct we get old/new values from
+     * @param newDefault New default value in the case that we're okay to upgrade and the new one isn't set
+     * @param defaultStr In some cases the default value isn't something sensable to expose to a user.
+     * In this case we allow the caller to pass in a string they'd prefer to show instead
+     * @param onRequestFinsihed Callback for handling user response
+     */
+    template <typename SettingsType>
+    void addItem(SettingsType& settings, QString name, NewType newDefault, QString defaultStr,
+                 std::function<void(UpgradableSettingResponse<OldType, NewType> const&)> onRequestFinished)
+    {
+        QVariant upgradeHasHappened = settings.value(upgradeHasHappenedName);
+        QVariant oldValue = settings.value(oldSettingsName);
+        // If upgradeHasHappened is either true or false we've already asked the user and they
+        // said no so we're stuck never upgrading
+        bool needsUpgrade = !upgradeHasHappened.isValid();
+
+        // If the user never set the old default we don't have to ask them
+        bool oldValueIsNull = !oldValue.isValid()
+                              || (defaultConstructedIsNull && oldValue.value<OldType>() == OldType());
+
+        bool needsSettingsRequest = false;
+
+        // We should only request a settings upgrade if we have never requested one
+        // before *and* the old settings have ever been set
+        if (needsUpgrade && !oldValueIsNull) {
+            needsSettingsRequest = true;
+        }
+
+        if (needsSettingsRequest) {
+            auto oldItem = std::shared_ptr<OldType>(new OldType(oldValue.value<OldType>()));
+            requestUpgradeItems.push_back({name, std::shared_ptr<NewType>(new NewType(newDefault)),
+                                           defaultStr, oldItem, onRequestFinished});
+        } else {
+            if (upgradeHasHappened.isValid() && upgradeHasHappened.value<bool>() == false) {
+                auto oldItem = std::shared_ptr<OldType>(new OldType(oldValue.value<OldType>()));
+                upgradeItems.push_back({name, nullptr, "", std::move(oldItem), onRequestFinished});
+            } else {
+                // We already know we don't need a settings request which means we're good to go for using the new type
+                QVariant newValue = settings.value(newSettingsName, newDefault);
+                auto newItem = std::shared_ptr<NewType>(new NewType(newValue.value<NewType>()));
+                upgradeItems.push_back({name, std::move(newItem), "", nullptr, onRequestFinished});
+            }
+        }
+    }
+
+
+private:
+    UpgradableSetting() = default;
+
+    // Note: shared_ptrs are used since UpgradeItem is intended to be stored in a vector. Thanks to
+    // vector semantics we cannot do that if we use unique_ptrs instead
+    struct UpgradeItem
+    {
+        QString name;
+        // Stores default or new depending on if we have already upgraded
+        std::shared_ptr<NewType> newItem;
+        // Sometimes the default string will be NULL to indicate an automatic value. In this case
+        // the caller passes in a string indicating what the value will actually be
+        QString defaultStr;
+        // Stores old if we are upgrading or we have decided we do not want to upgrade
+        std::shared_ptr<OldType> oldItem;
+        std::function<void(UpgradableSettingResponse<OldType, NewType> const&)> onRequestFinished;
+    };
+
+    QString oldSettingsName;
+    QString newSettingsName;
+    QString upgradeHasHappenedName;
+    QString upgradeMessage;
+    // Items we can upgrade for free
+    std::vector<UpgradeItem> upgradeItems;
+    // Items that require a prompt to upgrade
+    std::vector<UpgradeItem> requestUpgradeItems;
+    bool defaultConstructedIsNull = false;
+};
+
+class UpgradableSettingDetail
+{
+    template <typename OldType, typename NewType>
+    friend class UpgradableSetting;
+
+    struct MessageItem
+    {
+        QString name;
+        QString oldValue;
+        QString newDefault;
+    };
+
+    /**
+     * @brief Requests upgrade of setting to the user.
+     * @param[in] message Message to display
+     * @return true if the upgrade was successful for each item in items
+     */
+    static std::vector<bool> doUpgradeRequest(QString const& message, std::vector<MessageItem> items);
+};
+
+template <typename OldType, typename NewType>
+typename UpgradableSetting<OldType, NewType>::Builder&
+UpgradableSetting<OldType, NewType>::Builder::oldSettingsName(QString name)
+{
+    setting.oldSettingsName = std::move(name);
+    setMandatoryFields[mandatoryFieldsIdx(MandatoryFields::oldSettings)] = true;
+    return *this;
+}
+
+template <typename OldType, typename NewType>
+typename UpgradableSetting<OldType, NewType>::Builder&
+UpgradableSetting<OldType, NewType>::Builder::newSettingsName(QString name)
+{
+    setting.newSettingsName = std::move(name);
+    setMandatoryFields[mandatoryFieldsIdx(MandatoryFields::newSettings)] = true;
+    return *this;
+}
+
+template <typename OldType, typename NewType>
+typename UpgradableSetting<OldType, NewType>::Builder&
+UpgradableSetting<OldType, NewType>::Builder::upgradeHasHappenedName(QString name)
+{
+    setting.upgradeHasHappenedName = std::move(name);
+    setMandatoryFields[mandatoryFieldsIdx(MandatoryFields::upgradeHasHappened)] = true;
+    return *this;
+}
+
+template <typename OldType, typename NewType>
+typename UpgradableSetting<OldType, NewType>::Builder&
+UpgradableSetting<OldType, NewType>::Builder::upgradeMessage(QString message)
+{
+    setting.upgradeMessage = std::move(message);
+    setMandatoryFields[mandatoryFieldsIdx(MandatoryFields::upgradeMessage)] = true;
+    return *this;
+}
+
+template <typename OldType, typename NewType>
+typename UpgradableSetting<OldType, NewType>::Builder&
+UpgradableSetting<OldType, NewType>::Builder::defaultConstructedIsNull()
+{
+    setting.defaultConstructedIsNull = true;
+    return *this;
+}
+
+template <typename OldType, typename NewType>
+UpgradableSetting<OldType, NewType> UpgradableSetting<OldType, NewType>::Builder::build()
+{
+    assert(setMandatoryFields.all());
+    return setting;
+}
+
+template <typename OldType, typename NewType>
+void UpgradableSetting<OldType, NewType>::requestUpgrade()
+{
+    std::vector<UpgradableSettingDetail::MessageItem> messageItems;
+    messageItems.reserve(requestUpgradeItems.size());
+    std::transform(requestUpgradeItems.begin(), requestUpgradeItems.end(),
+                   std::back_inserter(messageItems), [&](UpgradeItem& upgradeItem) {
+                       QString name = upgradeItem.name;
+                       QString oldValue = static_cast<QString>(*upgradeItem.oldItem);
+                       QString newDefault = !upgradeItem.defaultStr.isEmpty()
+                                                ? upgradeItem.defaultStr
+                                                : static_cast<QString>(*upgradeItem.newItem);
+                       return UpgradableSettingDetail::MessageItem{name, oldValue, newDefault};
+                   });
+
+    std::vector<bool> requestResults =
+        UpgradableSettingDetail::doUpgradeRequest(upgradeMessage, messageItems);
+
+    assert(requestResults.size() == requestUpgradeItems.size());
+
+    for (size_t i = 0; i < requestResults.size(); ++i) {
+        auto& upgradeItem = requestUpgradeItems[i];
+        if (requestResults[i]) {
+            UpgradableSettingResponse<OldType, NewType> response(upgradeItem.newItem.get(), true);
+            upgradeItem.onRequestFinished(response);
+
+        } else {
+            UpgradableSettingResponse<OldType, NewType> response(upgradeItem.oldItem.get(), false);
+            upgradeItem.onRequestFinished(response);
+        }
+    }
+
+    for (auto& upgradeItem : upgradeItems) {
+        UpgradableSettingResponse<OldType, NewType> response(upgradeItem.newItem.get(), true);
+        upgradeItem.onRequestFinished(response);
+    }
+}
+
+#endif // UPGRADABLESETTING_H

--- a/src/widget/about/aboutfriendform.cpp
+++ b/src/widget/about/aboutfriendform.cpp
@@ -1,7 +1,7 @@
 #include "aboutfriendform.h"
-#include "src/widget/gui.h"
 #include "ui_aboutfriendform.h"
 #include "src/core/core.h"
+#include "src/widget/gui.h"
 
 #include <QFileDialog>
 #include <QMessageBox>
@@ -21,7 +21,7 @@ AboutFriendForm::AboutFriendForm(std::unique_ptr<IAboutFriend> _about, QWidget* 
     connect(ui->autogroupinvite, &QCheckBox::clicked, this, &AboutFriendForm::onAutoGroupInvite);
     connect(ui->selectSaveDir, &QPushButton::clicked, this, &AboutFriendForm::onSelectDirClicked);
     connect(ui->removeHistory, &QPushButton::clicked, this, &AboutFriendForm::onRemoveHistoryClicked);
-    about->connectTo_autoAcceptDirChanged([=](const QString& dir){ onAutoAcceptDirChanged(dir); });
+    about->connectTo_autoAcceptDirChanged([=](const QString& dir) { onAutoAcceptDirChanged(dir); });
 
     const QString dir = about->getAutoAcceptDir();
     ui->autoacceptfile->setChecked(!dir.isEmpty());
@@ -57,7 +57,7 @@ static QString getAutoAcceptDir(const QString& dir)
 
 void AboutFriendForm::onAutoAcceptDirClicked()
 {
-    const QString dir = [&]{
+    const QString dir = [&] {
         if (!ui->autoacceptfile->isChecked()) {
             return QString{};
         }
@@ -108,14 +108,15 @@ void AboutFriendForm::onAcceptedClicked()
 
 void AboutFriendForm::onRemoveHistoryClicked()
 {
-   const bool retYes = GUI::askQuestion(tr("Confirmation"),
-                                   tr("Are you sure to remove %1 chat history?").arg(about->getName()),
-                                   /* defaultAns = */ false, /* warning = */ true, /* yesno = */ true);
+    const bool retYes =
+        GUI::askQuestion(tr("Confirmation"),
+                         tr("Are you sure to remove %1 chat history?").arg(about->getName()),
+                         /* defaultAns = */ false, /* warning = */ true, /* yesno = */ true);
     if (!retYes) {
         return;
     }
 
-   const bool result = about->clearHistory();
+    const bool result = about->clearHistory();
 
     if (!result) {
         GUI::showWarning(tr("History removed"),

--- a/src/widget/about/aboutfriendform.h
+++ b/src/widget/about/aboutfriendform.h
@@ -30,10 +30,12 @@ signals:
 private slots:
     void onAutoAcceptDirChanged(const QString& path);
     void onAcceptedClicked();
-    void onAutoAcceptDirClicked();
+    void onAutoAcceptClicked();
     void onAutoAcceptCallClicked();
     void onAutoGroupInvite();
     void onSelectDirClicked();
+    void onOpenDirClicked();
+    void onResetSaveDirClicked();
     void onRemoveHistoryClicked();
 };
 

--- a/src/widget/about/aboutfriendform.ui
+++ b/src/widget/about/aboutfriendform.ui
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>AboutFriendForm</class>
- <widget class="QDialog" name="AboutUser">
+ <widget class="QDialog" name="AboutFriendForm">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>506</width>
-    <height>473</height>
+    <width>474</width>
+    <height>485</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -164,30 +164,6 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="0" colspan="2">
-      <widget class="QCheckBox" name="autoacceptfile">
-       <property name="accessibleDescription">
-        <string>Automatically accept files from contact if set</string>
-       </property>
-       <property name="text">
-        <string>Auto accept files</string>
-       </property>
-      </widget>
-     </item>
-     <item row="8" column="0">
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Default directory to save files:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="8" column="1">
-      <widget class="QPushButton" name="selectSaveDir">
-       <property name="text">
-        <string>Auto accept for this contact is disabled</string>
-       </property>
-      </widget>
-     </item>
      <item row="3" column="0" colspan="2">
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
@@ -227,6 +203,60 @@
         <string>Auto accept group invites</string>
        </property>
       </widget>
+     </item>
+     <item row="5" column="0" colspan="2">
+      <widget class="QCheckBox" name="autoacceptfile">
+       <property name="accessibleDescription">
+        <string>Automatically accept files from contact if set</string>
+       </property>
+       <property name="text">
+        <string>Auto accept files</string>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Default directory to save files:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="1">
+      <widget class="QPushButton" name="selectSaveDir">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Auto accept for this contact is disabled</string>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="1">
+      <layout class="QHBoxLayout" name="horizontalLayout_3">
+       <item>
+        <widget class="QPushButton" name="openDir">
+         <property name="text">
+          <string>Open Directory</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="resetSaveDir">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Reset</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </item>
     </layout>
    </item>
@@ -275,7 +305,6 @@
   <tabstop>publicKey</tabstop>
   <tabstop>autoacceptcall</tabstop>
   <tabstop>autoacceptfile</tabstop>
-  <tabstop>selectSaveDir</tabstop>
   <tabstop>removeHistory</tabstop>
   <tabstop>note</tabstop>
  </tabstops>
@@ -284,7 +313,7 @@
   <connection>
    <sender>buttonBox</sender>
    <signal>accepted()</signal>
-   <receiver>AboutUser</receiver>
+   <receiver>AboutFriendForm</receiver>
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
@@ -300,7 +329,7 @@
   <connection>
    <sender>buttonBox</sender>
    <signal>rejected()</signal>
-   <receiver>AboutUser</receiver>
+   <receiver>AboutFriendForm</receiver>
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">

--- a/src/widget/form/settings/generalform.cpp
+++ b/src/widget/form/settings/generalform.cpp
@@ -20,6 +20,7 @@
 #include "generalform.h"
 #include "ui_generalsettings.h"
 
+#include <QDesktopServices>
 #include <QFileDialog>
 #include <cmath>
 
@@ -245,6 +246,12 @@ void GeneralForm::on_autoSaveFilesDir_clicked()
 
     Settings::getInstance().setGlobalAutoAcceptDir(directory);
     bodyUI->autoSaveFilesDir->setText(directory);
+}
+
+void GeneralForm::on_openAutoSaveFilesDir_clicked()
+{
+    auto dir = Settings::getInstance().getGlobalAutoAcceptDir();
+    QDesktopServices::openUrl(QUrl::fromLocalFile(dir));
 }
 
 void GeneralForm::on_maxAutoAcceptSizeMB_editingFinished()

--- a/src/widget/form/settings/generalform.h
+++ b/src/widget/form/settings/generalform.h
@@ -55,6 +55,7 @@ private slots:
     void on_autoacceptFiles_stateChanged();
     void on_maxAutoAcceptSizeMB_editingFinished();
     void on_autoSaveFilesDir_clicked();
+    void on_openAutoSaveFilesDir_clicked();
     void on_checkUpdates_stateChanged();
 
 private:

--- a/src/widget/form/settings/generalsettings.ui
+++ b/src/widget/form/settings/generalsettings.ui
@@ -39,8 +39,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>1298</width>
-        <height>497</height>
+        <width>1284</width>
+        <height>524</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_4" stretch="0,0">
@@ -298,7 +298,7 @@ instead of closing itself.</string>
               </property>
              </widget>
             </item>
-            <item row="3" column="0">
+            <item row="4" column="0">
              <widget class="QCheckBox" name="autoacceptFiles">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
@@ -314,14 +314,21 @@ instead of closing itself.</string>
               </property>
              </widget>
             </item>
-            <item row="4" column="0">
+            <item row="3" column="1">
+             <widget class="QPushButton" name="openAutoSaveFilesDir">
+              <property name="text">
+               <string>Open Directory</string>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="0">
              <widget class="QLabel" name="maxAutoAcceptSizeLabel">
               <property name="text">
                <string>Max autoaccept file size (0 to disable):</string>
               </property>
              </widget>
             </item>
-            <item row="4" column="1">
+            <item row="5" column="1">
              <widget class="QDoubleSpinBox" name="maxAutoAcceptSizeMB">
               <property name="suffix">
                <string> MB</string>

--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -162,8 +162,11 @@ void FriendWidget::onContextMenuCalled(QContextMenuEvent* event)
     auto autoAccept =
         menu.addAction(tr("Auto accept files from this friend", "context menu entry"));
     autoAccept->setCheckable(true);
-    autoAccept->setChecked(!chatroom->autoAcceptEnabled());
+    autoAccept->setChecked(chatroom->autoAcceptEnabled());
     connect(autoAccept, &QAction::triggered, this, &FriendWidget::changeAutoAccept);
+
+    auto autoAcceptDir = menu.addAction(tr("Change auto accept dir...", "context menu entry"));
+    connect(autoAcceptDir, &QAction::triggered, this, &FriendWidget::changeAutoAcceptDir);
     menu.addSeparator();
 
     // TODO: move to model
@@ -278,15 +281,18 @@ void FriendWidget::moveToCircle(int newCircleId)
 
 void FriendWidget::changeAutoAccept(bool enable)
 {
-    if (enable) {
-        const auto oldDir = chatroom->getAutoAcceptDir();
-        const auto newDir =
-            QFileDialog::getExistingDirectory(Q_NULLPTR,
-                                              tr("Choose an auto accept directory", "popup title"),
-                                              oldDir);
+    chatroom->setAutoAccept(enable);
+}
+
+void FriendWidget::changeAutoAcceptDir()
+{
+    const auto oldDir = chatroom->getAutoAcceptDir();
+    const auto newDir =
+        QFileDialog::getExistingDirectory(Q_NULLPTR,
+                                          tr("Choose an auto accept directory", "popup title"),
+                                          oldDir);
+    if (!newDir.isEmpty()) {
         chatroom->setAutoAcceptDir(newDir);
-    } else {
-        chatroom->disableAutoAccept();
     }
 }
 void FriendWidget::showDetails()

--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -129,9 +129,7 @@ void FriendWidget::onContextMenuCalled(QContextMenuEvent* event)
 
     for (const auto group : chatroom->getGroups()) {
         const auto groupAction = inviteMenu->addAction(tr("Invite to group '%1'").arg(group.name));
-        connect(groupAction, &QAction::triggered, [=]() {
-            chatroom->inviteFriend(group.group);
-        });
+        connect(groupAction, &QAction::triggered, [=]() { chatroom->inviteFriend(group.group); });
     }
 
     const auto circleId = chatroom->getCircleId();
@@ -282,8 +280,10 @@ void FriendWidget::changeAutoAccept(bool enable)
 {
     if (enable) {
         const auto oldDir = chatroom->getAutoAcceptDir();
-        const auto newDir = QFileDialog::getExistingDirectory(
-            Q_NULLPTR, tr("Choose an auto accept directory", "popup title"), oldDir);
+        const auto newDir =
+            QFileDialog::getExistingDirectory(Q_NULLPTR,
+                                              tr("Choose an auto accept directory", "popup title"),
+                                              oldDir);
         chatroom->setAutoAcceptDir(newDir);
     } else {
         chatroom->disableAutoAccept();
@@ -313,8 +313,8 @@ void FriendWidget::setActive(bool active)
 {
     GenericChatroomWidget::setActive(active);
     if (isDefaultAvatar) {
-        const auto uri = active ? QStringLiteral(":img/contact_dark.svg")
-                                : QStringLiteral(":img/contact.svg");
+        const auto uri =
+            active ? QStringLiteral(":img/contact_dark.svg") : QStringLiteral(":img/contact.svg");
         avatar->setPixmap(QPixmap{uri});
     }
 }

--- a/src/widget/friendwidget.h
+++ b/src/widget/friendwidget.h
@@ -68,6 +68,7 @@ private slots:
     void removeFromCircle();
     void moveToCircle(int circleId);
     void changeAutoAccept(bool enable);
+    void changeAutoAcceptDir();
     void showDetails();
 
 public:


### PR DESCRIPTION
Closes #5375

Alright this one ended up being much more complicated than I thought, handling upgrade of settings is non-trivial. That being said I think I came up with an okay solution.

On first run with the change the user sees

![new_default_dir_upgrade_global](https://user-images.githubusercontent.com/1069811/46656627-57339800-cb63-11e8-8253-04fe32f4b9a4.PNG)

*if* they previously set the autoaccept direcotry

Then for each friend that they previously enabled upgrade on they see 

![new_default_dir_upgrade_friend](https://user-images.githubusercontent.com/1069811/46656636-5e5aa600-cb63-11e8-88f0-98727c108436.PNG)

That's the major idea here, rest of the changes are in the commit message (pasted here for convenience)

> feat(transfer): Change default autoaccept directory
> 
> * Implements clean upgrades to the new defaults by requesting user
> approval to use new defaults over previously set values
> * Changes default global autoaccept directory to appDataDir()/transfers
> * Changes each default user autoaccept directory to
> appDataDir()/transfrers/hashed_friend_public_key
> * Adds buttons in the about friend dialog and general settings dialog to
> open download directory
> * Decouples friend autoaccept from autoaccept dir
>     * Interaction with global autoaccept is still broken but that will
>     be resolved in #5376 
> * Adds ability to reset friend autoaccept dir to default in the about
> friend dialog
> * Images are now saved to the per-user transfer directory instead of the global
> images folder

Screenshots of new UI elements
![new_default_dir_context_menu](https://user-images.githubusercontent.com/1069811/46656891-e93ba080-cb63-11e8-81bd-114c47357cc6.PNG)
![new_default_dir_friend_about](https://user-images.githubusercontent.com/1069811/46656892-e93ba080-cb63-11e8-8243-170c768cf59f.PNG)
![new_default_dir_settings_page](https://user-images.githubusercontent.com/1069811/46656894-e93ba080-cb63-11e8-8e31-1a2932887881.PNG)

Given that this touches the same UI elements as #5373 the UI elements may not merge cleanly, in that case just reassign whichever goes in second to me and I can update them.

Tests I ran before pushing

* Global and User auto accept set
    * Do not accept global auto accept upgrade
        * Do not accept user auto accept upgrade
            * Downloads still go to user download dir
        * Accept user auto accept upgrade
            * Downlaods go to global download dir / hashed id
                * This is reasoanble behavior since the new default user download dir is supposed to be relative to the global one
    * Accept global auto accept upgrade
        * Do not accept user auto accept upgrade
            * Downloads go to user download dir
        * Accept user auto accept upgrade
            * Downloads go to new global download dir / hashed id

* Global set and User not set
    * Do not accept global upgrade
        * User upgrade not prompted
            * Files downloaded to global download dir
                * This interation is a little undesirable but will be cleaned up in #5376
        * Enable autoaccept for user
            * Files downloaded to global download dir / hashed id
                * This interation is a little undesirable but will be cleaned up in #5376
    * Accept global upgrade
        * User upgrade not prompted
            * Files downloaded to global download dir
                * This interation is a little undesirable but will be cleaned up in #5376
        * Enable autoaccept for user
            * Files downloaded to global download dir / hashed id
                * This interation is a little undesirable but will be cleaned up in #5376

* New Program Run (no qtox.ini)
    * No prompts
    * Default global autoaccept dir set to new global download dir
    * Same interactions as above

* Open directory in friend about page now opens user download dir
* Reset resets friend download dir to global dir / hashed id
* Download dir follows global dir change if default/reset

Tests can be run by opening a user profile after downgrading qtox, this should reset behavior so you can experience the upgrade logic again :) (with the side affect of disabling autoaccept for all users)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5380)
<!-- Reviewable:end -->
