### PR TITLE
refactor(id): use toxPk and groupId instead of core numbers

### DIFF
--- a/src/core/contactid.h
+++ b/src/core/contactid.h
@@ -28,9 +28,9 @@ protected:
     QByteArray id;
 };
 
-inline uint qHash(const std::shared_ptr<const ContactId> id)
+inline uint qHash(const ContactId& id)
 {
-    return qHash(id->getByteArray());
+    return qHash(id.getByteArray());
 }
 
 using ContactIdPtr = std::shared_ptr<const ContactId>;

--- a/src/friendlist.h
+++ b/src/friendlist.h
@@ -35,16 +35,16 @@ class FriendList
 {
 public:
     static Friend* addFriend(uint32_t friendId, const ToxPk& friendPk);
-    static Friend* findFriend(uint32_t friendId);
     static Friend* findFriend(const ToxPk& friendPk);
+    static const ToxPk& id2Key(uint32_t friendId);
     static QList<Friend*> getAllFriends();
-    static void removeFriend(uint32_t friendId, bool fake = false);
+    static void removeFriend(const ToxPk& friendPk, bool fake = false);
     static void clear();
-    static QString decideNickname(ToxPk peerPk, const QString origName); 
+    static QString decideNickname(const ToxPk& friendPk, const QString origName);
 
 private:
-    static QHash<uint32_t, Friend*> friendList;
-    static QHash<QByteArray, uint32_t> key2id;
+    static QHash<ToxPk, Friend*> friendList;
+    static QHash<uint32_t, ToxPk> id2key;
 };
 
 #endif // FRIENDLIST_H

--- a/src/grouplist.cpp
+++ b/src/grouplist.cpp
@@ -22,22 +22,22 @@
 #include <QDebug>
 #include <QHash>
 
-QHash<int, Group*> GroupList::groupList;
-
-Group* GroupList::addGroup(int groupId, const GroupId& persistentGroupId, const QString& name, bool isAvGroupchat,
+QHash<const GroupId, Group*> GroupList::groupList;
+QHash<uint32_t, GroupId> GroupList::id2key;
+Group* GroupList::addGroup(int groupNum, const GroupId& groupId, const QString& name, bool isAvGroupchat,
                            const QString& selfName)
 {
     auto checker = groupList.find(groupId);
     if (checker != groupList.end())
         qWarning() << "addGroup: groupId already taken";
 
-    Group* newGroup = new Group(groupId, persistentGroupId, name, isAvGroupchat, selfName);
+    Group* newGroup = new Group(groupNum, groupId, name, isAvGroupchat, selfName);
     groupList[groupId] = newGroup;
-
+    id2key[groupNum] = groupId;
     return newGroup;
 }
 
-Group* GroupList::findGroup(int groupId)
+Group* GroupList::findGroup(const GroupId& groupId)
 {
     auto g_it = groupList.find(groupId);
     if (g_it != groupList.end())
@@ -46,7 +46,12 @@ Group* GroupList::findGroup(int groupId)
     return nullptr;
 }
 
-void GroupList::removeGroup(int groupId, bool /*fake*/)
+const GroupId& GroupList::id2Key(uint32_t groupNum)
+{
+    return id2key[groupNum];
+}
+
+void GroupList::removeGroup(const GroupId& groupId, bool /*fake*/)
 {
     auto g_it = groupList.find(groupId);
     if (g_it != groupList.end()) {

--- a/src/grouplist.h
+++ b/src/grouplist.h
@@ -33,13 +33,15 @@ class GroupList
 {
 public:
     static Group* addGroup(int groupId, const GroupId& persistentGroupId, const QString& name, bool isAvGroupchat, const QString& selfName);
-    static Group* findGroup(int groupId);
-    static void removeGroup(int groupId, bool fake = false);
+    static Group* findGroup(const GroupId& groupId);
+    static const GroupId& id2Key(uint32_t groupNum);
+    static void removeGroup(const GroupId& groupId, bool fake = false);
     static QList<Group*> getAllGroups();
     static void clear();
 
 private:
-    static QHash<int, Group*> groupList;
+    static QHash<const GroupId, Group*> groupList;
+    static QHash<uint32_t, GroupId> id2key;
 };
 
 #endif // GROUPLIST_H

--- a/src/model/friend.cpp
+++ b/src/model/friend.cpp
@@ -57,7 +57,7 @@ void Friend::setName(const QString& _name)
     }
     if (userName != name) {
         userName = name;
-        emit nameChanged(friendId, name);
+        emit nameChanged(friendPk, name);
     }
 
     const auto newDisplayed = getDisplayedName();
@@ -74,7 +74,7 @@ void Friend::setAlias(const QString& alias)
     if (userAlias == alias) {
         return;
     }
-    emit aliasChanged(friendId, alias);
+    emit aliasChanged(friendPk, alias);
 
     // save old displayed name to be able to compare for changes
     const auto oldDisplayed = getDisplayedName();
@@ -98,7 +98,7 @@ void Friend::setStatusMessage(const QString& message)
 {
     if (statusMessage != message) {
         statusMessage = message;
-        emit statusMessageChanged(friendId, message);
+        emit statusMessageChanged(friendPk, message);
     }
 }
 
@@ -156,7 +156,7 @@ void Friend::setStatus(Status s)
 {
     if (friendStatus != s) {
         friendStatus = s;
-        emit statusChanged(friendId, friendStatus);
+        emit statusChanged(friendPk, friendStatus);
     }
 }
 

--- a/src/model/friend.h
+++ b/src/model/friend.h
@@ -55,10 +55,10 @@ public:
     bool isOnline() const;
 
 signals:
-    void nameChanged(uint32_t friendId, const QString& name);
-    void aliasChanged(uint32_t friendId, QString alias);
-    void statusChanged(uint32_t friendId, Status status);
-    void statusMessageChanged(uint32_t friendId, const QString& message);
+    void nameChanged(const ToxPk& friendId, const QString& name);
+    void aliasChanged(const ToxPk& friendId, QString alias);
+    void statusChanged(const ToxPk& friendId, Status status);
+    void statusMessageChanged(const ToxPk& friendId, const QString& message);
     void loadChatHistory();
 
 public slots:

--- a/src/model/group.cpp
+++ b/src/model/group.cpp
@@ -52,7 +52,7 @@ void Group::updatePeer(int peerId, QString name)
     ToxPk peerKey = Core::getInstance()->getGroupPeerPk(groupId, peerId);
     toxpks[peerKey] = name;
     qDebug() << "name change: " + name;
-    emit userListChanged(groupId, toxpks);
+    emit userListChanged(persistentGroupId, toxpks);
 }
 
 void Group::setName(const QString& newTitle)
@@ -61,8 +61,8 @@ void Group::setName(const QString& newTitle)
     if (!shortTitle.isEmpty() && title != shortTitle) {
         title = shortTitle;
         emit displayedNameChanged(title);
-        emit titleChangedByUser(groupId, title);
-        emit titleChanged(groupId, selfName, title);
+        emit titleChangedByUser(persistentGroupId, title);
+        emit titleChanged(persistentGroupId, selfName, title);
     }
 }
 
