### PR TITLE
fix(flatpak): use SVG for icon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ option(USE_FILTERAUDIO "Enable the echo canceling backend" ON)
 option(UPDATE_CHECK "Enable automatic update check" ON)
 option(USE_CCACHE "Use ccache when available" ON)
 option(SPELL_CHECK "Enable spell cheching support" ON)
+option(SVGZ_ICON "Compress the SVG icon of qTox" ON)
 option(ASAN "Compile with AddressSanitizer" OFF)
 
 # process generated files if cmake >= 3.10

--- a/cmake/Installation.cmake
+++ b/cmake/Installation.cmake
@@ -46,10 +46,17 @@ else()
     install(FILES ${path_from} DESTINATION ${path_to})
   endforeach(size)
 
+  # process the icon, compress if enabled
   set(SVG_SRC "${CMAKE_SOURCE_DIR}/img/icons/qtox.svg")
-  set(SVG_GZIP "${CMAKE_BINARY_DIR}/qtox.svgz")
-  install(CODE "
-  execute_process(COMMAND gzip -S z INPUT_FILE ${SVG_SRC} OUTPUT_FILE ${SVG_GZIP})
-  " COMPONENT Runtime)
-  install(FILES "${SVG_GZIP}" DESTINATION "share/icons/hicolor/scalable/apps")
+  if(${SVGZ_ICON})
+    set(SVG_GZIP "${CMAKE_BINARY_DIR}/qtox.svgz")
+    install(CODE "
+    execute_process(COMMAND gzip -S z INPUT_FILE ${SVG_SRC} OUTPUT_FILE ${SVG_GZIP})
+    " COMPONENT Runtime)
+    set(SVG_DEST "${SVG_GZIP}")
+  else()
+    set(SVG_DEST "${SVG_SRC}")
+  endif()
+  install(FILES "${SVG_DEST}" DESTINATION "share/icons/hicolor/scalable/apps")
+
 endif()

--- a/flatpak/build.sh
+++ b/flatpak/build.sh
@@ -26,7 +26,7 @@ echo "deb http://ftp.debian.org/debian stretch-backports main" > /etc/apt/source
 
 # Get packages
 apt-get update
-apt-get install $APT_FLAGS ca-certificates git elfutils wget xz-utils patch bzip2
+apt-get install $APT_FLAGS ca-certificates git elfutils wget xz-utils patch bzip2 librsvg2-2 librsvg2-common
 
 # install recent flatpak packages
 apt-get install $APT_FLAGS -t stretch-backports flatpak flatpak-builder

--- a/flatpak/io.github.qtox.qTox.json
+++ b/flatpak/io.github.qtox.qTox.json
@@ -145,6 +145,7 @@
         {
             "name": "qTox",
             "buildsystem": "cmake-ninja",
+            "config-opts": ["-DSVGZ_ICON=OFF"],
             "sources": [
                 {
                     "type": "dir",


### PR DESCRIPTION
Flatpak doesn't allow compressed SVGs as icons because this is against
the specification.

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5549)
<!-- Reviewable:end -->
