### PR TITLE
fix(ui): provide context when emitting friendWidgetRenamed()

### DIFF
--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -71,7 +71,7 @@ FriendWidget::FriendWidget(std::shared_ptr<FriendChatroom> chatroom, bool compac
     connect(nameLabel, &CroppingLabel::editFinished, frnd, &Friend::setAlias);
     // update on changes of the displayed name
     connect(frnd, &Friend::displayedNameChanged, nameLabel, &CroppingLabel::setText);
-    connect(frnd, &Friend::displayedNameChanged, [this](const QString /* &newName */){emit friendWidgetRenamed(this);});
+    connect(frnd, &Friend::displayedNameChanged, this, [this](const QString /* &newName */){emit friendWidgetRenamed(this);});
     connect(chatroom.get(), &FriendChatroom::activeChanged, this, &FriendWidget::setActive);
     statusMessageLabel->setTextFormat(Qt::PlainText);
 }


### PR DESCRIPTION
Qt5 documentation at http://doc.qt.io/qt-5/signalsandslots.html
explains:

"[...] we provide *this* as context in the call to connect(). The
context object provides information about in which thread the receiver
should be executed. This is important, as providing the context ensures
that the receiver is executed in the context thread."

Fixes #5495.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5499)
<!-- Reviewable:end -->
