### PR TITLE
fix(paths): create profile dir before calling ProfileLocker or Profile

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -159,11 +159,6 @@ void createLogFile(const Paths& paths)
     QFileInfo logFile{logFilePath};
     QDir logFileDir{logFile.dir()};
 
-    if (!logFileDir.mkpath(".")) {
-        qCritical() << "Couldn't create path for log file";
-        return;
-    }
-
     QByteArray logFilePathLocal{logFile.absoluteFilePath().toLocal8Bit()};
     FILE* mainLogFilePtr = fopen(logFilePathLocal.constData(), "a");
 

--- a/src/persistence/paths.cpp
+++ b/src/persistence/paths.cpp
@@ -101,7 +101,23 @@ Paths* Paths::makePaths(Portable mode)
 Paths::Paths(const QString& basePath, bool portable)
     : basePath{basePath}
     , portable{portable}
-{}
+{
+    QStringList allDirs{
+        getGlobalSettingsPath(),
+        getLogFilePath(),
+        getProfilesDir(),
+        getToxSaveDir(),
+        getAvatarsDir(),
+        getTransfersDir(),
+        getScreenshotsDir()
+        };
+    allDirs += getThemeDirs();
+    for (auto& dir : allDirs) {
+        if (!QDir{}.mkpath(dir)) {
+            qCritical() << "Couldn't create dir:" << dir;
+        }
+    }
+}
 
 /**
  * @brief Check if qTox is running in portable mode.

--- a/src/persistence/profile.cpp
+++ b/src/persistence/profile.cpp
@@ -608,7 +608,6 @@ void Profile::saveAvatar(const ToxPk& owner, const QByteArray& avatar)
     const QByteArray& pic = needEncrypt ? passkey->encrypt(avatar) : avatar;
 
     QString path = avatarPath(owner);
-    QDir{}.mkpath(Settings::getInstance().getPaths().getAvatarsDir());
     if (pic.isEmpty()) {
         QFile::remove(path);
     } else {

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -110,8 +110,6 @@ void Settings::loadGlobal()
     if (loaded)
         return;
 
-    createSettingsDir();
-
     QString filePath = paths.getGlobalSettingsPath();
 
     // If no settings file exist -- use the default one
@@ -2312,19 +2310,6 @@ void Settings::createPersonal(QString basename)
 
     ps.beginGroup("Privacy");
     ps.endGroup();
-}
-
-/**
- * @brief Creates a path to the settings dir, if it doesn't already exist
- */
-void Settings::createSettingsDir()
-{
-    QMutexLocker locker{&bigLock};
-
-    QString dir = Settings::getSettingsDirPath();
-    QDir directory(dir);
-    if (!directory.exists() && !directory.mkpath(directory.absolutePath()))
-        qCritical() << "Error while creating directory " << dir;
 }
 
 /**

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -139,7 +139,6 @@ public:
     ~Settings() override;
     static Settings& getInstance();
 
-    void createSettingsDir();
     void createPersonal(QString basename);
 
     void savePersonal();


### PR DESCRIPTION
Fix failure to create new profile due to profile dir not existing. Move
creation outside of Profile class due to ProfileLocker static functions.

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5462)
<!-- Reviewable:end -->
