### PR TITLE
fix(groups): correctly show peers in the call after joining call

### DIFF
--- a/src/widget/form/groupchatform.cpp
+++ b/src/widget/form/groupchatform.cpp
@@ -467,17 +467,8 @@ void GroupChatForm::onCallClicked()
 
 GenericNetCamView* GroupChatForm::createNetcam()
 {
-    GroupNetCamView* view = new GroupNetCamView(group->getId(), this);
-
-    const auto& names = group->getPeerList();
-    const auto ownPk = Core::getInstance()->getSelfPublicKey();
-    for (const auto& peerPk : names.keys()) {
-        if (peerPk != ownPk) {
-            static_cast<GroupNetCamView*>(view)->addPeer(peerPk, names.find(peerPk).value());
-        }
-    }
-
-    return view;
+    // leave view empty, it will pe populated once we receive audio from peers
+    return new GroupNetCamView(group->getId(), this);
 }
 
 void GroupChatForm::keyPressEvent(QKeyEvent* ev)


### PR DESCRIPTION
- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

Before when joining call, all member's avatar were shown:
![image](https://user-images.githubusercontent.com/10469203/51601386-0b5df200-1eb9-11e9-9ddf-fc01f355a55f.png)

After, only group members who are in the call's avatars are shown:
![image](https://user-images.githubusercontent.com/10469203/51601412-1a44a480-1eb9-11e9-9e07-6df71aa1f908.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5512)
<!-- Reviewable:end -->
