### PR TITLE
Added feature: ability to set custom audio files for qtox events

### DIFF
--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -25,6 +25,8 @@
 #include "src/persistence/settings.h"
 
 #include <QDebug>
+#include <QFile>
+#include <QDir>
 
 #include <cassert>
 
@@ -196,4 +198,31 @@ Audio& Audio::getInstance()
         static OpenAL instance;
         return instance;
     }
+}
+
+QString Audio::getSoundPath(QString fn)
+{
+    QString fullpath = Settings::getInstance().getSettingsDirPath() + fn;
+    if (QFile::exists(fullpath))
+        return fullpath;
+    else
+        return QString(":") + QDir::separator() + fn;
+}
+
+QString Audio::getSound(Sound s)
+{
+    switch (s) {
+    case Sound::Test:
+        return getSoundPath("audio/notification.s16le.pcm");
+    case Sound::NewMessage:
+        return getSoundPath("audio/notification.s16le.pcm");
+    case Sound::IncomingCall:
+        return getSoundPath("audio/ToxIncomingCall.s16le.pcm");
+    case Sound::OutgoingCall:
+        return getSoundPath("audio/ToxOutgoingCall.s16le.pcm");
+    case Sound::CallEnd:
+        return getSoundPath("audio/ToxEndCall.s16le.pcm");
+    }
+    assert(false);
+    return QString();
 }

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -44,23 +44,7 @@ public:
         CallEnd
     };
 
-    inline static QString getSound(Sound s)
-    {
-        switch (s) {
-        case Sound::Test:
-            return QStringLiteral(":/audio/notification.s16le.pcm");
-        case Sound::NewMessage:
-            return QStringLiteral(":/audio/notification.s16le.pcm");
-        case Sound::IncomingCall:
-            return QStringLiteral(":/audio/ToxIncomingCall.s16le.pcm");
-        case Sound::OutgoingCall:
-            return QStringLiteral(":/audio/ToxOutgoingCall.s16le.pcm");
-        case Sound::CallEnd:
-            return QStringLiteral(":/audio/ToxEndCall.s16le.pcm");
-        }
-        assert(false);
-        return QString();
-    }
+    static QString getSound(Sound s);
     static Audio& getInstance();
 
     virtual qreal outputVolume() const = 0;
@@ -115,6 +99,9 @@ protected:
     static constexpr uint32_t AUDIO_FRAME_SAMPLE_COUNT_PER_CHANNEL =
         AUDIO_FRAME_DURATION * AUDIO_SAMPLE_RATE / 1000;
     uint32_t AUDIO_FRAME_SAMPLE_COUNT_TOTAL = 0;
+
+private:
+    static QString getSoundPath(QString fn);
 
 signals:
     void frameAvailable(const int16_t* pcm, size_t sample_count, uint8_t channels,


### PR DESCRIPTION
- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

Sometimes you want to change notification sound but they were stored inside qtox binary. Audio files must be put in %APPDATA%/qtox/audio otherwise the default sound is used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5406)
<!-- Reviewable:end -->
