### PR TITLE
refactor(history): create db as part of schema upgrade

### DIFF
--- a/src/persistence/history.h
+++ b/src/persistence/history.h
@@ -200,6 +200,7 @@ private:
     static RawDatabase::Query generateFileFinished(RowId fileId, bool success,
                                                    const QString& filePath, const QByteArray& fileHash);
     void dbSchemaUpgrade();
+    void createCurrentSchema();
 
     std::shared_ptr<RawDatabase> db;
 


### PR DESCRIPTION
* update user_version as part of transaction, so that we rollback if update fails and don't increment version
* differentiate between two user_version 0 versions, to avoid the SQL error on new profile creation
* make table creation dependent on user_version, instead of creating tables if no exists every start

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5646)
<!-- Reviewable:end -->
