### PR TITLE
fix(groups): don't invalidate all audio sources when peer list changes

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -557,10 +557,6 @@ void Core::onGroupMessage(Tox*, uint32_t groupId, uint32_t peerId, Tox_Message_T
 void Core::onGroupPeerListChange(Tox*, uint32_t groupId, void* vCore)
 {
     const auto core = static_cast<Core*>(vCore);
-    if (core->getGroupAvEnabled(groupId)) {
-        CoreAV::invalidateGroupCallSources(groupId);
-    }
-
     qDebug() << QString("Group %1 peerlist changed").arg(groupId);
     emit core->groupPeerlistChanged(groupId);
 }

--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -501,11 +501,11 @@ void CoreAV::groupCallCallback(void* tox, uint32_t group, uint32_t peer, const i
     }
 
     Audio& audio = Audio::getInstance();
-    if(!call.havePeer(peer)) {
-        call.addPeer(peer);
+    if(!call.havePeer(peerPk)) {
+        call.addPeer(peerPk);
     }
 
-    audio.playAudioBuffer(call.getAlSource(peer), data, samples, channels, sample_rate);
+    audio.playAudioBuffer(call.getAlSource(peerPk), data, samples, channels, sample_rate);
 }
 
 /**
@@ -513,23 +513,13 @@ void CoreAV::groupCallCallback(void* tox, uint32_t group, uint32_t peer, const i
  * @param group Group Index
  * @param peer Peer Index
  */
-void CoreAV::invalidateGroupCallPeerSource(int group, int peer)
+void CoreAV::invalidateGroupCallPeerSource(int group, ToxPk peerPk)
 {
     auto it = groupCalls.find(group);
     if (it == groupCalls.end()) {
         return;
     }
-    it->second.removePeer(peer);
-}
-
-/**
- * @brief Called from core to make sure the sources for that group are invalidated when
- *        the peer list changes.
- * @param group Group Index
- */
-void CoreAV::invalidateGroupCallSources(int group)
-{
-    groupCalls.erase(group);
+    it->second.removePeer(peerPk);
 }
 
 /**

--- a/src/core/coreav.h
+++ b/src/core/coreav.h
@@ -79,8 +79,7 @@ public:
     static void groupCallCallback(void* tox, uint32_t group, uint32_t peer, const int16_t* data,
                                   unsigned samples, uint8_t channels, uint32_t sample_rate,
                                   void* core);
-    static void invalidateGroupCallPeerSource(int group, int peer);
-    static void invalidateGroupCallSources(int group);
+    void invalidateGroupCallPeerSource(int group, ToxPk peerPk);
 
 public slots:
     bool startCall(uint32_t friendNum, bool video);

--- a/src/core/toxcall.cpp
+++ b/src/core/toxcall.cpp
@@ -298,12 +298,12 @@ ToxGroupCall& ToxGroupCall::operator=(ToxGroupCall&& other) noexcept
     return *this;
 }
 
-void ToxGroupCall::removePeer(int peerId)
+void ToxGroupCall::removePeer(ToxPk peerId)
 {
     auto& audio = Audio::getInstance();
     const auto& sourceId = peers.find(peerId);
     if(sourceId == peers.constEnd()) {
-        qDebug() << "Peer:" << peerId << "does not have a source, can't remove";
+        qDebug() << "Peer does not have a source, can't remove";
         return;
     }
 
@@ -311,7 +311,7 @@ void ToxGroupCall::removePeer(int peerId)
     peers.remove(peerId);
 }
 
-void ToxGroupCall::addPeer(int peerId)
+void ToxGroupCall::addPeer(ToxPk peerId)
 {
     auto& audio = Audio::getInstance();
     uint sourceId = 0;
@@ -319,7 +319,7 @@ void ToxGroupCall::addPeer(int peerId)
     peers.insert(peerId, sourceId);
 }
 
-bool ToxGroupCall::havePeer(int peerId)
+bool ToxGroupCall::havePeer(ToxPk peerId)
 {
     const auto& sourceId = peers.find(peerId);
     return sourceId != peers.constEnd();
@@ -336,7 +336,7 @@ void ToxGroupCall::clearPeers()
     peers.clear();
 }
 
-quint32 ToxGroupCall::getAlSource(int peer)
+quint32 ToxGroupCall::getAlSource(ToxPk peer)
 {
     if(!havePeer(peer)) {
         qWarning() << "Getting alSource for non-existant peer";

--- a/src/core/toxcall.h
+++ b/src/core/toxcall.h
@@ -1,13 +1,15 @@
 #ifndef TOXCALL_H
 #define TOXCALL_H
 
-#include <memory>
+#include <src/core/toxpk.h>
+#include <tox/toxav.h>
+
 #include <QMap>
 #include <QMetaObject>
 #include <QtGlobal>
-#include <cstdint>
 
-#include <tox/toxav.h>
+#include <cstdint>
+#include <memory>
 
 class QTimer;
 class AudioFilterer;
@@ -96,15 +98,15 @@ public:
 
     ToxGroupCall& operator=(ToxGroupCall&& other) noexcept;
 
-    void removePeer(int peerId);
-    void addPeer(int peerId);
-    bool havePeer(int peerId);
+    void removePeer(ToxPk peerId);
+    void addPeer(ToxPk peerId);
+    bool havePeer(ToxPk peerId);
     void clearPeers();
 
-    quint32 getAlSource(int peer);
+    quint32 getAlSource(ToxPk peer);
 
 private:
-    QMap<int, quint32> peers;
+    QMap<ToxPk, quint32> peers;
 
     // If you add something here, don't forget to override the ctors and move operators!
 };

--- a/src/model/group.h
+++ b/src/model/group.h
@@ -65,6 +65,9 @@ signals:
     void userListChanged(uint32_t groupId, const QMap<ToxPk, QString>& toxpks);
 
 private:
+    void stopAudioOfDepartedPeers(const QList<ToxPk>& oldPks, const QMap<ToxPk, QString>& newPks);
+
+private:
     QString selfName;
     QString title;
     QMap<ToxPk, QString> toxpks;

--- a/src/widget/form/groupchatform.cpp
+++ b/src/widget/form/groupchatform.cpp
@@ -344,8 +344,8 @@ void GroupChatForm::sendJoinLeaveMessages()
             addSystemInfoMessage(tr("%1 has joined the group").arg(name), ChatMessage::INFO, QDateTime::currentDateTime());
         } else {
             Friend *f = FriendList::findFriend(peerPk);
-            if (groupLast[peerPk] != name 
-                    && peers.value(peerPk) == name 
+            if (groupLast[peerPk] != name
+                    && peers.value(peerPk) == name
                     && peerPk != Core::getInstance()->getSelfPublicKey() // ignore myself
                     && !(f != nullptr && f->hasAlias()) // ignore friends with aliases
                     ) {


### PR DESCRIPTION
Fix #5508

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5516)
<!-- Reviewable:end -->
