### PR TITLE
fix(alias): allow clearing alias from chatformheader

### DIFF
--- a/src/widget/chatformheader.cpp
+++ b/src/widget/chatformheader.cpp
@@ -121,7 +121,7 @@ ChatFormHeader::ChatFormHeader(QWidget* parent)
     nameLabel->setMinimumHeight(Style::getFont(Style::Medium).pixelSize());
     nameLabel->setEditable(true);
     nameLabel->setTextFormat(Qt::PlainText);
-    connect(nameLabel, &CroppingLabel::editFinished, this, &ChatFormHeader::onNameChanged);
+    connect(nameLabel, &CroppingLabel::editFinished, this, &ChatFormHeader::nameChanged);
 
     headTextLayout = new QVBoxLayout();
     headTextLayout->addStretch();
@@ -302,12 +302,4 @@ void ChatFormHeader::addLayout(QLayout* layout)
 void ChatFormHeader::addStretch()
 {
     headTextLayout->addStretch();
-}
-
-void ChatFormHeader::onNameChanged(const QString& name)
-{
-    if (!name.isEmpty()) {
-        nameLabel->setText(name);
-        emit nameChanged(name);
-    }
 }

--- a/src/widget/chatformheader.h
+++ b/src/widget/chatformheader.h
@@ -91,7 +91,6 @@ signals:
     void callRejected();
 
 private slots:
-    void onNameChanged(const QString& name);
     void retranslateUi();
     void updateButtonsView();
 


### PR DESCRIPTION
Now has the same logic as FriendWidget. Before clearing the field would result in no change being made, instead of clearing the alias.

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5608)
<!-- Reviewable:end -->
