### PR TITLE
[WIP] refactor: use non-deprecated functions to fix build with Qt 5.13

### DIFF
--- a/src/chatlog/content/filetransferwidget.cpp
+++ b/src/chatlog/content/filetransferwidget.cpp
@@ -225,12 +225,12 @@ void FileTransferWidget::paintEvent(QPaintEvent*)
     // Draw the widget background:
     painter.setClipRect(QRect(0, 0, width(), height()));
     painter.setBrush(QBrush(backgroundColor));
-    painter.drawRoundRect(geometry(), r * ratio, r);
+    painter.drawRoundedRect(geometry(), r * ratio, r);
 
     if (drawButtonAreaNeeded()) {
         // Draw the button background:
         QPainterPath buttonBackground;
-        buttonBackground.addRoundRect(width() - 2 * buttonFieldWidth - lineWidth * 2, 0,
+        buttonBackground.addRoundedRect(width() - 2 * buttonFieldWidth - lineWidth * 2, 0,
                                       buttonFieldWidth, buttonFieldWidth + lineWidth, 50, 50);
         buttonBackground.addRect(width() - 2 * buttonFieldWidth - lineWidth * 2, 0,
                                  buttonFieldWidth * 2, buttonFieldWidth / 2);
@@ -242,7 +242,7 @@ void FileTransferWidget::paintEvent(QPaintEvent*)
 
         // Draw the left button:
         QPainterPath leftButton;
-        leftButton.addRoundRect(QRect(width() - 2 * buttonFieldWidth - lineWidth, 0,
+        leftButton.addRoundedRect(QRect(width() - 2 * buttonFieldWidth - lineWidth, 0,
                                       buttonFieldWidth, buttonFieldWidth),
                                 50, 50);
         leftButton.addRect(QRect(width() - 2 * buttonFieldWidth - lineWidth, 0,
@@ -256,7 +256,7 @@ void FileTransferWidget::paintEvent(QPaintEvent*)
         // Draw the right button:
         painter.setBrush(QBrush(buttonColor));
         painter.setClipRect(QRect(width() - buttonFieldWidth, 0, buttonFieldWidth, buttonFieldWidth));
-        painter.drawRoundRect(geometry(), r * ratio, r);
+        painter.drawRoundedRect(geometry(), r * ratio, r);
     }
 }
 
@@ -615,7 +615,7 @@ void FileTransferWidget::showPreview(const QString& filename)
         ui->previewButton->show();
         // Show mouseover preview, but make sure it's not larger than 50% of the screen
         // width/height
-        const QRect desktopSize = QApplication::desktop()->screenGeometry();
+        const QRect desktopSize = QApplication::desktop()->geometry();
         const int maxPreviewWidth{desktopSize.width() / 2};
         const int maxPreviewHeight{desktopSize.height() / 2};
         const QImage previewImage = [&image, maxPreviewWidth, maxPreviewHeight]() {

--- a/src/widget/contentdialog.cpp
+++ b/src/widget/contentdialog.cpp
@@ -68,7 +68,7 @@ ContentDialog::ContentDialog(QWidget* parent)
                friendLayout->getLayoutOffline()};
 
     if (s.getGroupchatPosition()) {
-        layouts.swap(0, 1);
+        layouts.swapItemsAt(0, 1);
     }
 
     QWidget* friendWidget = new QWidget();
@@ -403,7 +403,7 @@ void ContentDialog::reorderLayouts(bool newGroupOnTop)
 {
     bool oldGroupOnTop = layouts.first() == groupLayout.getLayout();
     if (newGroupOnTop != oldGroupOnTop) {
-        layouts.swap(0, 1);
+        layouts.swapItemsAt(0, 1);
     }
 }
 

--- a/src/widget/form/groupchatform.cpp
+++ b/src/widget/form/groupchatform.cpp
@@ -293,7 +293,7 @@ void GroupChatForm::updateUserNames()
     // add the labels in alphabetical order into the layout
     auto nickLabelList = peerLabels.values();
 
-    qSort(nickLabelList.begin(), nickLabelList.end(), [](const QLabel* a, const QLabel* b)
+    std::sort(nickLabelList.begin(), nickLabelList.end(), [](const QLabel* a, const QLabel* b)
     {
         return a->text().toLower() < b->text().toLower();
     });

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -105,9 +105,11 @@ AVForm::AVForm(Audio* audio, CoreAV* coreAV, CameraSource& camera, IAudioSetting
 
     eventsInit();
 
-    QDesktopWidget* desktop = QApplication::desktop();
-    connect(desktop, &QDesktopWidget::resized, this, &AVForm::rescanDevices);
-    connect(desktop, &QDesktopWidget::screenCountChanged, this, &AVForm::rescanDevices);
+    QScreen* screen = QApplication::primaryScreen();
+
+    connect(screen, &QScreen::virtualGeometryChanged, this, &AVForm::rescanDevices);
+    connect(qApp, &QGuiApplication::screenAdded, this, &AVForm::rescanDevices);
+    connect(qApp, &QGuiApplication::screenRemoved, this, &AVForm::rescanDevices);
 
     Translator::registerHandler(std::bind(&AVForm::retranslateUi, this), this);
 }

--- a/src/widget/systemtrayicon.cpp
+++ b/src/widget/systemtrayicon.cpp
@@ -115,8 +115,8 @@ GdkPixbuf* SystemTrayIcon::convertQIconToPixbuf(const QIcon& icon)
     QImage image = icon.pixmap(64, 64).toImage();
     if (image.format() != QImage::Format_RGBA8888_Premultiplied)
         image = image.convertToFormat(QImage::Format_RGBA8888_Premultiplied);
-    guchar* image_bytes = new guchar[image.byteCount()];
-    memcpy(image_bytes, image.bits(), image.byteCount());
+    guchar* image_bytes = new guchar[image.sizeInBytes()];
+    memcpy(image_bytes, image.bits(), image.sizeInBytes());
 
     return gdk_pixbuf_new_from_data(image_bytes, GDK_COLORSPACE_RGB, image.hasAlphaChannel(), 8,
                                     image.width(), image.height(), image.bytesPerLine(),

--- a/src/widget/tool/callconfirmwidget.cpp
+++ b/src/widget/tool/callconfirmwidget.cpp
@@ -148,7 +148,7 @@ void CallConfirmWidget::paintEvent(QPaintEvent*)
     painter.setBrush(brush);
     painter.setPen(Qt::NoPen);
 
-    painter.drawRoundRect(mainRect, roundedFactor * rectRatio, roundedFactor);
+    painter.drawRoundedRect(mainRect, roundedFactor * rectRatio, roundedFactor);
     painter.drawPolygon(spikePoly);
 }
 

--- a/src/widget/tool/croppinglabel.cpp
+++ b/src/widget/tool/croppinglabel.cpp
@@ -100,7 +100,7 @@ QSize CroppingLabel::sizeHint() const
 
 QSize CroppingLabel::minimumSizeHint() const
 {
-    return QSize(fontMetrics().width("..."), QLabel::minimumSizeHint().height());
+    return QSize(fontMetrics().horizontalAdvance("..."), QLabel::minimumSizeHint().height());
 }
 
 void CroppingLabel::mouseReleaseEvent(QMouseEvent* e)
@@ -161,7 +161,7 @@ void CroppingLabel::minimizeMaximumWidth()
 {
     // This function chooses the smallest possible maximum width.
     // Text width + padding. Without padding, we'll have elipses.
-    setMaximumWidth(fontMetrics().width(origText) + fontMetrics().width("..."));
+    setMaximumWidth(fontMetrics().horizontalAdvance(origText) + fontMetrics().horizontalAdvance("..."));
 }
 
 void CroppingLabel::editingFinished()

--- a/src/widget/tool/screenshotgrabber.cpp
+++ b/src/widget/tool/screenshotgrabber.cpp
@@ -203,7 +203,7 @@ void ScreenshotGrabber::chooseHelperTooltipText(QRect rect)
 void ScreenshotGrabber::adjustTooltipPosition()
 {
     QRect recGL = QGuiApplication::primaryScreen()->virtualGeometry();
-    QRect rec = qApp->desktop()->screenGeometry(QCursor::pos());
+    QRect rec = qApp->screenAt(QCursor::pos())->geometry();
     const QRectF ttRect = this->helperToolbox->childrenBoundingRect();
     int x = qAbs(recGL.x()) + rec.x() + ((rec.width() - ttRect.width()) / 2);
     int y = qAbs(recGL.y()) + rec.y();


### PR DESCRIPTION
With the current build options, the deprecated warnings lead to a build failure, which this commit fixes (should the commits be split?).

I'm not sure everything is correct, but I haven't bumped into any major issues (yet).

The 'drawRoundedRect' works a bit differently compared to 'drawRoundRect', so that's probably something to look into.  It makes the filetransferwidget look a bit... funny, which actually is the main reason for why I didn't use the new functions already back when I first touched those parts a while ago. [1]

One major thing to note here though, is that some of the functions I've used are definitely not available in Qt 5.5.0, which is currently listed as the minimum Qt version for qTox.  Some of them were implemented as late as 5.10.  Actually, I think one might be only in 5.13... so this will definitely need more attention (I mainly used what the compiler suggested to be used, without, at first, really considering when the suggested things first appeared).

How ancient Qt should qTox support anyblue?  I'm not too familiar with what distributions other than Gentoo provide.

Should there be conditional code for different versions, instead of outright 'upgrading' some of these things at this time?

1. https://github.com/qTox/qTox/commit/9322f29e

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5552)
<!-- Reviewable:end -->
