### PR TITLE
Integrate Paths class into qTox code

### DIFF
--- a/src/model/profile/profileinfo.cpp
+++ b/src/model/profile/profileinfo.cpp
@@ -20,6 +20,7 @@
 #include "profileinfo.h"
 #include "src/core/core.h"
 #include "src/nexus.h"
+#include "src/persistence/paths.h"
 #include "src/persistence/profile.h"
 #include "src/persistence/settings.h"
 
@@ -202,7 +203,7 @@ IProfileInfo::SaveResult ProfileInfo::exportProfile(const QString& path) const
         return SaveResult::NoWritePermission;
     }
 
-    if (!QFile::copy(Settings::getInstance().getSettingsDirPath() + current, path)) {
+    if (!QFile::copy(Settings::getInstance().getPaths().getProfilesDir() + current, path)) {
         return SaveResult::Error;
     }
 

--- a/src/persistence/paths.cpp
+++ b/src/persistence/paths.cpp
@@ -11,6 +11,7 @@
 
 namespace {
 const QLatin1Literal globalSettingsFile{"qtox.ini"};
+const QLatin1Literal logFile{"qtox.log"};
 const QLatin1Literal profileFolder{"profiles"};
 const QLatin1Literal themeFolder{"themes"};
 const QLatin1Literal avatarsFolder{"avatars"};
@@ -132,6 +133,29 @@ QString Paths::getGlobalSettingsPath() const
     // we assume a writeable path for portable mode
 
     return path % QDir::separator() % globalSettingsFile;
+}
+
+/**
+ * @brief Returns the path to the log file "qtox.log"
+ * @return The path to the folder.
+ */
+QString Paths::getLogFilePath() const
+{
+    QString path;
+
+    if (portable) {
+        path = basePath;
+    } else {
+        path = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+        if (path.isEmpty()) {
+            qDebug() << "Can't find writable location for log file";
+            return {};
+        }
+    }
+
+    // we assume a writeable path for portable mode
+
+    return path % QDir::separator() % logFile;
 }
 
 /**

--- a/src/persistence/paths.h
+++ b/src/persistence/paths.h
@@ -17,6 +17,7 @@ public:
 
     bool isPortable() const;
     QString getGlobalSettingsPath() const;
+    QString getLogFilePath() const;
     QString getProfilesDir() const;
     QString getToxSaveDir() const;
     QString getAvatarsDir() const;

--- a/src/persistence/profile.cpp
+++ b/src/persistence/profile.cpp
@@ -23,11 +23,13 @@
 #include <QFileInfo>
 #include <QObject>
 #include <QSaveFile>
+#include <QStringBuilder>
 #include <QThread>
 
 #include <cassert>
 #include <sodium.h>
 
+#include "paths.h"
 #include "profile.h"
 #include "profilelocker.h"
 #include "settings.h"
@@ -96,6 +98,16 @@ void Profile::initCore(const QByteArray& toxsave, ICoreSettings& s, bool isNewPr
             Qt::ConnectionType::QueuedConnection);
 }
 
+QString Profile::getProfilePath(const QString &name)
+{
+    return Settings::getInstance().getPaths().getProfilesDir() % name;
+}
+
+QString Profile::getToxSavePath(const QString &name)
+{
+    return Settings::getInstance().getPaths().getToxSaveDir() % name % ".tox";
+}
+
 Profile::Profile(QString name, const QString& password, bool isNewProfile, const QByteArray& toxsave)
     : name{name}
     , isRemoved{false}
@@ -135,7 +147,7 @@ Profile* Profile::loadProfile(QString name, const QString& password)
     Profile* p = nullptr;
     qint64 fileSize = 0;
 
-    QString path = Settings::getInstance().getSettingsDirPath() + name + ".tox";
+    QString path = getToxSavePath(name);
     QFile saveFile(path);
     qDebug() << "Loading tox save " << path;
 
@@ -259,9 +271,9 @@ Profile::~Profile()
  * @param extension Raw extension, e.g. "jpeg" not ".jpeg".
  * @return Vector of filenames.
  */
-QStringList Profile::getFilesByExt(QString extension)
+QStringList Profile::getFilesByExt(const QString& directory, const QString& extension)
 {
-    QDir dir(Settings::getInstance().getSettingsDirPath());
+    QDir dir{directory};
     QStringList out;
     dir.setFilter(QDir::Files | QDir::NoDotAndDotDot);
     dir.setNameFilters(QStringList("*." + extension));
@@ -281,7 +293,11 @@ QStringList Profile::getFilesByExt(QString extension)
 void Profile::scanProfiles()
 {
     profiles.clear();
-    QStringList toxfiles = getFilesByExt("tox"), inifiles = getFilesByExt("ini");
+    const QString toxDir{Settings::getInstance().getPaths().getToxSaveDir()};
+    const QString profileDir{Settings::getInstance().getPaths().getProfilesDir()};
+    QStringList toxfiles = getFilesByExt(toxDir, "tox");
+    QStringList inifiles = getFilesByExt(profileDir, "ini");
+
     for (QString toxfile : toxfiles) {
         if (!inifiles.contains(toxfile)) {
             Settings::getInstance().createPersonal(toxfile);
@@ -358,7 +374,7 @@ bool Profile::saveToxSave(QByteArray data)
     ProfileLocker::assertLock();
     assert(ProfileLocker::getCurLockName() == name);
 
-    QString path = Settings::getInstance().getSettingsDirPath() + name + ".tox";
+    QString path = getToxSavePath(name);
     qDebug() << "Saving tox save to " << path;
     QSaveFile saveFile(path);
     if (!saveFile.open(QIODevice::WriteOnly)) {
@@ -399,8 +415,9 @@ bool Profile::saveToxSave(QByteArray data)
 QString Profile::avatarPath(const ToxPk& owner, bool forceUnencrypted)
 {
     const QString ownerStr = owner.toString();
+    const QString avatarDir{Settings::getInstance().getPaths().getAvatarsDir()};
     if (!encrypted || forceUnencrypted) {
-        return Settings::getInstance().getSettingsDirPath() + "avatars/" + ownerStr + ".png";
+        return avatarDir + ownerStr + ".png";
     }
 
     QByteArray idData = ownerStr.toUtf8();
@@ -414,7 +431,7 @@ QString Profile::avatarPath(const ToxPk& owner, bool forceUnencrypted)
     QByteArray hash(hashSize, 0);
     crypto_generichash((uint8_t*)hash.data(), hashSize, (uint8_t*)idData.data(), idData.size(),
                        (uint8_t*)pubkeyData.data(), pubkeyData.size());
-    return Settings::getInstance().getSettingsDirPath() + "avatars/" + hash.toHex().toUpper() + ".png";
+    return avatarDir + hash.toHex().toUpper() + ".png";
 }
 
 /**
@@ -591,7 +608,7 @@ void Profile::saveAvatar(const ToxPk& owner, const QByteArray& avatar)
     const QByteArray& pic = needEncrypt ? passkey->encrypt(avatar) : avatar;
 
     QString path = avatarPath(owner);
-    QDir(Settings::getInstance().getSettingsDirPath()).mkdir("avatars");
+    QDir{}.mkpath(Settings::getInstance().getPaths().getAvatarsDir());
     if (pic.isEmpty()) {
         QFile::remove(path);
     } else {
@@ -669,8 +686,8 @@ void Profile::removeAvatar(const ToxPk& owner)
 
 bool Profile::exists(QString name)
 {
-    QString path = Settings::getInstance().getSettingsDirPath() + name;
-    return QFile::exists(path + ".tox");
+    const QString path{getToxSavePath(name)};
+    return QFile::exists(path);
 }
 
 /**
@@ -691,7 +708,7 @@ bool Profile::isEncrypted() const
 bool Profile::isEncrypted(QString name)
 {
     uint8_t data[TOX_PASS_ENCRYPTION_EXTRA_LENGTH] = {0};
-    QString path = Settings::getInstance().getSettingsDirPath() + name + ".tox";
+    QString path = getToxSavePath(name);
     QFile saveFile(path);
     if (!saveFile.open(QIODevice::ReadOnly)) {
         qWarning() << "Couldn't open tox save " << path;
@@ -725,11 +742,11 @@ QStringList Profile::remove()
             i--;
         }
     }
-    QString path = Settings::getInstance().getSettingsDirPath() + name;
+
     ProfileLocker::unlock();
 
-    QFile profileMain{path + ".tox"};
-    QFile profileConfig{path + ".ini"};
+    QFile profileMain{getToxSavePath(name)};
+    QFile profileConfig{getProfilePath(name) + ".ini"};
 
     QStringList ret;
 
@@ -761,15 +778,12 @@ QStringList Profile::remove()
  */
 bool Profile::rename(QString newName)
 {
-    QString path = Settings::getInstance().getSettingsDirPath() + name,
-            newPath = Settings::getInstance().getSettingsDirPath() + newName;
-
     if (!ProfileLocker::lock(newName)) {
         return false;
     }
 
-    QFile::rename(path + ".tox", newPath + ".tox");
-    QFile::rename(path + ".ini", newPath + ".ini");
+    QFile::rename(getToxSavePath(name), getToxSavePath(newName));
+    QFile::rename(getProfilePath(name) + ".ini", getProfilePath(newName) + ".ini");
     if (database) {
         database->rename(newName);
     }
@@ -878,5 +892,5 @@ QString Profile::setPassword(const QString& newPassword)
  */
 QString Profile::getDbPath(const QString& profileName)
 {
-    return Settings::getInstance().getSettingsDirPath() + profileName + ".db";
+    return getProfilePath(profileName) + ".db";
 }

--- a/src/persistence/profile.h
+++ b/src/persistence/profile.h
@@ -99,10 +99,12 @@ private slots:
 
 private:
     Profile(QString name, const QString& password, bool newProfile, const QByteArray& toxsave);
-    static QStringList getFilesByExt(QString extension);
+    static QStringList getFilesByExt(const QString& directory, const QString& extension);
     QString avatarPath(const ToxPk& owner, bool forceUnencrypted = false);
     bool saveToxSave(QByteArray data);
     void initCore(const QByteArray& toxsave, ICoreSettings& s, bool isNewProfile);
+    static QString getProfilePath(const QString& name);
+    static QString getToxSavePath(const QString& name);
 
 private:
     std::unique_ptr<Core> core = nullptr;

--- a/src/persistence/profilelocker.cpp
+++ b/src/persistence/profilelocker.cpp
@@ -19,6 +19,7 @@
 
 
 #include "profilelocker.h"
+#include "src/persistence/paths.h"
 #include "src/persistence/settings.h"
 #include <QDebug>
 #include <QDir>
@@ -38,7 +39,7 @@ QString ProfileLocker::curLockName;
 
 QString ProfileLocker::lockPathFromName(const QString& name)
 {
-    return Settings::getInstance().getSettingsDirPath() + '/' + name + ".lock";
+    return Settings::getInstance().getPaths().getProfilesDir() + name + ".lock";
 }
 
 /**

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -725,7 +725,7 @@ QString Settings::getSettingsDirPath() const
 {
     QMutexLocker locker{&bigLock};
     QString settingsFile {paths.getGlobalSettingsPath()};
-    return QFileInfo{settingsFile}.dir().absolutePath();
+    return QFileInfo{settingsFile}.dir().absolutePath() + QDir::separator();
 }
 
 const QList<DhtServer>& Settings::getDhtServerList() const

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -22,6 +22,7 @@
 #include "src/core/core.h"
 #include "src/core/corefile.h"
 #include "src/nexus.h"
+#include "src/persistence/paths.h"
 #include "src/persistence/profile.h"
 #include "src/persistence/profilelocker.h"
 #include "src/persistence/settingsserializer.h"
@@ -62,8 +63,19 @@ Settings* Settings::settings{nullptr};
 QMutex Settings::bigLock{QMutex::Recursive};
 QThread* Settings::settingsThread{nullptr};
 
-Settings::Settings()
-    : loaded(false)
+/**
+ * @brief Factory method for the Settings class
+ * @param paths Paths object, providing all important paths
+ * @return Settings object on success, nullptr else
+ */
+Settings* Settings::makeSettings(const Paths& paths) {
+    settings = new Settings{paths};
+    return settings;
+}
+
+Settings::Settings(const Paths& paths)
+    : paths{paths}
+    , loaded(false)
     , useCustomDhtList{false}
     , makeToxPortable{false}
     , currentProfileId(0)
@@ -81,6 +93,7 @@ Settings::~Settings()
     settingsThread->exit(0);
     settingsThread->wait();
     delete settingsThread;
+    settings = nullptr;
 }
 
 /**
@@ -88,16 +101,7 @@ Settings::~Settings()
  */
 Settings& Settings::getInstance()
 {
-    if (!settings)
-        settings = new Settings();
-
     return *settings;
-}
-
-void Settings::destroyInstance()
-{
-    delete settings;
-    settings = nullptr;
 }
 
 void Settings::loadGlobal()
@@ -175,8 +179,11 @@ void Settings::loadGlobal()
         }
         autoAwayTime = s.value("autoAwayTime", 10).toInt();
         checkUpdates = s.value("checkUpdates", true).toBool();
-        notifySound = s.value("notifySound", true).toBool(); // note: notifySound and busySound UI elements are now under UI settings
-        busySound = s.value("busySound", false).toBool();    // page, but kept under General in settings file to be backwards compatible
+        // note: notifySound and busySound UI elements are now under UI settings
+        // page, but kept under General in settings file to be backwards compatible
+        notifySound = s.value("notifySound", true).toBool();
+        busySound = s.value("busySound", false).toBool();
+
         fauxOfflineMessaging = s.value("fauxOfflineMessaging", true).toBool();
         autoSaveEnabled = s.value("autoSaveEnabled", false).toBool();
         globalAutoAcceptDir = s.value("globalAutoAcceptDir",

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -58,7 +58,6 @@
  * @brief Toxme info like name@server
  */
 
-const QString Settings::globalSettingsFile = "qtox.ini";
 Settings* Settings::settings{nullptr};
 QMutex Settings::bigLock{QMutex::Recursive};
 QThread* Settings::settingsThread{nullptr};
@@ -113,25 +112,12 @@ void Settings::loadGlobal()
 
     createSettingsDir();
 
-    QString localSettingsPath = qApp->applicationDirPath() + QDir::separator() + globalSettingsFile;
-
-    if (QFile(localSettingsPath).exists()) {
-        QSettings ps(localSettingsPath, QSettings::IniFormat);
-        ps.setIniCodec("UTF-8");
-        ps.beginGroup("Advanced");
-        makeToxPortable = ps.value("makeToxPortable", false).toBool();
-        ps.endGroup();
-    } else {
-        makeToxPortable = false;
-    }
-
-    QDir dir(getSettingsDirPath());
-    QString filePath = dir.filePath(globalSettingsFile);
+    QString filePath = paths.getGlobalSettingsPath();
 
     // If no settings file exist -- use the default one
     if (!QFile(filePath).exists()) {
         qDebug() << "No settings file found, using defaults";
-        filePath = ":/conf/" + globalSettingsFile;
+        filePath = ":/conf/qtox.ini";
     }
 
     qDebug() << "Loading settings from " + filePath;
@@ -334,13 +320,7 @@ void Settings::loadPersonal(Profile* profile)
 {
     QMutexLocker locker{&bigLock};
 
-    QDir dir(getSettingsDirPath());
-    QString filePath = dir.filePath(globalSettingsFile);
-
-    // load from a profile specific friend data list if possible
-    QString tmp = dir.filePath(profile->getName() + ".ini");
-    if (QFile(tmp).exists()) // otherwise, filePath remains the global file
-        filePath = tmp;
+    const QString filePath{paths.getProfilesDir()};
 
     qDebug() << "Loading personal settings from" << filePath;
 
@@ -466,7 +446,7 @@ void Settings::saveGlobal()
     if (!loaded)
         return;
 
-    QString path = getSettingsDirPath() + globalSettingsFile;
+    QString path = paths.getGlobalSettingsPath();
     qDebug() << "Saving global settings at " + path;
 
     QSettings s(path, QSettings::IniFormat);
@@ -739,25 +719,8 @@ uint32_t Settings::makeProfileId(const QString& profile)
 QString Settings::getSettingsDirPath() const
 {
     QMutexLocker locker{&bigLock};
-    if (makeToxPortable)
-        return qApp->applicationDirPath() + QDir::separator();
-
-// workaround for https://bugreports.qt-project.org/browse/QTBUG-38845
-#ifdef Q_OS_WIN
-    return QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::HomeLocation)
-                           + QDir::separator() + "AppData" + QDir::separator() + "Roaming"
-                           + QDir::separator() + "tox")
-           + QDir::separator();
-#elif defined(Q_OS_OSX)
-    return QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::HomeLocation)
-                           + QDir::separator() + "Library" + QDir::separator()
-                           + "Application Support" + QDir::separator() + "Tox")
-           + QDir::separator();
-#else
-    return QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::ConfigLocation)
-                           + QDir::separator() + "tox")
-           + QDir::separator();
-#endif
+    QString settingsFile {paths.getGlobalSettingsPath()};
+    return QFileInfo{settingsFile}.dir().absolutePath();
 }
 
 /**
@@ -874,15 +837,7 @@ bool Settings::getMakeToxPortable() const
 
 void Settings::setMakeToxPortable(bool newValue)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (newValue != makeToxPortable) {
-        QFile(getSettingsDirPath() + globalSettingsFile).remove();
-        makeToxPortable = newValue;
-        saveGlobal();
-
-        emit makeToxPortableChanged(makeToxPortable);
-    }
+    // TODO(sudden6): to be removed
 }
 
 bool Settings::getAutorun() const

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -728,33 +728,6 @@ QString Settings::getSettingsDirPath() const
     return QFileInfo{settingsFile}.dir().absolutePath();
 }
 
-/**
- * @brief Get path to directory, where the application cache are stored.
- * @return Path to application cache, ends with a directory separator.
- */
-QString Settings::getAppCacheDirPath() const
-{
-    QMutexLocker locker{&bigLock};
-    if (makeToxPortable)
-        return qApp->applicationDirPath() + QDir::separator();
-
-// workaround for https://bugreports.qt-project.org/browse/QTBUG-38845
-#ifdef Q_OS_WIN
-    return QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::HomeLocation)
-                           + QDir::separator() + "AppData" + QDir::separator() + "Roaming"
-                           + QDir::separator() + "tox")
-           + QDir::separator();
-#elif defined(Q_OS_OSX)
-    return QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::HomeLocation)
-                           + QDir::separator() + "Library" + QDir::separator()
-                           + "Application Support" + QDir::separator() + "Tox")
-           + QDir::separator();
-#else
-    return QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::CacheLocation))
-           + QDir::separator();
-#endif
-}
-
 const QList<DhtServer>& Settings::getDhtServerList() const
 {
     QMutexLocker locker{&bigLock};

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -712,6 +712,11 @@ uint32_t Settings::makeProfileId(const QString& profile)
     return dwords[0] ^ dwords[1] ^ dwords[2] ^ dwords[3];
 }
 
