### PR TITLE
fix(ui): fix typo, make 's' in user(s) conditional

### DIFF
--- a/src/widget/about/aboutfriendform.ui
+++ b/src/widget/about/aboutfriendform.ui
@@ -118,7 +118,7 @@
         <enum>Qt::LeftToRight</enum>
        </property>
        <property name="text">
-        <string>Public key (no ToxID):</string>
+        <string>Public key (not ToxID):</string>
        </property>
       </widget>
      </item>

--- a/src/widget/form/groupchatform.cpp
+++ b/src/widget/form/groupchatform.cpp
@@ -513,11 +513,7 @@ void GroupChatForm::keyReleaseEvent(QKeyEvent* ev)
 void GroupChatForm::updateUserCount()
 {
     const int peersCount = group->getPeersCount();
-    if (peersCount == 1) {
-        nusersLabel->setText(tr("1 user in chat", "Number of users in chat"));
-    } else {
-        nusersLabel->setText(tr("%1 users in chat", "Number of users in chat").arg(peersCount));
-    }
+    nusersLabel->setText(tr("%n user(s) in chat", "Number of users in chat", peersCount));
 }
 
 void GroupChatForm::retranslateUi()

--- a/src/widget/groupwidget.cpp
+++ b/src/widget/groupwidget.cpp
@@ -161,7 +161,7 @@ void GroupWidget::mouseMoveEvent(QMouseEvent* ev)
 void GroupWidget::updateUserCount()
 {
     int peersCount = chatroom->getGroup()->getPeersCount();
-    statusMessageLabel->setText(tr("%n user(s) in chat", "", peersCount));
+    statusMessageLabel->setText(tr("%n user(s) in chat", "Number of users in chat", peersCount));
 }
 
 void GroupWidget::setAsActiveChatroom()


### PR DESCRIPTION
- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5630)
<!-- Reviewable:end -->
