### PR TITLE
feat(build): remove timestamps from build to allow reproducible builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,13 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wstrict-overflow")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wstrict-aliasing")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
 
+# avoid timestamps in binary for reproducible builds, not added until GCC 4.9
+include(CheckCXXCompilerFlag)
+CHECK_CXX_COMPILER_FLAG(-Wdate-time COMPILER_SUPPORTS_WDATE_TIME)
+if(COMPILER_SUPPORTS_WDATE_TIME)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wdate-time")
+endif()
+
 if (NOT WIN32)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-all")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wstack-protector")
@@ -100,6 +107,15 @@ include_directories(${CMAKE_BINARY_DIR})
 include_directories(${CMAKE_SOURCE_DIR})
 
 include(Dependencies)
+
+if(NOT Qt5Widgets_VERSION VERSION_LESS "5.9")
+  # Drop the file modification time of source files from generated files
+  # to help with reproducible builds. We do not use QFileInfo.lastModified
+  # so this has no unwanted side effects. This mtime started appearing in
+  # Qt 5.8. The option to force the old file format without mtime was
+  # added in Qt 5.9. See https://bugreports.qt.io/browse/QTBUG-58769
+  set(RCC_OPTIONS ${RCC_OPTIONS} -format-version 1)
+endif()
 
 ################################################################################
 #

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -199,14 +199,6 @@ add_definitions(
   -DGIT_VERSION="${GIT_VERSION}"
 )
 
-if (NOT TIMESTAMP)
-  execute_process(
-    COMMAND date +%s
-    OUTPUT_VARIABLE TIMESTAMP
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-  )
-endif()
-
 set(APPLE_EXT False)
 if (FOUNDATION_FOUND AND IOKIT_FOUND)
   set(APPLE_EXT True)
@@ -230,6 +222,5 @@ if (PLATFORM_EXTENSIONS)
 endif()
 
 add_definitions(
-  -DTIMESTAMP=${TIMESTAMP}
   -DLOG_TO_FILE=1
 )


### PR DESCRIPTION
avoid Qt embedding timestamps into translations after copying .ts to .qm to work towards reproducible builds. Now reproducible locally as long as there is absolutely no change to environment.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5524)
<!-- Reviewable:end -->
