### PR TITLE
fix(TravisCI): build windows for release tags too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,11 @@ branches:
 stages:
   - Linux
   - name: "Windows Stage 1: Dependencies (OpenSSL, Qt)"
-    if: type = push AND branch = master
+    if: type = push
   - name: "Windows Stage 2: Dependencies (other)"
-    if: type = push AND branch = master
+    if: type = push
   - name: "Windows Stage 3: qTox"
-    if: type = push AND branch = master
+    if: type = push
 
 jobs:
   include:


### PR DESCRIPTION
- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

I think this was an error in previous TravisCI modifications, but I can not really test this until we do a release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5637)
<!-- Reviewable:end -->
