### PR TITLE
chore(cmake): let CMake choose which platform dependent code to compile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -524,17 +524,27 @@ if (PLATFORM_EXTENSIONS)
     src/platform/autorun.h
     src/platform/capslock.h
     src/platform/timer.h
-    src/platform/autorun_osx.cpp
-    src/platform/autorun_win.cpp
-    src/platform/autorun_xdg.cpp
-    src/platform/capslock_osx.cpp
-    src/platform/capslock_win.cpp
-    src/platform/capslock_x11.cpp
-    src/platform/timer_osx.cpp
-    src/platform/timer_win.cpp
-    src/platform/timer_x11.cpp
-    src/platform/x11_display.cpp
   )
+  if (WIN32)
+    set(${PROJECT_NAME}_SOURCES ${${PROJECT_NAME}_SOURCES}
+      src/platform/autorun_win.cpp
+      src/platform/capslock_win.cpp
+      src/platform/timer_win.cpp
+    )
+  elseif (${X11_EXT})
+    set(${PROJECT_NAME}_SOURCES ${${PROJECT_NAME}_SOURCES}
+      src/platform/autorun_xdg.cpp
+      src/platform/capslock_x11.cpp
+      src/platform/timer_x11.cpp
+      src/platform/x11_display.cpp
+    )
+  elseif (${APPLE_EXT})
+    set(${PROJECT_NAME}_SOURCES ${${PROJECT_NAME}_SOURCES}
+      src/platform/autorun_osx.cpp
+      src/platform/capslock_osx.cpp
+      src/platform/timer_osx.cpp
+    )
+  endif()
 endif()
 
 add_definitions(-DQT_MESSAGELOGCONTEXT=1)

--- a/src/platform/autorun_osx.cpp
+++ b/src/platform/autorun_osx.cpp
@@ -17,7 +17,6 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#if defined(__APPLE__) && defined(__MACH__)
 #include "src/platform/autorun.h"
 #include <QCoreApplication>
 #include <QDir>
@@ -48,5 +47,3 @@ bool Platform::getAutorun()
 {
     return state;
 }
-
-#endif // defined(__APPLE__) && defined(__MACH__)

--- a/src/platform/autorun_win.cpp
+++ b/src/platform/autorun_win.cpp
@@ -18,7 +18,6 @@
 */
 
 #include <QApplication>
-#ifdef Q_OS_WIN32
 #include "src/persistence/settings.h"
 #include "src/platform/autorun.h"
 #include <string>
@@ -101,5 +100,3 @@ bool Platform::getAutorun()
     RegCloseKey(key);
     return result;
 }
-
-#endif // Q_OS_WIN32

--- a/src/platform/autorun_xdg.cpp
+++ b/src/platform/autorun_xdg.cpp
@@ -18,7 +18,6 @@
 */
 
 #include <QApplication>
-#if defined(Q_OS_UNIX) && !defined(__APPLE__) && !defined(__MACH__)
 #include "src/persistence/settings.h"
 #include "src/platform/autorun.h"
 #include <QDir>
@@ -69,5 +68,3 @@ bool Platform::getAutorun()
 {
     return QFile(getAutostartFilePath(getAutostartDirPath())).exists();
 }
-
-#endif // defined(Q_OS_UNIX) && !defined(__APPLE__) && !defined(__MACH__)

--- a/src/platform/capslock_osx.cpp
+++ b/src/platform/capslock_osx.cpp
@@ -18,7 +18,6 @@
 */
 
 #include <QtCore/qsystemdetection.h>
-#if defined(__APPLE__) && defined(__MACH__)
 #include "src/platform/capslock.h"
 
 // TODO: Implement for osx
@@ -26,5 +25,3 @@ bool Platform::capsLockEnabled()
 {
     return false;
 }
-
-#endif // defined(__APPLE__) && defined(__MACH__)

--- a/src/platform/capslock_win.cpp
+++ b/src/platform/capslock_win.cpp
@@ -18,7 +18,6 @@
 */
 
 #include <QtCore/qsystemdetection.h>
-#ifdef Q_OS_WIN32
 #include "src/platform/capslock.h"
 #include <windows.h>
 
