### PR TITLE
fix(groups): enable AV groups after load

### DIFF
--- a/INSTALL.fa.md
+++ b/INSTALL.fa.md
@@ -49,7 +49,7 @@
 |---------------|-------------|----------------------------------------------------------|
 | [Qt]          | >= 5.5.0    | concurrent, core, gui, network, opengl, svg, widget, xml |
 | [GCC]/[MinGW] | >= 4.8      | C++11 enabled                                            |
-| [toxcore]     | >= 0.2.6    | core, av                                                 |
+| [toxcore]     | >= 0.2.10   | core, av                                                 |
 | [FFmpeg]      | >= 2.6.0    | avformat, avdevice, avcodec, avutil, swscale             |
 | [CMake]       | >= 2.8.11   |                                                          |
 | [OpenAL Soft] | >= 1.16.0   |                                                          |

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -39,7 +39,7 @@
 |---------------|-------------|----------------------------------------------------------|
 | [Qt]          | >= 5.5.0    | concurrent, core, gui, network, opengl, svg, widget, xml |
 | [GCC]/[MinGW] | >= 4.8      | C++11 enabled                                            |
-| [toxcore]     | >= 0.2.6    | core, av                                                 |
+| [toxcore]     | >= 0.2.10   | core, av                                                 |
 | [FFmpeg]      | >= 2.6.0    | avformat, avdevice, avcodec, avutil, swscale             |
 | [CMake]       | >= 2.8.11   |                                                          |
 | [OpenAL Soft] | >= 1.16.0   |                                                          |

--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ During this time we want to prepare qTox for upcoming new features of toxcore.
 The next steps are:
 
 
-* remove support for toxcore < 0.2.0
 * move all toxcore abstractions into their own subproject
 * write basic tests for this Core
 * format the code base


### PR DESCRIPTION
Fix #5509

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

This uses a new API defined in https://github.com/TokTok/c-toxcore/pull/1305 (and a toxcore release once it is merged).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5525)
<!-- Reviewable:end -->
