### PR TITLE
fix(ui): update UI when leaving group call due to being last member

### DIFF
--- a/src/widget/form/groupchatform.cpp
+++ b/src/widget/form/groupchatform.cpp
@@ -183,8 +183,7 @@ void GroupChatForm::onUserListChanged()
     const bool online = peersCount > 1;
     headWidget->updateCallButtons(online, inCall);
     if (inCall && (!online || !group->isAvGroupchat())) {
-        Core::getInstance()->getAv()->leaveGroupCall(group->getId());
-        hideNetcam();
+        leaveGroupCall();
     }
 }
 
@@ -446,11 +445,7 @@ void GroupChatForm::onCallClicked()
         inCall = true;
         showNetcam();
     } else {
-        av->leaveGroupCall(group->getId());
-        audioInputFlag = false;
-        audioOutputFlag = false;
-        inCall = false;
-        hideNetcam();
+        leaveGroupCall();
     }
 
     const int peersCount = group->getPeersCount();
@@ -574,4 +569,14 @@ void GroupChatForm::onLabelContextMenuRequested(const QPoint& localPos)
 
         s.setBlackList(blackList);
     }
+}
+
+void GroupChatForm::leaveGroupCall()
+{
+    CoreAV* av = Core::getInstance()->getAv();
+    av->leaveGroupCall(group->getId());
+    audioInputFlag = false;
+    audioOutputFlag = false;
+    inCall = false;
+    hideNetcam();
 }

--- a/src/widget/form/groupchatform.h
+++ b/src/widget/form/groupchatform.h
@@ -68,6 +68,7 @@ private:
     void updateUserCount();
     void updateUserNames();
     void sendJoinLeaveMessages();
+    void leaveGroupCall();
 
 private:
     Group* group;


### PR DESCRIPTION
- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5526)
<!-- Reviewable:end -->
