### PR TITLE
chore(cmake): add libatomic to target_link_libraries when required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -683,6 +683,7 @@ add_library(${PROJECT_NAME}_static
   ${${PROJECT_NAME}_QM_FILES}
   ${${PROJECT_NAME}_RESOURCES})
 target_link_libraries(${PROJECT_NAME}_static
+  ${CMAKE_REQUIRED_LIBRARIES}
   ${ALL_LIBRARIES})
 
 add_executable(${PROJECT_NAME}
@@ -692,6 +693,7 @@ add_executable(${PROJECT_NAME}
   src/main.cpp)
 target_link_libraries(${PROJECT_NAME}
   ${PROJECT_NAME}_static
+  ${CMAKE_REQUIRED_LIBRARIES}
   ${ALL_LIBRARIES})
 
 include(Testing)

--- a/cmake/CheckAtomic.cmake
+++ b/cmake/CheckAtomic.cmake
@@ -8,7 +8,7 @@ INCLUDE(CheckLibraryExists)
 
 function(check_working_cxx_atomics varname)
   set(OLD_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
-  set(CMAKE_REQUIRED_FLAGS "-std=c++11")
+  set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -std=c++11")
   CHECK_CXX_SOURCE_COMPILES("
 #include <atomic>
 std::atomic<int> x;
@@ -34,10 +34,26 @@ int main() {
   set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})
 endfunction(check_working_cxx_atomics64)
 
+# Determine if the compiler has GCC-compatible command-line syntax.
+
+if(NOT DEFINED COMPILER_IS_GCC_COMPATIBLE)
+  if(CMAKE_COMPILER_IS_GNUCXX)
+    set(COMPILER_IS_GCC_COMPATIBLE ON)
+  elseif( MSVC )
+    set(COMPILER_IS_GCC_COMPATIBLE OFF)
+  elseif( "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" )
+    set(COMPILER_IS_GCC_COMPATIBLE ON)
+  elseif( "${CMAKE_CXX_COMPILER_ID}" MATCHES "Intel" )
+    set(COMPILER_IS_GCC_COMPATIBLE ON)
+  else()
+    message(STATUS "Warning: Unknown compiler, assume GCC compatible")
+    set(COMPILER_IS_GCC_COMPATIBLE ON)
+  endif()
+endif()
 
 # This isn't necessary on MSVC, so avoid command-line switch annoyance
 # by only running on GCC-like hosts.
-if (LLVM_COMPILER_IS_GCC_COMPATIBLE)
+if (COMPILER_IS_GCC_COMPATIBLE)
   # First check if atomics work without the library.
   check_working_cxx_atomics(HAVE_CXX_ATOMICS_WITHOUT_LIB)
   # If not, check if the library exists, and atomics work with it.
@@ -74,34 +90,4 @@ if(NOT HAVE_CXX_ATOMICS64_WITHOUT_LIB)
   else()
     message(FATAL_ERROR "Host compiler appears to require libatomic, but cannot find it.")
   endif()
-endif()
-
-## TODO: This define is only used for the legacy atomic operations in
-## llvm's Atomic.h, which should be replaced.  Other code simply
-## assumes C++11 <atomic> works.
-CHECK_CXX_SOURCE_COMPILES("
-#ifdef _MSC_VER
-#include <Intrin.h> /* Workaround for PR19898. */
-#include <windows.h>
-#endif
-int main() {
-#ifdef _MSC_VER
-        volatile LONG val = 1;
-        MemoryBarrier();
-        InterlockedCompareExchange(&val, 0, 1);
-        InterlockedIncrement(&val);
-        InterlockedDecrement(&val);
-#else
-        volatile unsigned long val = 1;
-        __sync_synchronize();
-        __sync_val_compare_and_swap(&val, 1, 0);
-        __sync_add_and_fetch(&val, 1);
-        __sync_sub_and_fetch(&val, 1);
-#endif
-        return 0;
-      }
-" LLVM_HAS_ATOMICS)
-
-if( NOT LLVM_HAS_ATOMICS )
-  message(STATUS "Warning: LLVM will be built thread-unsafe because atomic builtins are missing")
 endif()


### PR DESCRIPTION
Looks like CMAKE_REQUIRED_LIBRARIES are not automatically linked against.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5589)
<!-- Reviewable:end -->
