### PR TITLE
chore(build): update apt-get in build-docs before installing deps

### DIFF
--- a/.travis/build-docs.sh
+++ b/.travis/build-docs.sh
@@ -20,6 +20,7 @@
 set -eu -o pipefail
 
 # Obtain doxygen and its deps
+sudo apt-get update -qq
 sudo apt-get install doxygen graphviz
 
 # can fail due to travis cloning only `depth=50`


### PR DESCRIPTION
- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

Error in all recent CI, from build-docs job:
```
0.07s$ ./.travis/$JOB.sh
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Package doxygen is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
E: Package 'doxygen' has no installation candidate
The command "./.travis/$JOB.sh" exited with 100.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5390)
<!-- Reviewable:end -->
