### PR TITLE
fix(video): correctly align data passed to toxcore

### DIFF
--- a/src/video/videoframe.cpp
+++ b/src/video/videoframe.cpp
@@ -575,7 +575,9 @@ AVFrame* VideoFrame::generateAVFrame(const QSize& dimensions, const int pixelFor
 
     int bufSize;
 
-    if (!requireAligned || (dimensions.width() % 8 == 0 && dimensions.height() % 8 == 0)) {
+    const bool alreadyAligned = dimensions.width() % dataAlignment == 0 && dimensions.height() % dataAlignment == 0;
+
+    if (!requireAligned || alreadyAligned) {
         bufSize = av_image_alloc(ret->data, ret->linesize, dimensions.width(), dimensions.height(),
                                  static_cast<AVPixelFormat>(pixelFormat), dataAlignment);
     } else {


### PR DESCRIPTION
fixes #5402

c-toxcore requires each plane to be aligned at 1 byte boundaries.
Because of this bug we alligned it at 32 byte boundaries if the height
and width were a multiple of 8.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5424)
<!-- Reviewable:end -->
