### PR TITLE
Add Apparmor profile

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -26,6 +26,7 @@
   - [sqlcipher](#sqlcipher)
   - [Compile toxcore](#compile-toxcore)
   - [Compile qTox](#compile-qtox)
+  - [Security hardening with AppArmor](#security-hardening-with-apparmor)
 - [OS X](#osx)
 - [Windows](#windows)
   - [Cross-compile from Linux](#cross-compile-from-linux)
@@ -585,6 +586,12 @@ After installing the required dependencies, run `bootstrap.sh` and then run the
 the packages necessary for building `.deb`s, so be prepared to type your
 password for sudo.
 
+---
+
+### Security hardening with AppArmor
+
+See [AppArmor] to enable confinement for increased security.
+
 
 <a name="osx" />
 
@@ -817,6 +824,7 @@ Switches:
     included
 
 
+[AppArmor]: /security/apparmor/README.md
 [Atk]: https://wiki.gnome.org/Accessibility
 [Cairo]: https://www.cairographics.org/
 [Check]: https://libcheck.github.io/check/

--- a/security/apparmor/2.12.1/install.sh
+++ b/security/apparmor/2.12.1/install.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -e -u pipefail
+
+readonly SCRIPT_DIR=$(dirname $(readlink -f $0))
+
+if [[ $(id -u) != 0 ]]
+then
+    >&2 echo "Please run as root."
+    exit 1
+fi
+
+if [[ -z $(which apparmor_parser) ]]
+then
+   >&2 echo "AppArmor not found."
+   exit 1
+fi
+
+echo "Copying AppArmor files..."
+[[ ! -d "/etc/apparmor.d/tunables/usr.bin.qtox.d/" ]] && mkdir -v "/etc/apparmor.d/tunables/usr.bin.qtox.d/"
+cp -v "${SCRIPT_DIR}/tunables/usr.bin.qtox" "/etc/apparmor.d/tunables/"
+cp -v "${SCRIPT_DIR}/usr.bin.qtox" "/etc/apparmor.d/"
+touch "/etc/apparmor.d/local/usr.bin.qtox"
+
+echo "Restarting AppArmor..."
+systemctl restart apparmor
+
+echo "Done."
+

--- a/security/apparmor/2.12.1/tunables/usr.bin.qtox
+++ b/security/apparmor/2.12.1/tunables/usr.bin.qtox
@@ -1,0 +1,12 @@
+@{qtox_prefix} = /usr /usr/local
+
+# Allow to read & write into mounted media, etc.
+# for convenient sending & receiving of files.
+@{qtox_additional_rw_dirs} = /mnt /media
+
+# Create /etc/apparmor.d/tunables/usr.bin.qtox.d/local file to append values as
+# needed, such as:
+# @{qtox_prefix} += @{HOME}/opt/qtox
+# @{qtox_additional_rw_dirs} = /data/nfs_storage
+#include if exists <tunables/usr.bin.qtox.d/>
+

--- a/security/apparmor/2.12.1/tunables/usr.bin.qtox
+++ b/security/apparmor/2.12.1/tunables/usr.bin.qtox
@@ -8,5 +8,5 @@
 # needed, such as:
 # @{qtox_prefix} += @{HOME}/opt/qtox
 # @{qtox_additional_rw_dirs} = /data/nfs_storage
-#include if exists <tunables/usr.bin.qtox.d/>
+#include <tunables/usr.bin.qtox.d/>
 

--- a/security/apparmor/2.12.1/usr.bin.qtox
+++ b/security/apparmor/2.12.1/usr.bin.qtox
@@ -226,6 +226,10 @@ profile qtox /usr{,/local}/bin/qtox {
   # so we deny this path to protect from loading exploits from /tmp.
   deny /tmp/#[0-9][0-9][0-9][0-9][0-9] m,
 
+  # libfontconfig bug? Should not write to root-owned dirs.
+  deny /usr/share/fonts/** w,
+  deny /var/cache/fontconfig/ w,
+
   # System files
 
   /usr/share/hunspell/* r,
@@ -276,6 +280,7 @@ profile qtox /usr{,/local}/bin/qtox {
   owner /{,var/}run/user/[0-9]*[0-9]/qTox*.slave-socket rwl -> /{,var/}run/user/[0-9]*[0-9]/#[0-9]*[0-9], # file dialog
   owner @{HOME}/.cache/Tox/ w,
   owner @{HOME}/.cache/Tox/qTox/{,**} rw,
+  owner @{HOME}/.cache/fontconfig/** rwk,
   owner @{HOME}/.cache/qTox/{,**} rw,
   owner @{HOME}/.cache/thumbnails/** rw, # receiving image file produces thumbnail?
   owner @{HOME}/.config/menus/ r, # file dialog
@@ -285,6 +290,9 @@ profile qtox /usr{,/local}/bin/qtox {
   owner @{HOME}/.config/qToxrc.lock rwk,
   owner @{HOME}/.config/tox/** l -> @{HOME}/.config/tox/**, # QSaveFile?
   owner @{HOME}/.config/tox/{,**} rwk,
+  owner @{HOME}/.fonts/.uuid* rw,
+  owner @{HOME}/.fonts/.uuid.* l -> @{HOME}/.fonts/.uuid.*,
+  owner @{HOME}/.fonts/.uuid.*/ rw,
   owner @{HOME}/.local/share/qTox/{,**} rw,
   owner @{HOME}/.local/share/user-places.xbel r, # file dialog
   owner @{PROC}/@{pid}/cmdline r,

--- a/security/apparmor/2.12.1/usr.bin.qtox
+++ b/security/apparmor/2.12.1/usr.bin.qtox
@@ -295,6 +295,7 @@ profile qtox /usr{,/local}/bin/qtox {
   owner @{HOME}/.fonts/.uuid* rw,
   owner @{HOME}/.fonts/.uuid.* l -> @{HOME}/.fonts/.uuid.*,
   owner @{HOME}/.fonts/.uuid.*/ rw,
+  owner @{HOME}/.local/share/Tox/{,**} rw,
   owner @{HOME}/.local/share/qTox/{,**} rw,
   owner @{HOME}/.local/share/user-places.xbel r, # file dialog
   owner @{PROC}/@{pid}/cmdline r,

--- a/security/apparmor/2.12.1/usr.bin.qtox
+++ b/security/apparmor/2.12.1/usr.bin.qtox
@@ -48,6 +48,83 @@ profile qtox /usr{,/local}/bin/qtox {
     member=Get
     peer=(label=unconfined),
 
+  dbus receive
+    bus=session
+    path=/
+    interface=org.freedesktop.DBus.Introspectable
+    member=Introspect
+    peer=(label=unconfined),
+
+  dbus send
+    bus=session
+    path=/StatusNotifierWatcher
+    interface=org.freedesktop.DBus.Introspectable
+    member=Introspect
+    peer=(label=unconfined),
+
+  dbus send
+    bus=session
+    path=/StatusNotifierWatcher
+    interface=org.freedesktop.DBus.Properties
+    member=Get
+    peer=(label=unconfined),
+
+  dbus send
+    bus=system
+    path=/org/freedesktop/NetworkManager
+    interface=org.freedesktop.DBus.Properties
+    member=GetAll
+    peer=(label=unconfined),
+
+  dbus send
+    bus=system
+    path=/org/freedesktop/NetworkManager
+    interface=org.freedesktop.NetworkManager
+    member=GetDevices
+    peer=(label=unconfined),
+
+  dbus receive
+    bus=system
+    path=/org/freedesktop/NetworkManager
+    interface=org.freedesktop.NetworkManager
+    member=PropertiesChanged
+    peer=(label=unconfined),
+
+  dbus send
+    bus=system
+    path=/org/freedesktop/NetworkManager/Settings
+    interface=org.freedesktop.NetworkManager.Settings
+    member=ListConnections
+    peer=(label=unconfined),
+
+  dbus send
+    bus=system
+    path=/org/freedesktop/NetworkManager/Settings/[0-9]*
+    interface=org.freedesktop.NetworkManager.Settings.Connection
+    member=GetSettings
+    peer=(label=unconfined),
+
+  dbus send
+    bus=system
+    path=/org/freedesktop/NetworkManager/ActiveConnection/[0-9]*
+    interface=org.freedesktop.DBus.Properties
+    member=GetAll
+    peer=(label=unconfined),
+
+  dbus receive
+    bus=system
+    path=/org/freedesktop/NetworkManager/ActiveConnection/[0-9]*
+    interface=org.freedesktop.NetworkManager.Connection.Active
+    member=PropertiesChanged
+    peer=(label=unconfined),
+
+  dbus send
+    bus=system
+    path=/org/freedesktop/NetworkManager/Devices/[0-9]*
+    interface=org.freedesktop.DBus.Properties
+    member=GetAll
+    peer=(label=unconfined),
+
   # System files
 
   /usr/share/hunspell/* r,

--- a/security/apparmor/2.12.1/usr.bin.qtox
+++ b/security/apparmor/2.12.1/usr.bin.qtox
@@ -50,6 +50,7 @@ profile qtox /usr{,/local}/bin/qtox {
 
   # System files
 
+  /usr/share/hunspell/* r,
   @{qtox_additional_rw_dirs}/ r,
   @{qtox_additional_rw_dirs}/** rw,
 

--- a/security/apparmor/2.12.1/usr.bin.qtox
+++ b/security/apparmor/2.12.1/usr.bin.qtox
@@ -313,4 +313,18 @@ profile qtox /usr{,/local}/bin/qtox {
   # commit b0456adbd86aab73e4a19013fdfed22da98ed455
   /sys/devices/pci[0-9]*/**/{device,subsystem_device,subsystem_vendor,uevent,vendor} r,
 
+  # Backport kde abstraction
+  # commit aae838faca57905d2dbc27db7bffd595c09d26f0
+  # commit dc3b73daf9f648336a6f9ab90103acc962c0bf40
+  /etc/xdg/kdeglobals r,
+  /usr/share/knotifications5/*.notifyrc r, # KNotification::sendEvent()
+  /usr/share/kubuntu-default-settings/kf5-settings/* r,
+  owner @{HOME}/.cache/ksycoca5_??_* r, # KDE System Configuration Cache
+  owner @{HOME}/.config/baloofilerc r, # indexing options (excludes, etc), used by KFileWidget
+  owner @{HOME}/.config/dolphinrc r, # settings used by KFileWidget
+  owner @{HOME}/.config/kde.org/libphonon.conf r, # for KNotifications::sendEvent()
+  owner @{HOME}/.config/kdeglobals r, # global settings, used by Breeze style, etc.
+  owner @{HOME}/.config/klanguageoverridesrc r, # per-application languages, for KDEPrivate::initializeLanguages() from libKF5XmlGui.so
+  owner @{HOME}/.config/trashrc r, # Used by KFileWidget
+
 }

--- a/security/apparmor/2.12.1/usr.bin.qtox
+++ b/security/apparmor/2.12.1/usr.bin.qtox
@@ -22,7 +22,7 @@ profile qtox /usr{,/local}/bin/qtox {
 
   # Main executable
 
-  @{qtox_prefix}/bin mr,
+  @{qtox_prefix}/bin/qtox mr,
 
   # Other executables
 

--- a/security/apparmor/2.12.1/usr.bin.qtox
+++ b/security/apparmor/2.12.1/usr.bin.qtox
@@ -1,0 +1,103 @@
+#include <tunables/global>
+#include <tunables/usr.bin.qtox>
+
+# using variables in profile name is not yet recommended due to issues with
+# AppArmor tools
+# TODO: use this alternative in the future when available
+#profile qtox @{qtox_prefix}/bin/qtox {
+profile qtox /usr{,/local}/bin/qtox {
+  #include <abstractions/audio>
+  #include <abstractions/base>
+  #include <abstractions/dbus-session-strict>
+  #include <abstractions/dri-enumerate>
+  #include <abstractions/gnome>
+  #include <abstractions/kde-globals-write>
+  #include <abstractions/kde-icon-cache-write>
+  #include <abstractions/kde>
+  #include <abstractions/mesa>
+  #include <abstractions/nameservice>
+  #include <abstractions/qt5-compose-cache-write>
+  #include <abstractions/qt5-settings-write>
+  #include <abstractions/recent-documents-write>
+  #include <abstractions/video>
+
+  # Site-specific additions and overrides. See local/README for details.
+  #include if exists <local/usr.bin.qtox>
+
+  # Main executable
+
+  @{qtox_prefix}/bin mr,
+
+  # Other executables
+
+  #TODO: use xdg-open abstraction when it's available
+  /usr/bin/xdg-open PUx,
+
+  # Networking
+
+  network tcp,
+  network udp,
+
+  # System files
+
+  @{qtox_additional_rw_dirs}/ r,
+  @{qtox_additional_rw_dirs}/** rw,
+
+  # Sensitive directory access!!!
+  # Allow navigating directories with file dialog, to access directory you
+  # can write (read) file to, for most convenience (though against maximum
+  # security). Note: this allows reading only directory contents (list),
+  # not the files itself.
+  /{,**/} r,
+
+  /dev/ r,
+  /dev/dri/ r,
+  /dev/video[0-9]* rw, # webcam
+  /etc/fstab r, # file dialog
+  /etc/xdg/menus/ r, # file dialog
+  /proc/sys/kernel/core_pattern r, # for  KCrash::initialize()
+  /proc/sys/kernel/random/boot_id r, # for QSysInfo::bootUniqueId(), mvoe to qt5 abstraction?
+  /run/udev/data/*:* r, # libKF5KIOFileWidgets.so -> libudev.so (KDE file dialog)
+  /sys/bus/ r, # file dialog
+  /sys/bus/usb/devices/ r, # file dialog
+  /sys/class/ r, # file dialog
+  /sys/devices/system/node/ r,  # for ld-linux-x86-64.so -> libnuma1.so
+  /sys/devices/system/node/node[0-9]*/meminfo r, # for ld-linux-x86-64.so -> libnuma1.so
+  /usr/share/emoticons/{,**} r,
+  /usr/share/kservices5/{,**} r, # file dialog
+  /usr/share/mime/ r, # file dialog
+  /usr/share/plasma/look-and-feel/*/contents/defaults r, # TODO: move to kde abstraction?
+  /usr/share/sounds/ r, # file dialog (alert)
+
+  # User files
+
+  # Sensitive file access!!!
+  # Allow reading & writing into $HOME, EXCEPT for dot files and directories,
+  # for most convenience (though against maximum security).
+  owner @{HOME}/ r,
+  owner @{HOME}/[^.]* rw,
+  owner @{HOME}/[^.]*/{,**} rw,
+  # QSaveFile security measures? While saving log file
+  owner @{HOME}/[^.]* l -> @{HOME}/#[0-9]*[0-9],
+  owner @{HOME}/[^.]*/** l -> @{HOME}/#[0-9]*[0-9],
+
+  owner /{,var/}run/user/@{uid}/#[0-9]*[0-9] rw, # file dialog
+  owner /{,var/}run/user/@{uid}/qTox*.slave-socket rwl -> /{,var/}run/user/@{uid}/#[0-9]*[0-9], # file dialog
+  owner @{HOME}/.cache/Tox/ w,
+  owner @{HOME}/.cache/Tox/qTox/{,**} rw,
+  owner @{HOME}/.cache/thumbnails/** rw, # receiving image file produces thumbnail?
+  owner @{HOME}/.config/menus/ r, # file dialog
+  owner @{HOME}/.config/menus/applications-merged/ r, # file dialog
+  owner @{HOME}/.config/qToxrc rw,
+  owner @{HOME}/.config/qToxrc.?????? rwl -> @{HOME}/.config/#[0-9]*[0-9], # QSaveFile?
+  owner @{HOME}/.config/qToxrc.lock rwk,
+  owner @{HOME}/.config/tox/** l -> @{HOME}/.config/tox/**, # QSaveFile?
+  owner @{HOME}/.config/tox/{,**} rwk,
+  owner @{HOME}/.local/share/user-places.xbel r, # file dialog
+  owner @{PROC}/@{pid}/cmdline r,
+
+  # Backport from more recent qt5-compose-cache-write abstraction
+  # commit 1250402471d9d83134b0faa90239a733a37f23f0
+  owner @{HOME}/.cache/qt_compose_cache_{little,big}_endian_* rwl -> @{HOME}/.cache/#[0-9]*[0-9],
+  owner @{HOME}/.cache/#[0-9]*[0-9] rw, # QSaveFile (anonymous shared memory)
+}

--- a/security/apparmor/2.12.1/usr.bin.qtox
+++ b/security/apparmor/2.12.1/usr.bin.qtox
@@ -11,6 +11,7 @@ profile qtox /usr{,/local}/bin/qtox {
   #include <abstractions/dbus-session-strict>
   #include <abstractions/dri-enumerate>
   #include <abstractions/gnome>
+  #include <abstractions/ibus>
   #include <abstractions/kde>
   #include <abstractions/nameservice>
   #include <abstractions/video>

--- a/security/apparmor/2.12.1/usr.bin.qtox
+++ b/security/apparmor/2.12.1/usr.bin.qtox
@@ -28,6 +28,8 @@ profile qtox /usr{,/local}/bin/qtox {
 
   #TODO: use xdg-open abstraction when it's available
   /usr/bin/xdg-open PUx,
+  #TODO: use named profile or abstraction when it's available
+  /usr/lib/@{multiarch}/libexec/kf5/kioslave PUx,
 
   # Additional libraries
 

--- a/security/apparmor/2.12.1/usr.bin.qtox
+++ b/security/apparmor/2.12.1/usr.bin.qtox
@@ -10,7 +10,6 @@ profile qtox /usr{,/local}/bin/qtox {
   #include <abstractions/base>
   #include <abstractions/dbus-accessibility>
   #include <abstractions/dbus-session-strict>
-  #include <abstractions/dri-enumerate>
   #include <abstractions/gnome>
   #include <abstractions/ibus>
   #include <abstractions/kde>
@@ -259,5 +258,9 @@ profile qtox /usr{,/local}/bin/qtox {
   owner @{HOME}/.local/share/RecentDocuments/#[0-9]* rw,
   owner @{HOME}/.local/share/RecentDocuments/*.desktop rwl -> @{HOME}/.local/share/RecentDocuments/#[0-9]*,
   owner @{HOME}/.local/share/RecentDocuments/*.lock rwk,
+
+  # Backport dri-enumerate abstraction
+  # commit b0456adbd86aab73e4a19013fdfed22da98ed455
+  /sys/devices/pci[0-9]*/**/{device,subsystem_device,subsystem_vendor,uevent,vendor} r,
 
 }

--- a/security/apparmor/2.12.1/usr.bin.qtox
+++ b/security/apparmor/2.12.1/usr.bin.qtox
@@ -15,6 +15,7 @@ profile qtox /usr{,/local}/bin/qtox {
   #include <abstractions/ibus>
   #include <abstractions/kde>
   #include <abstractions/nameservice>
+  #include <abstractions/openssl>
   #include <abstractions/video>
 
   # Site-specific additions and overrides. See local/README for details.

--- a/security/apparmor/2.12.1/usr.bin.qtox
+++ b/security/apparmor/2.12.1/usr.bin.qtox
@@ -62,11 +62,18 @@ profile qtox /usr{,/local}/bin/qtox {
     member=Introspect
     peer=(label=unconfined),
 
-  dbus send
+  dbus (send,receive)
     bus=session
     path=/StatusNotifierWatcher
     interface=org.freedesktop.DBus.Properties
     member=Get
+    peer=(label=unconfined),
+
+  dbus receive
+    bus=session
+    path=/StatusNotifierItem
+    interface=org.freedesktop.DBus.Properties
+    member=GetAll
     peer=(label=unconfined),
 
   dbus send
@@ -123,6 +130,41 @@ profile qtox /usr{,/local}/bin/qtox {
     path=/org/freedesktop/NetworkManager/Devices/[0-9]*
     interface=org.freedesktop.DBus.Properties
     member=GetAll
+    peer=(label=unconfined),
+
+  dbus send
+    bus=session
+    path=/StatusNotifierWatcher
+    interface=org.kde.StatusNotifierWatcher
+    member=RegisterStatusNotifierItem
+    peer=(label=unconfined),
+
+  dbus receive
+    bus=session
+    path=/StatusNotifierItem
+    interface=org.kde.StatusNotifierItem
+    member=Activate
+    peer=(label=unconfined),
+
+  dbus (send,receive)
+    bus=session
+    path=/MenuBar
+    interface=com.canonical.dbusmenu
+    member=GetLayout
+    peer=(label=unconfined),
+
+  dbus (send,receive)
+    bus=session
+    path=/MenuBar
+    interface=com.canonical.dbusmenu
+    member={AboutToShow,Event}
+    peer=(label=unconfined),
+
+  dbus send
+    bus=session
+    path=/StatusNotifierItem
+    interface=org.kde.StatusNotifierItem
+    member={NewIcon,NewToolTip}
     peer=(label=unconfined),
 
   # System files

--- a/security/apparmor/2.12.1/usr.bin.qtox
+++ b/security/apparmor/2.12.1/usr.bin.qtox
@@ -183,6 +183,7 @@ profile qtox /usr{,/local}/bin/qtox {
   owner @{HOME}/.config/qToxrc.lock rwk,
   owner @{HOME}/.config/tox/** l -> @{HOME}/.config/tox/**, # QSaveFile?
   owner @{HOME}/.config/tox/{,**} rwk,
+  owner @{HOME}/.local/share/qTox/{,**} rw,
   owner @{HOME}/.local/share/user-places.xbel r, # file dialog
   owner @{PROC}/@{pid}/cmdline r,
 

--- a/security/apparmor/2.12.1/usr.bin.qtox
+++ b/security/apparmor/2.12.1/usr.bin.qtox
@@ -27,6 +27,11 @@ profile qtox /usr{,/local}/bin/qtox {
   #TODO: use xdg-open abstraction when it's available
   /usr/bin/xdg-open PUx,
 
+  # Additional libraries
+
+  # Allow /usr/local/lib/libtoxcore.so...
+  @{qtox_prefix}/lib/*.so* mr,
+
   # Networking
 
   network tcp,

--- a/security/apparmor/2.12.1/usr.bin.qtox
+++ b/security/apparmor/2.12.1/usr.bin.qtox
@@ -11,18 +11,12 @@ profile qtox /usr{,/local}/bin/qtox {
   #include <abstractions/dbus-session-strict>
   #include <abstractions/dri-enumerate>
   #include <abstractions/gnome>
-  #include <abstractions/kde-globals-write>
-  #include <abstractions/kde-icon-cache-write>
   #include <abstractions/kde>
-  #include <abstractions/mesa>
   #include <abstractions/nameservice>
-  #include <abstractions/qt5-compose-cache-write>
-  #include <abstractions/qt5-settings-write>
-  #include <abstractions/recent-documents-write>
   #include <abstractions/video>
 
   # Site-specific additions and overrides. See local/README for details.
-  #include if exists <local/usr.bin.qtox>
+  #include <local/usr.bin.qtox>
 
   # Main executable
 
@@ -81,8 +75,8 @@ profile qtox /usr{,/local}/bin/qtox {
   owner @{HOME}/[^.]* l -> @{HOME}/#[0-9]*[0-9],
   owner @{HOME}/[^.]*/** l -> @{HOME}/#[0-9]*[0-9],
 
-  owner /{,var/}run/user/@{uid}/#[0-9]*[0-9] rw, # file dialog
-  owner /{,var/}run/user/@{uid}/qTox*.slave-socket rwl -> /{,var/}run/user/@{uid}/#[0-9]*[0-9], # file dialog
+  owner /{,var/}run/user/[0-9]*[0-9]/#[0-9]*[0-9] rw, # file dialog
+  owner /{,var/}run/user/[0-9]*[0-9]/qTox*.slave-socket rwl -> /{,var/}run/user/[0-9]*[0-9]/#[0-9]*[0-9], # file dialog
   owner @{HOME}/.cache/Tox/ w,
   owner @{HOME}/.cache/Tox/qTox/{,**} rw,
   owner @{HOME}/.cache/thumbnails/** rw, # receiving image file produces thumbnail?
@@ -100,4 +94,51 @@ profile qtox /usr{,/local}/bin/qtox {
   # commit 1250402471d9d83134b0faa90239a733a37f23f0
   owner @{HOME}/.cache/qt_compose_cache_{little,big}_endian_* rwl -> @{HOME}/.cache/#[0-9]*[0-9],
   owner @{HOME}/.cache/#[0-9]*[0-9] rw, # QSaveFile (anonymous shared memory)
+
+  # Backport kde-globals-write abstraction
+  # commit fae93f1b6c7a28bb77ad186ab1de41372630272b
+  owner @{HOME}/.config/#[0-9]* rw,
+  owner @{HOME}/.config/kdeglobals rw,
+  owner @{HOME}/.config/kdeglobals.?????? rwl -> @{HOME}/.config/#[0-9]*,
+  owner @{HOME}/.config/kdeglobals.lock rwk,
+
+  # Backport kde-icon-cache-write abstraction
+  # commit 94014c09f09fc63229bb10fea3f0727113fe5bae
+  owner @{HOME}/.cache/icon-cache.kcache rw, # for KIconLoader
+
+  # Backport mesa abstraction
+  # commit b5be5964609b4e0927af7c9e4f0276e50ccdc3e3
+
+  # System files
+  /dev/dri/ r, # libGLX_mesa.so calls drmGetDevice2()
+  /usr/share/drirc.d/{,*.conf} r,
+
+  # User files
+  owner @{HOME}/.cache/ w, # if user clears all caches
+  owner @{HOME}/.cache/mesa_shader_cache/ w,
+  owner @{HOME}/.cache/mesa_shader_cache/index rw,
+  owner @{HOME}/.cache/mesa_shader_cache/??/ w,
+  owner @{HOME}/.cache/mesa_shader_cache/??/* rwk,
+  # End of backported mesa abstraction
+
+  # Backport qt5-compose-cache-write abstraction
+  # commit 1250402471d9d83134b0faa90239a733a37f23f0
+  owner @{HOME}/.cache/qt_compose_cache_{little,big}_endian_* rwl -> @{HOME}/.cache/#[0-9]*[0-9],
+  owner @{HOME}/.cache/#[0-9]*[0-9] rw, # QSaveFile (anonymous shared memory)
+
+  # Backport qt5-settings-write abstraction
+  # commit 8f6a8fb1942122705af4c45168922c4afd696c8a
+  owner @{HOME}/.config/#[0-9]*[0-9] rw,
+  owner @{HOME}/.config/QtProject.conf rwl -> @{HOME}/.config/#[0-9]*[0-9],
+  # for temporary files like QtProject.conf.Aqrgeb
+  owner @{HOME}/.config/QtProject.conf.?????? rwl -> @{HOME}/.config/#[0-9]*[0-9],
+  owner @{HOME}/.config/QtProject.conf.lock rwk,
+
+  # Backport recent-documents-write
+  # commit 4fe8ae97c43d72d7f5a948c7149f5ea35339832a
+  owner @{HOME}/.local/share/RecentDocuments/ rw,
+  owner @{HOME}/.local/share/RecentDocuments/#[0-9]* rw,
+  owner @{HOME}/.local/share/RecentDocuments/*.desktop rwl -> @{HOME}/.local/share/RecentDocuments/#[0-9]*,
+  owner @{HOME}/.local/share/RecentDocuments/*.lock rwk,
+
 }

--- a/security/apparmor/2.12.1/usr.bin.qtox
+++ b/security/apparmor/2.12.1/usr.bin.qtox
@@ -390,4 +390,8 @@ profile qtox /usr{,/local}/bin/qtox {
   owner @{HOME}/.config/klanguageoverridesrc r, # per-application languages, for KDEPrivate::initializeLanguages() from libKF5XmlGui.so
   owner @{HOME}/.config/trashrc r, # Used by KFileWidget
 
+  # Backport dri-common abstraction
+  # commit 2d8d2f06d5697d9692330686bb5ddb0095621144
+  /usr/share/drirc.d/{,*.conf} r,
+
 }

--- a/security/apparmor/2.12.1/usr.bin.qtox
+++ b/security/apparmor/2.12.1/usr.bin.qtox
@@ -8,6 +8,7 @@
 profile qtox /usr{,/local}/bin/qtox {
   #include <abstractions/audio>
   #include <abstractions/base>
+  #include <abstractions/dbus-accessibility>
   #include <abstractions/dbus-session-strict>
   #include <abstractions/dri-enumerate>
   #include <abstractions/gnome>
@@ -37,6 +38,15 @@ profile qtox /usr{,/local}/bin/qtox {
 
   network tcp,
   network udp,
+
+  # DBus
+
+  dbus send
+    bus=session
+    path=/org/a11y/bus
+    interface=org.freedesktop.DBus.Properties
+    member=Get
+    peer=(label=unconfined),
 
   # System files
 

--- a/security/apparmor/2.12.1/usr.bin.qtox
+++ b/security/apparmor/2.12.1/usr.bin.qtox
@@ -85,6 +85,7 @@ profile qtox /usr{,/local}/bin/qtox {
   owner /{,var/}run/user/[0-9]*[0-9]/qTox*.slave-socket rwl -> /{,var/}run/user/[0-9]*[0-9]/#[0-9]*[0-9], # file dialog
   owner @{HOME}/.cache/Tox/ w,
   owner @{HOME}/.cache/Tox/qTox/{,**} rw,
+  owner @{HOME}/.cache/qTox/{,**} rw,
   owner @{HOME}/.cache/thumbnails/** rw, # receiving image file produces thumbnail?
   owner @{HOME}/.config/menus/ r, # file dialog
   owner @{HOME}/.config/menus/applications-merged/ r, # file dialog

--- a/security/apparmor/2.12.1/usr.bin.qtox
+++ b/security/apparmor/2.12.1/usr.bin.qtox
@@ -169,6 +169,55 @@ profile qtox /usr{,/local}/bin/qtox {
     member={NewIcon,NewToolTip}
     peer=(label=unconfined),
 
+  dbus send
+    bus=system
+    path=/org/freedesktop/UPower
+    interface=org.freedesktop.DBus.Introspectable
+    member=Introspect
+    peer=(label=unconfined),
+
+  dbus send
+    bus=system
+    path=/org/freedesktop/UDisks2/{block_devices,block_devices/*,drives,drives/*}
+    interface=org.freedesktop.DBus.Introspectable
+    member=Introspect
+    peer=(label=unconfined),
+
+  dbus send
+    bus=system
+    path=/org/freedesktop/UDisks2/{block_devices,drives}/*
+    interface=org.freedesktop.DBus.Properties
+    member={Get,GetAll}
+    peer=(label=unconfined),
+
+  dbus send
+    bus=session
+    path=/org/freedesktop/DBus
+    interface=org.freedesktop.DBus
+    member=GetConnectionUnixUser
+    peer=(label=unconfined),
+
+  dbus send
+    bus=session
+    path=/
+    interface=org.kde.KDirNotify
+    member={enteredDirectory,leftDirectory}
+    peer=(label=unconfined),
+
+  dbus receive
+    bus=session
+    path=/
+    interface=org.kde.KDirNotify
+    member=FilesAdded
+    peer=(label=unconfined),
+
+  dbus send
+    bus=session
+    path=/KLauncher
+    interface=org.kde.KSlaveLauncher
+    member=requestSlave
+    peer=(label=unconfined),
+
   # Denied files
 
   # libpcre2 on openSUSE tries to mmap() shared memory on directory.
@@ -201,6 +250,7 @@ profile qtox /usr{,/local}/bin/qtox {
   /sys/bus/ r, # file dialog
   /sys/bus/usb/devices/ r, # file dialog
   /sys/class/ r, # file dialog
+  /sys/devices/**/uevent r, # file dialog
   /sys/devices/system/node/ r,  # for ld-linux-x86-64.so -> libnuma1.so
   /sys/devices/system/node/node[0-9]*/meminfo r, # for ld-linux-x86-64.so -> libnuma1.so
   /usr/share/emoticons/{,**} r,
@@ -208,6 +258,7 @@ profile qtox /usr{,/local}/bin/qtox {
   /usr/share/mime/ r, # file dialog
   /usr/share/plasma/look-and-feel/*/contents/defaults r, # TODO: move to kde abstraction?
   /usr/share/sounds/ r, # file dialog (alert)
+  /{,var/}run/udev/data/* r, # file dialog
 
   # User files
 

--- a/security/apparmor/2.12.1/usr.bin.qtox
+++ b/security/apparmor/2.12.1/usr.bin.qtox
@@ -167,6 +167,14 @@ profile qtox /usr{,/local}/bin/qtox {
     member={NewIcon,NewToolTip}
     peer=(label=unconfined),
 
+  # Denied files
+
+  # libpcre2 on openSUSE tries to mmap() shared memory on directory.
+  # see: https://lists.ubuntu.com/archives/apparmor/2019-January/011925.html
+  # AppArmor does not allow to distinguish "real" file vs shared memory one,
+  # so we deny this path to protect from loading exploits from /tmp.
+  deny /tmp/#[0-9][0-9][0-9][0-9][0-9] m,
+
   # System files
 
   /usr/share/hunspell/* r,

--- a/security/apparmor/2.12.1/usr.bin.qtox
+++ b/security/apparmor/2.12.1/usr.bin.qtox
@@ -38,8 +38,10 @@ profile qtox /usr{,/local}/bin/qtox {
 
   # Networking
 
-  network tcp,
-  network udp,
+  network inet udp,
+  network inet6 udp,
+  network inet tcp,
+  network inet6 tcp,
 
   # DBus
 

--- a/security/apparmor/2.12.1/usr.bin.qtox
+++ b/security/apparmor/2.12.1/usr.bin.qtox
@@ -126,6 +126,28 @@ profile qtox /usr{,/local}/bin/qtox {
   owner @{HOME}/.cache/mesa_shader_cache/??/* rwk,
   # End of backported mesa abstraction
 
+  # Backport qt5 abstraction
+  # commit 67816c42cfbadd85aa5cbb086284076c4c289881
+
+  # Additional libraries
+
+  /usr/lib{,64,/@{multiarch}}/qt5/plugins/**.so mr,
+  /usr/lib{,64,/@{multiarch}}/qt5/qml/**.so mr,
+  /usr/lib{,64,/@{multiarch}}/qt5/qml/**.{qmlc,jsc} mr, # Precompiled QML/JavaScript modules
+
+  # System files
+
+  /etc/xdg/QtProject/qtlogging.ini r,
+  /usr/share/qt5/translations/*.qm r,
+  /usr/lib{,64,/@{multiarch}}/qt5/plugins/** r,
+  /usr/lib{,64,/@{multiarch}}/qt5/qml/** r,
+
+  # User files
+
+  owner @{HOME}/.config/QtProject.conf r, # common settings for QFileDialog, etc (application might need write access)
+  owner @{HOME}/.cache/qt_compose_cache_{little,big}_endian_* r, # for "platforminputcontexts" plugins
+  # End of backported qt5 abstractions
+
   # Backport qt5-compose-cache-write abstraction
   # commit 1250402471d9d83134b0faa90239a733a37f23f0
   owner @{HOME}/.cache/qt_compose_cache_{little,big}_endian_* rwl -> @{HOME}/.cache/#[0-9]*[0-9],

--- a/security/apparmor/2.12.1/usr.bin.qtox
+++ b/security/apparmor/2.12.1/usr.bin.qtox
@@ -258,6 +258,8 @@ profile qtox /usr{,/local}/bin/qtox {
   /sys/devices/system/node/ r,  # for ld-linux-x86-64.so -> libnuma1.so
   /sys/devices/system/node/node[0-9]*/meminfo r, # for ld-linux-x86-64.so -> libnuma1.so
   /usr/share/emoticons/{,**} r,
+  /usr/share/hwdata/pnp.ids r, # For OpenSUSE only?
+  /usr/share/icu/[0-9]*.[0-9]*/icudt[0-9]*.dat r, # For OpenSUSE only?
   /usr/share/kservices5/{,**} r, # file dialog
   /usr/share/mime/ r, # file dialog
   /usr/share/plasma/look-and-feel/*/contents/defaults r, # TODO: move to kde abstraction?

--- a/security/apparmor/2.13.2/install.sh
+++ b/security/apparmor/2.13.2/install.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -e -u pipefail
+
+readonly SCRIPT_DIR=$(dirname $(readlink -f $0))
+
+if [[ $(id -u) != 0 ]]
+then
+    >&2 echo "Please run as root."
+    exit 1
+fi
+
+if [[ -z $(which apparmor_parser) ]]
+then
+   >&2 echo "AppArmor not found."
+   exit 1
+fi
+
+#NOTE: we do not need to create /etc/apparmor.d/tunables/usr.bin.qtox.d/ or
+#/etc/apparmor.d/local/usr.bin.qtox because AppArmor >2.13 support #include if
+#exists
+
+echo "Copying AppArmor files..."
+cp -v "${SCRIPT_DIR}/tunables/usr.bin.qtox" "/etc/apparmor.d/tunables/"
+cp -v "${SCRIPT_DIR}/usr.bin.qtox" "/etc/apparmor.d/"
+
+echo "Restarting AppArmor..."
+systemctl restart apparmor
+
+echo "Done."
+

--- a/security/apparmor/2.13.2/tunables/usr.bin.qtox
+++ b/security/apparmor/2.13.2/tunables/usr.bin.qtox
@@ -1,0 +1,12 @@
+@{qtox_prefix} = /usr /usr/local
+
+# Allow to read & write into mounted media, etc.
+# for convenient sending & receiving of files.
+@{qtox_additional_rw_dirs} = /mnt /media
+
+# Create /etc/apparmor.d/tunables/usr.bin.qtox.d/local file to append values as
+# needed, such as:
+# @{qtox_prefix} += @{HOME}/opt/qtox
+# @{qtox_additional_rw_dirs} = /data/nfs_storage
+#include if exists <tunables/usr.bin.qtox.d/>
+

--- a/security/apparmor/2.13.2/usr.bin.qtox
+++ b/security/apparmor/2.13.2/usr.bin.qtox
@@ -174,6 +174,14 @@ profile qtox /usr{,/local}/bin/qtox {
     member={NewIcon,NewToolTip}
     peer=(label=unconfined),
 
+  # Denied files
+
+  # libpcre2 on openSUSE tries to mmap() shared memory on directory.
+  # see: https://lists.ubuntu.com/archives/apparmor/2019-January/011925.html
+  # AppArmor does not allow to distinguish "real" file vs shared memory one,
+  # so we deny this path to protect from loading exploits from /tmp.
+  deny /tmp/#[0-9][0-9][0-9][0-9][0-9] m,
+
   # System files
 
   /usr/share/hunspell/* r,

--- a/security/apparmor/2.13.2/usr.bin.qtox
+++ b/security/apparmor/2.13.2/usr.bin.qtox
@@ -35,6 +35,8 @@ profile qtox /usr{,/local}/bin/qtox {
 
   #TODO: use xdg-open abstraction when it's available
   /usr/bin/xdg-open PUx,
+  #TODO: use named profile or abstraction when it's available
+  /usr/lib/@{multiarch}/libexec/kf5/kioslave PUx,
 
   # Additional libraries
 

--- a/security/apparmor/2.13.2/usr.bin.qtox
+++ b/security/apparmor/2.13.2/usr.bin.qtox
@@ -33,6 +33,11 @@ profile qtox /usr{,/local}/bin/qtox {
   #TODO: use xdg-open abstraction when it's available
   /usr/bin/xdg-open PUx,
 
+  # Additional libraries
+
+  # Allow /usr/local/lib/libtoxcore.so...
+  @{qtox_prefix}/lib/*.so* mr,
+
   # Networking
 
   network tcp,

--- a/security/apparmor/2.13.2/usr.bin.qtox
+++ b/security/apparmor/2.13.2/usr.bin.qtox
@@ -1,0 +1,103 @@
+#include <tunables/global>
+#include <tunables/usr.bin.qtox>
+
+# using variables in profile name is not yet recommended due to issues with
+# AppArmor tools
+# TODO: use this alternative in the future when available
+#profile qtox @{qtox_prefix}/bin/qtox {
+profile qtox /usr{,/local}/bin/qtox {
+  #include <abstractions/audio>
+  #include <abstractions/base>
+  #include <abstractions/dbus-session-strict>
+  #include <abstractions/dri-enumerate>
+  #include <abstractions/gnome>
+  #include <abstractions/kde-globals-write>
+  #include <abstractions/kde-icon-cache-write>
+  #include <abstractions/kde>
+  #include <abstractions/mesa>
+  #include <abstractions/nameservice>
+  #include <abstractions/qt5-compose-cache-write>
+  #include <abstractions/qt5-settings-write>
+  #include <abstractions/recent-documents-write>
+  #include <abstractions/video>
+
+  # Site-specific additions and overrides. See local/README for details.
+  #include if exists <local/usr.bin.qtox>
+
+  # Main executable
+
+  @{qtox_prefix}/bin mr,
+
+  # Other executables
+
+  #TODO: use xdg-open abstraction when it's available
+  /usr/bin/xdg-open PUx,
+
+  # Networking
+
+  network tcp,
+  network udp,
+
+  # System files
+
+  @{qtox_additional_rw_dirs}/ r,
+  @{qtox_additional_rw_dirs}/** rw,
+
+  # Sensitive directory access!!!
+  # Allow navigating directories with file dialog, to access directory you
+  # can write (read) file to, for most convenience (though against maximum
+  # security). Note: this allows reading only directory contents (list),
+  # not the files itself.
+  /{,**/} r,
+
+  /dev/ r,
+  /dev/dri/ r,
+  /dev/video[0-9]* rw, # webcam
+  /etc/fstab r, # file dialog
+  /etc/xdg/menus/ r, # file dialog
+  /proc/sys/kernel/core_pattern r, # for  KCrash::initialize()
+  /proc/sys/kernel/random/boot_id r, # for QSysInfo::bootUniqueId(), mvoe to qt5 abstraction?
+  /run/udev/data/*:* r, # libKF5KIOFileWidgets.so -> libudev.so (KDE file dialog)
+  /sys/bus/ r, # file dialog
+  /sys/bus/usb/devices/ r, # file dialog
+  /sys/class/ r, # file dialog
+  /sys/devices/system/node/ r,  # for ld-linux-x86-64.so -> libnuma1.so
+  /sys/devices/system/node/node[0-9]*/meminfo r, # for ld-linux-x86-64.so -> libnuma1.so
+  /usr/share/emoticons/{,**} r,
+  /usr/share/kservices5/{,**} r, # file dialog
+  /usr/share/mime/ r, # file dialog
+  /usr/share/plasma/look-and-feel/*/contents/defaults r, # TODO: move to kde abstraction?
+  /usr/share/sounds/ r, # file dialog (alert)
+
+  # User files
+
+  # Sensitive file access!!!
+  # Allow reading & writing into $HOME, EXCEPT for dot files and directories,
+  # for most convenience (though against maximum security).
+  owner @{HOME}/ r,
+  owner @{HOME}/[^.]* rw,
+  owner @{HOME}/[^.]*/{,**} rw,
+  # QSaveFile security measures? While saving log file
+  owner @{HOME}/[^.]* l -> @{HOME}/#[0-9]*[0-9],
+  owner @{HOME}/[^.]*/** l -> @{HOME}/#[0-9]*[0-9],
+
+  owner /{,var/}run/user/@{uid}/#[0-9]*[0-9] rw, # file dialog
+  owner /{,var/}run/user/@{uid}/qTox*.slave-socket rwl -> /{,var/}run/user/@{uid}/#[0-9]*[0-9], # file dialog
+  owner @{HOME}/.cache/Tox/ w,
+  owner @{HOME}/.cache/Tox/qTox/{,**} rw,
+  owner @{HOME}/.cache/thumbnails/** rw, # receiving image file produces thumbnail?
+  owner @{HOME}/.config/menus/ r, # file dialog
+  owner @{HOME}/.config/menus/applications-merged/ r, # file dialog
+  owner @{HOME}/.config/qToxrc rw,
+  owner @{HOME}/.config/qToxrc.?????? rwl -> @{HOME}/.config/#[0-9]*[0-9], # QSaveFile?
+  owner @{HOME}/.config/qToxrc.lock rwk,
+  owner @{HOME}/.config/tox/** l -> @{HOME}/.config/tox/**, # QSaveFile?
+  owner @{HOME}/.config/tox/{,**} rwk,
+  owner @{HOME}/.local/share/user-places.xbel r, # file dialog
+  owner @{PROC}/@{pid}/cmdline r,
+
+  # Backport from more recent qt5-compose-cache-write abstraction
+  # commit 1250402471d9d83134b0faa90239a733a37f23f0
+  owner @{HOME}/.cache/qt_compose_cache_{little,big}_endian_* rwl -> @{HOME}/.cache/#[0-9]*[0-9],
+  owner @{HOME}/.cache/#[0-9]*[0-9] rw, # QSaveFile (anonymous shared memory)
+}

--- a/security/apparmor/2.13.2/usr.bin.qtox
+++ b/security/apparmor/2.13.2/usr.bin.qtox
@@ -189,6 +189,7 @@ profile qtox /usr{,/local}/bin/qtox {
   owner @{HOME}/.config/qToxrc.lock rwk,
   owner @{HOME}/.config/tox/** l -> @{HOME}/.config/tox/**, # QSaveFile?
   owner @{HOME}/.config/tox/{,**} rwk,
+  owner @{HOME}/.local/share/qTox/{,**} rw,
   owner @{HOME}/.local/share/user-places.xbel r, # file dialog
   owner @{PROC}/@{pid}/cmdline r,
 

--- a/security/apparmor/2.13.2/usr.bin.qtox
+++ b/security/apparmor/2.13.2/usr.bin.qtox
@@ -91,6 +91,7 @@ profile qtox /usr{,/local}/bin/qtox {
   owner /{,var/}run/user/@{uid}/qTox*.slave-socket rwl -> /{,var/}run/user/@{uid}/#[0-9]*[0-9], # file dialog
   owner @{HOME}/.cache/Tox/ w,
   owner @{HOME}/.cache/Tox/qTox/{,**} rw,
+  owner @{HOME}/.cache/qTox/{,**} rw,
   owner @{HOME}/.cache/thumbnails/** rw, # receiving image file produces thumbnail?
   owner @{HOME}/.config/menus/ r, # file dialog
   owner @{HOME}/.config/menus/applications-merged/ r, # file dialog

--- a/security/apparmor/2.13.2/usr.bin.qtox
+++ b/security/apparmor/2.13.2/usr.bin.qtox
@@ -176,6 +176,55 @@ profile qtox /usr{,/local}/bin/qtox {
     member={NewIcon,NewToolTip}
     peer=(label=unconfined),
 
+  dbus send
+    bus=system
+    path=/org/freedesktop/UPower
+    interface=org.freedesktop.DBus.Introspectable
+    member=Introspect
+    peer=(label=unconfined),
+
+  dbus send
+    bus=system
+    path=/org/freedesktop/UDisks2/{block_devices,block_devices/*,drives,drives/*}
+    interface=org.freedesktop.DBus.Introspectable
+    member=Introspect
+    peer=(label=unconfined),
+
+  dbus send
+    bus=system
+    path=/org/freedesktop/UDisks2/{block_devices,drives}/*
+    interface=org.freedesktop.DBus.Properties
+    member={Get,GetAll}
+    peer=(label=unconfined),
+
+  dbus send
+    bus=session
+    path=/org/freedesktop/DBus
+    interface=org.freedesktop.DBus
+    member=GetConnectionUnixUser
+    peer=(label=unconfined),
+
+  dbus send
+    bus=session
+    path=/
+    interface=org.kde.KDirNotify
+    member={enteredDirectory,leftDirectory}
+    peer=(label=unconfined),
+
+  dbus receive
+    bus=session
+    path=/
+    interface=org.kde.KDirNotify
+    member=FilesAdded
+    peer=(label=unconfined),
+
+  dbus send
+    bus=session
+    path=/KLauncher
+    interface=org.kde.KSlaveLauncher
+    member=requestSlave
+    peer=(label=unconfined),
+
   # Denied files
 
   # libpcre2 on openSUSE tries to mmap() shared memory on directory.
@@ -208,6 +257,7 @@ profile qtox /usr{,/local}/bin/qtox {
   /sys/bus/ r, # file dialog
   /sys/bus/usb/devices/ r, # file dialog
   /sys/class/ r, # file dialog
+  /sys/devices/**/uevent r, # file dialog
   /sys/devices/system/node/ r,  # for ld-linux-x86-64.so -> libnuma1.so
   /sys/devices/system/node/node[0-9]*/meminfo r, # for ld-linux-x86-64.so -> libnuma1.so
   /usr/share/emoticons/{,**} r,
@@ -215,6 +265,7 @@ profile qtox /usr{,/local}/bin/qtox {
   /usr/share/mime/ r, # file dialog
   /usr/share/plasma/look-and-feel/*/contents/defaults r, # TODO: move to kde abstraction?
   /usr/share/sounds/ r, # file dialog (alert)
+  /{,var/}run/udev/data/* r, # file dialog
 
   # User files
 

--- a/security/apparmor/2.13.2/usr.bin.qtox
+++ b/security/apparmor/2.13.2/usr.bin.qtox
@@ -325,4 +325,8 @@ profile qtox /usr{,/local}/bin/qtox {
   owner @{HOME}/.config/klanguageoverridesrc r, # per-application languages, for KDEPrivate::initializeLanguages() from libKF5XmlGui.so
   owner @{HOME}/.config/trashrc r, # Used by KFileWidget
 
+  # Backport dri-common abstraction
+  # commit 2d8d2f06d5697d9692330686bb5ddb0095621144
+  /usr/share/drirc.d/{,*.conf} r,
+
 }

--- a/security/apparmor/2.13.2/usr.bin.qtox
+++ b/security/apparmor/2.13.2/usr.bin.qtox
@@ -29,7 +29,7 @@ profile qtox /usr{,/local}/bin/qtox {
 
   # Main executable
 
-  @{qtox_prefix}/bin mr,
+  @{qtox_prefix}/bin/qtox mr,
 
   # Other executables
 

--- a/security/apparmor/2.13.2/usr.bin.qtox
+++ b/security/apparmor/2.13.2/usr.bin.qtox
@@ -247,4 +247,19 @@ profile qtox /usr{,/local}/bin/qtox {
   # commit 1250402471d9d83134b0faa90239a733a37f23f0
   owner @{HOME}/.cache/qt_compose_cache_{little,big}_endian_* rwl -> @{HOME}/.cache/#[0-9]*[0-9],
   owner @{HOME}/.cache/#[0-9]*[0-9] rw, # QSaveFile (anonymous shared memory)
+
+  # Backport kde abstraction
+  # commit aae838faca57905d2dbc27db7bffd595c09d26f0
+  # commit dc3b73daf9f648336a6f9ab90103acc962c0bf40
+  /etc/xdg/kdeglobals r,
+  /usr/share/knotifications5/*.notifyrc r, # KNotification::sendEvent()
+  /usr/share/kubuntu-default-settings/kf5-settings/* r,
+  owner @{HOME}/.cache/ksycoca5_??_* r, # KDE System Configuration Cache
+  owner @{HOME}/.config/baloofilerc r, # indexing options (excludes, etc), used by KFileWidget
+  owner @{HOME}/.config/dolphinrc r, # settings used by KFileWidget
+  owner @{HOME}/.config/kde.org/libphonon.conf r, # for KNotifications::sendEvent()
+  owner @{HOME}/.config/kdeglobals r, # global settings, used by Breeze style, etc.
+  owner @{HOME}/.config/klanguageoverridesrc r, # per-application languages, for KDEPrivate::initializeLanguages() from libKF5XmlGui.so
+  owner @{HOME}/.config/trashrc r, # Used by KFileWidget
+
 }

--- a/security/apparmor/2.13.2/usr.bin.qtox
+++ b/security/apparmor/2.13.2/usr.bin.qtox
@@ -56,6 +56,7 @@ profile qtox /usr{,/local}/bin/qtox {
 
   # System files
 
+  /usr/share/hunspell/* r,
   @{qtox_additional_rw_dirs}/ r,
   @{qtox_additional_rw_dirs}/** rw,
 

--- a/security/apparmor/2.13.2/usr.bin.qtox
+++ b/security/apparmor/2.13.2/usr.bin.qtox
@@ -45,8 +45,10 @@ profile qtox /usr{,/local}/bin/qtox {
 
   # Networking
 
-  network tcp,
-  network udp,
+  network inet udp,
+  network inet6 udp,
+  network inet tcp,
+  network inet6 tcp,
 
   # DBus
 

--- a/security/apparmor/2.13.2/usr.bin.qtox
+++ b/security/apparmor/2.13.2/usr.bin.qtox
@@ -69,11 +69,18 @@ profile qtox /usr{,/local}/bin/qtox {
     member=Introspect
     peer=(label=unconfined),
 
-  dbus send
+  dbus (send,receive)
     bus=session
     path=/StatusNotifierWatcher
     interface=org.freedesktop.DBus.Properties
     member=Get
+    peer=(label=unconfined),
+
+  dbus receive
+    bus=session
+    path=/StatusNotifierItem
+    interface=org.freedesktop.DBus.Properties
+    member=GetAll
     peer=(label=unconfined),
 
   dbus send
@@ -130,6 +137,41 @@ profile qtox /usr{,/local}/bin/qtox {
     path=/org/freedesktop/NetworkManager/Devices/[0-9]*
     interface=org.freedesktop.DBus.Properties
     member=GetAll
+    peer=(label=unconfined),
+
+  dbus send
+    bus=session
+    path=/StatusNotifierWatcher
+    interface=org.kde.StatusNotifierWatcher
+    member=RegisterStatusNotifierItem
+    peer=(label=unconfined),
+
+  dbus receive
+    bus=session
+    path=/StatusNotifierItem
+    interface=org.kde.StatusNotifierItem
+    member=Activate
+    peer=(label=unconfined),
+
+  dbus (send,receive)
+    bus=session
+    path=/MenuBar
+    interface=com.canonical.dbusmenu
+    member=GetLayout
+    peer=(label=unconfined),
+
+  dbus (send,receive)
+    bus=session
+    path=/MenuBar
+    interface=com.canonical.dbusmenu
+    member={AboutToShow,Event}
+    peer=(label=unconfined),
+
+  dbus send
+    bus=session
+    path=/StatusNotifierItem
+    interface=org.kde.StatusNotifierItem
+    member={NewIcon,NewToolTip}
     peer=(label=unconfined),
 
   # System files

--- a/security/apparmor/2.13.2/usr.bin.qtox
+++ b/security/apparmor/2.13.2/usr.bin.qtox
@@ -8,6 +8,7 @@
 profile qtox /usr{,/local}/bin/qtox {
   #include <abstractions/audio>
   #include <abstractions/base>
+  #include <abstractions/dbus-accessibility>
   #include <abstractions/dbus-session-strict>
   #include <abstractions/dri-enumerate>
   #include <abstractions/gnome>
@@ -43,6 +44,15 @@ profile qtox /usr{,/local}/bin/qtox {
 
   network tcp,
   network udp,
+
+  # DBus
+
+  dbus send
+    bus=session
+    path=/org/a11y/bus
+    interface=org.freedesktop.DBus.Properties
+    member=Get
+    peer=(label=unconfined),
 
   # System files
 

--- a/security/apparmor/2.13.2/usr.bin.qtox
+++ b/security/apparmor/2.13.2/usr.bin.qtox
@@ -11,6 +11,7 @@ profile qtox /usr{,/local}/bin/qtox {
   #include <abstractions/dbus-session-strict>
   #include <abstractions/dri-enumerate>
   #include <abstractions/gnome>
+  #include <abstractions/ibus>
   #include <abstractions/kde-globals-write>
   #include <abstractions/kde-icon-cache-write>
   #include <abstractions/kde>

--- a/security/apparmor/2.13.2/usr.bin.qtox
+++ b/security/apparmor/2.13.2/usr.bin.qtox
@@ -54,6 +54,83 @@ profile qtox /usr{,/local}/bin/qtox {
     member=Get
     peer=(label=unconfined),
 
+  dbus receive
+    bus=session
+    path=/
+    interface=org.freedesktop.DBus.Introspectable
+    member=Introspect
+    peer=(label=unconfined),
+
+  dbus send
+    bus=session
+    path=/StatusNotifierWatcher
+    interface=org.freedesktop.DBus.Introspectable
+    member=Introspect
+    peer=(label=unconfined),
+
+  dbus send
+    bus=session
+    path=/StatusNotifierWatcher
+    interface=org.freedesktop.DBus.Properties
+    member=Get
+    peer=(label=unconfined),
+
+  dbus send
+    bus=system
+    path=/org/freedesktop/NetworkManager
+    interface=org.freedesktop.DBus.Properties
+    member=GetAll
+    peer=(label=unconfined),
+
+  dbus send
+    bus=system
+    path=/org/freedesktop/NetworkManager
+    interface=org.freedesktop.NetworkManager
+    member=GetDevices
+    peer=(label=unconfined),
+
+  dbus receive
+    bus=system
+    path=/org/freedesktop/NetworkManager
+    interface=org.freedesktop.NetworkManager
+    member=PropertiesChanged
+    peer=(label=unconfined),
+
+  dbus send
+    bus=system
+    path=/org/freedesktop/NetworkManager/Settings
+    interface=org.freedesktop.NetworkManager.Settings
+    member=ListConnections
+    peer=(label=unconfined),
+
+  dbus send
+    bus=system
+    path=/org/freedesktop/NetworkManager/Settings/[0-9]*
+    interface=org.freedesktop.NetworkManager.Settings.Connection
+    member=GetSettings
+    peer=(label=unconfined),
+
+  dbus send
+    bus=system
+    path=/org/freedesktop/NetworkManager/ActiveConnection/[0-9]*
+    interface=org.freedesktop.DBus.Properties
+    member=GetAll
+    peer=(label=unconfined),
+
+  dbus receive
+    bus=system
+    path=/org/freedesktop/NetworkManager/ActiveConnection/[0-9]*
+    interface=org.freedesktop.NetworkManager.Connection.Active
+    member=PropertiesChanged
+    peer=(label=unconfined),
+
+  dbus send
+    bus=system
+    path=/org/freedesktop/NetworkManager/Devices/[0-9]*
+    interface=org.freedesktop.DBus.Properties
+    member=GetAll
+    peer=(label=unconfined),
+
   # System files
 
   /usr/share/hunspell/* r,

--- a/security/apparmor/2.13.2/usr.bin.qtox
+++ b/security/apparmor/2.13.2/usr.bin.qtox
@@ -18,6 +18,7 @@ profile qtox /usr{,/local}/bin/qtox {
   #include <abstractions/kde>
   #include <abstractions/mesa>
   #include <abstractions/nameservice>
+  #include <abstractions/openssl>
   #include <abstractions/qt5-compose-cache-write>
   #include <abstractions/qt5-settings-write>
   #include <abstractions/recent-documents-write>

--- a/security/apparmor/2.13.2/usr.bin.qtox
+++ b/security/apparmor/2.13.2/usr.bin.qtox
@@ -233,6 +233,10 @@ profile qtox /usr{,/local}/bin/qtox {
   # so we deny this path to protect from loading exploits from /tmp.
   deny /tmp/#[0-9][0-9][0-9][0-9][0-9] m,
 
+  # libfontconfig bug? Should not write to root-owned dirs.
+  deny /usr/share/fonts/** w,
+  deny /var/cache/fontconfig/ w,
+
   # System files
 
   /usr/share/hunspell/* r,
@@ -283,6 +287,7 @@ profile qtox /usr{,/local}/bin/qtox {
   owner /{,var/}run/user/@{uid}/qTox*.slave-socket rwl -> /{,var/}run/user/@{uid}/#[0-9]*[0-9], # file dialog
   owner @{HOME}/.cache/Tox/ w,
   owner @{HOME}/.cache/Tox/qTox/{,**} rw,
+  owner @{HOME}/.cache/fontconfig/** rwk,
   owner @{HOME}/.cache/qTox/{,**} rw,
   owner @{HOME}/.cache/thumbnails/** rw, # receiving image file produces thumbnail?
   owner @{HOME}/.config/menus/ r, # file dialog
@@ -292,6 +297,9 @@ profile qtox /usr{,/local}/bin/qtox {
   owner @{HOME}/.config/qToxrc.lock rwk,
   owner @{HOME}/.config/tox/** l -> @{HOME}/.config/tox/**, # QSaveFile?
   owner @{HOME}/.config/tox/{,**} rwk,
+  owner @{HOME}/.fonts/.uuid* rw,
+  owner @{HOME}/.fonts/.uuid.* l -> @{HOME}/.fonts/.uuid.*,
+  owner @{HOME}/.fonts/.uuid.*/ rw,
   owner @{HOME}/.local/share/qTox/{,**} rw,
   owner @{HOME}/.local/share/user-places.xbel r, # file dialog
   owner @{PROC}/@{pid}/cmdline r,

--- a/security/apparmor/2.13.2/usr.bin.qtox
+++ b/security/apparmor/2.13.2/usr.bin.qtox
@@ -265,6 +265,8 @@ profile qtox /usr{,/local}/bin/qtox {
   /sys/devices/system/node/ r,  # for ld-linux-x86-64.so -> libnuma1.so
   /sys/devices/system/node/node[0-9]*/meminfo r, # for ld-linux-x86-64.so -> libnuma1.so
   /usr/share/emoticons/{,**} r,
+  /usr/share/hwdata/pnp.ids r, # For OpenSUSE only?
+  /usr/share/icu/[0-9]*.[0-9]*/icudt[0-9]*.dat r, # For OpenSUSE only?
   /usr/share/kservices5/{,**} r, # file dialog
   /usr/share/mime/ r, # file dialog
   /usr/share/plasma/look-and-feel/*/contents/defaults r, # TODO: move to kde abstraction?

--- a/security/apparmor/2.13.2/usr.bin.qtox
+++ b/security/apparmor/2.13.2/usr.bin.qtox
@@ -302,6 +302,7 @@ profile qtox /usr{,/local}/bin/qtox {
   owner @{HOME}/.fonts/.uuid* rw,
   owner @{HOME}/.fonts/.uuid.* l -> @{HOME}/.fonts/.uuid.*,
   owner @{HOME}/.fonts/.uuid.*/ rw,
+  owner @{HOME}/.local/share/Tox/{,**} rw,
   owner @{HOME}/.local/share/qTox/{,**} rw,
   owner @{HOME}/.local/share/user-places.xbel r, # file dialog
   owner @{PROC}/@{pid}/cmdline r,

--- a/security/apparmor/README.md
+++ b/security/apparmor/README.md
@@ -1,20 +1,33 @@
 # Hardening qTox with AppArmor
 
-qTox can be confined with AppArmor on Linux to reduce attack vectors in case remote code execution exploit is being used. Please note that [MAC's] (of course) does not guarantee perfect security, but it will:
-- Deny access to your `~/.bashrc`, `~/.ssh/*` `~/.config/path/to/your/password/manager/file`, etc.
+qTox can be confined with AppArmor on Linux to reduce attack vectors in case
+remote code execution exploit is being used. Please note that [MAC's] (of
+course) does not guarantee perfect security, but it will:
+- Deny access to your `~/.bashrc`, `~/.ssh/*`
+  `~/.config/path/to/your/password/manager/file`, etc.
 - Deny creating autostart entries (in `~/.config/autostart`, etc).
 - Deny launching random executables (like `sudo`, `su`, etc...).
 - And more.
 
-Consider using additional security measures like [Firejail] to improve security even more.
+Consider using additional security measures like [Firejail] to improve security
+even more.
 
-Please also note that not all distributions has full AppArmor feature set available. For example, Debian (at least up to Debian 10 (buster)) does not have network, DBus mediation available. Also, X Server, shared user configuration files (like `~/.config/QtProject.conf`, caches, etc), opening web links via unconfined browsers introduces additional attack vectors, too. So please be cautious even with number of security measures applied.
+Please also note that not all distributions has full AppArmor feature set
+available. For example, Debian (at least up to Debian 10 (buster)) does not have
+network, DBus mediation available. Also, X Server, shared user configuration
+files (like `~/.config/QtProject.conf`, caches, etc), opening web links via
+unconfined browsers introduces additional attack vectors, too. So please be
+cautious even with number of security measures applied.
 
-**AppArmor profile attaches only to `/usr/bin/qtox` and `/usr/local/bin/qtox` executables by default**. See [Tuning permissions](#tuning-permissions) for custom setups.
+**AppArmor profile attaches only to `/usr/bin/qtox` and `/usr/local/bin/qtox`
+executables by default**. See [Tuning permissions](#tuning-permissions) for
+custom setups.
 
 ## Installing profile
 
-Select AppArmor profile from appropriate `security/apparmor/X` subdirectory depending on what AppArmor version is available for your Linux distribution release:
+Select AppArmor profile from appropriate `security/apparmor/X` subdirectory
+depending on what AppArmor version is available for your Linux distribution
+release:
 
 - 2.13.2
   - Debian 10 (buster) (or newer)
@@ -32,7 +45,8 @@ Restart `qTox` if it was already running before enabling AppArmor profile.
 
 ## Checking if qTox is actually confined
 
-Run `aa-status` command line utility and check if `qTox` is listed within `X processes are in enforced mode.` list:
+Run `aa-status` command line utility and check if `qTox` is listed within `X
+processes are in enforced mode.` list:
 ```
 sudo aa-status
    ...
@@ -51,11 +65,14 @@ ps auxZ | fgrep qtox
 qtox (enforce)                  vincas   16315  2.0  1.1 1502292 180220 ?      SLl  12:21   0:38 /usr/bin/qtox
 ```
 
-If OK it's marked as `(enforce)`. `uncofined` means AppArmor profile is not attached to the process, no confinement is being applied.
+If OK it's marked as `(enforce)`. `uncofined` means AppArmor profile is not
+attached to the process, no confinement is being applied.
 
 ## Troubleshooting
 
-If you believe that some feature is unavailable, or some files you need access to are inaccessible due to enforced AppArmor profile, check system logs for the hints.
+If you believe that some feature is unavailable, or some files you need access
+to are inaccessible due to enforced AppArmor profile, check system logs for the
+hints.
 
 On Debian/Ubuntu:
 
@@ -74,19 +91,27 @@ type=AVC msg=audit(1549793273.269:149): apparmor="DENIED" operation="open" profi
 rridesrc" pid=3037 comm="qtox" requested_mask="r" denied_mask="r" fsuid=1000 ouid=1000
 ```
 
-This means that `r`ead access was denied to the file `/home/vincas/.config/klanguageoverridesrc`, owned by you (ouid 1000), by AppArmor profile `qtox` (available in `/etc/apparmor.d/usr.bin.qtox`).
+This means that `r`ead access was denied to the file
+`/home/vincas/.config/klanguageoverridesrc`, owned by you (ouid 1000), by
+AppArmor profile `qtox` (available in `/etc/apparmor.d/usr.bin.qtox`).
 
-Please create issue if you detect new AppArmor `DENIED` messages and you believe that these denials are relevant for other users too. Meanwhile, workaround by adding manual rule. DO NOT modify `/etc/apparmor.d/usr.bin.qtox` directly! See [Tuning permissions](#tuning-permissions) for fixing access issues.
+Please create issue if you detect new AppArmor `DENIED` messages and you believe
+that these denials are relevant for other users too. Meanwhile, workaround by
+adding manual rule. DO NOT modify `/etc/apparmor.d/usr.bin.qtox` directly! See
+[Tuning permissions](#tuning-permissions) for fixing access issues.
 
 ## Tuning permissions
 
-If you need access to files (for file sharing) other than from your `$HOME` or mounted media, create/modify `/etc/apparmor.d/tunables/usr.bin.qtox.d/local` file and append writable path variable:
+If you need access to files (for file sharing) other than from your `$HOME` or
+mounted media, create/modify `/etc/apparmor.d/tunables/usr.bin.qtox.d/local`
+file and append writable path variable:
 
 ```
 @{qtox_additional_rw_dirs} += /path/to/some/directory
 ```
 
-Alternatively, if you need more custom/advanced rules (not only for file access), create/modify `/etc/apparmor.d/local/usr.bin.qtox` file.
+Alternatively, if you need more custom/advanced rules (not only for file
+access), create/modify `/etc/apparmor.d/local/usr.bin.qtox` file.
 
 Rule example for reading only, recursively (note the comma!):
 
@@ -105,17 +130,22 @@ Restart AppArmor to reload profiles after modifications:
 sudo systemctl restart apparmor
 ```
 
-If AppArmor restart fails, check syntax errors by invoking AppArmor parser directly:
+If AppArmor restart fails, check syntax errors by invoking AppArmor parser
+directly:
 
 ```
 sudo apparmor_parser -r /etc/apparmor.d/usr.bin.qtox
 ```
 
-For custom installations, when `qTox` executable is not `/usr/bin/qtox` or `/usr/local/bin/qtox`:
-1. create `/etc/apparmor.d/tunables/usr.bin.qtox.d/local`, adding `@{qtox_prefix} += /path/to/your/custom/install/prefix` line.
-2. modify `/etc/apparmor.d/usr.bin.qtox` profile attachement path: `profile qtox /{usr{,local}/bin/qtox,path/to/your/qtox_executable} {`
+For custom installations, when `qTox` executable is not `/usr/bin/qtox` or
+`/usr/local/bin/qtox`:
+1. create `/etc/apparmor.d/tunables/usr.bin.qtox.d/local`, adding
+   `@{qtox_prefix} += /path/to/your/custom/install/prefix` line.
+2. modify `/etc/apparmor.d/usr.bin.qtox` profile attachement path: `profile qtox
+   /{usr{,local}/bin/qtox,path/to/your/qtox_executable} {`
 
-Restart AppArmor and [check](#checking-if-qtox-is-actually-confined) if `qTox` process under custom path is actually confined.
+Restart AppArmor and [check](#checking-if-qtox-is-actually-confined) if `qTox`
+process under custom path is actually confined.
 
 ## Other resources
 

--- a/security/apparmor/README.md
+++ b/security/apparmor/README.md
@@ -113,7 +113,7 @@ sudo apparmor_parser -r /etc/apparmor.d/usr.bin.qtox
 
 For custom installations, when `qTox` executable is not `/usr/bin/qtox` or `/usr/local/bin/qtox`:
 1. create `/etc/apparmor.d/tunables/usr.bin.qtox.d/local`, adding `@{qtox_prefix} += /path/to/your/custom/install/prefix` line.
-2. modify `/etc/apparmor.d/usr.bin.qtox` profile attachement path: `profile qtox /usr{,local}/bin/qtox,/path/to/your/qtox_executable {`
+2. modify `/etc/apparmor.d/usr.bin.qtox` profile attachement path: `profile qtox /{usr{,local}/bin/qtox,path/to/your/qtox_executable} {`
 
 Restart AppArmor and [check](#checking-if-qtox-is-actually-confined) if `qTox` process under custom path is actually confined.
 

--- a/security/apparmor/README.md
+++ b/security/apparmor/README.md
@@ -26,8 +26,7 @@ Select AppArmor profile from appropriate `security/apparmor/X` subdirectory depe
 To enable AppArmor profile on your system, run prepared install script:
 
 ```
-cd security/apparmor/x.y.z
-sudo ./install.sh
+sudo security/apparmor/x.y.z/install.sh
 ```
 Restart `qTox` if it was already running before enabling AppArmor profile.
 

--- a/security/apparmor/README.md
+++ b/security/apparmor/README.md
@@ -1,12 +1,12 @@
 # Hardening qTox with AppArmor
 
-qTox can be confined with AppArmor on Linux to reduce attack vectors in case remote code execution exploit is being used. Please note that [MAC's](https://en.wikipedia.org/wiki/Mandatory_access_control) (of course) does not guarantee perfect security, but it will:
+qTox can be confined with AppArmor on Linux to reduce attack vectors in case remote code execution exploit is being used. Please note that [MAC's] (of course) does not guarantee perfect security, but it will:
 - Deny access to your `~/.bashrc`, `~/.ssh/*` `~/.config/path/to/your/password/manager/file`, etc.
 - Deny creating autostart entries (in `~/.config/autostart`, etc).
 - Deny launching random executables (like `sudo`, `su`, etc...).
 - And more.
 
-Consider using additional security measures like [Firejail](https://firejail.wordpress.com/) to improve security even more.
+Consider using additional security measures like [Firejail] to improve security even more.
 
 Please also note that not all distributions has full AppArmor feature set available. For example, Debian (at least up to Debian 10 (buster)) does not have network, DBus mediation available. Also, X Server, shared user configuration files (like `~/.config/QtProject.conf`, caches, etc), opening web links via unconfined browsers introduces additional attack vectors, too. So please be cautious even with number of security measures applied.
 
@@ -119,5 +119,10 @@ Restart AppArmor and [check](#checking-if-qtox-is-actually-confined) if `qTox` p
 
 ## Other resources
 
-Check [Debian](https://wiki.debian.org/AppArmor), [Ubuntu](https://wiki.ubuntu.com/AppArmor), [Upstream AppArmor](https://gitlab.com/apparmor/apparmor/wikis/home) Wiki pages for more info.
+Check [Debian], [Ubuntu], [Upstream AppArmor] Wiki pages for more info.
 
+[Debian]: https://wiki.debian.org/AppArmor
+[Firejail]: https://firejail.wordpress.com
+[MAC's]: https://en.wikipedia.org/wiki/Mandatory_access_control
+[Ubuntu]: https://wiki.ubuntu.com/AppArmor
+[Upstream AppArmor]: https://gitlab.com/apparmor/apparmor/wikis/home

--- a/security/apparmor/README.md
+++ b/security/apparmor/README.md
@@ -12,7 +12,7 @@ course) does not guarantee perfect security, but it will:
 Consider using additional security measures like [Firejail] to improve security
 even more.
 
-Please also note that not all distributions has full AppArmor feature set
+Please also note that not all distributions have full AppArmor feature set
 available. For example, Debian (at least up to Debian 10 (buster)) does not have
 network, DBus mediation available. Also, X Server, shared user configuration
 files (like `~/.config/QtProject.conf`, caches, etc), opening web links via
@@ -65,7 +65,7 @@ ps auxZ | fgrep qtox
 qtox (enforce)                  vincas   16315  2.0  1.1 1502292 180220 ?      SLl  12:21   0:38 /usr/bin/qtox
 ```
 
-If OK it's marked as `(enforce)`. `uncofined` means AppArmor profile is not
+If OK it's marked as `(enforce)`. `unconfined` means AppArmor profile is not
 attached to the process, no confinement is being applied.
 
 ## Troubleshooting

--- a/security/apparmor/README.md
+++ b/security/apparmor/README.md
@@ -1,0 +1,124 @@
+# Hardening qTox with AppArmor
+
+qTox can be confined with AppArmor on Linux to reduce attack vectors in case remote code execution exploit is being used. Please note that [MAC's](https://en.wikipedia.org/wiki/Mandatory_access_control) (of course) does not guarantee perfect security, but it will:
+- Deny access to your `~/.bashrc`, `~/.ssh/*` `~/.config/path/to/your/password/manager/file`, etc.
+- Deny creating autostart entries (in `~/.config/autostart`, etc).
+- Deny launching random executables (like `sudo`, `su`, etc...).
+- And more.
+
+Consider using additional security measures like [Firejail](https://firejail.wordpress.com/) to improve security even more.
+
+Please also note that not all distributions has full AppArmor feature set available. For example, Debian (at least up to Debian 10 (buster)) does not have network, DBus mediation available. Also, X Server, shared user configuration files (like `~/.config/QtProject.conf`, caches, etc), opening web links via unconfined browsers introduces additional attack vectors, too. So please be cautious even with number of security measures applied.
+
+**AppArmor profile attaches only to `/usr/bin/qtox` and `/usr/local/bin/qtox` executables by default**. See [Tuning permissions](#tuning-permissions) for custom setups.
+
+## Installing profile
+
+Select AppArmor profile from appropriate `security/apparmor/X` subdirectory depending on what AppArmor version is available for your Linux distribution release:
+
+- 2.13.2
+  - Debian 10 (buster) (or newer)
+  - openSUSE Tumbleweed
+- 2.12.1
+  - Debian 9 (stretch) or older
+  - Ubuntu 19.04 or older
+
+To enable AppArmor profile on your system, run prepared install script:
+
+```
+cd security/apparmor/x.y.z
+sudo ./install.sh
+```
+Restart `qTox` if it was already running before enabling AppArmor profile.
+
+## Checking if qTox is actually confined
+
+Run `aa-status` command line utility and check if `qTox` is listed within `X processes are in enforced mode.` list:
+```
+sudo aa-status
+   ...
+21 processes are in enforce mode.
+   /usr/lib/ipsec/charon (2421)            
+   /usr/sbin/cups-browsed (839)
+   ...
+   /usr/bin/qtox (16315) qtox
+   ...
+```
+
+Alternatively, use `ps` and `grep`:
+
+```
+ps auxZ | fgrep qtox
+qtox (enforce)                  vincas   16315  2.0  1.1 1502292 180220 ?      SLl  12:21   0:38 /usr/bin/qtox
+```
+
+If OK it's marked as `(enforce)`. `uncofined` means AppArmor profile is not attached to the process, no confinement is being applied.
+
+## Troubleshooting
+
+If you believe that some feature is unavailable, or some files you need access to are inaccessible due to enforced AppArmor profile, check system logs for the hints.
+
+On Debian/Ubuntu:
+
+```
+sudo fgrep DENIED /var/log/syslog
+```
+
+On openSUSE, OR if you have `auditd` daemon installed:
+```
+sudo fgrep DENIED /var/log/audit/audit.log
+```
+
+You will see messages like this:
+```
+type=AVC msg=audit(1549793273.269:149): apparmor="DENIED" operation="open" profile="qtox" name="/home/vincas/.config/klanguageove
+rridesrc" pid=3037 comm="qtox" requested_mask="r" denied_mask="r" fsuid=1000 ouid=1000
+```
+
+This means that `r`ead access was denied to the file `/home/vincas/.config/klanguageoverridesrc`, owned by you (ouid 1000), by AppArmor profile `qtox` (available in `/etc/apparmor.d/usr.bin.qtox`).
+
+Please create issue if you detect new AppArmor `DENIED` messages and you believe that these denials are relevant for other users too. Meanwhile, workaround by adding manual rule. DO NOT modify `/etc/apparmor.d/usr.bin.qtox` directly! See [Tuning permissions](#tuning-permissions) for fixing access issues.
+
+## Tuning permissions
+
+If you need access to files (for file sharing) other than from your `$HOME` or mounted media, create/modify `/etc/apparmor.d/tunables/usr.bin.qtox.d/local` file and append writable path variable:
+
+```
+@{qtox_additional_rw_dirs} += /path/to/some/directory
+```
+
+Alternatively, if you need more custom/advanced rules (not only for file access), create/modify `/etc/apparmor.d/local/usr.bin.qtox` file.
+
+Rule example for reading only, recursively (note the comma!):
+
+```
+/path/to/directory/** r,
+```
+
+For reading and writing, recursively:
+```
+/path/to/directory/** rw,
+```
+
+Restart AppArmor to reload profiles after modifications:
+
+```
+sudo systemctl restart apparmor
+```
+
+If AppArmor restart fails, check syntax errors by invoking AppArmor parser directly:
+
+```
+sudo apparmor_parser -r /etc/apparmor.d/usr.bin.qtox
+```
+
+For custom installations, when `qTox` executable is not `/usr/bin/qtox` or `/usr/local/bin/qtox`:
+1. create `/etc/apparmor.d/tunables/usr.bin.qtox.d/local`, adding `@{qtox_prefix} += /path/to/your/custom/install/prefix` line.
+2. modify `/etc/apparmor.d/usr.bin.qtox` profile attachement path: `profile qtox /usr{,local}/bin/qtox,/path/to/your/qtox_executable {`
+
+Restart AppArmor and [check](#checking-if-qtox-is-actually-confined) if `qTox` process under custom path is actually confined.
+
+## Other resources
+
+Check [Debian](https://wiki.debian.org/AppArmor), [Ubuntu](https://wiki.ubuntu.com/AppArmor), [Upstream AppArmor](https://gitlab.com/apparmor/apparmor/wikis/home) Wiki pages for more info.
+


### PR DESCRIPTION
Introduce AppArmor profile increaced security in Linux, reducing simplest attack vectors.

AppArmor profiles where developed on various distros - Debian Strech and Debian Buster (Sid) with KDE/Gnome, Ubuntu 18.04, openSUSE Tumbleweed, and maybe more configurations I do not recall.

Closes #5484

- [ x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5577)
<!-- Reviewable:end -->
