### PR TITLE
refactor(messages): don't use receipt 0 as unsent, simplify class state

### DIFF
--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -689,7 +689,7 @@ void ChatForm::onStatusMessage(const QString& message)
 void ChatForm::onReceiptReceived(quint32 friendId, ReceiptNum receipt)
 {
     if (friendId == f->getId()) {
-        offlineEngine->dischargeReceipt(receipt);
+        offlineEngine->onReceiptReceived(receipt);
     }
 }
 
@@ -770,7 +770,7 @@ void ChatForm::dropEvent(QDropEvent* ev)
 void ChatForm::clearChatArea()
 {
     GenericChatForm::clearChatArea(/* confirm = */ false, /* inform = */ true);
-    offlineEngine->removeAllReceipts();
+    offlineEngine->removeAllMessages();
 }
 
 QString getMsgAuthorDispName(const ToxPk& authorPk, const QString& dispName)
@@ -931,15 +931,23 @@ void ChatForm::sendLoadedMessage(ChatMessage::Ptr chatMsg, MessageMetadata const
         return;
     }
 
-    ReceiptNum receipt{0};
+    ReceiptNum receipt;
+    bool  messageSent{false};
     if (f->getStatus() != Status::Offline) {
         Core* core = Core::getInstance();
         uint32_t friendId = f->getId();
         QString stringMsg = chatMsg->toString();
-        metadata.isAction ? core->sendAction(friendId, stringMsg, receipt)
-                          : core->sendMessage(friendId, stringMsg, receipt);
+        messageSent = metadata.isAction ? core->sendAction(friendId, stringMsg, receipt)
+                                        : core->sendMessage(friendId, stringMsg, receipt);
+        if (!messageSent) {
+            qWarning() << "Failed to send loaded message, adding to offline messaging";
+        }
     }
-    getOfflineMsgEngine()->registerReceipt(receipt, metadata.id, chatMsg);
+    if (messageSent) {
+        getOfflineMsgEngine()->addSentSavedMessage(receipt, metadata.id, chatMsg);
+    } else {
+        getOfflineMsgEngine()->addSavedMessage(metadata.id, chatMsg);
+    }
 }
 
 void ChatForm::onScreenshotClicked()
@@ -1128,11 +1136,15 @@ void ChatForm::SendMessageStr(QString msg)
             historyPart = ACTION_PREFIX + part;
         }
 
-        ReceiptNum receipt{0};
+        ReceiptNum receipt;
+        bool messageSent{false};
         if (f->getStatus() != Status::Offline) {
             Core* core = Core::getInstance();
             uint32_t friendId = f->getId();
-            isAction ? core->sendAction(friendId, part, receipt) : core->sendMessage(friendId, part, receipt);
+            messageSent = isAction ? core->sendAction(friendId, part, receipt) : core->sendMessage(friendId, part, receipt);
+            if (!messageSent) {
+                qCritical() << "Failed to send message, adding to offline messaging";
+            }
         }
 
         ChatMessage::Ptr ma = createSelfMessage(part, timestamp, isAction, false);
@@ -1144,8 +1156,12 @@ void ChatForm::SendMessageStr(QString msg)
             QString name = Core::getInstance()->getUsername();
             bool isSent = !Settings::getInstance().getFauxOfflineMessaging();
             history->addNewMessage(pk, historyPart, selfPk, timestamp, isSent, name,
-                                   [offMsgEngine, receipt, ma](RowId id) {
-                                       offMsgEngine->registerReceipt(receipt, id, ma);
+                                   [messageSent, offMsgEngine, receipt, ma](RowId id) {
+                                        if (messageSent) {
+                                            offMsgEngine->addSentSavedMessage(receipt, id, ma);
+                                        } else {
+                                            offMsgEngine->addSavedMessage(id, ma);
+                                        }
                                    });
         } else {
             // TODO: Make faux-offline messaging work partially with the history disabled

--- a/src/widget/form/settings/privacyform.cpp
+++ b/src/widget/form/settings/privacyform.cpp
@@ -58,8 +58,8 @@ PrivacyForm::~PrivacyForm()
 void PrivacyForm::on_cbKeepHistory_stateChanged()
 {
     Settings::getInstance().setEnableLogging(bodyUI->cbKeepHistory->isChecked());
-    Widget::getInstance()->clearAllReceipts();
     if (!bodyUI->cbKeepHistory->isChecked()) {
+        Widget::getInstance()->clearAllReceipts();
         QMessageBox::StandardButton dialogDelHistory;
         dialogDelHistory =
             QMessageBox::question(nullptr, tr("Confirmation"),

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1218,7 +1218,7 @@ void Widget::onReceiptRecieved(int friendId, ReceiptNum receipt)
         return;
     }
 
-    chatForms[friendId]->getOfflineMsgEngine()->dischargeReceipt(receipt);
+    chatForms[friendId]->getOfflineMsgEngine()->onReceiptReceived(receipt);
 }
 
 void Widget::addFriendDialog(const Friend* frnd, ContentDialog* dialog)
@@ -2177,7 +2177,7 @@ void Widget::clearAllReceipts()
 {
     QList<Friend*> frnds = FriendList::getAllFriends();
     for (Friend* f : frnds) {
-        chatForms[f->getId()]->getOfflineMsgEngine()->removeAllReceipts();
+        chatForms[f->getId()]->getOfflineMsgEngine()->removeAllMessages();
     }
 }
 


### PR DESCRIPTION
- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5539)
<!-- Reviewable:end -->
