### PR TITLE
fix(history): save name to history for friend invite message

### DIFF
--- a/src/persistence/profile.cpp
+++ b/src/persistence/profile.cpp
@@ -563,11 +563,12 @@ void Profile::onRequestSent(const ToxPk& friendPk, const QString& message)
         return;
     }
 
-    QString pkStr = friendPk.toString();
-    QString inviteStr = Core::tr("/me offers friendship, \"%1\"").arg(message);
-    QString selfStr = core->getSelfPublicKey().toString();
-    QDateTime datetime = QDateTime::currentDateTime();
-    history->addNewMessage(pkStr, inviteStr, selfStr, datetime, true, QString());
+    const QString pkStr = friendPk.toString();
+    const QString inviteStr = Core::tr("/me offers friendship, \"%1\"").arg(message);
+    const QString selfStr = core->getSelfPublicKey().toString();
+    const QDateTime datetime = QDateTime::currentDateTime();
+    const QString name = core->getUsername();
+    history->addNewMessage(pkStr, inviteStr, selfStr, datetime, true, name);
 }
 
 /**


### PR DESCRIPTION
This avoids an extra alias table entry for the empty name. It is not possible to safely heal existing databases, since friend invite message is a normal action message making it hard to change the alias ID used by it, and the alias in the alias table could be used by any other messages if the user's name has ever truely been blank. Just avoid the incorrect alias entry for new chats.

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5640)
<!-- Reviewable:end -->
