### PR TITLE
chore(deploy): publish hashes of windows setup files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -152,6 +152,7 @@ deploy:
     api_key:
       secure: "BRbzTWRvadALRQSTihMKruOj64ydxusMUS9FQR//qFlS345ZYfYta43W//4LcWWDKtj6IvA6DRqNdabgWnpbpxpnm9gVftGUdOKlU3niPZhwsMkB2M12QHUnAP6DVOfGPvdciBV+6mu73SSxniEcrYjZ1CrRX7mknmehPpVKxNk="
     file: "./qTox.dmg"
+    file: "./qTox.dmg.sha256"
     on:
       condition: $TRAVIS_OS_NAME == osx
       repo: qTox/qTox

--- a/.travis.yml
+++ b/.travis.yml
@@ -163,6 +163,7 @@ deploy:
     api_key:
       secure: "BRbzTWRvadALRQSTihMKruOj64ydxusMUS9FQR//qFlS345ZYfYta43W//4LcWWDKtj6IvA6DRqNdabgWnpbpxpnm9gVftGUdOKlU3niPZhwsMkB2M12QHUnAP6DVOfGPvdciBV+6mu73SSxniEcrYjZ1CrRX7mknmehPpVKxNk="
     file: "./workspace/x86_64/qtox/release/setup-qtox-x86_64-release.exe"
+    file: "./workspace/x86_64/qtox/release/setup-qtox-x86_64-release.exe.sha256"
     on:
       condition: $WINDOWS_BUILD_ARCH_CACHE_TRICK_VARIABLE == x86_64 && -f /home/travis/build/qTox/qTox/stage3 && -f /home/travis/build/qTox/qTox/release
       repo: qTox/qTox
@@ -174,6 +175,7 @@ deploy:
     api_key:
       secure: "BRbzTWRvadALRQSTihMKruOj64ydxusMUS9FQR//qFlS345ZYfYta43W//4LcWWDKtj6IvA6DRqNdabgWnpbpxpnm9gVftGUdOKlU3niPZhwsMkB2M12QHUnAP6DVOfGPvdciBV+6mu73SSxniEcrYjZ1CrRX7mknmehPpVKxNk="
     file: "./workspace/i686/qtox/release/setup-qtox-i686-release.exe"
+    file: "./workspace/i686/qtox/release/setup-qtox-i686-release.exe.sha256"
     on:
       condition: $WINDOWS_BUILD_ARCH_CACHE_TRICK_VARIABLE == i686 && -f /home/travis/build/qTox/qTox/stage3 && -f /home/travis/build/qTox/qTox/release
       repo: qTox/qTox

--- a/.travis/build-osx.sh
+++ b/.travis/build-osx.sh
@@ -19,6 +19,8 @@
 # Fail out on error
 set -eu -o pipefail
 
+readonly BIN_NAME="qTox.dmg"
+
 # accelerate builds with ccache
 install_ccache() {
     # manually update even though `install` will already update, due to bug:
@@ -40,7 +42,6 @@ build() {
 
 # check if binary was built
 check() {
-    local BIN_NAME="qTox.dmg"
     if [[ ! -s "$BIN_NAME" ]]
     then
         echo "There's no $BIN_NAME !"
@@ -48,9 +49,14 @@ check() {
     fi
 }
 
+make_hash() {
+    shasum -a 256 "$BIN_NAME" > "$BIN_NAME".sha256
+}
+
 main() {
     install_ccache
     build
     check
+    make_hash
 }
 main

--- a/.travis/build-windows.sh
+++ b/.travis/build-windows.sh
@@ -134,6 +134,14 @@ then
   sha256sum windows/cross-compile/build.sh > "$CACHE_DIR"/hash
 fi
 
+# Generate checksum files for releases
+if [ "$STAGE" == "stage3" && "$BUILD_TYPE" == "release" ]
+then
+  readonly OUT_DIR=./workspace/"$ARCH"/qtox/"$BUILD_TYPE"/
+  readonly NAME=setup-qtox-"$ARCH"-"$BUILD_TYPE".exe
+  sha256sum "$OUT_DIR""$NAME" > "$OUT_DIR""$NAME".sha256
+fi
+
 # Purely for debugging
 touch "$CACHE_DIR"/"$STAGE"
 ls -lbh "$CACHE_DIR"

--- a/appimage/build-appimage.sh
+++ b/appimage/build-appimage.sh
@@ -66,5 +66,7 @@ fi
 # use the version number in the name when building a tag on Travis CI
 if [ -n "$TRAVIS_TAG" ]
 then
-    mv ./output/*.AppImage ./output/qTox-"$TRAVIS_TAG".x86_64.AppImage
+    readonly OUTFILE=./output/qTox-"$TRAVIS_TAG".x86_64.AppImage
+    mv ./output/*.AppImage "$OUTFILE"
+    sha256sum "$OUTFILE" > "$OUTFILE".sha256
 fi

--- a/flatpak/build-flatpak.sh
+++ b/flatpak/build-flatpak.sh
@@ -48,5 +48,7 @@ fi
 # use the version number in the name when building a tag on Travis CI
 if [ -n "$TRAVIS_TAG" ]
 then
-    mv ./output/*.flatpak ./output/qTox-"$TRAVIS_TAG".x86_64.flatpak
+    readonly OUTFILE=./output/qTox-"$TRAVIS_TAG".x86_64.flatpak
+    mv ./output/*.flatpak "$OUTFILE"
+    sha256sum "$OUTFILE" > "$OUTFILE".sha256
 fi


### PR DESCRIPTION
- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

fixes #2670

WIP status, because I will add hashes for the other files too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5502)
<!-- Reviewable:end -->
