### PR TITLE
docs(apparmor): Update AppArmor documentation about Ubuntu

### DIFF
--- a/security/apparmor/README.md
+++ b/security/apparmor/README.md
@@ -31,10 +31,11 @@ release:
 
 - 2.13.2
   - Debian 10 (buster) (or newer)
+  - Ubuntu 19.04 (Disco Dingo) (or newer)
   - openSUSE Tumbleweed
 - 2.12.1
   - Debian 9 (stretch) or older
-  - Ubuntu 19.04 or older
+  - Ubuntu 18.10 or older
 
 To enable AppArmor profile on your system, run prepared install script:
 


### PR DESCRIPTION
Ubuntu 19.04 was released with AppArmor 2.13.2 [0].

Update documentation to hint users that they can use AppArmor profile with latest AppArmor features on Ubuntu 19.04 release.

[0] https://packages.ubuntu.com/disco/admin/apparmor

- [] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5638)
<!-- Reviewable:end -->
