### PR TITLE
fix unitialized variable (in v1.16.3)

### DIFF
--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -133,6 +133,7 @@ GenericChatForm::GenericChatForm(const Contact* contact, QWidget* parent)
     : QWidget(parent, Qt::Window)
     , audioInputFlag(false)
     , audioOutputFlag(false)
+    , searchAfterLoadHistory(false)
 {
     curRow = 0;
     headWidget = new ChatFormHeader();


### PR DESCRIPTION
undefined behavior sanitizer complained about initialized variable:
src/widget/form/chatform.cpp:781:9: runtime error: load of value 190, which is not a valid value for type 'bool'

This commit is against v1.16.3 tag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5553)
<!-- Reviewable:end -->
