### PR TITLE
fix(widget): always force show window on activate event

### DIFF
--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -81,10 +81,12 @@
 bool toxActivateEventHandler(const QByteArray&)
 {
     Widget* widget = Nexus::getDesktopGUI();
-    if (!widget)
+    if (!widget) {
         return true;
-    if (!widget->isActiveWindow())
-        widget->forceShow();
+    }
+
+    qDebug() << "Handling [activate] event from other instance";
+    widget->forceShow();
 
     return true;
 }


### PR DESCRIPTION
fixes #5459

I tested this on KDE, where it still works without any regression.

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5466)
<!-- Reviewable:end -->
