### PR TITLE
fix(widget): fix freeze on showMainGui

### DIFF
--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1850,8 +1850,6 @@ Group* Widget::createGroup(int groupId, const GroupId& groupPersistentId)
     }
 
     const auto groupName = tr("Groupchat #%1").arg(groupId);
-    Core* core = core;
-
     bool enabled = core->getGroupAvEnabled(groupId);
     Group* newgroup = GroupList::addGroup(groupId, groupPersistentId, groupName, enabled, core->getUsername());
     std::shared_ptr<GroupChatroom> chatroom(new GroupChatroom(newgroup));
@@ -2412,7 +2410,6 @@ void Widget::setActiveToolMenuButton(ActiveToolMenuButton newActiveButton)
 
 void Widget::retranslateUi()
 {
-    Core* core = core;
     ui->retranslateUi(this);
     setUsername(core->getUsername());
     setStatusMessage(core->getStatusMessage());


### PR DESCRIPTION
Don't use copied uninitialized shadowing Core* in Widget

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5616)
<!-- Reviewable:end -->
