### PR TITLE
chore: temporarily disable spell checking for MacOS

### DIFF
--- a/osx/qTox-Mac-Deployer-ULTIMATE.sh
+++ b/osx/qTox-Mac-Deployer-ULTIMATE.sh
@@ -173,7 +173,7 @@ install() {
 
     # verbose so that build output is shown, otherwise qt5 build has no output for >10 mins
     # and is killed by Travis CI
-    brew install --verbose ffmpeg libexif qrencode qt5 sqlcipher openal-soft kf5-sonnet
+    brew install --verbose ffmpeg libexif qrencode qt5 sqlcipher openal-soft #kf5-sonnet
 
     fcho "Cloning filter_audio ... "
     git clone --branch v0.0.1 --depth=1 https://github.com/irungentoo/filter_audio "$FILTERAUIO_DIR"
@@ -236,7 +236,7 @@ build() {
     fcho "Now working in ${PWD}"
     fcho "Starting cmake ..."
     export CMAKE_PREFIX_PATH=$(brew --prefix qt5)
-    cmake -H$QTOX_DIR -B. -DUPDATE_CHECK=ON
+    cmake -H$QTOX_DIR -B. -DUPDATE_CHECK=ON -DSPELL_CHECK=OFF
     make -j$(sysctl -n hw.ncpu)
 }
 


### PR DESCRIPTION
- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

EDIT: The reason for this is, that `kf5-sonnet` seems currently broken on our Travis + brew setup. See https://github.com/KDE-mac/homebrew-kde/issues/285

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5572)
<!-- Reviewable:end -->
