### PR TITLE
refacotr(core): strong type message receipt and row ID

### DIFF
--- a/src/core/core.h
+++ b/src/core/core.h
@@ -25,6 +25,7 @@
 #include "toxid.h"
 
 #include "src/core/dhtserver.h"
+#include "src/util/strongtype.h"
 #include <tox/tox.h>
 
 #include <QMutex>
@@ -51,6 +52,8 @@ enum class Status
 class Core;
 
 using ToxCorePtr = std::unique_ptr<Core>;
+using ReceiptNum = NamedType<uint32_t, struct ReceiptNumTag>;
+Q_DECLARE_METATYPE(ReceiptNum);
 
 class Core : public QObject
 {
@@ -118,11 +121,11 @@ public slots:
     void setUsername(const QString& username);
     void setStatusMessage(const QString& message);
 
-    int sendMessage(uint32_t friendId, const QString& message);
+    bool sendMessage(uint32_t friendId, const QString& message, ReceiptNum& receipt);
     void sendGroupMessage(int groupId, const QString& message);
     void sendGroupAction(int groupId, const QString& message);
     void changeGroupTitle(int groupId, const QString& title);
-    int sendAction(uint32_t friendId, const QString& action);
+    bool sendAction(uint32_t friendId, const QString& action, ReceiptNum& receipt);
     void sendTyping(uint32_t friendId, bool typing);
 
     void sendAvatarFile(uint32_t friendId, const QByteArray& data);
@@ -200,7 +203,7 @@ signals:
     void groupSentFailed(int groupId);
     void actionSentResult(uint32_t friendId, const QString& action, int success);
 
-    void receiptRecieved(int friedId, int receipt);
+    void receiptRecieved(int friedId, ReceiptNum receipt);
 
     void failedToRemoveFriend(uint32_t friendId);
 
@@ -234,7 +237,7 @@ private:
     static void onReadReceiptCallback(Tox* tox, uint32_t friendId, uint32_t receipt, void* core);
 
     void sendGroupMessageWithType(int groupId, const QString& message, Tox_Message_Type type);
-    int sendMessageWithType(uint32_t friendId, const QString& message, Tox_Message_Type type);
+    bool sendMessageWithType(uint32_t friendId, const QString& message, Tox_Message_Type type, ReceiptNum& receipt);
     bool parsePeerQueryError(Tox_Err_Conference_Peer_Query error) const;
     bool parseConferenceJoinError(Tox_Err_Conference_Join error) const;
     bool checkConnection();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -365,6 +365,7 @@ int main(int argc, char* argv[])
 
     QObject::connect(a.get(), &QApplication::aboutToQuit, cleanup);
 
+    qRegisterMetaType<ReceiptNum>();
     // Run
     int errorcode = a->exec();
 

--- a/src/persistence/db/rawdatabase.cpp
+++ b/src/persistence/db/rawdatabase.cpp
@@ -645,7 +645,7 @@ void RawDatabase::process()
             }
 
             if (query.insertCallback)
-                query.insertCallback(sqlite3_last_insert_rowid(sqlite));
+                query.insertCallback(RowId{sqlite3_last_insert_rowid(sqlite)});
         }
 
         if (trans.success != nullptr)

--- a/src/persistence/db/rawdatabase.h
+++ b/src/persistence/db/rawdatabase.h
@@ -13,6 +13,7 @@
 #include <atomic>
 #include <functional>
 #include <memory>
+#include "src/util/strongtype.h"
 
 /// The two following defines are required to use SQLCipher
 /// They are used by the sqlite3.h header
@@ -21,6 +22,8 @@
 
 #include <sqlite3.h>
 
