### PR TITLE
fix(groups): only leave audio call if in a call

### DIFF
--- a/src/widget/form/groupchatform.cpp
+++ b/src/widget/form/groupchatform.cpp
@@ -182,7 +182,7 @@ void GroupChatForm::onUserListChanged()
     const int peersCount = group->getPeersCount();
     const bool online = peersCount > 1;
     headWidget->updateCallButtons(online, inCall);
-    if (!online || !group->isAvGroupchat()) {
+    if (inCall && (!online || !group->isAvGroupchat())) {
         Core::getInstance()->getAv()->leaveGroupCall(group->getId());
         hideNetcam();
     }


### PR DESCRIPTION
Removes debug log spam of leaving audio call every time someone joins a
text group.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5487)
<!-- Reviewable:end -->
