### PR TITLE
fix(core): remove pgc code

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -460,21 +460,11 @@ void Core::onGroupInvite(Tox* tox, uint32_t friendId, Tox_Conference_Type type,
     switch (type) {
     case TOX_CONFERENCE_TYPE_TEXT:
         qDebug() << QString("Text group invite by %1").arg(friendId);
-        if (friendId == UINT32_MAX) {
-            // Rejoining existing (persistent) conference after disconnect and reconnect.
-            tox_conference_join(tox, friendId, cookie, length, nullptr);
-            return;
-        }
         emit core->groupInviteReceived(inviteInfo);
         break;
 
     case TOX_CONFERENCE_TYPE_AV:
         qDebug() << QString("AV group invite by %1").arg(friendId);
-        if (friendId == UINT32_MAX) {
-            // Rejoining existing (persistent) AV conference after disconnect and reconnect.
-            toxav_join_av_groupchat(tox, friendId, cookie, length, CoreAV::groupCallCallback, core);
-            return;
-        }
         emit core->groupInviteReceived(inviteInfo);
         break;
 


### PR DESCRIPTION
This code was needed for the pgc implementation, but is not needed for
minipgc

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5401)
<!-- Reviewable:end -->
