### PR TITLE
Move logs and settings to use the `Paths` module

### DIFF
--- a/src/persistence/paths.cpp
+++ b/src/persistence/paths.cpp
@@ -11,6 +11,7 @@
 
 namespace {
 const QLatin1Literal globalSettingsFile{"qtox.ini"};
+const QLatin1Literal logFile{"qtox.log"};
 const QLatin1Literal profileFolder{"profiles"};
 const QLatin1Literal themeFolder{"themes"};
 const QLatin1Literal avatarsFolder{"avatars"};
@@ -132,6 +133,29 @@ QString Paths::getGlobalSettingsPath() const
     // we assume a writeable path for portable mode
 
     return path % QDir::separator() % globalSettingsFile;
+}
+
+/**
+ * @brief Returns the path to the log file "qtox.log"
+ * @return The path to the folder.
+ */
+QString Paths::getLogFilePath() const
+{
+    QString path;
+
+    if (portable) {
+        path = basePath;
+    } else {
+        path = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+        if (path.isEmpty()) {
+            qDebug() << "Can't find writable location for log file";
+            return {};
+        }
+    }
+
+    // we assume a writeable path for portable mode
+
+    return path % QDir::separator() % logFile;
 }
 
 /**

--- a/src/persistence/paths.h
+++ b/src/persistence/paths.h
@@ -17,6 +17,7 @@ public:
 
     bool isPortable() const;
     QString getGlobalSettingsPath() const;
+    QString getLogFilePath() const;
     QString getProfilesDir() const;
     QString getToxSaveDir() const;
     QString getAvatarsDir() const;

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -22,6 +22,7 @@
 #include "src/core/core.h"
 #include "src/core/corefile.h"
 #include "src/nexus.h"
+#include "src/persistence/paths.h"
 #include "src/persistence/profile.h"
 #include "src/persistence/profilelocker.h"
 #include "src/persistence/settingsserializer.h"
@@ -62,8 +63,20 @@ Settings* Settings::settings{nullptr};
 QMutex Settings::bigLock{QMutex::Recursive};
 QThread* Settings::settingsThread{nullptr};
 
-Settings::Settings()
-    : loaded(false)
+/**
+ * @brief Factory method for the Settings class
+ * @param paths Paths object, providing all important paths
+ * @return Settings object on success, nullptr else
+ */
+Settings* Settings::makeSettings(const Paths& paths) {
+    Settings* s = new Settings{paths};
+    settings = s;
+    return s;
+}
+
+Settings::Settings(const Paths& paths)
+    : paths{paths}
+    , loaded(false)
     , useCustomDhtList{false}
     , makeToxPortable{false}
     , currentProfileId(0)
@@ -81,6 +94,7 @@ Settings::~Settings()
     settingsThread->exit(0);
     settingsThread->wait();
     delete settingsThread;
+    settings = nullptr;
 }
 
 /**
@@ -88,16 +102,7 @@ Settings::~Settings()
  */
 Settings& Settings::getInstance()
 {
-    if (!settings)
-        settings = new Settings();
-
     return *settings;
-}
-
-void Settings::destroyInstance()
-{
-    delete settings;
-    settings = nullptr;
 }
 
 void Settings::loadGlobal()
@@ -175,8 +180,12 @@ void Settings::loadGlobal()
         }
         autoAwayTime = s.value("autoAwayTime", 10).toInt();
         checkUpdates = s.value("checkUpdates", true).toBool();
-        notifySound = s.value("notifySound", true).toBool(); // note: notifySound and busySound UI elements are now under UI settings
-        busySound = s.value("busySound", false).toBool();    // page, but kept under General in settings file to be backwards compatible
+        notifySound =
+            s.value("notifySound", true)
+                .toBool(); // note: notifySound and busySound UI elements are now under UI settings
+        busySound = s.value("busySound", false).toBool(); // page, but kept under General in
+                                                          // settings file to be backwards
+                                                          // compatible
         fauxOfflineMessaging = s.value("fauxOfflineMessaging", true).toBool();
         autoSaveEnabled = s.value("autoSaveEnabled", false).toBool();
         globalAutoAcceptDir = s.value("globalAutoAcceptDir",

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -37,6 +37,7 @@
 #include <QObject>
 #include <QPixmap>
 
+class Paths;
 class Profile;
 
 namespace Db {
@@ -134,8 +135,8 @@ public:
     };
 
 public:
+    static Settings* makeSettings(const Paths& paths);
     static Settings& getInstance();
-    static void destroyInstance();
     QString getSettingsDirPath() const;
     QString getAppDataDirPath() const;
     QString getAppCacheDirPath() const;
@@ -572,7 +573,7 @@ public:
 private:
     struct friendProp;
 
-    Settings();
+    Settings(const Paths &paths);
     ~Settings();
     Settings(Settings& settings) = delete;
     Settings& operator=(const Settings&) = delete;
@@ -583,6 +584,7 @@ public slots:
     void savePersonal(Profile* profile);
 
 private:
+    const Paths& paths;
     bool loaded;
 
     bool useCustomDhtList;
@@ -693,7 +695,8 @@ private:
         friendProp() = delete;
         friendProp(QString addr)
             : addr(addr)
-        {}
+        {
+        }
         QString alias = "";
         QString addr = "";
         QString autoAcceptDir = "";

--- a/test/persistence/paths_test.cpp
+++ b/test/persistence/paths_test.cpp
@@ -41,6 +41,7 @@ private:
 
 namespace {
 const QLatin1Literal globalSettingsFile{"qtox.ini"};
+const QLatin1Literal logFile{"qtox.log"};
 const QLatin1Literal profileFolder{"profiles"};
 const QLatin1Literal themeFolder{"themes"};
 const QLatin1Literal avatarsFolder{"avatars"};
@@ -112,10 +113,11 @@ void TestPaths::checkPathsNonPortable()
 
     const QString appData{QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)};
     const QString appConfig{QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation)};
-
+    const QString cache{QStandardPaths::writableLocation(QStandardPaths::CacheLocation)};
 
     verifyqToxPath(paths->getProfilesDir(), appData, profileFolder % sep);
     verifyqToxPath(paths->getGlobalSettingsPath(), appConfig, globalSettingsFile);
+    verifyqToxPath(paths->getLogFilePath(), cache, logFile);
     verifyqToxPath(paths->getScreenshotsDir(), appData, screenshotsFolder % sep);
     verifyqToxPath(paths->getTransfersDir(), appData, transfersFolder % sep);
 
@@ -153,6 +155,7 @@ void TestPaths::checkPathsPortable()
 
     verifyqToxPath(paths->getProfilesDir(), basePath, profileFolder % sep);
     verifyqToxPath(paths->getGlobalSettingsPath(), basePath, globalSettingsFile);
+    verifyqToxPath(paths->getLogFilePath(), basePath, logFile);
     verifyqToxPath(paths->getScreenshotsDir(), basePath, screenshotsFolder % sep);
     verifyqToxPath(paths->getTransfersDir(), basePath, transfersFolder % sep);
 


### PR DESCRIPTION
- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

This makes the logger the first user of the `Paths` module, settings stores a reference to it, but doesn't use it yet, because I need to finish and test the upgrade code first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5434)
<!-- Reviewable:end -->
