### PR TITLE
refactor: make ToxCall non-moveable

### DIFF
--- a/src/core/coreav.h
+++ b/src/core/coreav.h
@@ -129,8 +129,10 @@ private:
     std::unique_ptr<ToxAV, ToxAVDeleter> toxav;
     std::unique_ptr<QThread> coreavThread;
     QTimer* iterateTimer = nullptr;
-    static std::map<uint32_t, ToxFriendCall> calls;
-    static std::map<int, ToxGroupCall> groupCalls;
+    using ToxFriendCallPtr = std::unique_ptr<ToxFriendCall>;
+    static std::map<uint32_t, ToxFriendCallPtr> calls;
+    using ToxGroupCallPtr = std::unique_ptr<ToxGroupCall>;
+    static std::map<int, ToxGroupCallPtr> groupCalls;
     std::atomic_flag threadSwitchLock;
 
     friend class Audio;

--- a/src/core/toxcall.h
+++ b/src/core/toxcall.h
@@ -25,10 +25,10 @@ protected:
 
 public:
     ToxCall(const ToxCall& other) = delete;
-    ToxCall(ToxCall&& other) noexcept;
+    ToxCall(ToxCall&& other) = delete;
 
     ToxCall& operator=(const ToxCall& other) = delete;
-    ToxCall& operator=(ToxCall&& other) noexcept;
+    ToxCall& operator=(ToxCall&& other) = delete;
 
     bool isActive() const;
     void setActive(bool value);
@@ -66,8 +66,8 @@ class ToxFriendCall : public ToxCall
 public:
     ToxFriendCall() = delete;
     ToxFriendCall(uint32_t friendId, bool VideoEnabled, CoreAV& av);
-    ToxFriendCall(ToxFriendCall&& other) noexcept;
-    ToxFriendCall& operator=(ToxFriendCall&& other) noexcept;
+    ToxFriendCall(ToxFriendCall&& other) = delete;
+    ToxFriendCall& operator=(ToxFriendCall&& other) = delete;
     ~ToxFriendCall();
 
     void startTimeout(uint32_t callId);
@@ -93,10 +93,10 @@ class ToxGroupCall : public ToxCall
 public:
     ToxGroupCall() = delete;
     ToxGroupCall(int GroupNum, CoreAV& av);
-    ToxGroupCall(ToxGroupCall&& other) noexcept;
+    ToxGroupCall(ToxGroupCall&& other) = delete;
     ~ToxGroupCall();
 
-    ToxGroupCall& operator=(ToxGroupCall&& other) noexcept;
+    ToxGroupCall& operator=(ToxGroupCall&& other) = delete;
 
     void removePeer(ToxPk peerId);
     void addPeer(ToxPk peerId);


### PR DESCRIPTION
We don't need move functionality and the code for it is complex and
error prone.

This is a fraction of  #5240 and a bit reworked.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5533)
<!-- Reviewable:end -->