+using RowId = NamedType<int64_t, struct RowIdTag>;
+Q_DECLARE_METATYPE(RowId);
 
 class RawDatabase : QObject
 {
@@ -31,13 +34,13 @@ public:
     {
     public:
         Query(QString query, QVector<QByteArray> blobs = {},
-              const std::function<void(int64_t)>& insertCallback = {})
+              const std::function<void(RowId)>& insertCallback = {})
             : query{query.toUtf8()}
             , blobs{blobs}
             , insertCallback{insertCallback}
         {
         }
-        Query(QString query, const std::function<void(int64_t)>& insertCallback)
+        Query(QString query, const std::function<void(RowId)>& insertCallback)
             : query{query.toUtf8()}
             , insertCallback{insertCallback}
         {
@@ -52,7 +55,7 @@ public:
     private:
         QByteArray query;
         QVector<QByteArray> blobs;
-        std::function<void(int64_t)> insertCallback;
+        std::function<void(RowId)> insertCallback;
         std::function<void(const QVector<QVariant>&)> rowCallback;
         QVector<sqlite3_stmt*> statements;
 

--- a/src/persistence/history.h
+++ b/src/persistence/history.h
@@ -95,7 +95,7 @@ struct FileDbInsertionData
 {
     FileDbInsertionData();
 
-    int64_t historyId;
+    RowId historyId;
     QString friendPk;
     QString fileId;
     QString fileName;
@@ -111,7 +111,7 @@ class History : public QObject, public std::enable_shared_from_this<History>
 public:
     struct HistMessage
     {
-        HistMessage(qint64 id, bool isSent, QDateTime timestamp, QString chat, QString dispName,
+        HistMessage(RowId id, bool isSent, QDateTime timestamp, QString chat, QString dispName,
                     QString sender, QString message)
             : chat{chat}
             , sender{sender}
@@ -122,7 +122,7 @@ public:
             , content(std::move(message))
         {}
 
-        HistMessage(qint64 id, bool isSent, QDateTime timestamp, QString chat, QString dispName,
+        HistMessage(RowId id, bool isSent, QDateTime timestamp, QString chat, QString dispName,
                     QString sender, ToxFile file)
             : chat{chat}
             , sender{sender}
@@ -138,7 +138,7 @@ public:
         QString sender;
         QString dispName;
         QDateTime timestamp;
-        qint64 id;
+        RowId id;
         bool isSent;
         HistMessageContent content;
     };
@@ -161,7 +161,7 @@ public:
     void removeFriendHistory(const QString& friendPk);
     void addNewMessage(const QString& friendPk, const QString& message, const QString& sender,
                        const QDateTime& time, bool isSent, QString dispName,
-                       const std::function<void(int64_t)>& insertIdCallback = {});
+                       const std::function<void(RowId)>& insertIdCallback = {});
 
     void addNewFileMessage(const QString& friendPk, const QString& fileId,
                            const QString& fileName, const QString& filePath, int64_t size,
@@ -177,27 +177,27 @@ public:
                                      const ParameterSearch& parameter);
     QDateTime getStartDateChatHistory(const QString& friendPk);
 
-    void markAsSent(qint64 messageId);
+    void markAsSent(RowId messageId);
 
 protected:
     QVector<RawDatabase::Query>
     generateNewMessageQueries(const QString& friendPk, const QString& message,
                               const QString& sender, const QDateTime& time, bool isSent,
-                              QString dispName, std::function<void(int64_t)> insertIdCallback = {});
+                              QString dispName, std::function<void(RowId)> insertIdCallback = {});
 
 signals:
     void fileInsertionReady(FileDbInsertionData data);
-    void fileInserted(int64_t dbId, QString fileId);
+    void fileInserted(RowId dbId, QString fileId);
 
 private slots:
     void onFileInsertionReady(FileDbInsertionData data);
-    void onFileInserted(int64_t dbId, QString fileId);
+    void onFileInserted(RowId dbId, QString fileId);
 
 private:
     QList<HistMessage> getChatHistory(const QString& friendPk, const QDateTime& from,
                                       const QDateTime& to, int numMessages);
 
-    static RawDatabase::Query generateFileFinished(int64_t fileId, bool success,
+    static RawDatabase::Query generateFileFinished(RowId fileId, bool success,
                                                    const QString& filePath, const QByteArray& fileHash);
     void dbSchemaUpgrade();
 
@@ -211,7 +211,7 @@ private:
         bool success = false;
         QString filePath;
         QByteArray fileHash;
-        int64_t fileId = -1;
+        RowId fileId{-1};
     };
 
     // This needs to be a shared pointer to avoid callback lifetime issues

--- a/src/persistence/offlinemsgengine.h
+++ b/src/persistence/offlinemsgengine.h
@@ -21,6 +21,8 @@
 #define OFFLINEMSGENGINE_H
 
 #include "src/chatlog/chatmessage.h"
+#include "src/core/core.h"
+#include "src/persistence/db/rawdatabase.h"
 #include <QDateTime>
 #include <QMap>
 #include <QMutex>
@@ -36,32 +38,32 @@ public:
     explicit OfflineMsgEngine(Friend*);
     virtual ~OfflineMsgEngine() = default;
 
-    void dischargeReceipt(int receipt);
-    void registerReceipt(int receipt, int64_t messageID, ChatMessage::Ptr msg);
+    void dischargeReceipt(ReceiptNum receipt);
+    void registerReceipt(ReceiptNum receipt, RowId messageID, ChatMessage::Ptr msg);
     void deliverOfflineMsgs();
 
 public slots:
     void removeAllReceipts();
-    void updateTimestamp(int receiptId);
+    void updateTimestamp(ReceiptNum receiptId);
 
 private:
-    void processReceipt(int receiptId);
+    void processReceipt(ReceiptNum receiptId);
     struct Receipt
     {
         bool bRowValid{false};
-        int64_t rowId{0};
+        RowId rowId{0};
         bool bRecepitReceived{false};
     };
 
     struct MsgPtr
     {
         ChatMessage::Ptr msg;
-        int receipt;
+        ReceiptNum receipt;
     };
     QMutex mutex;
     Friend* f;
-    QHash<int, Receipt> receipts;
-    QMap<int64_t, MsgPtr> undeliveredMsgs;
+    QHash<ReceiptNum, Receipt> receipts;
+    QMap<RowId, MsgPtr> undeliveredMsgs;
 
     static const int offlineTimeout;
 };

--- a/src/util/strongtype.h
+++ b/src/util/strongtype.h
@@ -1,0 +1,55 @@
+/*
+    Copyright © 2019 by The qTox Project Contributors
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef STORNGTYPE_H
+#define STORNGTYPE_H
+
+#include <QHash>
+
+/* This class facilitates creating a named class which wraps underlying POD,
+ * avoiding implict casts and arithmetic of the underlying data.
+ * Usage: Declare named type with arbitrary tag, then hook up Qt metatype for use
+ * in signals/slots. For queued connections, registering the metatype is also
+ * required before the type is used.
+ *   using ReceiptNum = NamedType<uint32_t, struct ReceiptNumTag>;
+ *   Q_DECLARE_METATYPE(ReceiptNum);
+ *   qRegisterMetaType<ReceiptNum>();
+ */
+
+template <typename T, typename Parameter>
+class NamedType
+{
+public:
+    NamedType() {}
+    explicit NamedType(T const& value) : value_(value) {}
+    T& get() { return value_; }
+    T const& get() const {return value_; }
+    bool operator==(const NamedType& rhs) const { return value_ == rhs.value_; }
+    bool operator<(const NamedType& rhs) const { return value_ < rhs.value_; }
+    bool operator>(const NamedType& rhs) const { return value_ > rhs.value_; }
+
+private:
+    T value_;
+};
+
+template <typename T, typename Parameter>
+inline uint qHash(const NamedType<T,Parameter> &key, uint seed = 0) {
+    return qHash(key.get(), seed);
+}
+#endif // STORNGTYPE_H

--- a/src/widget/form/chatform.h
+++ b/src/widget/form/chatform.h
@@ -103,7 +103,7 @@ private slots:
     void onFriendNameChanged(const QString& name);
     void onFriendMessageReceived(quint32 friendId, const QString& message, bool isAction);
     void onStatusMessage(const QString& message);
-    void onReceiptReceived(quint32 friendId, int receipt);
+    void onReceiptReceived(quint32 friendId, ReceiptNum receipt);
     void onLoadHistory();
     void onUpdateTime();
     void sendImage(const QPixmap& pixmap);
@@ -117,10 +117,10 @@ private:
         const bool isSelf;
         const bool needSending;
         const bool isAction;
-        const qint64 id;
+        const RowId id;
         const ToxPk authorPk;
         const QDateTime msgDateTime;
-        MessageMetadata(bool isSelf, bool needSending, bool isAction, qint64 id, ToxPk authorPk,
+        MessageMetadata(bool isSelf, bool needSending, bool isAction, RowId id, ToxPk authorPk,
                         QDateTime msgDateTime)
             : isSelf{isSelf}
             , needSending{needSending}

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -240,7 +240,7 @@ void Widget::init()
     connect(updateCheck.get(), &UpdateCheck::updateAvailable, this, &Widget::onUpdateAvailable);
 #endif
     settingsWidget = new SettingsWidget(updateCheck.get(), this);
-#if UPDATE_CHECK_ENABLED 
+#if UPDATE_CHECK_ENABLED
     updateCheck->checkForUpdate();
 #endif
 
@@ -1013,7 +1013,7 @@ void Widget::addFriend(uint32_t friendId, const ToxPk& friendPk)
     connect(widget, &FriendWidget::copyFriendIdToClipboard, this, &Widget::copyFriendIdToClipboard);
     connect(widget, &FriendWidget::contextMenuCalled, widget, &FriendWidget::onContextMenuCalled);
     connect(widget, SIGNAL(removeFriend(int)), this, SLOT(removeFriend(int)));
-    
+
     Profile* profile = Nexus::getProfile();
     connect(profile, &Profile::friendAvatarSet, widget, &FriendWidget::onAvatarSet);
     connect(profile, &Profile::friendAvatarRemoved, widget, &FriendWidget::onAvatarRemoved);
@@ -1218,7 +1218,7 @@ void Widget::onFriendMessageReceived(int friendId, const QString& message, bool 
     newFriendMessageAlert(friendId);
 }
 
-void Widget::onReceiptRecieved(int friendId, int receipt)
+void Widget::onReceiptRecieved(int friendId, ReceiptNum receipt)
 {
     Friend* f = FriendList::findFriend(friendId);
     if (!f) {

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -167,7 +167,7 @@ public slots:
     void onFriendMessageReceived(int friendId, const QString& message, bool isAction);
     void onFriendRequestReceived(const ToxPk& friendPk, const QString& message);
     void updateFriendActivity(const Friend* frnd);
-    void onReceiptRecieved(int friendId, int receipt);
+    void onReceiptRecieved(int friendId, ReceiptNum receipt);
     void onEmptyGroupCreated(int groupId, const QString& title);
     void onGroupInviteReceived(const GroupInvite& inviteInfo);
     void onGroupInviteAccepted(const GroupInvite& inviteInfo);


### PR DESCRIPTION
Avoid implicit casting and invalid arithmetic.

Note: there's a offlinemsgengine refactor coming after this one that will stop us from ignoring failure and treating receipt 0 specially.

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5534)
<!-- Reviewable:end -->
