### PR TITLE
fix(ui): show empty status as placeholder instead of as status

### DIFF
--- a/src/mainwindow.ui
+++ b/src/mainwindow.ui
@@ -663,7 +663,7 @@
                  <property name="accessibleDescription">
                   <string>Set your status message that will be shown to others</string>
                  </property>
-                 <property name="text">
+                 <property name="placeholderText">
                   <string>Your status</string>
                  </property>
                  <property name="textFormat">

--- a/src/widget/tool/croppinglabel.cpp
+++ b/src/widget/tool/croppinglabel.cpp
@@ -85,6 +85,12 @@ void CroppingLabel::setText(const QString& text)
     setElidedText();
 }
 
+void CroppingLabel::setPlaceholderText(const QString& text)
+{
+    textEdit->setPlaceholderText(text);
+    setElidedText();
+}
+
 void CroppingLabel::resizeEvent(QResizeEvent* ev)
 {
     setElidedText();
@@ -129,8 +135,12 @@ void CroppingLabel::setElidedText()
         setToolTip(Qt::convertFromPlainText(origText, Qt::WhiteSpaceNormal));
     else
         setToolTip(QString());
-
-    QLabel::setText(elidedText);
+    if (!elidedText.isEmpty()) {
+        QLabel::setText(elidedText);
+    } else {
+        // NOTE: it would be nice if the label had custom styling when it was default
+        QLabel::setText(textEdit->placeholderText());
+    }
 }
 
 void CroppingLabel::hideTextEdit()

--- a/src/widget/tool/croppinglabel.h
+++ b/src/widget/tool/croppinglabel.h
@@ -39,6 +39,7 @@ public slots:
 
 public slots:
     void setText(const QString& text);
+    void setPlaceholderText(const QString& text);
     void minimizeMaximumWidth();
 
 signals:

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -909,16 +909,11 @@ void Widget::onStatusMessageChanged(const QString& newStatusMessage)
 
 void Widget::setStatusMessage(const QString& statusMessage)
 {
-    if (statusMessage.isEmpty()) {
-        ui->statusLabel->setText(tr("Your status"));
-        ui->statusLabel->setToolTip(tr("Your status"));
-    } else {
-        ui->statusLabel->setText(statusMessage);
-        // escape HTML from tooltips and preserve newlines
-        // TODO: move newspace preservance to a generic function
-        ui->statusLabel->setToolTip("<p style='white-space:pre'>" + statusMessage.toHtmlEscaped()
-                                    + "</p>");
-    }
+    ui->statusLabel->setText(statusMessage);
+    // escape HTML from tooltips and preserve newlines
+    // TODO: move newspace preservance to a generic function
+    ui->statusLabel->setToolTip("<p style='white-space:pre'>" + statusMessage.toHtmlEscaped()
+                                + "</p>");
 }
 
 void Widget::reloadHistory()


### PR DESCRIPTION
- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

Before:
![old-status](https://user-images.githubusercontent.com/10469203/57335122-8baa0b00-70d6-11e9-877a-447949f06aac.png)

After:
![status](https://user-images.githubusercontent.com/10469203/57335004-3a9a1700-70d6-11e9-815b-ae654787eaec.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5649)
<!-- Reviewable:end -->
