### PR TITLE
Move Status out of Widget, make asset path not dependent on translation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,6 +323,8 @@ set(${PROJECT_NAME}_SOURCES
   src/model/groupinvite.h
   src/model/group.cpp
   src/model/group.h
+  src/model/status.cpp
+  src/model/status.h
   src/model/interface.h
   src/model/profile/iprofileinfo.h
   src/model/profile/profileinfo.cpp

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -27,6 +27,7 @@
 #include "src/core/toxoptions.h"
 #include "src/core/toxstring.h"
 #include "src/model/groupinvite.h"
+#include "src/model/status.h"
 #include "src/nexus.h"
 #include "src/net/bootstrapnodeupdater.h"
 #include "src/persistence/profile.h"
@@ -506,18 +507,18 @@ void Core::onStatusMessageChanged(Tox*, uint32_t friendId, const uint8_t* cMessa
 
 void Core::onUserStatusChanged(Tox*, uint32_t friendId, Tox_User_Status userstatus, void* core)
 {
-    Status status;
+    Status::Status status;
     switch (userstatus) {
     case TOX_USER_STATUS_AWAY:
-        status = Status::Away;
+        status = Status::Status::Away;
         break;
 
     case TOX_USER_STATUS_BUSY:
-        status = Status::Busy;
+        status = Status::Status::Busy;
         break;
 
     default:
-        status = Status::Online;
+        status = Status::Status::Online;
         break;
     }
 
@@ -527,9 +528,9 @@ void Core::onUserStatusChanged(Tox*, uint32_t friendId, Tox_User_Status userstat
 void Core::onConnectionStatusChanged(Tox*, uint32_t friendId, Tox_Connection status, void* vCore)
 {
     Core* core = static_cast<Core*>(vCore);
-    Status friendStatus = status != TOX_CONNECTION_NONE ? Status::Online : Status::Offline;
+    Status::Status friendStatus = status != TOX_CONNECTION_NONE ? Status::Status::Online : Status::Status::Offline;
     // Ignore Online because it will be emited from onUserStatusChanged
-    bool isOffline = friendStatus == Status::Offline;
+    bool isOffline = friendStatus == Status::Status::Offline;
     if (isOffline) {
         emit core->friendStatusChanged(friendId, friendStatus);
         core->checkLastOnline(friendId);
@@ -908,11 +909,11 @@ QString Core::getStatusMessage() const
 /**
  * @brief Returns our user status
  */
-Status Core::getStatus() const
+Status::Status Core::getStatus() const
 {
     QMutexLocker ml{&coreLoopLock};
 
-    return static_cast<Status>(tox_self_get_status(tox.get()));
+    return static_cast<Status::Status>(tox_self_get_status(tox.get()));
 }
 
 void Core::setStatusMessage(const QString& message)
@@ -933,21 +934,21 @@ void Core::setStatusMessage(const QString& message)
     emit statusMessageSet(message);
 }
 
-void Core::setStatus(Status status)
+void Core::setStatus(Status::Status status)
 {
     QMutexLocker ml{&coreLoopLock};
 
     Tox_User_Status userstatus;
     switch (status) {
-    case Status::Online:
+    case Status::Status::Online:
         userstatus = TOX_USER_STATUS_NONE;
         break;
 
-    case Status::Away:
+    case Status::Status::Away:
         userstatus = TOX_USER_STATUS_AWAY;
         break;
 
-    case Status::Busy:
+    case Status::Status::Busy:
         userstatus = TOX_USER_STATUS_BUSY;
         break;
 

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -27,6 +27,7 @@
 #include "groupid.h"
 
 #include "src/util/strongtype.h"
+#include "src/model/status.h"
 #include <tox/tox.h>
 
 #include <QMutex>
@@ -42,16 +43,6 @@ class CoreFile;
 class ICoreSettings;
 class GroupInvite;
 class Profile;
-
-enum class Status
-{
-    Online = 0,
-    Away,
-    Busy,
-    Offline,
-    Blocked
-};
-
 class Core;
 
 using ToxCorePtr = std::unique_ptr<Core>;
@@ -97,7 +88,7 @@ public:
     void quitGroupChat(int groupId) const;
 
     QString getUsername() const;
-    Status getStatus() const;
+    Status::Status getStatus() const;
     QString getStatusMessage() const;
     ToxId getSelfId() const;
     ToxPk getSelfPublicKey() const;
@@ -118,7 +109,7 @@ public slots:
     void removeFriend(uint32_t friendId);
     void removeGroup(int groupId);
 
-    void setStatus(Status status);
+    void setStatus(Status::Status status);
     void setUsername(const QString& username);
     void setStatusMessage(const QString& message);
 
@@ -144,12 +135,12 @@ signals:
 
     void usernameSet(const QString& username);
     void statusMessageSet(const QString& message);
-    void statusSet(Status status);
+    void statusSet(Status::Status status);
     void idSet(const ToxId& id);
 
     void failedToSetUsername(const QString& username);
     void failedToSetStatusMessage(const QString& message);
-    void failedToSetStatus(Status status);
+    void failedToSetStatus(Status::Status status);
     void failedToSetTyping(bool typing);
 
     void avReady();
@@ -165,7 +156,7 @@ signals:
     void friendMessageReceived(uint32_t friendId, const QString& message, bool isAction);
     void friendAdded(uint32_t friendId, const ToxPk& friendPk);
 
-    void friendStatusChanged(uint32_t friendId, Status status);
+    void friendStatusChanged(uint32_t friendId, Status::Status status);
     void friendStatusMessageChanged(uint32_t friendId, const QString& message);
     void friendUsernameChanged(uint32_t friendId, const QString& username);
     void friendTypingChanged(uint32_t friendId, bool isTyping);

--- a/src/core/corefile.cpp
+++ b/src/core/corefile.cpp
@@ -23,6 +23,7 @@
 #include "toxfile.h"
 #include "toxstring.h"
 #include "src/persistence/settings.h"
+#include "src/model/status.h"
 #include <QDebug>
 #include <QDir>
 #include <QFile>
@@ -528,9 +529,9 @@ void CoreFile::onFileRecvChunkCallback(Tox* tox, uint32_t friendId, uint32_t fil
     }
 }
 
-void CoreFile::onConnectionStatusChanged(uint32_t friendId, Status state)
+void CoreFile::onConnectionStatusChanged(uint32_t friendId, Status::Status state)
 {
-    bool isOffline = state == Status::Offline;
+    bool isOffline = state == Status::Status::Offline;
     // TODO: Actually resume broken file transfers
     // We need to:
     // - Start a new file transfer with the same 32byte file ID with toxcore

--- a/src/core/corefile.h
+++ b/src/core/corefile.h
@@ -21,19 +21,21 @@
 #ifndef COREFILE_H
 #define COREFILE_H
 
-#include <cstddef>
-#include <cstdint>
-#include <memory>
 #include <tox/tox.h>
 
 #include "toxfile.h"
 #include "src/core/core.h"
 #include "src/core/toxpk.h"
+#include "src/model/status.h"
 
 #include <QHash>
 #include <QMutex>
 #include <QObject>
 #include <QString>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
 
 struct Tox;
 class CoreFile;
@@ -100,7 +102,7 @@ private:
     static QString getCleanFileName(QString filename);
 
 private slots:
-    void onConnectionStatusChanged(uint32_t friendId, Status state);
+    void onConnectionStatusChanged(uint32_t friendId, Status::Status state);
 
 private:
     QHash<uint64_t, ToxFile> fileMap;

--- a/src/model/friend.cpp
+++ b/src/model/friend.cpp
@@ -20,6 +20,7 @@
 
 #include "friend.h"
 #include "src/model/group.h"
+#include "src/model/status.h"
 #include "src/grouplist.h"
 #include "src/persistence/profile.h"
 #include "src/widget/form/chatform.h"
@@ -30,7 +31,7 @@ Friend::Friend(uint32_t friendId, const ToxPk& friendPk, const QString& userAlia
     , friendPk{friendPk}
     , friendId{friendId}
     , hasNewEvents{false}
-    , friendStatus{Status::Offline}
+    , friendStatus{Status::Status::Offline}
 {
     if (userName.isEmpty()) {
         this->userName = friendPk.toString();
@@ -152,7 +153,7 @@ bool Friend::getEventFlag() const
     return hasNewEvents;
 }
 
-void Friend::setStatus(Status s)
+void Friend::setStatus(Status::Status s)
 {
     if (friendStatus != s) {
         friendStatus = s;
@@ -160,12 +161,12 @@ void Friend::setStatus(Status s)
     }
 }
 
-Status Friend::getStatus() const
+Status::Status Friend::getStatus() const
 {
     return friendStatus;
 }
 
 bool Friend::isOnline() const
 {
-    return friendStatus != Status::Offline && friendStatus != Status::Blocked;
+    return friendStatus != Status::Status::Offline && friendStatus != Status::Status::Blocked;
 }

--- a/src/model/friend.h
+++ b/src/model/friend.h
@@ -24,6 +24,7 @@
 #include "src/core/core.h"
 #include "src/core/toxid.h"
 #include "src/core/contactid.h"
+#include "src/model/status.h"
 #include <QObject>
 #include <QString>
 
@@ -50,14 +51,14 @@ public:
     uint32_t getId() const override;
     const ContactId& getPersistentId() const override;
 
-    void setStatus(Status s);
-    Status getStatus() const;
+    void setStatus(Status::Status s);
+    Status::Status getStatus() const;
     bool isOnline() const;
 
 signals:
     void nameChanged(const ToxPk& friendId, const QString& name);
     void aliasChanged(const ToxPk& friendId, QString alias);
-    void statusChanged(const ToxPk& friendId, Status status);
+    void statusChanged(const ToxPk& friendId, Status::Status status);
     void statusMessageChanged(const ToxPk& friendId, const QString& message);
     void loadChatHistory();
 
@@ -70,7 +71,7 @@ private:
     ToxPk friendPk;
     uint32_t friendId;
     bool hasNewEvents;
-    Status friendStatus;
+    Status::Status friendStatus;
 };
 
 #endif // FRIEND_H

--- a/src/model/status.cpp
+++ b/src/model/status.cpp
@@ -28,13 +28,6 @@
 
 namespace Status
 {
-    QPixmap getIconPixmap(QString path, uint32_t w, uint32_t h)
-    {
-        QPixmap pix(w, h);
-        pix.load(path);
-        return pix;
-    }
-
     QString getTitle(Status status)
     {
         switch (status) {
@@ -52,24 +45,6 @@ namespace Status
 
         assert(false);
         return QStringLiteral("");
-    }
-
-    Status getFromString(QString status)
-    {
-        if (status == QStringLiteral("online"))
-            return Status::Online;
-        else if (status == QStringLiteral("away"))
-            return Status::Away;
-        else if (status == QStringLiteral("busy"))
-            return Status::Busy;
-        else if (status == QStringLiteral("offline"))
-            return Status::Offline;
-        else if (status == QStringLiteral("blocked"))
-            return Status::Blocked;
-        else {
-            assert(false);
-            return Status::Offline;
-        }
     }
 
     QString getIconPath(Status status, bool event)

--- a/src/model/status.cpp
+++ b/src/model/status.cpp
@@ -47,24 +47,32 @@ namespace Status
         return QStringLiteral("");
     }
 
+    QString getAssetSuffix(Status status)
+    {
+        switch (status) {
+        case Status::Online:
+            return "online";
+        case Status::Away:
+            return "away";
+        case Status::Busy:
+            return "busy";
+        case Status::Offline:
+            return "offline";
+        case Status::Blocked:
+            return "blocked";
+        }
+        assert(false);
+        return QStringLiteral("");
+    }
+
     QString getIconPath(Status status, bool event)
     {
         const QString eventSuffix = event ? QStringLiteral("_notification") : QString();
-
-        switch (status) {
-        case Status::Online:
-            return ":/img/status/online" + eventSuffix + ".svg";
-        case Status::Away:
-            return ":/img/status/away" + eventSuffix + ".svg";
-        case Status::Busy:
-            return ":/img/status/busy" + eventSuffix + ".svg";
-        case Status::Offline:
-            return ":/img/status/offline" + eventSuffix + ".svg";
-        case Status::Blocked:
-            return ":/img/status/blocked.svg";
+        const QString statusSuffix = getAssetSuffix(status);
+        if (status == Status::Blocked) {
+            return ":/img/status/" + statusSuffix + ".svg";
+        } else {
+            return ":/img/status/" + statusSuffix + eventSuffix + ".svg";
         }
-        qWarning() << "Status unknown";
-        assert(false);
-        return QString{};
     }
 } // namespace Status

--- a/src/model/status.cpp
+++ b/src/model/status.cpp
@@ -1,0 +1,95 @@
+/*
+    Copyright © 2019 by The qTox Project Contributors
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <src/model/status.h>
+
+#include <QString>
+#include <QPixmap>
+#include <QDebug>
+#include <QObject>
+
+#include <cassert>
+
+namespace Status
+{
+    QPixmap getIconPixmap(QString path, uint32_t w, uint32_t h)
+    {
+        QPixmap pix(w, h);
+        pix.load(path);
+        return pix;
+    }
+
+    QString getTitle(Status status)
+    {
+        switch (status) {
+        case Status::Online:
+            return QObject::tr("online", "contact status");
+        case Status::Away:
+            return QObject::tr("away", "contact status");
+        case Status::Busy:
+            return QObject::tr("busy", "contact status");
+        case Status::Offline:
+            return QObject::tr("offline", "contact status");
+        case Status::Blocked:
+            return QObject::tr("blocked", "contact status");
+        }
+
+        assert(false);
+        return QStringLiteral("");
+    }
+
+    Status getFromString(QString status)
+    {
+        if (status == QStringLiteral("online"))
+            return Status::Online;
+        else if (status == QStringLiteral("away"))
+            return Status::Away;
+        else if (status == QStringLiteral("busy"))
+            return Status::Busy;
+        else if (status == QStringLiteral("offline"))
+            return Status::Offline;
+        else if (status == QStringLiteral("blocked"))
+            return Status::Blocked;
+        else {
+            assert(false);
+            return Status::Offline;
+        }
+    }
+
+    QString getIconPath(Status status, bool event)
+    {
+        const QString eventSuffix = event ? QStringLiteral("_notification") : QString();
+
+        switch (status) {
+        case Status::Online:
+            return ":/img/status/online" + eventSuffix + ".svg";
+        case Status::Away:
+            return ":/img/status/away" + eventSuffix + ".svg";
+        case Status::Busy:
+            return ":/img/status/busy" + eventSuffix + ".svg";
+        case Status::Offline:
+            return ":/img/status/offline" + eventSuffix + ".svg";
+        case Status::Blocked:
+            return ":/img/status/blocked.svg";
+        }
+        qWarning() << "Status unknown";
+        assert(false);
+        return QString{};
+    }
+} // namespace Status

--- a/src/model/status.h
+++ b/src/model/status.h
@@ -1,0 +1,44 @@
+/*
+    Copyright © 2019 by The qTox Project Contributors
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <QString>
+#include <QPixmap>
+
+#ifndef STATUS_H
+#define STATUS_H
+
+namespace Status
+{
+    // Status::Status is weird, but Status is a fitting name for both the namespace and enum class..
+    enum class Status
+    {
+        Online = 0,
+        Away,
+        Busy,
+        Offline,
+        Blocked
+    };
+
+    QString getIconPath(Status status, bool event = false);
+    QPixmap getIconPixmap(QString path, uint32_t w, uint32_t h);
+    QString getTitle(Status status);
+    Status getFromString(QString status);
+}
+
+#endif // STATUS_H

--- a/src/model/status.h
+++ b/src/model/status.h
@@ -37,6 +37,7 @@ namespace Status
 
     QString getIconPath(Status status, bool event = false);
     QString getTitle(Status status);
+    QString getAssetSuffix(Status status);
 }
 
 #endif // STATUS_H

--- a/src/model/status.h
+++ b/src/model/status.h
@@ -36,9 +36,7 @@ namespace Status
     };
 
     QString getIconPath(Status status, bool event = false);
-    QPixmap getIconPixmap(QString path, uint32_t w, uint32_t h);
     QString getTitle(Status status);
-    Status getFromString(QString status);
 }
 
 #endif // STATUS_H

--- a/src/net/avatarbroadcaster.cpp
+++ b/src/net/avatarbroadcaster.cpp
@@ -21,6 +21,7 @@
 #include "avatarbroadcaster.h"
 #include "src/core/core.h"
 #include "src/core/corefile.h"
+#include "src/model/status.h"
 #include <QDebug>
 #include <QObject>
 
@@ -36,7 +37,7 @@ QByteArray AvatarBroadcaster::avatarData;
 QMap<uint32_t, bool> AvatarBroadcaster::friendsSentTo;
 
 static QMetaObject::Connection autoBroadcastConn;
-static auto autoBroadcast = [](uint32_t friendId, Status) {
+static auto autoBroadcast = [](uint32_t friendId, Status::Status) {
     AvatarBroadcaster::sendAvatarTo(friendId);
 };
 

--- a/src/nexus.cpp
+++ b/src/nexus.cpp
@@ -23,6 +23,7 @@
 #include "src/core/core.h"
 #include "src/core/coreav.h"
 #include "src/model/groupinvite.h"
+#include "src/model/status.h"
 #include "src/persistence/profile.h"
 #include "src/widget/widget.h"
 #include "video/camerasource.h"
@@ -83,7 +84,7 @@ void Nexus::start()
     qDebug() << "Starting up";
 
     // Setup the environment
-    qRegisterMetaType<Status>("Status");
+    qRegisterMetaType<Status::Status>("Status::Status");
     qRegisterMetaType<vpx_image>("vpx_image");
     qRegisterMetaType<uint8_t>("uint8_t");
     qRegisterMetaType<uint16_t>("uint16_t");

--- a/src/widget/categorywidget.cpp
+++ b/src/widget/categorywidget.cpp
@@ -21,6 +21,7 @@
 #include "friendlistlayout.h"
 #include "friendlistwidget.h"
 #include "friendwidget.h"
+#include "src/model/status.h"
 #include "src/widget/style.h"
 #include "tool/croppinglabel.h"
 #include <QBoxLayout>
@@ -126,7 +127,7 @@ void CategoryWidget::editName()
     nameLabel->setMaximumWidth(QWIDGETSIZE_MAX);
 }
 
-void CategoryWidget::addFriendWidget(FriendWidget* w, Status s)
+void CategoryWidget::addFriendWidget(FriendWidget* w, Status::Status s)
 {
     listLayout->addFriendWidget(w, s);
     updateStatus();
@@ -134,7 +135,7 @@ void CategoryWidget::addFriendWidget(FriendWidget* w, Status s)
     w->reloadTheme(); // Otherwise theme will change when moving to another circle.
 }
 
-void CategoryWidget::removeFriendWidget(FriendWidget* w, Status s)
+void CategoryWidget::removeFriendWidget(FriendWidget* w, Status::Status s)
 {
     listLayout->removeFriendWidget(w, s);
     updateStatus();

--- a/src/widget/categorywidget.h
+++ b/src/widget/categorywidget.h
@@ -22,6 +22,7 @@
 
 #include "genericchatitemwidget.h"
 #include "src/core/core.h"
+#include "src/model/status.h"
 
 class FriendListLayout;
 class FriendListWidget;
@@ -39,8 +40,8 @@ public:
     void setExpanded(bool isExpanded, bool save = true);
     void setName(const QString& name, bool save = true);
 
-    void addFriendWidget(FriendWidget* w, Status s);
-    void removeFriendWidget(FriendWidget* w, Status s);
+    void addFriendWidget(FriendWidget* w, Status::Status s);
+    void removeFriendWidget(FriendWidget* w, Status::Status s);
     void updateStatus();
 
     bool hasChatrooms() const;

--- a/src/widget/contentdialog.cpp
+++ b/src/widget/contentdialog.cpp
@@ -34,6 +34,7 @@
 #include "src/model/chatroom/friendchatroom.h"
 #include "src/model/friend.h"
 #include "src/model/group.h"
+#include "src/model/status.h"
 #include "src/persistence/settings.h"
 #include "src/widget/contentlayout.h"
 #include "src/widget/friendwidget.h"
@@ -196,8 +197,8 @@ void ContentDialog::removeFriend(const ToxPk& friendPk)
         cycleContacts(/* forward = */ true, /* inverse = */ false);
     }
 
-    friendLayout->removeFriendWidget(chatroomWidget, Status::Offline);
-    friendLayout->removeFriendWidget(chatroomWidget, Status::Online);
+    friendLayout->removeFriendWidget(chatroomWidget, Status::Status::Offline);
+    friendLayout->removeFriendWidget(chatroomWidget, Status::Status::Online);
 
     chatroomWidget->deleteLater();
 
@@ -385,8 +386,8 @@ void ContentDialog::updateTitleAndStatusIcon()
         return;
     }
 
-    Status currentStatus = activeChatroomWidget->getFriend()->getStatus();
-    setWindowIcon(QIcon{Widget::getStatusIconPath(currentStatus)});
+    Status::Status currentStatus = activeChatroomWidget->getFriend()->getStatus();
+    setWindowIcon(QIcon{Status::getIconPath(currentStatus)});
 }
 
 /**
@@ -590,7 +591,7 @@ bool ContentDialog::containsContact(const ContactId& contactId) const
     return contactWidgets.contains(contactId);
 }
 
-void ContentDialog::updateFriendStatus(const ToxPk& friendPk, Status status)
+void ContentDialog::updateFriendStatus(const ToxPk& friendPk, Status::Status status)
 {
     auto widget = qobject_cast<FriendWidget*>(contactWidgets.value(friendPk));
     addFriendWidget(widget, status);
@@ -633,7 +634,7 @@ void ContentDialog::updateFriendWidget(const ToxPk& friendPk, QString alias)
     Friend* f = FriendList::findFriend(friendPk);
     FriendWidget* friendWidget = qobject_cast<FriendWidget*>(contactWidgets[friendPk]);
 
-    Status status = f->getStatus();
+    Status::Status status = f->getStatus();
     friendLayout->addFriendWidget(friendWidget, status);
 }
 
@@ -698,7 +699,7 @@ QLayout* ContentDialog::nextLayout(QLayout* layout, bool forward) const
     return layouts[next];
 }
 
-void ContentDialog::addFriendWidget(FriendWidget* widget, Status status)
+void ContentDialog::addFriendWidget(FriendWidget* widget, Status::Status status)
 {
     friendLayout->addFriendWidget(widget, status);
 }

--- a/src/widget/contentdialog.h
+++ b/src/widget/contentdialog.h
@@ -22,7 +22,9 @@
 
 #include "src/widget/genericchatitemlayout.h"
 #include "src/widget/tool/activatedialog.h"
-#include "src/core/core.h" // Status
+#include "src/model/status.h"
+#include "src/core/groupid.h"
+#include "src/core/toxpk.h"
 
 #include <memory>
 #include <tuple>
@@ -68,13 +70,13 @@ public:
     void onVideoShow(QSize size);
     void onVideoHide();
 
-    void addFriendWidget(FriendWidget* widget, Status status);
+    void addFriendWidget(FriendWidget* widget, Status::Status status);
     bool isActiveWidget(GenericChatroomWidget* widget);
 
     bool hasContactWidget(const ContactId& contactId) const;
     void focusContact(const ContactId& friendPk);
     bool containsContact(const ContactId& friendPk) const;
-    void updateFriendStatus(const ToxPk& friendPk, Status status);
+    void updateFriendStatus(const ToxPk& friendPk, Status::Status status);
     void updateContactStatusLight(const ContactId& contactId);
     bool isContactWidgetActive(const ContactId& contactId);
 

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -27,6 +27,7 @@
 #include "src/core/coreav.h"
 #include "src/core/corefile.h"
 #include "src/model/friend.h"
+#include "src/model/status.h"
 #include "src/nexus.h"
 #include "src/persistence/history.h"
 #include "src/persistence/offlinemsgengine.h"
@@ -40,10 +41,12 @@
 #include "src/widget/style.h"
 #include "src/widget/tool/callconfirmwidget.h"
 #include "src/widget/tool/chattextedit.h"
+#include "src/widget/tool/croppinglabel.h"
 #include "src/widget/tool/screenshotgrabber.h"
 #include "src/widget/translator.h"
 #include "src/widget/widget.h"
 
+#include <QApplication>
 #include <QClipboard>
 #include <QFileDialog>
 #include <QFileInfo>
@@ -51,6 +54,7 @@
 #include <QMimeData>
 #include <QPushButton>
 #include <QScrollBar>
+#include <QSplitter>
 #include <QStringBuilder>
 
 #include <cassert>
@@ -612,7 +616,7 @@ void ChatForm::onFileSendFailed(uint32_t friendId, const QString& fname)
                          QDateTime::currentDateTime());
 }
 
-void ChatForm::onFriendStatusChanged(uint32_t friendId, Status status)
+void ChatForm::onFriendStatusChanged(uint32_t friendId, Status::Status status)
 {
     // Disable call buttons if friend is offline
     if (friendId != f->getId()) {
@@ -629,7 +633,7 @@ void ChatForm::onFriendStatusChanged(uint32_t friendId, Status status)
     updateCallButtons();
 
     if (Settings::getInstance().getStatusChangeNotificationEnabled()) {
-        QString fStatus = Widget::getStatusTitle(status);
+        QString fStatus = Status::getTitle(status);
         addSystemInfoMessage(tr("%1 is now %2", "e.g. \"Dubslow is now online\"")
                                  .arg(f->getDisplayedName())
                                  .arg(fStatus),

--- a/src/widget/form/chatform.h
+++ b/src/widget/form/chatform.h
@@ -28,6 +28,7 @@
 #include "genericchatform.h"
 #include "src/core/core.h"
 #include "src/persistence/history.h"
+#include "src/model/status.h"
 #include "src/widget/tool/screenshotgrabber.h"
 
 class CallConfirmWidget;
@@ -99,7 +100,7 @@ private slots:
     void onVolMuteToggle();
 
     void onFileSendFailed(uint32_t friendId, const QString& fname);
-    void onFriendStatusChanged(quint32 friendId, Status status);
+    void onFriendStatusChanged(quint32 friendId, Status::Status status);
     void onFriendTypingChanged(quint32 friendId, bool isTyping);
     void onFriendNameChanged(const QString& name);
     void onFriendMessageReceived(quint32 friendId, const QString& message, bool isAction);

--- a/src/widget/form/settings/advancedform.cpp
+++ b/src/widget/form/settings/advancedform.cpp
@@ -30,6 +30,7 @@
 #include "src/core/core.h"
 #include "src/core/coreav.h"
 #include "src/nexus.h"
+#include "src/model/status.h"
 #include "src/persistence/profile.h"
 #include "src/persistence/settings.h"
 #include "src/widget/gui.h"
@@ -222,7 +223,7 @@ void AdvancedForm::on_reconnectButton_clicked()
         return;
     }
 
-    emit Core::getInstance()->statusSet(Status::Offline);
+    emit Core::getInstance()->statusSet(Status::Status::Offline);
     Nexus::getProfile()->restartCore();
 }
 

--- a/src/widget/friendlistlayout.cpp
+++ b/src/widget/friendlistlayout.cpp
@@ -16,6 +16,7 @@
 #include "friendlistwidget.h"
 #include "friendwidget.h"
 #include "src/model/friend.h"
+#include "src/model/status.h"
 #include "src/friendlist.h"
 #include <cassert>
 
@@ -46,12 +47,12 @@ void FriendListLayout::init()
     addLayout(friendOfflineLayout.getLayout());
 }
 
-void FriendListLayout::addFriendWidget(FriendWidget* w, Status s)
+void FriendListLayout::addFriendWidget(FriendWidget* w, Status::Status s)
 {
     friendOfflineLayout.removeSortedWidget(w);
     friendOnlineLayout.removeSortedWidget(w);
 
-    if (s == Status::Offline) {
+    if (s == Status::Status::Offline) {
         friendOfflineLayout.addSortedWidget(w);
         return;
     }
@@ -59,9 +60,9 @@ void FriendListLayout::addFriendWidget(FriendWidget* w, Status s)
     friendOnlineLayout.addSortedWidget(w);
 }
 
-void FriendListLayout::removeFriendWidget(FriendWidget* widget, Status s)
+void FriendListLayout::removeFriendWidget(FriendWidget* widget, Status::Status s)
 {
-    if (s == Status::Offline)
+    if (s == Status::Status::Offline)
         friendOfflineLayout.removeSortedWidget(widget);
     else
         friendOnlineLayout.removeSortedWidget(widget);
@@ -123,7 +124,7 @@ QLayout* FriendListLayout::getLayoutOffline() const
     return friendOfflineLayout.getLayout();
 }
 
-QLayout* FriendListLayout::getFriendLayout(Status s) const
+QLayout* FriendListLayout::getFriendLayout(Status::Status s) const
 {
-    return s == Status::Offline ? friendOfflineLayout.getLayout() : friendOnlineLayout.getLayout();
+    return s == Status::Status::Offline ? friendOfflineLayout.getLayout() : friendOnlineLayout.getLayout();
 }

--- a/src/widget/friendlistlayout.h
+++ b/src/widget/friendlistlayout.h
@@ -16,6 +16,7 @@
 #define FRIENDLISTLAYOUT_H
 
 #include "genericchatitemlayout.h"
+#include "src/model/status.h"
 #include "src/core/core.h"
 #include <QBoxLayout>
 
@@ -29,8 +30,8 @@ public:
     explicit FriendListLayout();
     explicit FriendListLayout(QWidget* parent);
 
-    void addFriendWidget(FriendWidget* widget, Status s);
-    void removeFriendWidget(FriendWidget* widget, Status s);
+    void addFriendWidget(FriendWidget* widget, Status::Status s);
+    void removeFriendWidget(FriendWidget* widget, Status::Status s);
     int indexOfFriendWidget(GenericChatItemWidget* widget, bool online) const;
     void moveFriendWidgets(FriendListWidget* listWidget);
     int friendOnlineCount() const;
@@ -45,7 +46,7 @@ public:
 
 private:
     void init();
-    QLayout* getFriendLayout(Status s) const;
+    QLayout* getFriendLayout(Status::Status s) const;
 
     GenericChatItemLayout friendOnlineLayout;
     GenericChatItemLayout friendOfflineLayout;

--- a/src/widget/friendlistwidget.cpp
+++ b/src/widget/friendlistwidget.cpp
@@ -26,6 +26,7 @@
 #include "src/friendlist.h"
 #include "src/model/friend.h"
 #include "src/model/group.h"
+#include "src/model/status.h"
 #include "src/persistence/settings.h"
 #include <QDragEnterEvent>
 #include <QDragLeaveEvent>
@@ -289,7 +290,7 @@ void FriendListWidget::addGroupWidget(GroupWidget* widget)
     });
 }
 
-void FriendListWidget::addFriendWidget(FriendWidget* w, Status s, int circleIndex)
+void FriendListWidget::addFriendWidget(FriendWidget* w, Status::Status s, int circleIndex)
 {
     CircleWidget* circleWidget = CircleWidget::getFromID(circleIndex);
     if (circleWidget == nullptr)
@@ -609,7 +610,7 @@ void FriendListWidget::dayTimeout()
     dayTimer->start(timeUntilTomorrow());
 }
 
-void FriendListWidget::moveWidget(FriendWidget* widget, Status s, bool add)
+void FriendListWidget::moveWidget(FriendWidget* widget, Status::Status s, bool add)
 {
     if (mode == Name) {
         const Friend* f = widget->getFriend();

--- a/src/widget/friendlistwidget.h
+++ b/src/widget/friendlistwidget.h
@@ -22,6 +22,7 @@
 
 #include "genericchatitemlayout.h"
 #include "src/core/core.h"
+#include "src/model/status.h"
 #include <QWidget>
 
 class QVBoxLayout;
@@ -50,7 +51,7 @@ public:
     Mode getMode() const;
 
     void addGroupWidget(GroupWidget* widget);
-    void addFriendWidget(FriendWidget* w, Status s, int circleIndex);
+    void addFriendWidget(FriendWidget* w, Status::Status s, int circleIndex);
     void removeGroupWidget(GroupWidget* w);
     void removeFriendWidget(FriendWidget* w);
     void addCircleWidget(int id);
@@ -72,7 +73,7 @@ public slots:
     void renameCircleWidget(CircleWidget* circleWidget, const QString& newName);
     void onFriendWidgetRenamed(FriendWidget* friendWidget);
     void onGroupchatPositionChanged(bool top);
-    void moveWidget(FriendWidget* w, Status s, bool add = false);
+    void moveWidget(FriendWidget* w, Status::Status s, bool add = false);
 
 protected:
     void dragEnterEvent(QDragEnterEvent* event) override;

--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -29,6 +29,7 @@
 #include "src/model/chatroom/friendchatroom.h"
 #include "src/model/friend.h"
 #include "src/model/group.h"
+#include "src/model/status.h"
 #include "src/persistence/settings.h"
 #include "src/widget/about/aboutfriendform.h"
 #include "src/widget/contentdialogmanager.h"
@@ -62,7 +63,7 @@ FriendWidget::FriendWidget(std::shared_ptr<FriendChatroom> chatroom, bool compac
     , isDefaultAvatar{true}
 {
     avatar->setPixmap(QPixmap(":/img/contact.svg"));
-    statusPic.setPixmap(QPixmap(Widget::getStatusIconPath(Status::Offline)));
+    statusPic.setPixmap(QPixmap(Status::getIconPath(Status::Status::Offline)));
     statusPic.setMargin(3);
 
     auto frnd = chatroom->getFriend();
@@ -324,7 +325,7 @@ void FriendWidget::updateStatusLight()
 {
     const auto frnd = chatroom->getFriend();
     const bool event = frnd->getEventFlag();
-    statusPic.setPixmap(QPixmap(Widget::getStatusIconPath(frnd->getStatus(), event)));
+    statusPic.setPixmap(QPixmap(Status::getIconPath(frnd->getStatus(), event)));
 
     if (event) {
         const Settings& s = Settings::getInstance();

--- a/src/widget/groupwidget.cpp
+++ b/src/widget/groupwidget.cpp
@@ -34,6 +34,7 @@
 #include "src/model/friend.h"
 #include "src/friendlist.h"
 #include "src/model/group.h"
+#include "src/model/status.h"
 #include "src/grouplist.h"
 #include "src/widget/contentdialogmanager.h"
 #include "src/widget/friendwidget.h"
@@ -48,7 +49,7 @@ GroupWidget::GroupWidget(std::shared_ptr<GroupChatroom> chatroom, bool compact)
     , chatroom{chatroom}
 {
     avatar->setPixmap(Style::scaleSvgImage(":img/group.svg", avatar->width(), avatar->height()));
-    statusPic.setPixmap(QPixmap(Widget::getStatusIconPath(Status::Online)));
+    statusPic.setPixmap(QPixmap(Status::getIconPath(Status::Status::Online)));
     statusPic.setMargin(3);
 
     Group* g = chatroom->getGroup();
@@ -181,7 +182,7 @@ void GroupWidget::updateStatusLight()
     Group* g = chatroom->getGroup();
 
     const bool event = g->getEventFlag();
-    statusPic.setPixmap(QPixmap(Widget::getStatusIconPath(Status::Online, event)));
+    statusPic.setPixmap(QPixmap(Status::getIconPath(Status::Status::Online, event)));
     statusPic.setMargin(event ? 1 : 3);
 }
 

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -437,15 +437,9 @@ void Widget::updateIcons()
         return;
     }
 
-    QString status;
-    if (eventIcon) {
-        status = QStringLiteral("event");
-    } else {
-        status = ui->statusButton->property("status").toString();
-        if (!status.length()) {
-            status = QStringLiteral("offline");
-        }
-    }
+    const QString assetSuffix = eventIcon ? "event" :
+        Status::getAssetSuffix(static_cast<Status::Status>(ui->statusButton->property("status").toInt()));
+
 
     // Some builds of Qt appear to have a bug in icon loading:
     // QIcon::hasThemeIcon is sometimes unaware that the icon returned
@@ -474,11 +468,11 @@ void Widget::updateIcons()
     }
 
     QIcon ico;
-    if (!hasThemeIconBug && QIcon::hasThemeIcon("qtox-" + status)) {
-        ico = QIcon::fromTheme("qtox-" + status);
+    if (!hasThemeIconBug && QIcon::hasThemeIcon("qtox-" + assetSuffix)) {
+        ico = QIcon::fromTheme("qtox-" + assetSuffix);
     } else {
         QString color = settings.getLightTrayIcon() ? "light" : "dark";
-        QString path = ":/img/taskbar/" + color + "/taskbar_" + status + ".svg";
+        QString path = ":/img/taskbar/" + color + "/taskbar_" + assetSuffix + ".svg";
         QSvgRenderer renderer(path);
 
         // Prepare a QImage with desired characteritisc
@@ -649,7 +643,7 @@ void Widget::onBadProxyCore()
 
 void Widget::onStatusSet(Status::Status status)
 {
-    ui->statusButton->setProperty("status", getTitle(status));
+    ui->statusButton->setProperty("status", static_cast<int>(status));
     ui->statusButton->setIcon(prepareIcon(getIconPath(status), icon_size, icon_size));
     updateIcons();
 }
@@ -1968,7 +1962,7 @@ void Widget::onUserAwayCheck()
 {
 #ifdef QTOX_PLATFORM_EXT
     uint32_t autoAwayTime = settings.getAutoAwayTime() * 60 * 1000;
-    bool online = ui->statusButton->property("status").toString() == "online";
+    bool online = static_cast<Status::Status>(ui->statusButton->property("status").toInt()) == Status::Status::Online;
     bool away = autoAwayTime && Platform::getIdleTime() >= autoAwayTime;
 
     if (online && away) {

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -135,11 +135,7 @@ public:
     void reloadHistory();
 
     void reloadTheme();
-    static QString getStatusIconPath(Status status, bool event = false);
     static inline QIcon prepareIcon(QString path, int w = 0, int h = 0);
-    static QPixmap getStatusIconPixmap(QString path, uint32_t w, uint32_t h);
-    static QString getStatusTitle(Status status);
-    static Status getStatusFromString(QString status);
 
     void searchCircle(CircleWidget* circleWidget);
     bool groupsVisible() const;
@@ -154,7 +150,7 @@ public slots:
     void forceShow();
     void onConnected();
     void onDisconnected();
-    void onStatusSet(Status status);
+    void onStatusSet(Status::Status status);
     void onFailedToStartCore();
     void onBadProxyCore();
     void onSelfAvatarLoaded(const QPixmap& pic);
@@ -162,7 +158,7 @@ public slots:
     void setStatusMessage(const QString& statusMessage);
     void addFriend(uint32_t friendId, const ToxPk& friendPk);
     void addFriendFailed(const ToxPk& userId, const QString& errorInfo = QString());
-    void onFriendStatusChanged(int friendId, Status status);
+    void onFriendStatusChanged(int friendId, Status::Status status);
     void onFriendStatusMessageChanged(int friendId, const QString& message);
     void onFriendDisplayedNameChanged(const QString& displayed);
     void onFriendUsernameChanged(int friendId, const QString& username);
@@ -193,8 +189,8 @@ public slots:
 signals:
     void friendRequestAccepted(const ToxPk& friendPk);
     void friendRequested(const ToxId& friendAddress, const QString& message);
-    void statusSet(Status status);
-    void statusSelected(Status status);
+    void statusSet(Status::Status status);
+    void statusSelected(Status::Status status);
     void usernameChanged(const QString& username);
     void changeGroupTitle(uint32_t groupnumber, const QString& title);
     void statusMessageChanged(const QString& statusMessage);


### PR DESCRIPTION
- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5636)
<!-- Reviewable:end -->
