### PR TITLE
feat(groups): show who is in a group call before joining

### DIFF
--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -485,6 +485,8 @@ void CoreAV::groupCallCallback(void* tox, uint32_t group, uint32_t peer, const i
         return;
     }
 
+    emit c->groupPeerAudioPlaying(group, peer);
+
     CoreAV* cav = c->getAv();
 
     auto it = cav->groupCalls.find(group);
@@ -493,8 +495,6 @@ void CoreAV::groupCallCallback(void* tox, uint32_t group, uint32_t peer, const i
     }
 
     ToxGroupCall& call = it->second;
-
-    emit c->groupPeerAudioPlaying(group, peer);
 
     if (call.getMuteVol() || !call.isActive()) {
         return;


### PR DESCRIPTION
Fix #5507

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5514)
<!-- Reviewable:end -->
