### PR TITLE
fix: check valid date in getDateWhereFindPhrase (#5396)

### DIFF
--- a/src/persistence/history.cpp
+++ b/src/persistence/history.cpp
@@ -540,6 +540,11 @@ QDateTime History::getDateWhereFindPhrase(const QString& friendPk, const QDateTi
     }
 
     QDateTime date = from;
+
+    if (!date.isValid()) {
+        date = QDateTime::currentDateTime();
+    }
+
     if (parameter.period == PeriodSearch::AfterDate || parameter.period == PeriodSearch::BeforeDate) {
         date = QDateTime(parameter.date);
     }


### PR DESCRIPTION
- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5467)
<!-- Reviewable:end -->
