### PR TITLE
feat(core): prepare qTox for groupchat saving

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -250,6 +250,7 @@ void Core::onStarted()
     emit idSet(id);
 
     loadFriends();
+    loadGroups();
 
     process(); // starts its own timer
     av->start();
@@ -990,16 +991,15 @@ void Core::loadFriends()
 {
     QMutexLocker ml{coreLoopLock.get()};
 
-    const uint32_t friendCount = tox_self_get_friend_list_size(tox.get());
+    const size_t friendCount = tox_self_get_friend_list_size(tox.get());
     if (friendCount == 0) {
         return;
     }
 
-    // assuming there are not that many friends to fill up the whole stack
     uint32_t* ids = new uint32_t[friendCount];
     tox_self_get_friend_list(tox.get(), ids);
     uint8_t friendPk[TOX_PUBLIC_KEY_SIZE] = {0x00};
-    for (uint32_t i = 0; i < friendCount; ++i) {
+    for (size_t i = 0; i < friendCount; ++i) {
         if (!tox_friend_get_public_key(tox.get(), ids[i], friendPk, nullptr)) {
             continue;
         }
@@ -1010,6 +1010,25 @@ void Core::loadFriends()
         checkLastOnline(ids[i]);
     }
     delete[] ids;
+}
+
+void Core::loadGroups()
+{
+    QMutexLocker ml{coreLoopLock.get()};
+
+    const size_t groupCount = tox_conference_get_chatlist_size(tox.get());
+    if (groupCount == 0) {
+        return;
+    }
+
+    uint32_t* groupIds = new uint32_t[groupCount];
+    tox_conference_get_chatlist(tox.get(), groupIds);
+
+    for(size_t i = 0; i < groupCount; ++i) {
+        emit emptyGroupCreated(static_cast<int>(groupIds[i]));
+    }
+
+    delete[] groupIds;
 }
 
 void Core::checkLastOnline(uint32_t friendId)

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -245,6 +245,7 @@ private:
     void makeTox(QByteArray savedata, ICoreSettings* s);
     void makeAv();
     void loadFriends();
+    void loadGroups();
     void bootstrapDht();
 
     void checkLastOnline(uint32_t friendId);


### PR DESCRIPTION
This change creates groups on startup of Core. We need this once
https://github.com/TokTok/c-toxcore/pull/1156 is merged to load existing
groups.

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)


Marked as WIP, because I didn't have a chance to test it yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5417)
<!-- Reviewable:end -->
