### PR TITLE
fix(AVForm): don't load gain when device not ready

### DIFF
--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -571,8 +571,6 @@ void AVForm::on_outDevCombobox_currentIndexChanged(int deviceIndex)
     }
 
     playbackSlider->setEnabled(outputEnabled);
-    playbackSlider->setSliderPosition(
-        getStepsFromValue(audio->outputVolume(), audio->minOutputVolume(), audio->maxOutputVolume()));
 }
 
 void AVForm::on_playbackSlider_valueChanged(int sliderSteps)


### PR DESCRIPTION
This fixes a problem when the audio backend is not yet ready, but we try
to access it's volume.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5648)
<!-- Reviewable:end -->
