### PR TITLE
fix(settings): load personal settings before constructing core

### DIFF
--- a/src/nexus.cpp
+++ b/src/nexus.cpp
@@ -270,7 +270,7 @@ void Nexus::setProfile(Profile* profile)
 {
     getInstance().profile = profile;
     if (profile)
-        Settings::getInstance().loadPersonal(profile);
+        Settings::getInstance().loadPersonal(profile->getName(), profile->getPasskey());
 }
 
 /**

--- a/src/persistence/profile.h
+++ b/src/persistence/profile.h
@@ -98,7 +98,7 @@ private slots:
     void onAvatarOfferReceived(uint32_t friendId, uint32_t fileId, const QByteArray& avatarHash);
 
 private:
-    Profile(QString name, const QString& password, bool newProfile, const QByteArray& toxsave);
+    Profile(QString name, const QString& password, bool newProfile, const QByteArray& toxsave, std::unique_ptr<ToxEncrypt> passKey);
     static QStringList getFilesByExt(QString extension);
     QString avatarPath(const ToxPk& owner, bool forceUnencrypted = false);
     bool saveToxSave(QByteArray data);

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -273,17 +273,7 @@ void Settings::loadGlobal()
     loaded = true;
 }
 
-void Settings::loadPersonal()
-{
-    Profile* profile = Nexus::getProfile();
-    if (!profile) {
-        qCritical() << "No active profile, couldn't load personal settings";
-        return;
-    }
-    loadPersonal(profile);
-}
-
-void Settings::loadPersonal(Profile* profile)
+void Settings::loadPersonal(QString profileName, const ToxEncrypt* passKey)
 {
     QMutexLocker locker{&bigLock};
 
@@ -291,13 +281,13 @@ void Settings::loadPersonal(Profile* profile)
     QString filePath = dir.filePath(globalSettingsFile);
 
     // load from a profile specific friend data list if possible
-    QString tmp = dir.filePath(profile->getName() + ".ini");
+    QString tmp = dir.filePath(profileName + ".ini");
     if (QFile(tmp).exists()) // otherwise, filePath remains the global file
         filePath = tmp;
 
     qDebug() << "Loading personal settings from" << filePath;
 
-    SettingsSerializer ps(filePath, profile->getPasskey());
+    SettingsSerializer ps(filePath, passKey);
     ps.load();
     friendLst.clear();
 

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -146,8 +146,7 @@ public:
     void savePersonal();
 
     void loadGlobal();
-    void loadPersonal();
-    void loadPersonal(Profile* profile);
+    void loadPersonal(QString profileName, const ToxEncrypt* passKey);
 
     void resetToDefault();
 


### PR DESCRIPTION
Fix proxy settings not being passed to toxcore, bug present since
857416294999fa62204d7117deb3daf5c5d73621. Not present in any releases.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5596)
<!-- Reviewable:end -->
