### PR TITLE
New History Load Dialog

### DIFF
--- a/src/persistence/history.h
+++ b/src/persistence/history.h
@@ -149,6 +149,12 @@ public:
         uint count;
     };
 
+    struct YearMessages
+    {
+        uint year;
+        uint count;
+    };
+
 public:
     explicit History(std::shared_ptr<RawDatabase> db);
     ~History();
@@ -179,6 +185,7 @@ public:
 
     void markAsSent(RowId messageId);
 
+    QList<YearMessages> getChatHistoryYears(const ToxPk &friendPk);
 protected:
     QVector<RawDatabase::Query>
     generateNewMessageQueries(const QString& friendPk, const QString& message,

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -985,7 +985,7 @@ void ChatForm::onLoadHistory()
         return;
     }
 
-    LoadHistoryDialog dlg(f->getPublicKey(), *history);
+    LoadHistoryDialog dlg(f->getPublicKey(), *history, &Settings::getInstance());
     if (dlg.exec()) {
         QDateTime fromTime = dlg.getFromDate();
         loadHistoryByDateRange(fromTime);

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -985,7 +985,7 @@ void ChatForm::onLoadHistory()
         return;
     }
 
-    LoadHistoryDialog dlg(f->getPublicKey());
+    LoadHistoryDialog dlg(f->getPublicKey(), *history);
     if (dlg.exec()) {
         QDateTime fromTime = dlg.getFromDate();
         loadHistoryByDateRange(fromTime);

--- a/src/widget/form/loadhistorydialog.cpp
+++ b/src/widget/form/loadhistorydialog.cpp
@@ -26,21 +26,23 @@
 #include <QTextCharFormat>
 #include <QCalendarWidget>
 
-LoadHistoryDialog::LoadHistoryDialog(const ToxPk& friendPk, History &history, QWidget* parent)
+LoadHistoryDialog::LoadHistoryDialog(const ToxPk& friendPk, History &history, Settings* settings, QWidget* parent)
     : QDialog(parent)
     , ui(new Ui::LoadHistoryDialog)
     , friendPk(friendPk)
     , history{history}
+    , settings{settings}
 {
     ui->setupUi(this);
     getYears();
     ui->yearsTree->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
 }
 
-LoadHistoryDialog::LoadHistoryDialog(History &history, QWidget* parent)
+LoadHistoryDialog::LoadHistoryDialog(History &history, Settings* settings, QWidget* parent)
     : QDialog(parent)
     , ui(new Ui::LoadHistoryDialog)
     , history{history}
+    , settings{settings}
 {
     ui->setupUi(this);
 }
@@ -94,7 +96,15 @@ void LoadHistoryDialog::getYears()
         for(auto elem: date_counts) {
             QTreeWidgetItem* dayItem = new QTreeWidgetItem(year);
             QDate exact = start.addDays(elem.offsetDays);
-            dayItem->setData(0, Qt::DisplayRole, exact.toString(Settings::getInstance().getDateFormat()));
+
+            QString date{};
+            if(settings == nullptr) {
+                date = exact.toString();
+            } else {
+                date = exact.toString(settings->getDateFormat());
+            }
+
+            dayItem->setData(0, Qt::DisplayRole, date);
             dayItem->setData(1, Qt::DisplayRole, elem.count);
             dayItem->setData(0, Qt::UserRole, exact);   // store date in machine form here
         }

--- a/src/widget/form/loadhistorydialog.cpp
+++ b/src/widget/form/loadhistorydialog.cpp
@@ -19,28 +19,28 @@
 
 #include "loadhistorydialog.h"
 #include "ui_loadhistorydialog.h"
-#include "src/nexus.h"
 #include "src/persistence/history.h"
-#include "src/persistence/profile.h"
 #include "src/persistence/settings.h"
 #include <QDate>
 #include <QLabel>
 #include <QTextCharFormat>
 #include <QCalendarWidget>
 
-LoadHistoryDialog::LoadHistoryDialog(const ToxPk& friendPk, QWidget* parent)
+LoadHistoryDialog::LoadHistoryDialog(const ToxPk& friendPk, History &history, QWidget* parent)
     : QDialog(parent)
     , ui(new Ui::LoadHistoryDialog)
     , friendPk(friendPk)
+    , history{history}
 {
     ui->setupUi(this);
     getYears();
     ui->yearsTree->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
 }
 
-LoadHistoryDialog::LoadHistoryDialog(QWidget* parent)
+LoadHistoryDialog::LoadHistoryDialog(History &history, QWidget* parent)
     : QDialog(parent)
     , ui(new Ui::LoadHistoryDialog)
+    , history{history}
 {
     ui->setupUi(this);
 }
@@ -73,8 +73,7 @@ void LoadHistoryDialog::setInfoLabel(const QString& info)
 
 void LoadHistoryDialog::getYears()
 {
-    History* history = Nexus::getProfile()->getHistory();
-    auto counts = history->getChatHistoryYears(this->friendPk);
+    auto counts = history.getChatHistoryYears(this->friendPk);
 
     auto tree = ui->yearsTree;
 
@@ -90,7 +89,7 @@ void LoadHistoryDialog::getYears()
 
         const QDate start(count.year, 1, 1);
         const QDate end = start.addYears(1);
-        QList<History::DateMessages> date_counts = history->getChatHistoryCounts(this->friendPk, start, end);
+        QList<History::DateMessages> date_counts = history.getChatHistoryCounts(this->friendPk, start, end);
 
         for(auto elem: date_counts) {
             QTreeWidgetItem* dayItem = new QTreeWidgetItem(year);

--- a/src/widget/form/loadhistorydialog.h
+++ b/src/widget/form/loadhistorydialog.h
@@ -41,10 +41,8 @@ public:
     void setTitle(const QString& title);
     void setInfoLabel(const QString& info);
 
-public slots:
-    void highlightDates(int year, int month);
-
 private:
+    void getYears();
     Ui::LoadHistoryDialog* ui;
     const ToxPk friendPk;
 };

--- a/src/widget/form/loadhistorydialog.h
+++ b/src/widget/form/loadhistorydialog.h
@@ -29,14 +29,15 @@ class LoadHistoryDialog;
 }
 
 class History;
+class Settings;
 
 class LoadHistoryDialog : public QDialog
 {
     Q_OBJECT
 
 public:
-    explicit LoadHistoryDialog(const ToxPk& friendPk, History& history, QWidget* parent = nullptr);
-    explicit LoadHistoryDialog(History& history, QWidget* parent = nullptr);
+    explicit LoadHistoryDialog(const ToxPk& friendPk, History& history, Settings* settings = nullptr, QWidget* parent = nullptr);
+    explicit LoadHistoryDialog(History& history, Settings* settings = nullptr, QWidget* parent = nullptr);
     ~LoadHistoryDialog();
 
     QDateTime getFromDate();
@@ -48,6 +49,7 @@ private:
     Ui::LoadHistoryDialog* ui;
     const ToxPk friendPk;
     History& history;
+    Settings* settings = nullptr;
 };
 
 #endif // LOADHISTORYDIALOG_H

--- a/src/widget/form/loadhistorydialog.h
+++ b/src/widget/form/loadhistorydialog.h
@@ -28,13 +28,15 @@ namespace Ui {
 class LoadHistoryDialog;
 }
 
+class History;
+
 class LoadHistoryDialog : public QDialog
 {
     Q_OBJECT
 
 public:
-    explicit LoadHistoryDialog(const ToxPk& friendPk, QWidget* parent = nullptr);
-    explicit LoadHistoryDialog(QWidget* parent = nullptr);
+    explicit LoadHistoryDialog(const ToxPk& friendPk, History& history, QWidget* parent = nullptr);
+    explicit LoadHistoryDialog(History& history, QWidget* parent = nullptr);
     ~LoadHistoryDialog();
 
     QDateTime getFromDate();
@@ -45,6 +47,7 @@ private:
     void getYears();
     Ui::LoadHistoryDialog* ui;
     const ToxPk friendPk;
+    History& history;
 };
 
 #endif // LOADHISTORYDIALOG_H

--- a/src/widget/form/loadhistorydialog.ui
+++ b/src/widget/form/loadhistorydialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>347</width>
-    <height>264</height>
+    <width>404</width>
+    <height>316</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -25,10 +25,29 @@
     </widget>
    </item>
    <item>
-    <widget class="QCalendarWidget" name="fromDate">
-     <property name="gridVisible">
-      <bool>false</bool>
+    <widget class="QTreeWidget" name="yearsTree">
+     <property name="selectionMode">
+      <enum>QAbstractItemView::SingleSelection</enum>
      </property>
+     <attribute name="headerCascadingSectionResizes">
+      <bool>false</bool>
+     </attribute>
+     <attribute name="headerShowSortIndicator" stdset="0">
+      <bool>false</bool>
+     </attribute>
+     <attribute name="headerStretchLastSection">
+      <bool>true</bool>
+     </attribute>
+     <column>
+      <property name="text">
+       <string>Date</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Messages</string>
+      </property>
+     </column>
     </widget>
    </item>
    <item>

--- a/src/widget/form/searchsettingsform.cpp
+++ b/src/widget/form/searchsettingsform.cpp
@@ -145,7 +145,7 @@ void SearchSettingsForm::onRegularClicked(const bool checked)
 void SearchSettingsForm::onChoiceDate()
 {
     // FIXME(sudden6): this is a hack, pass in History without the need for Nexus
-    LoadHistoryDialog dlg{*Nexus::getProfile()->getHistory()};
+    LoadHistoryDialog dlg{*Nexus::getProfile()->getHistory(), &Settings::getInstance()};
     dlg.setTitle(tr("Select Date Dialog"));
     dlg.setInfoLabel(tr("Select a date"));
     if (dlg.exec()) {

--- a/src/widget/form/searchsettingsform.cpp
+++ b/src/widget/form/searchsettingsform.cpp
@@ -1,5 +1,7 @@
 #include "searchsettingsform.h"
 #include "ui_searchsettingsform.h"
+#include "src/nexus.h"
+#include "src/persistence/profile.h"
 #include "src/persistence/settings.h"
 #include "src/widget/style.h"
 #include "src/widget/form/loadhistorydialog.h"
@@ -142,7 +144,8 @@ void SearchSettingsForm::onRegularClicked(const bool checked)
 
 void SearchSettingsForm::onChoiceDate()
 {
-    LoadHistoryDialog dlg;
+    // FIXME(sudden6): this is a hack, pass in History without the need for Nexus
+    LoadHistoryDialog dlg{*Nexus::getProfile()->getHistory()};
     dlg.setTitle(tr("Select Date Dialog"));
     dlg.setInfoLabel(tr("Select a date"));
     if (dlg.exec()) {


### PR DESCRIPTION
- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)
![new dialog](https://user-images.githubusercontent.com/5585762/51703992-30b54200-2018-11e9-804e-514781df7671.png)

The dialog provides the exact same functionality as the previous one (select one date, until which the history is loaded).

Improves the state of #5501 but still doesn't implement loading a date range. I want to merge this now because I prefer smaller incremental changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5521)
<!-- Reviewable:end -->
