### PR TITLE
refactor(avatar): split up setAvatar function

### DIFF
--- a/src/model/profile/profileinfo.h
+++ b/src/model/profile/profileinfo.h
@@ -20,6 +20,7 @@
 #include "iprofileinfo.h"
 
 class Core;
+class QFile;
 class QPoint;
 class Profile;
 
@@ -50,6 +51,9 @@ public:
     void removeAvatar() override;
 
 private:
+    IProfileInfo::SetAvatarResult createAvatarFromFile(QFile& file, QByteArray& avatar);
+    IProfileInfo::SetAvatarResult byteArrayToPng(QByteArray inData, QByteArray& outPng);
+    IProfileInfo::SetAvatarResult scalePngToAvatar(QByteArray& avatar);
     Profile* const profile;
     Core* const core;
 };


### PR DESCRIPTION
Don't convert to QPixMap before saving. Allow for use of file without re-encoding once metadata stripping is available for PNGs.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5609)
<!-- Reviewable:end -->
