### PR TITLE
fix(groups): don't add friend alias to groups they aren't in

### DIFF
--- a/src/model/friend.cpp
+++ b/src/model/friend.cpp
@@ -87,11 +87,9 @@ void Friend::setAlias(const QString& alias)
     }
 
     for (Group* g : GroupList::getAllGroups()) {
-        if (userAlias.isEmpty()) {
-            g->updateUsername(friendPk, userName);
-            continue;
+        if (g->getPeerList().contains(friendPk)) {
+            g->updateUsername(friendPk, newDisplayed);
         }
-        g->updateUsername(friendPk, userAlias);
     }
 }
 


### PR DESCRIPTION
Fix #5657

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5659)
<!-- Reviewable:end -->
