### PR TITLE
refactor: remove support for c-toxcore < 0.2.0

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -84,12 +84,8 @@ void Core::registerCallbacks(Tox* tox)
     tox_callback_friend_read_receipt(tox, onReadReceiptCallback);
     tox_callback_conference_invite(tox, onGroupInvite);
     tox_callback_conference_message(tox, onGroupMessage);
-#if TOX_VERSION_IS_API_COMPATIBLE(0, 2, 0)
     tox_callback_conference_peer_list_changed(tox, onGroupPeerListChange);
     tox_callback_conference_peer_name(tox, onGroupPeerNameChange);
-#else
-    tox_callback_conference_namelist_change(tox, onGroupNamelistChange);
-#endif
     tox_callback_conference_title(tox, onGroupTitleChange);
     tox_callback_file_chunk_request(tox, CoreFile::onFileDataCallback);
     tox_callback_file_recv(tox, CoreFile::onFileReceiveCallback);
@@ -482,7 +478,6 @@ void Core::onGroupMessage(Tox*, uint32_t groupId, uint32_t peerId, Tox_Message_T
     emit core->groupMessageReceived(groupId, peerId, message, isAction);
 }
 
-#if TOX_VERSION_IS_API_COMPATIBLE(0, 2, 0)
 void Core::onGroupPeerListChange(Tox*, uint32_t groupId, void* core)
 {
     const auto coreAv = static_cast<Core*>(core)->getAv();
@@ -501,22 +496,6 @@ void Core::onGroupPeerNameChange(Tox*, uint32_t groupId, uint32_t peerId, const 
     qDebug() << QString("Group %1, Peer %2, name changed to %3").arg(groupId).arg(peerId).arg(newName);
     emit static_cast<Core*>(core)->groupPeerNameChanged(groupId, peerId, newName);
 }
-
-#else
-// for toxcore < 0.2.0, aka old groups
-void Core::onGroupNamelistChange(Tox*, uint32_t groupId, uint32_t peerId,
-                                 TOX_CONFERENCE_STATE_CHANGE change, void* core)
-{
-    CoreAV* coreAv = static_cast<Core*>(core)->getAv();
-    const auto changed = change == TOX_CONFERENCE_STATE_CHANGE_PEER_EXIT;
-    if (changed && coreAv->isGroupAvEnabled(groupId)) {
-        CoreAV::invalidateGroupCallPeerSource(groupId, peerId);
-    }
-
-    qDebug() << QString("Group namelist change %1:%2 %3").arg(groupId).arg(peerId).arg(change);
-    emit static_cast<Core*>(core)->groupNamelistChanged(groupId, peerId, change);
-}
-#endif
 
 void Core::onGroupTitleChange(Tox*, uint32_t groupId, uint32_t peerId, const uint8_t* cTitle,
                               size_t length, void* vCore)

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -228,14 +228,9 @@ private:
                               const uint8_t* cookie, size_t length, void* vCore);
     static void onGroupMessage(Tox* tox, uint32_t groupId, uint32_t peerId, Tox_Message_Type type,
                                const uint8_t* cMessage, size_t length, void* vCore);
-#if TOX_VERSION_IS_API_COMPATIBLE(0, 2, 0)
     static void onGroupPeerListChange(Tox*, uint32_t groupId, void* core);
     static void onGroupPeerNameChange(Tox*, uint32_t groupId, uint32_t peerId, const uint8_t* name,
                                       size_t length, void* core);
-#else
-    static void onGroupNamelistChange(Tox* tox, uint32_t groupId, uint32_t peerId,
-                                      TOX_CONFERENCE_STATE_CHANGE change, void* core);
-#endif
     static void onGroupTitleChange(Tox* tox, uint32_t groupId, uint32_t peerId,
                                    const uint8_t* cTitle, size_t length, void* vCore);
     static void onReadReceiptCallback(Tox* tox, uint32_t friendId, uint32_t receipt, void* core);

--- a/src/core/coreav.h
+++ b/src/core/coreav.h
@@ -25,7 +25,6 @@
 #include <QObject>
 #include <atomic>
 #include <memory>
-#include <tox/tox.h> // for TOX_VERSION_IS_API_COMPATIBLE macro
 #include <tox/toxav.h>
 
 class Friend;
@@ -77,14 +76,9 @@ public:
     bool isCallOutputMuted(const Friend* f) const;
     void toggleMuteCallInput(const Friend* f);
     void toggleMuteCallOutput(const Friend* f);
-#if TOX_VERSION_IS_API_COMPATIBLE(0, 2, 0)
     static void groupCallCallback(void* tox, uint32_t group, uint32_t peer, const int16_t* data,
                                   unsigned samples, uint8_t channels, uint32_t sample_rate,
                                   void* core);