@@ -72,7 +72,7 @@ void Group::setTitle(const QString& author, const QString& newTitle)
     if (!shortTitle.isEmpty() && title != shortTitle) {
         title = shortTitle;
         emit displayedNameChanged(title);
-        emit titleChanged(groupId, author, title);
+        emit titleChanged(persistentGroupId, author, title);
     }
 }
 
@@ -114,7 +114,7 @@ void Group::regeneratePeerList()
     if (avGroupchat) {
         stopAudioOfDepartedPeers(oldPeers, toxpks);
     }
-    emit userListChanged(groupId, toxpks);
+    emit userListChanged(persistentGroupId, toxpks);
 }
 
 bool Group::peerHasNickname(ToxPk pk)
@@ -125,7 +125,7 @@ bool Group::peerHasNickname(ToxPk pk)
 void Group::updateUsername(ToxPk pk, const QString newName)
 {
     toxpks[pk] = newName;
-    emit userListChanged(groupId, toxpks);
+    emit userListChanged(persistentGroupId, toxpks);
 }
 
 bool Group::isAvGroupchat() const
@@ -138,7 +138,7 @@ uint32_t Group::getId() const
     return groupId;
 }
 
-const ContactId& Group::getPersistentId() const
+const GroupId& Group::getPersistentId() const
 {
     return persistentGroupId;
 }

--- a/src/model/group.h
+++ b/src/model/group.h
@@ -37,7 +37,7 @@ public:
     Group(int groupId, const GroupId persistentGroupId, const QString& name, bool isAvGroupchat, const QString& selfName);
     bool isAvGroupchat() const;
     uint32_t getId() const override;
-    const ContactId& getPersistentId() const override;
+    const GroupId& getPersistentId() const override;
     int getPeersCount() const;
     void regeneratePeerList();
     const QMap<ToxPk, QString>& getPeerList() const;
@@ -60,9 +60,9 @@ public:
     QString getSelfName() const;
 
 signals:
-    void titleChangedByUser(uint32_t groupId, const QString& title);
-    void titleChanged(uint32_t groupId, const QString& author, const QString& title);
-    void userListChanged(uint32_t groupId, const QMap<ToxPk, QString>& toxpks);
+    void titleChangedByUser(const GroupId& groupId, const QString& title);
+    void titleChanged(const GroupId& groupId, const QString& author, const QString& title);
+    void userListChanged(const GroupId& groupId, const QMap<ToxPk, QString>& toxpks);
 
 private:
     void stopAudioOfDepartedPeers(const QList<ToxPk>& oldPks, const QMap<ToxPk, QString>& newPks);

--- a/src/video/netcamview.cpp
+++ b/src/video/netcamview.cpp
@@ -31,10 +31,10 @@
 #include <QFrame>
 #include <QLabel>
 
-NetCamView::NetCamView(int friendId, QWidget* parent)
+NetCamView::NetCamView(ToxPk friendPk, QWidget* parent)
     : GenericNetCamView(parent)
     , selfFrame{nullptr}