@@ -26,5 +25,3 @@ bool Platform::capsLockEnabled()
 {
     return GetKeyState(VK_CAPITAL) == 1;
 }
-
-#endif // Q_OS_WIN32

--- a/src/platform/capslock_x11.cpp
+++ b/src/platform/capslock_x11.cpp
@@ -18,7 +18,6 @@
 */
 
 #include <QtCore/qsystemdetection.h>
-#if defined(Q_OS_UNIX) && !defined(__APPLE__) && !defined(__MACH__)
 #include "src/platform/capslock.h"
 #include "src/platform/x11_display.h"
 #include <X11/XKBlib.h>
@@ -39,6 +38,3 @@ bool Platform::capsLockEnabled()
     X11Display::unlock();
     return caps_state;
 }
-
-
-#endif // defined(Q_OS_UNIX) && !defined(__APPLE__) && !defined(__MACH__)

--- a/src/platform/timer_osx.cpp
+++ b/src/platform/timer_osx.cpp
@@ -24,7 +24,6 @@
 */
 
 #include <QtCore/qsystemdetection.h>
-#if defined(__APPLE__) && defined(__MACH__)
 #include "src/platform/timer.h"
 #include <CoreFoundation/CoreFoundation.h>
 #include <IOKit/IOKitLib.h>
@@ -50,5 +49,3 @@ uint32_t Platform::getIdleTime()
 
     return idleTime_ns / 1000000;
 }
-
-#endif // defined(__APPLE__) && defined(__MACH__)

--- a/src/platform/timer_win.cpp
+++ b/src/platform/timer_win.cpp
@@ -18,7 +18,6 @@
 */
 
 #include <QtCore/qsystemdetection.h>
-#ifdef Q_OS_WIN32
 #include "src/platform/timer.h"
 #include <windows.h>
 
@@ -30,5 +29,3 @@ uint32_t Platform::getIdleTime()
         return GetTickCount() - info.dwTime;
     return 0;
 }
-
-#endif // Q_OS_WIN32

--- a/src/platform/timer_x11.cpp
+++ b/src/platform/timer_x11.cpp
@@ -16,7 +16,6 @@
 */
 
 #include <QtCore/qsystemdetection.h>
-#if defined(Q_OS_UNIX) && !defined(__APPLE__) && !defined(__MACH__)
 #include "src/platform/timer.h"
 #include "src/platform/x11_display.h"
 #include <QDebug>
@@ -47,5 +46,3 @@ uint32_t Platform::getIdleTime()
     X11Display::unlock();
     return idleTime;
 }
-
-#endif // Q_OS_UNIX

--- a/src/platform/x11_display.cpp
+++ b/src/platform/x11_display.cpp
@@ -18,7 +18,6 @@
 */
 
 #include <QtCore/qsystemdetection.h>
-#if defined(Q_OS_UNIX) && !defined(__APPLE__) && !defined(__MACH__)
 #include "src/platform/x11_display.h"
 #include <QMutex>
 #include <X11/Xlib.h>
@@ -60,5 +59,3 @@ void X11Display::unlock()
     X11DisplayPrivate::getSingleInstance().mutex.unlock();
 }
 }
-
-#endif // Q_OS_UNIX && !defined(__APPLE__) && !defined(__MACH__)

--- a/src/platform/x11_display.h
+++ b/src/platform/x11_display.h
@@ -22,8 +22,6 @@
 #ifndef PLATFORM_X11_DISPLAY_H
 #define PLATFORM_X11_DISPLAY_H
 
-#if defined(Q_OS_UNIX) && !defined(__APPLE__) && !defined(__MACH__)
-
 typedef struct _XDisplay Display;
 
 namespace Platform {
@@ -34,8 +32,6 @@ void unlock();
 }
 
 }
-
-#endif // Q_OS_UNIX && !defined(__APPLE__) && !defined(__MACH__)
 
 #endif // PLATFORM_X11_DISPLAY_H
 


### PR DESCRIPTION
Macros can be hard to manipulate and vary among different compilers and
platforms. For example, GNU Hurd has `__MACH__` defined but not
`__APPLE__`.

Let CMake choose them during configuration.

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5449)
<!-- Reviewable:end -->
