### PR TITLE
fix(audio): input device not closed under certain circumstances

### DIFF
--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -544,6 +544,11 @@ void AVForm::on_inDevCombobox_currentIndexChanged(int deviceIndex)
     audioSettings->setInDev(deviceName);
 
     audio->reinitInput(deviceName);
+    subscribedToAudioIn = inputEnabled;
+    if (inputEnabled) {
+        audio->subscribeInput();
+    }
+
     microphoneSlider->setEnabled(inputEnabled);
     if (!inputEnabled) {
         volumeDisplay->setValue(volumeDisplay->minimum());


### PR DESCRIPTION
fixes #3625

Input device was not closed after the following steps:
- Select "Disabled" for audio source
- Switch away from A/V settings
- Switch back to A/V settings
- Switch to some audio input device
- Switch away from A/V settings
-> audio input device still open, but unused

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5523)
<!-- Reviewable:end -->