-    , friendPk{FriendList::findFriend(friendId)->getPublicKey()}
+    , friendPk{friendPk}
     , e(false)
 {
     videoSurface = new VideoSurface(Nexus::getProfile()->loadAvatar(friendPk), this);

--- a/src/video/netcamview.h
+++ b/src/video/netcamview.h
@@ -35,7 +35,7 @@ class NetCamView : public GenericNetCamView
     Q_OBJECT
 
 public:
-    NetCamView(int friendId, QWidget* parent = nullptr);
+    NetCamView(ToxPk friendPk, QWidget* parent = nullptr);
     ~NetCamView();
 
     virtual void show(VideoSource* source, const QString& title);

--- a/src/widget/circlewidget.cpp
+++ b/src/widget/circlewidget.cpp
@@ -142,8 +142,11 @@ void CircleWidget::contextMenuEvent(QContextMenuEvent* event)
 
 void CircleWidget::dragEnterEvent(QDragEnterEvent* event)
 {
-    ToxId toxId(event->mimeData()->text());
-    Friend* f = FriendList::findFriend(toxId.getPublicKey());
+    if(!event->mimeData()->hasFormat("toxPk")) {
+        return;
+    }
+    ToxPk toxPk(event->mimeData()->data("toxPk"));
+    Friend* f = FriendList::findFriend(toxPk);
     if (f != nullptr)
         event->acceptProposedAction();
 
@@ -165,14 +168,17 @@ void CircleWidget::dropEvent(QDropEvent* event)
     if (!widget)
         return;
 
+    if (!event->mimeData()->hasFormat("toxPk")) {
+        return;
+    }
     // Check, that the user has a friend with the same ToxId
-    ToxId toxId(event->mimeData()->text());
-    Friend* f = FriendList::findFriend(toxId.getPublicKey());
+    ToxPk toxPk{event->mimeData()->data("toxPk")};
+    Friend* f = FriendList::findFriend(toxPk);
     if (!f)
         return;
 
     // Save CircleWidget before changing the Id
-    int circleId = Settings::getInstance().getFriendCircleID(toxId.getPublicKey());
+    int circleId = Settings::getInstance().getFriendCircleID(toxPk);
     CircleWidget* circleWidget = getFromID(circleId);
 
     addFriendWidget(widget, f->getStatus());

--- a/src/widget/contentdialog.cpp
+++ b/src/widget/contentdialog.cpp
@@ -458,8 +458,9 @@ void ContentDialog::dragEnterEvent(QDragEnterEvent* event)
     FriendWidget* frnd = qobject_cast<FriendWidget*>(o);
     GroupWidget* group = qobject_cast<GroupWidget*>(o);
     if (frnd) {
-        ToxId toxId(event->mimeData()->text());
-        Friend* contact = FriendList::findFriend(toxId.getPublicKey());
+        assert(event->mimeData()->hasFormat("toxPk"));
+        ToxPk toxPk{event->mimeData()->data("toxPk")};
+        Friend* contact = FriendList::findFriend(toxPk);
         if (!contact) {
             return;
         }
@@ -471,11 +472,7 @@ void ContentDialog::dragEnterEvent(QDragEnterEvent* event)
             event->acceptProposedAction();
         }
     } else if (group) {
-        qDebug() << event->mimeData()->formats();
-        if (!event->mimeData()->hasFormat("groupId")) {
-            return;
-        }
-
+        assert(event->mimeData()->hasFormat("groupId"));
         GroupId groupId = GroupId{event->mimeData()->data("groupId")};
         Group* contact = GroupList::findGroup(groupId);
         if (!contact) {
@@ -494,8 +491,9 @@ void ContentDialog::dropEvent(QDropEvent* event)
     FriendWidget* frnd = qobject_cast<FriendWidget*>(o);
     GroupWidget* group = qobject_cast<GroupWidget*>(o);
     if (frnd) {
-        ToxId toxId(event->mimeData()->text());
-        Friend* contact = FriendList::findFriend(toxId.getPublicKey());
+        assert(event->mimeData()->hasFormat("toxPk"));
+        const ToxPk toxId(event->mimeData()->data("toxPk"));
+        Friend* contact = FriendList::findFriend(toxId);
         if (!contact) {
             return;
         }
@@ -503,11 +501,8 @@ void ContentDialog::dropEvent(QDropEvent* event)
         Widget::getInstance()->addFriendDialog(contact, this);
         ensureSplitterVisible();
     } else if (group) {
-        if (!event->mimeData()->hasFormat("groupId")) {
-            return;
-        }
-
-        int groupId = event->mimeData()->data("groupId").toInt();
+        assert(event->mimeData()->hasFormat("groupId"));
+        const GroupId groupId(event->mimeData()->data("groupId"));
         Group* contact = GroupList::findGroup(groupId);
         if (!contact) {
             return;

--- a/src/widget/contentdialog.h
+++ b/src/widget/contentdialog.h
@@ -58,8 +58,8 @@ public:
 
     FriendWidget* addFriend(std::shared_ptr<FriendChatroom> chatroom, GenericChatForm* form);
     GroupWidget* addGroup(std::shared_ptr<GroupChatroom> chatroom, GenericChatForm* form);
-    void removeFriend(int friendId);
-    void removeGroup(int groupId);
+    void removeFriend(const ToxPk& friendPk);
+    void removeGroup(const GroupId& groupId);
     int chatroomWidgetCount() const;
     void ensureSplitterVisible();
     void updateTitleAndStatusIcon();
@@ -71,23 +71,14 @@ public:
     void addFriendWidget(FriendWidget* widget, Status status);
     bool isActiveWidget(GenericChatroomWidget* widget);
 
-    bool hasFriendWidget(int friendId) const;
-    bool hasGroupWidget(int groupId) const;
+    bool hasContactWidget(const ContactId& contactId) const;
+    void focusContact(const ContactId& friendPk);
+    bool containsContact(const ContactId& friendPk) const;
+    void updateFriendStatus(const ToxPk& friendPk, Status status);
+    void updateContactStatusLight(const ContactId& contactId);
+    bool isContactWidgetActive(const ContactId& contactId);
 
-    void focusFriend(int friendId);
-    void focusGroup(int groupId);
-
-    bool containsFriend(int friendId) const;
-    bool containsGroup(int groupId) const;
-
-    void updateFriendStatus(int friendId, Status status);
-    void updateFriendStatusLight(int friendId);
-    void updateGroupStatusLight(int groupId);
-
-    bool isFriendWidgetActive(int friendId);
-    bool isGroupWidgetActive(int groupId);
-
-    void setStatusMessage(int friendId, const QString& message);
+    void setStatusMessage(const ToxPk& friendPk, const QString& message);
 
 signals:
     void friendDialogShown(const Friend* f);
@@ -114,7 +105,7 @@ public slots:
     void activate(GenericChatroomWidget* widget);
 
 private slots:
-    void updateFriendWidget(uint32_t friendId, QString alias);
+    void updateFriendWidget(const ToxPk& friendPk, QString alias);
     void onGroupchatPositionChanged(bool top);
 
 private:
@@ -126,7 +117,7 @@ private:
     void saveSplitterState();
     QLayout* nextLayout(QLayout* layout, bool forward) const;
     int getCurrentLayout(QLayout*& layout);
-    void focusCommon(int id, QHash<int, GenericChatroomWidget*> list);
+    void focusCommon(const ContactId& id, QHash<const ContactId&, GenericChatroomWidget*> list);
 
 private:
 
@@ -139,11 +130,8 @@ private:
     QSize videoSurfaceSize;
     int videoCount;
 
-    QHash<int, GenericChatroomWidget*> friendWidgets;
-    QHash<int, GenericChatroomWidget*> groupWidgets;
-
-    QHash<int, GenericChatForm*> friendChatForms;
-    QHash<int, GenericChatForm*> groupChatForms;
+    QHash<const ContactId&, GenericChatroomWidget*> contactWidgets;
+    QHash<const ContactId&, GenericChatForm*> contactChatForms;
 
     QString username;
 };

--- a/src/widget/contentdialogmanager.h
+++ b/src/widget/contentdialogmanager.h
@@ -20,8 +20,12 @@
 #ifndef _CONTENT_DIALOG_MANAGER_H_
 #define _CONTENT_DIALOG_MANAGER_H_
 
-#include <QObject>
+#include "src/core/contactid.h"
+#include "src/core/toxpk.h"
+#include "src/core/groupid.h"
 #include "contentdialog.h"
+
+#include <QObject>
 
 /**
  * @breaf Manage all content dialogs
@@ -31,16 +35,13 @@ class ContentDialogManager : public QObject
     Q_OBJECT
 public:
     ContentDialog* current();
-    bool friendWidgetExists(int friendId);
-    bool groupWidgetExists(int groupId);
-    void focusFriend(int friendId);
-    void focusGroup(int groupId);
-    void updateFriendStatus(int friendId);
-    void updateGroupStatus(int groupId);
-    bool isFriendWidgetActive(int friendId);
-    bool isGroupWidgetActive(int groupId);
-    ContentDialog* getFriendDialog(int friendId) const;
-    ContentDialog* getGroupDialog(int groupId) const;
+    bool contactWidgetExists(const ContactId& groupId);
+    void focusContact(const ContactId& contactId);
+    void updateFriendStatus(const ToxPk& friendPk);
+    void updateGroupStatus(const GroupId& friendPk);
+    bool isContactWidgetActive(const ContactId& contactId);
+    ContentDialog* getFriendDialog(const ToxPk& friendPk) const;
+    ContentDialog* getGroupDialog(const GroupId& friendPk) const;
 
     FriendWidget* addFriendToDialog(ContentDialog* dialog, std::shared_ptr<FriendChatroom> chatroom, GenericChatForm* form);
     GroupWidget* addGroupToDialog(ContentDialog* dialog, std::shared_ptr<GroupChatroom> chatroom, GenericChatForm* form);
@@ -54,12 +55,11 @@ private slots:
     void onDialogActivate();
 
 private:
-    ContentDialog* focusDialog(int id, const QHash<int, ContentDialog*>& list);
+    ContentDialog* focusDialog(const ContactId& id, const QHash<const ContactId&, ContentDialog*>& list);
 
     ContentDialog* currentDialog = nullptr;
 
-    QHash<int, ContentDialog*> friendDialogs;
-    QHash<int, ContentDialog*> groupDialogs;
+    QHash<const ContactId&, ContentDialog*> contactDialogs;
 
     static ContentDialogManager* instance;
 };

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -340,7 +340,7 @@ void ChatForm::onFileRecvRequest(ToxFile file)
         return;
     }
 
-    Widget::getInstance()->newFriendMessageAlert(file.friendId);
+    Widget::getInstance()->newFriendMessageAlert(f->getPublicKey());
     QString name;
     ToxPk friendId = f->getPublicKey();
     if (friendId != previousId) {
@@ -694,7 +694,7 @@ GenericNetCamView* ChatForm::createNetcam()
 {
     qDebug() << "creating netcam";
     uint32_t friendId = f->getId();
-    NetCamView* view = new NetCamView(friendId, this);
+    NetCamView* view = new NetCamView(f->getPublicKey(), this);
     CoreAV* av = Core::getInstance()->getAv();
     VideoSource* source = av->getVideoSourceFromCall(friendId);
     view->show(source, f->getDisplayedName());

--- a/src/widget/form/groupchatform.cpp
+++ b/src/widget/form/groupchatform.cpp
@@ -398,16 +398,22 @@ void GroupChatForm::peerAudioPlaying(ToxPk peerPk)
 
 void GroupChatForm::dragEnterEvent(QDragEnterEvent* ev)
 {
-    ToxId toxId = ToxId(ev->mimeData()->text());
-    Friend* frnd = FriendList::findFriend(toxId.getPublicKey());
+    if (!ev->mimeData()->hasFormat("toxPk")) {
+        return;
+    }
+    ToxPk toxPk{ev->mimeData()->data("toxPk")};
+    Friend* frnd = FriendList::findFriend(toxPk);
     if (frnd)
         ev->acceptProposedAction();
 }
 
 void GroupChatForm::dropEvent(QDropEvent* ev)
 {
-    ToxId toxId = ToxId(ev->mimeData()->text());
-    Friend* frnd = FriendList::findFriend(toxId.getPublicKey());
+    if (!ev->mimeData()->hasFormat("toxPk")) {
+        return;
+    }
+    ToxPk toxPk{ev->mimeData()->data("toxPk")};
+    Friend* frnd = FriendList::findFriend(toxPk);
     if (!frnd)
         return;
 

--- a/src/widget/form/groupchatform.cpp
+++ b/src/widget/form/groupchatform.cpp
@@ -22,6 +22,7 @@
 #include "tabcompleter.h"
 #include "src/core/core.h"
 #include "src/core/coreav.h"
+#include "src/core/groupid.h"
 #include "src/chatlog/chatlog.h"
 #include "src/chatlog/content/text.h"
 #include "src/model/friend.h"
@@ -187,7 +188,7 @@ void GroupChatForm::onUserListChanged()
     }
 }
 
-void GroupChatForm::onTitleChanged(uint32_t groupId, const QString& author, const QString& title)
+void GroupChatForm::onTitleChanged(const GroupId& groupId, const QString& author, const QString& title)
 {
     Q_UNUSED(groupId);
     if (author.isEmpty()) {

--- a/src/widget/form/groupchatform.h
+++ b/src/widget/form/groupchatform.h
@@ -31,6 +31,7 @@ class Group;
 class TabCompleter;
 class FlowLayout;
 class QTimer;
+class GroupId;
 
 class GroupChatForm : public GenericChatForm
 {
@@ -49,7 +50,7 @@ private slots:
     void onVolMuteToggle();
     void onCallClicked();
     void onUserListChanged();
-    void onTitleChanged(uint32_t groupId, const QString& author, const QString& title);
+    void onTitleChanged(const GroupId& groupId, const QString& author, const QString& title);
     void searchInBegin(const QString& phrase, const ParameterSearch& parameter) override;
     void onSearchUp(const QString& phrase, const ParameterSearch& parameter) override;
     void onSearchDown(const QString& phrase, const ParameterSearch& parameter) override;

--- a/src/widget/friendlistwidget.cpp
+++ b/src/widget/friendlistwidget.cpp
@@ -565,8 +565,11 @@ void FriendListWidget::cycleContacts(GenericChatroomWidget* activeChatroomWidget
 
 void FriendListWidget::dragEnterEvent(QDragEnterEvent* event)
 {
-    ToxId toxId(event->mimeData()->text());
-    Friend* frnd = FriendList::findFriend(toxId.getPublicKey());
+    if (!event->mimeData()->hasFormat("toxPk")) {
+        return;
+    }
+    ToxPk toxPk(event->mimeData()->data("toxPk"));;
+    Friend* frnd = FriendList::findFriend(toxPk);
     if (frnd)
         event->acceptProposedAction();
 }
@@ -580,8 +583,8 @@ void FriendListWidget::dropEvent(QDropEvent* event)
         return;
 
     // Check, that the user has a friend with the same ToxPk
-    const QByteArray data = QByteArray::fromHex(event->mimeData()->text().toLatin1());
-    const ToxPk toxPk{data};
+    assert(event->mimeData()->hasFormat("toxPk"));
+    const ToxPk toxPk{event->mimeData()->data("toxPk")};
     Friend* f = FriendList::findFriend(toxPk);
     if (!f)
         return;

--- a/src/widget/friendlistwidget.cpp
+++ b/src/widget/friendlistwidget.cpp
@@ -282,7 +282,7 @@ void FriendListWidget::addGroupWidget(GroupWidget* widget)
     groupLayout.addSortedWidget(widget);
     Group* g = widget->getGroup();
     connect(g, &Group::titleChanged,
-            [=](uint32_t groupId, const QString& author, const QString& name) {
+            [=](const GroupId& groupId, const QString& author, const QString& name) {
         Q_UNUSED(groupId);
         Q_UNUSED(author);
         renameGroupWidget(widget, name);

--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -425,7 +425,9 @@ void FriendWidget::mouseMoveEvent(QMouseEvent* ev)
     const int distance = (dragStartPos - ev->pos()).manhattanLength();
     if (distance > QApplication::startDragDistance()) {
         QMimeData* mdata = new QMimeData;
-        mdata->setText(getFriend()->getPublicKey().toString());
+        const Friend* frnd = getFriend();
+        mdata->setText(frnd->getDisplayedName());
+        mdata->setData("toxPk", frnd->getPublicKey().getByteArray());
 
         QDrag* drag = new QDrag(this);
         drag->setMimeData(mdata);

--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -105,8 +105,8 @@ void FriendWidget::onContextMenuCalled(QContextMenuEvent* event)
     QMenu menu;
 
     const auto frnd = chatroom->getFriend();
-    const auto friendId = frnd->getId();
-    const auto contentDialog = ContentDialogManager::getInstance()->getFriendDialog(friendId);
+    const auto friendPk = frnd->getPublicKey();
+    const auto contentDialog = ContentDialogManager::getInstance()->getFriendDialog(friendPk);
 
     // TODO: move to model
     if (!contentDialog || contentDialog->chatroomWidgetCount() > 1) {
@@ -115,7 +115,7 @@ void FriendWidget::onContextMenuCalled(QContextMenuEvent* event)
     }
 
     // TODO: move to model
-    if (contentDialog && contentDialog->hasFriendWidget(friendId)) {
+    if (contentDialog && contentDialog->hasContactWidget(friendPk)) {
         const auto removeChatWindow = menu.addAction(tr("Remove chat from this window"));
         connect(removeChatWindow, &QAction::triggered, this, &FriendWidget::removeChatWindow);
     }
@@ -170,10 +170,10 @@ void FriendWidget::onContextMenuCalled(QContextMenuEvent* event)
     menu.addSeparator();
 
     // TODO: move to model
-    if (!contentDialog || !contentDialog->hasFriendWidget(friendId)) {
+    if (!contentDialog || !contentDialog->hasContactWidget(friendPk)) {
         const auto removeAction =
             menu.addAction(tr("Remove friend", "Menu to remove the friend from our friendlist"));
-        connect(removeAction, &QAction::triggered, this, [=]() { emit removeFriend(friendId); },
+        connect(removeAction, &QAction::triggered, this, [=]() { emit removeFriend(friendPk); },
                 Qt::QueuedConnection);
     }
 
@@ -194,9 +194,9 @@ void FriendWidget::onContextMenuCalled(QContextMenuEvent* event)
 void FriendWidget::removeChatWindow()
 {
     const auto frnd = chatroom->getFriend();
-    const auto friendId = frnd->getId();
-    ContentDialog* contentDialog = ContentDialogManager::getInstance()->getFriendDialog(friendId);
-    contentDialog->removeFriend(friendId);
+    const auto friendPk = frnd->getPublicKey();
+    ContentDialog* contentDialog = ContentDialogManager::getInstance()->getFriendDialog(friendPk);
+    contentDialog->removeFriend(friendPk);
 }
 
 namespace {
@@ -359,6 +359,11 @@ QString FriendWidget::getStatusString() const
 const Friend* FriendWidget::getFriend() const
 {
     return chatroom->getFriend();
+}
+
+const Contact* FriendWidget::getContact() const
+{
+    return getFriend();
 }
 
 void FriendWidget::search(const QString& searchString, bool hide)

--- a/src/widget/friendwidget.h
+++ b/src/widget/friendwidget.h
@@ -40,13 +40,14 @@ public:
     void resetEventFlags() override final;
     QString getStatusString() const override final;
     const Friend* getFriend() const override final;
+    const Contact* getContact() const override final;
 
     void search(const QString& searchString, bool hide = false);
 
 signals:
     void friendWidgetClicked(FriendWidget* widget);
-    void removeFriend(int friendId);
-    void copyFriendIdToClipboard(int friendId);
+    void removeFriend(const ToxPk& friendPk);
+    void copyFriendIdToClipboard(const ToxPk& friendPk);
     void contextMenuCalled(QContextMenuEvent* event);
     void friendHistoryRemoved();
     void friendWidgetRenamed(FriendWidget* friendWidget);

--- a/src/widget/genericchatroomwidget.h
+++ b/src/widget/genericchatroomwidget.h
@@ -29,7 +29,7 @@ class QHBoxLayout;
 class ContentLayout;
 class Friend;
 class Group;
-
+class Contact;
 class GenericChatroomWidget : public GenericChatItemWidget
 {
     Q_OBJECT
@@ -42,6 +42,7 @@ public slots:
     virtual void updateStatusLight() = 0;
     virtual void resetEventFlags() = 0;
     virtual QString getStatusString() const = 0;
+    virtual const Contact* getContact() const = 0;
     virtual const Friend* getFriend() const
     {
         return nullptr;

--- a/src/widget/groupwidget.cpp
+++ b/src/widget/groupwidget.cpp
@@ -44,7 +44,7 @@
 
 GroupWidget::GroupWidget(std::shared_ptr<GroupChatroom> chatroom, bool compact)
     : GenericChatroomWidget(compact)
-    , groupId{static_cast<int>(chatroom->getGroup()->getId())}
+    , groupId{chatroom->getGroup()->getPersistentId()}
     , chatroom{chatroom}
 {
     avatar->setPixmap(Style::scaleSvgImage(":img/group.svg", avatar->width(), avatar->height()));
@@ -68,7 +68,7 @@ GroupWidget::~GroupWidget()
     Translator::unregister(this);
 }
 
-void GroupWidget::updateTitle(uint32_t groupId, const QString& author, const QString& newName)
+void GroupWidget::updateTitle(const GroupId& groupId, const QString& author, const QString& newName)
 {
     Q_UNUSED(groupId);
     Q_UNUSED(author);
@@ -96,7 +96,7 @@ void GroupWidget::contextMenuEvent(QContextMenuEvent* event)
         openChatWindow = menu.addAction(tr("Open chat in new window"));
     }
 
-    if (contentDialog && contentDialog->hasGroupWidget(groupId)) {
+    if (contentDialog && contentDialog->hasContactWidget(groupId)) {
         removeChatWindow = menu.addAction(tr("Remove chat from this window"));
     }
 
@@ -202,6 +202,11 @@ void GroupWidget::editName()
 Group* GroupWidget::getGroup() const
 {
     return chatroom->getGroup();
+}
+
+const Contact* GroupWidget::getContact() const
+{
+    return getGroup();
 }
 
 void GroupWidget::resetEventFlags()

--- a/src/widget/groupwidget.cpp
+++ b/src/widget/groupwidget.cpp
@@ -147,8 +147,9 @@ void GroupWidget::mouseMoveEvent(QMouseEvent* ev)
 
     if ((dragStartPos - ev->pos()).manhattanLength() > QApplication::startDragDistance()) {
         QMimeData* mdata = new QMimeData;
-        mdata->setText(getGroup()->getName());
-        mdata->setData("groupId", QByteArray::number(getGroup()->getId()));
+        const Group* group = getGroup();
+        mdata->setText(group->getName());
+        mdata->setData("groupId", group->getPersistentId().getByteArray());
 
         QDrag* drag = new QDrag(this);
         drag->setMimeData(mdata);
@@ -216,9 +217,10 @@ void GroupWidget::resetEventFlags()
 
 void GroupWidget::dragEnterEvent(QDragEnterEvent* ev)
 {
-    // TODO: Send ToxPk in mimeData
-    const ToxId toxId = ToxId(ev->mimeData()->text());
-    const ToxPk pk = toxId.getPublicKey();
+    if (!ev->mimeData()->hasFormat("toxPk")) {
+        return;
+    }
+    const ToxPk pk{ev->mimeData()->data("toxPk")};
     if (chatroom->friendExists(pk)) {
         ev->acceptProposedAction();
     }
@@ -237,8 +239,10 @@ void GroupWidget::dragLeaveEvent(QDragLeaveEvent*)
 
 void GroupWidget::dropEvent(QDropEvent* ev)
 {
-    const ToxId toxId = ToxId(ev->mimeData()->text());
-    const ToxPk pk = toxId.getPublicKey();
+    if (!ev->mimeData()->hasFormat("toxPk")) {
+        return;
+    }
+    const ToxPk pk{ev->mimeData()->data("toxPk")};
     if (!chatroom->friendExists(pk)) {
         return;
     }

--- a/src/widget/groupwidget.h
+++ b/src/widget/groupwidget.h
@@ -23,6 +23,7 @@
 #include "genericchatroomwidget.h"
 
 #include "src/model/chatroom/groupchatroom.h"
+#include "src/core/groupid.h"
 
 #include <memory>
 
@@ -38,12 +39,13 @@ public:
     void resetEventFlags() final override;
     QString getStatusString() const final override;
     Group* getGroup() const final override;
+    const Contact* getContact() const final override;
     void setName(const QString& name);
     void editName();
 
 signals:
     void groupWidgetClicked(GroupWidget* widget);
-    void removeGroup(int groupId);
+    void removeGroup(const GroupId& groupId);
 
 protected:
     void contextMenuEvent(QContextMenuEvent* event) final override;
@@ -55,11 +57,11 @@ protected:
 
 private slots:
     void retranslateUi();
-    void updateTitle(uint32_t groupId, const QString& author, const QString& newName);
+    void updateTitle(const GroupId& groupId, const QString& author, const QString& newName);
     void updateUserCount();
 
 public:
-    int groupId;
+    GroupId groupId;
 
 private:
     std::shared_ptr<GroupChatroom> chatroom;

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -120,8 +120,8 @@ public:
     void showUpdateDownloadProgress();
     void addFriendDialog(const Friend* frnd, ContentDialog* dialog);
     void addGroupDialog(Group* group, ContentDialog* dialog);
-    bool newFriendMessageAlert(int friendId, bool sound = true);
-    bool newGroupMessageAlert(int groupId, bool notify);
+    bool newFriendMessageAlert(const ToxPk& friendId, bool sound = true);
+    bool newGroupMessageAlert(const GroupId& groupId, bool notify);
     bool getIsWindowMinimized();
     void updateIcons();
 
@@ -166,21 +166,22 @@ public slots:
     void onFriendStatusMessageChanged(int friendId, const QString& message);
     void onFriendDisplayedNameChanged(const QString& displayed);
     void onFriendUsernameChanged(int friendId, const QString& username);
-    void onFriendAliasChanged(uint32_t friendId, const QString& alias);
-    void onFriendMessageReceived(int friendId, const QString& message, bool isAction);
+    void onFriendAliasChanged(const ToxPk& friendId, const QString& alias);
+    void onFriendMessageReceived(uint32_t friendnumber, const QString& message, bool isAction);
     void onFriendRequestReceived(const ToxPk& friendPk, const QString& message);
     void updateFriendActivity(const Friend* frnd);
-    void onEmptyGroupCreated(int groupNum, const GroupId& groupId, const QString& title);
+    void onEmptyGroupCreated(uint32_t groupnumber, const GroupId& groupId, const QString& title);
     void onGroupJoined(int groupNum, const GroupId& groupId);
     void onGroupInviteReceived(const GroupInvite& inviteInfo);
     void onGroupInviteAccepted(const GroupInvite& inviteInfo);
     void onGroupMessageReceived(int groupnumber, int peernumber, const QString& message, bool isAction);
-    void onGroupPeerlistChanged(int groupnumber);
-    void onGroupPeerNameChanged(int groupnumber, int peernumber, const QString& newName);
-    void onGroupTitleChanged(int groupnumber, const QString& author, const QString& title);
+    void onGroupPeerlistChanged(uint32_t groupnumber);
+    void onGroupPeerNameChanged(uint32_t groupnumber, int peernumber, const QString& newName);
+    void onGroupTitleChanged(uint32_t groupnumber, const QString& author, const QString& title);
+    void titleChangedByUser(const GroupId& groupId, const QString& title);
     void onGroupPeerAudioPlaying(int groupnumber, ToxPk peerPk);
-    void onGroupSendFailed(int groupId);
-    void onFriendTypingChanged(int friendId, bool isTyping);
+    void onGroupSendFailed(uint32_t groupnumber);
+    void onFriendTypingChanged(uint32_t friendnumber, bool isTyping);
     void nextContact();
     void previousContact();
     void onFriendDialogShown(const Friend* f);
@@ -195,6 +196,7 @@ signals:
     void statusSet(Status status);
     void statusSelected(Status status);
     void usernameChanged(const QString& username);
+    void changeGroupTitle(uint32_t groupnumber, const QString& title);
     void statusMessageChanged(const QString& statusMessage);
     void resized();
     void windowStateChanged(Qt::WindowStates states);
@@ -207,9 +209,9 @@ private slots:
     void openNewDialog(GenericChatroomWidget* widget);
     void onChatroomWidgetClicked(GenericChatroomWidget* widget);
     void onStatusMessageChanged(const QString& newStatusMessage);
-    void removeFriend(int friendId);
-    void copyFriendIdToClipboard(int friendId);
-    void removeGroup(int groupId);
+    void removeFriend(const ToxPk& friendId);
+    void copyFriendIdToClipboard(const ToxPk& friendId);
+    void removeGroup(const GroupId& groupId);
     void setStatusOnline();
     void setStatusAway();
     void setStatusBusy();
@@ -242,7 +244,7 @@ private:
     bool newMessageAlert(QWidget* currentWindow, bool isActive, bool sound = true, bool notify = true);
     void setActiveToolMenuButton(ActiveToolMenuButton newActiveButton);
     void hideMainForms(GenericChatroomWidget* chatroomWidget);
-    Group* createGroup(int groupId, const GroupId& groupPersistentId);
+    Group* createGroup(uint32_t groupnumber, const GroupId& groupId);
     void removeFriend(Friend* f, bool fake = false);
     void removeGroup(Group* g, bool fake = false);
     void saveWindowGeometry();
@@ -312,13 +314,13 @@ private:
     int icon_size;
     Settings& settings;
 
-    QMap<uint32_t, FriendWidget*> friendWidgets;
-    QMap<uint32_t, std::shared_ptr<FriendChatroom>> friendChatrooms;
-    QMap<uint32_t, ChatForm*> chatForms;
+    QMap<ToxPk, FriendWidget*> friendWidgets;
+    QMap<ToxPk, std::shared_ptr<FriendChatroom>> friendChatrooms;
+    QMap<ToxPk, ChatForm*> chatForms;
 
-    QMap<uint32_t, GroupWidget*> groupWidgets;
-    QMap<uint32_t, std::shared_ptr<GroupChatroom>> groupChatrooms;
-    QMap<uint32_t, QSharedPointer<GroupChatForm>> groupChatForms;
+    QMap<GroupId, GroupWidget*> groupWidgets;
+    QMap<GroupId, std::shared_ptr<GroupChatroom>> groupChatrooms;
+    QMap<GroupId, QSharedPointer<GroupChatForm>> groupChatForms;
     Core* core = nullptr;
 
 #if DESKTOP_NOTIFICATIONS


### PR DESCRIPTION
Allows creating classes for blocked friends which have toxPks but no
core number.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5623)
<!-- Reviewable:end -->