+const Paths &Settings::getPaths() const
+{
+    return paths;
+}
+
 /**
  * @brief Get path to directory, where the settings files are stored.
  * @return Path to settings directory, ends with a directory separator.
@@ -721,38 +726,6 @@ QString Settings::getSettingsDirPath() const
     QMutexLocker locker{&bigLock};
     QString settingsFile {paths.getGlobalSettingsPath()};
     return QFileInfo{settingsFile}.dir().absolutePath();
-}
-
-/**
- * @brief Get path to directory, where the application data are stored.
- * @return Path to application data, ends with a directory separator.
- */
-QString Settings::getAppDataDirPath() const
-{
-    QMutexLocker locker{&bigLock};
-    if (makeToxPortable)
-        return qApp->applicationDirPath() + QDir::separator();
-
-// workaround for https://bugreports.qt-project.org/browse/QTBUG-38845
-#ifdef Q_OS_WIN
-    return QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::HomeLocation)
-                           + QDir::separator() + "AppData" + QDir::separator() + "Roaming"
-                           + QDir::separator() + "tox")
-           + QDir::separator();
-#elif defined(Q_OS_OSX)
-    return QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::HomeLocation)
-                           + QDir::separator() + "Library" + QDir::separator()
-                           + "Application Support" + QDir::separator() + "Tox")
-           + QDir::separator();
-#else
-    /*
-     * TODO: Change QStandardPaths::DataLocation to AppDataLocation when upgrate Qt to 5.4+
-     * For now we need support Qt 5.3, so we use deprecated DataLocation
-     * BTW, it's not a big deal since for linux AppDataLocation and DataLocation are equal
-     */
-    return QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::DataLocation))
-           + QDir::separator();
-#endif
 }
 
 /**

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -139,7 +139,6 @@ public:
     ~Settings() override;
     static Settings& getInstance();
     QString getSettingsDirPath() const;
-    QString getAppDataDirPath() const;
     QString getAppCacheDirPath() const;
 
     void createSettingsDir();
@@ -570,6 +569,7 @@ public:
     }
 
     static uint32_t makeProfileId(const QString& profile);
+    const Paths& getPaths() const;
 
 private:
     struct friendProp;

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -138,7 +138,6 @@ public:
     static Settings* makeSettings(const Paths& paths);
     ~Settings() override;
     static Settings& getInstance();
-    QString getSettingsDirPath() const;
 
     void createSettingsDir();
     void createPersonal(QString basename);
@@ -578,6 +577,8 @@ private:
     Settings& operator=(const Settings&) = delete;
     void savePersonal(QString profileName, const ToxEncrypt* passkey);
     friendProp& getOrInsertFriendPropRef(const ToxPk& id);
+
+    QString getSettingsDirPath() const;
 
 public slots:
     void savePersonal(Profile* profile);

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -37,6 +37,7 @@
 #include <QObject>
 #include <QPixmap>
 
+class Paths;
 class Profile;
 
 namespace Db {
@@ -134,8 +135,9 @@ public:
     };
 
 public:
+    static Settings* makeSettings(const Paths& paths);
+    ~Settings() override;
     static Settings& getInstance();
-    static void destroyInstance();
     QString getSettingsDirPath() const;
     QString getAppDataDirPath() const;
     QString getAppCacheDirPath() const;
@@ -572,8 +574,7 @@ public:
 private:
     struct friendProp;
 
-    Settings();
-    ~Settings();
+    Settings(const Paths &paths);
     Settings(Settings& settings) = delete;
     Settings& operator=(const Settings&) = delete;
     void savePersonal(QString profileName, const ToxEncrypt* passkey);
@@ -583,6 +584,7 @@ public slots:
     void savePersonal(Profile* profile);
 
 private:
+    const Paths& paths;
     bool loaded;
 
     bool useCustomDhtList;
@@ -693,7 +695,8 @@ private:
         friendProp() = delete;
         friendProp(QString addr)
             : addr(addr)
-        {}
+        {
+        }
         QString alias = "";
         QString addr = "";
         QString autoAcceptDir = "";

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -139,7 +139,6 @@ public:
     ~Settings() override;
     static Settings& getInstance();
     QString getSettingsDirPath() const;
-    QString getAppCacheDirPath() const;
 
     void createSettingsDir();
     void createPersonal(QString basename);

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -30,6 +30,7 @@
 #include "src/persistence/history.h"
 #include "src/persistence/offlinemsgengine.h"
 #include "src/persistence/profile.h"
+#include "src/persistence/paths.h"
 #include "src/persistence/settings.h"
 #include "src/video/netcamview.h"
 #include "src/widget/chatformheader.h"
@@ -893,16 +894,13 @@ void ChatForm::doScreenshot()
 
 void ChatForm::sendImage(const QPixmap& pixmap)
 {
-    QDir(Settings::getInstance().getAppDataDirPath()).mkpath("images");
-
+    QString filepath{Settings::getInstance().getPaths().getScreenshotsDir()};
     // use ~ISO 8601 for screenshot timestamp, considering FS limitations
     // https://en.wikipedia.org/wiki/ISO_8601
     // Windows has to be supported, thus filename can't have `:` in it :/
     // Format should be: `qTox_Screenshot_yyyy-MM-dd HH-mm-ss.zzz.png`
-    QString filepath = QString("%1images%2qTox_Image_%3.png")
-                           .arg(Settings::getInstance().getAppDataDirPath())
-                           .arg(QDir::separator())
-                           .arg(QDateTime::currentDateTime().toString("yyyy-MM-dd HH-mm-ss.zzz"));
+    filepath += QString("qTox_Image_%1.png")
+                       .arg(QDateTime::currentDateTime().toString("yyyy-MM-dd HH-mm-ss.zzz"));
     QFile file(filepath);
 
     if (file.open(QFile::ReadWrite)) {

--- a/src/widget/form/profileform.cpp
+++ b/src/widget/form/profileform.cpp
@@ -22,6 +22,7 @@
 #include "src/core/core.h"
 #include "src/model/profile/iprofileinfo.h"
 #include "src/net/toxme.h"
+#include "src/persistence/paths.h"
 #include "src/persistence/profile.h"
 #include "src/persistence/profilelocker.h"
 #include "src/persistence/settings.h"
@@ -227,10 +228,7 @@ void ProfileForm::show(ContentLayout* contentLayout)
     contentLayout->mainContent->layout()->addWidget(this);
     QWidget::show();
     prFileLabelUpdate();
-    bool portable = Settings::getInstance().getMakeToxPortable();
-    QString defaultPath = QDir(Settings::getInstance().getSettingsDirPath()).path().trimmed();
-    QString appPath = QApplication::applicationDirPath();
-    QString dirPath = portable ? appPath : defaultPath;
+    QString dirPath = Settings::getInstance().getPaths().getProfilesDir();
 
     QString dirPrLink =
         tr("Current profile location: %1").arg(QString("<a href=\"file://%1\">%1</a>").arg(dirPath));

--- a/src/widget/form/settings/advancedform.cpp
+++ b/src/widget/form/settings/advancedform.cpp
@@ -30,6 +30,7 @@
 #include "src/core/core.h"
 #include "src/core/coreav.h"
 #include "src/nexus.h"
+#include "src/persistence/paths.h"
 #include "src/persistence/profile.h"
 #include "src/persistence/settings.h"
 #include "src/widget/gui.h"
@@ -107,8 +108,7 @@ void AdvancedForm::on_btnExportLog_clicked()
         return;
     }
 
-    QString logFileDir = Settings::getInstance().getAppCacheDirPath();
-    QString logfile = logFileDir + "qtox.log";
+    QString logfile = Settings::getInstance().getPaths().getLogFilePath();
 
     QFile file(logfile);
     if (file.exists()) {
@@ -126,8 +126,7 @@ void AdvancedForm::on_btnExportLog_clicked()
 
 void AdvancedForm::on_btnCopyDebug_clicked()
 {
-    QString logFileDir = Settings::getInstance().getAppCacheDirPath();
-    QString logfile = logFileDir + "qtox.log";
+    QString logfile = Settings::getInstance().getPaths().getLogFilePath();
 
     QFile file(logfile);
     if (!file.exists()) {

--- a/src/widget/tool/profileimporter.cpp
+++ b/src/widget/tool/profileimporter.cpp
@@ -25,6 +25,7 @@
 #include <QPushButton>
 
 #include "src/core/core.h"
+#include "src/persistence/paths.h"
 #include "src/persistence/settings.h"
 
 /**
@@ -105,8 +106,8 @@ bool ProfileImporter::importProfile(const QString& path)
         return false; // ingore importing non-tox file
     }
 
-    QString settingsPath = Settings::getInstance().getSettingsDirPath();
-    QString profilePath = QDir(settingsPath).filePath(profile + Core::TOX_EXT);
+    QString profileDir = Settings::getInstance().getPaths().getProfilesDir();
+    QString profilePath = QDir(profileDir).filePath(profile + Core::TOX_EXT);
 
     if (QFileInfo(profilePath).exists()) {
         QString title = tr("Profile already exists", "import confirm title");

--- a/test/persistence/paths_test.cpp
+++ b/test/persistence/paths_test.cpp
@@ -41,6 +41,7 @@ private:
 
 namespace {
 const QLatin1Literal globalSettingsFile{"qtox.ini"};
+const QLatin1Literal logFile{"qtox.log"};
 const QLatin1Literal profileFolder{"profiles"};
 const QLatin1Literal themeFolder{"themes"};
 const QLatin1Literal avatarsFolder{"avatars"};
@@ -112,10 +113,11 @@ void TestPaths::checkPathsNonPortable()
 
     const QString appData{QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)};
     const QString appConfig{QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation)};
-
+    const QString cache{QStandardPaths::writableLocation(QStandardPaths::CacheLocation)};
 
     verifyqToxPath(paths->getProfilesDir(), appData, profileFolder % sep);
     verifyqToxPath(paths->getGlobalSettingsPath(), appConfig, globalSettingsFile);
+    verifyqToxPath(paths->getLogFilePath(), cache, logFile);
     verifyqToxPath(paths->getScreenshotsDir(), appData, screenshotsFolder % sep);
     verifyqToxPath(paths->getTransfersDir(), appData, transfersFolder % sep);
 
@@ -153,6 +155,7 @@ void TestPaths::checkPathsPortable()
 
     verifyqToxPath(paths->getProfilesDir(), basePath, profileFolder % sep);
     verifyqToxPath(paths->getGlobalSettingsPath(), basePath, globalSettingsFile);
+    verifyqToxPath(paths->getLogFilePath(), basePath, logFile);
     verifyqToxPath(paths->getScreenshotsDir(), basePath, screenshotsFolder % sep);
     verifyqToxPath(paths->getTransfersDir(), basePath, transfersFolder % sep);
 


### PR DESCRIPTION
- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

This PR provides the integration for the Paths module in the existing code. I decided to pass `Paths` via a getter function through the `Settings` class in order to keep the amount of changes manageable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5440)
<!-- Reviewable:end -->
