### PR TITLE
chore: update TravisCI OSx minimum supported version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,7 +105,7 @@ matrix:
           - /opt/build-windows/x86_64
     - stage: "macOS, AppImage and Flatpak"
       os: osx
-      osx_image: xcode7.3
+      osx_image: xcode9.2
       env: JOB=build-osx
     - stage: "macOS, AppImage and Flatpak"
       os: linux

--- a/.travis/build-osx.sh
+++ b/.travis/build-osx.sh
@@ -17,7 +17,7 @@
 #
 
 # Fail out on error
-set -e -o pipefail
+set -eu -o pipefail
 
 # accelerate builds with ccache
 install_ccache() {
@@ -43,16 +43,7 @@ check() {
     fi
 }
 
-# The system ruby in Travis CI is too old, use latest stable
-get_ruby_version() {
-    rvm get stable
-    [[ -s "$HOME/.rvm/scripts/rvm" ]] && source "$HOME/.rvm/scripts/rvm"
-    rvm use ruby --install --default
-    echo rvm_auto_reload_flag=1 >> ~/.rvmrc
-}
-
 main() {
-    get_ruby_version
     install_ccache
     build
     check

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -579,11 +579,10 @@ password for sudo.
 
 ## OS X
 
-Supported OS X versions: >=10.8.
+Supported OS X versions: >=10.8. (NOTE: only 10.12 is tested during CI)
 
-Compiling qTox on OS X for development requires 3 tools:
-[Xcode](https://developer.apple.com/xcode/),
-[Qt 5.4+](https://www.qt.io/qt5-4/) and [homebrew](https://brew.sh).
+Compiling qTox on OS X for development requires 2 tools:
+[Xcode](https://developer.apple.com/xcode/) and [homebrew](https://brew.sh).
 
 ### Automated Script
 


### PR DESCRIPTION
The reason to update is, that brew only supports 10.12 officialy and
with binary packages so our CI builds started failing because compiling took too long.

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5405)
<!-- Reviewable:end -->
