### PR TITLE
fix(groups): don't freeze when opening AV settings during group call

### DIFF
--- a/src/audio/backend/openal.h
+++ b/src/audio/backend/openal.h
@@ -118,7 +118,7 @@ private:
 
 protected:
     QThread* audioThread;
-    mutable QMutex audioLock;
+    mutable QMutex audioLock{QMutex::Recursive};
 
     ALCdevice* alInDev = nullptr;
     quint32 inSubscriptions = 0;


### PR DESCRIPTION
Fix #5510

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5517)
<!-- Reviewable:end -->