-#else
-    static void groupCallCallback(void* tox, int group, int peer, const int16_t* data, unsigned samples,
-                                  uint8_t channels, unsigned sample_rate, void* core);
-#endif
     static void invalidateGroupCallPeerSource(int group, int peer);
     static void invalidateGroupCallSources(int group);
 

--- a/src/core/toxencrypt.cpp
+++ b/src/core/toxencrypt.cpp
@@ -18,7 +18,6 @@
 */
 
 #include "toxencrypt.h"
-#include <tox/tox.h>  // TOX_VERSION_IS_API_COMPATIBLE
 #include <tox/toxencryptsave.h>
 
 #include <QByteArray>
@@ -158,15 +157,9 @@ std::unique_ptr<ToxEncrypt> ToxEncrypt::makeToxEncrypt(const QString& password)
 {
     const QByteArray pass = password.toUtf8();
     TOX_ERR_KEY_DERIVATION error;
-#if TOX_VERSION_IS_API_COMPATIBLE(0, 2, 0)
     Tox_Pass_Key* const passKey = tox_pass_key_derive(
         reinterpret_cast<const uint8_t*>(pass.constData()),
         static_cast<size_t>(pass.length()), &error);
-#else
-    Tox_Pass_Key* const passKey = tox_pass_key_new();
-    tox_pass_key_derive(passKey, reinterpret_cast<const uint8_t*>(pass.constData()),
-                        static_cast<size_t>(pass.length()), &error);
-#endif
 
     if (error != TOX_ERR_KEY_DERIVATION_OK) {
         tox_pass_key_free(passKey);
@@ -204,15 +197,9 @@ std::unique_ptr<ToxEncrypt> ToxEncrypt::makeToxEncrypt(const QString& password, 
 
     QByteArray pass = password.toUtf8();
     TOX_ERR_KEY_DERIVATION keyError;
-#if TOX_VERSION_IS_API_COMPATIBLE(0, 2, 0)
     Tox_Pass_Key* const passKey = tox_pass_key_derive_with_salt(
         reinterpret_cast<const uint8_t*>(pass.constData()),
         static_cast<size_t>(pass.length()), salt, &keyError);
-#else
-    Tox_Pass_Key* const passKey = tox_pass_key_new();
-    tox_pass_key_derive_with_salt(passKey, reinterpret_cast<const uint8_t*>(pass.constData()),
-                                  static_cast<size_t>(pass.length()), salt, &keyError);
-#endif
 
     if (keyError != TOX_ERR_KEY_DERIVATION_OK) {
         tox_pass_key_free(passKey);

--- a/src/nexus.cpp
+++ b/src/nexus.cpp
@@ -208,8 +208,6 @@ void Nexus::showMainGUI()
     connect(core, &Core::friendMessageReceived, widget, &Widget::onFriendMessageReceived);
     connect(core, &Core::groupInviteReceived, widget, &Widget::onGroupInviteReceived);
     connect(core, &Core::groupMessageReceived, widget, &Widget::onGroupMessageReceived);
-    connect(core, &Core::groupNamelistChanged, widget,
-            &Widget::onGroupNamelistChangedOld); // TODO(sudden6): toxcore < 0.2.0, remove
     connect(core, &Core::groupPeerlistChanged, widget, &Widget::onGroupPeerlistChanged);
     connect(core, &Core::groupPeerNameChanged, widget, &Widget::onGroupPeerNameChanged);
     connect(core, &Core::groupTitleChanged, widget, &Widget::onGroupTitleChanged);

--- a/src/persistence/db/rawdatabase.cpp
+++ b/src/persistence/db/rawdatabase.cpp
@@ -20,7 +20,6 @@
 #include "rawdatabase.h"
 
 #include <cassert>
-#include <tox/tox.h>  // TOX_VERSION_IS_API_COMPATIBLE
 #include <tox/toxencryptsave.h>
 
 #include <QCoreApplication>
@@ -488,15 +487,9 @@ QString RawDatabase::deriveKey(const QString& password)
 
     static const uint8_t expandConstant[TOX_PASS_SALT_LENGTH + 1] =
         "L'ignorance est le pire des maux";
-#if TOX_VERSION_IS_API_COMPATIBLE(0, 2, 0)
     const std::unique_ptr<Tox_Pass_Key, PassKeyDeleter> key(tox_pass_key_derive_with_salt(
         reinterpret_cast<const uint8_t*>(passData.data()),
         static_cast<std::size_t>(passData.size()), expandConstant, nullptr));
-#else
-    const std::unique_ptr<Tox_Pass_Key, PassKeyDeleter> key(tox_pass_key_new());
-    tox_pass_key_derive_with_salt(key.get(), reinterpret_cast<const uint8_t*>(passData.data()),
-                                  static_cast<std::size_t>(passData.size()), expandConstant, nullptr);
-#endif
     return QByteArray(reinterpret_cast<char*>(key.get()) + 32, 32).toHex();
 }
 
@@ -521,17 +514,10 @@ QString RawDatabase::deriveKey(const QString& password, const QByteArray& salt)
 
     static_assert(TOX_PASS_KEY_LENGTH >= 32, "toxcore must provide 256bit or longer keys");
 
-#if TOX_VERSION_IS_API_COMPATIBLE(0, 2, 0)
     const std::unique_ptr<Tox_Pass_Key, PassKeyDeleter> key(tox_pass_key_derive_with_salt(
         reinterpret_cast<const uint8_t*>(passData.data()),
         static_cast<std::size_t>(passData.size()),
         reinterpret_cast<const uint8_t*>(salt.constData()), nullptr));
-#else
-    const std::unique_ptr<Tox_Pass_Key, PassKeyDeleter> key(tox_pass_key_new());
-    tox_pass_key_derive_with_salt(key.get(), reinterpret_cast<const uint8_t*>(passData.data()),
-                                  static_cast<std::size_t>(passData.size()),
-                                  reinterpret_cast<const uint8_t*>(salt.constData()), nullptr);
-#endif
     return QByteArray(reinterpret_cast<char*>(key.get()) + 32, 32).toHex();
 }
 

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1761,7 +1761,6 @@ void Widget::onGroupMessageReceived(int groupnumber, int peernumber, const QStri
 
 void Widget::onGroupPeerlistChanged(int groupnumber)
 {
-#if TOX_VERSION_IS_API_COMPATIBLE(0, 2, 0)
     Group* g = GroupList::findGroup(groupnumber);
     if (!g) {
         qDebug() << "onGroupNamelistChanged: Group " << groupnumber << " not found, creating it";
@@ -1771,12 +1770,10 @@ void Widget::onGroupPeerlistChanged(int groupnumber)
         }
     }
     g->regeneratePeerList();
-#endif
 }
 
 void Widget::onGroupPeerNameChanged(int groupnumber, int peernumber, const QString& newName)
 {
-#if TOX_VERSION_IS_API_COMPATIBLE(0, 2, 0)
     Group* g = GroupList::findGroup(groupnumber);
     if (!g) {
         qDebug() << "onGroupNamelistChanged: Group " << groupnumber << " not found, creating it";
@@ -1792,40 +1789,6 @@ void Widget::onGroupPeerNameChanged(int groupnumber, int peernumber, const QStri
     }
 
     g->updatePeer(peernumber, setName);
-#endif
-}
-
-/**
- * @deprecated Remove after dropping support for toxcore 0.1.x
- */
-void Widget::onGroupNamelistChangedOld(int groupnumber, int peernumber, uint8_t Change)
-{
-#if !(TOX_VERSION_IS_API_COMPATIBLE(0, 2, 0))
-    Group* g = GroupList::findGroup(groupnumber);
-    if (!g) {
-        qDebug() << "onGroupNamelistChanged: Group " << groupnumber << " not found, creating it";
-        g = createGroup(groupnumber);
-        if (!g) {
-            return;
-        }
-    }
-
-    TOX_CONFERENCE_STATE_CHANGE change = static_cast<TOX_CONFERENCE_STATE_CHANGE>(Change);
-    if (change == TOX_CONFERENCE_STATE_CHANGE_PEER_JOIN) {
-        g->regeneratePeerList();
-    } else if (change == TOX_CONFERENCE_STATE_CHANGE_PEER_EXIT) {
-        g->regeneratePeerList();
-    } else if (change == TOX_CONFERENCE_STATE_CHANGE_PEER_NAME_CHANGE) // core overwrites old name
-                                                                       // before telling us it
-                                                                       // changed...
-    {
-        QString name = Nexus::getCore()->getGroupPeerName(groupnumber, peernumber);
-        if (name.isEmpty())
-            name = tr("<Empty>", "Placeholder when someone's name in a group chat is empty");
-
-        g->updatePeer(peernumber, name);
-    }
-#endif
 }
 
 void Widget::onGroupTitleChanged(int groupnumber, const QString& author, const QString& title)

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -171,7 +171,6 @@ public slots:
     void onGroupInviteReceived(const GroupInvite& inviteInfo);
     void onGroupInviteAccepted(const GroupInvite& inviteInfo);
     void onGroupMessageReceived(int groupnumber, int peernumber, const QString& message, bool isAction);
-    void onGroupNamelistChangedOld(int groupnumber, int peernumber, uint8_t change);
     void onGroupPeerlistChanged(int groupnumber);
     void onGroupPeerNameChanged(int groupnumber, int peernumber, const QString& newName);
     void onGroupTitleChanged(int groupnumber, const QString& author, const QString& title);


### PR DESCRIPTION
This code is only a maintainance burden and not used anymore.

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5409)
<!-- Reviewable:end -->
