### PR TITLE
fix(chatlog): update timestamp when db is slower than ack

### DIFF
--- a/src/persistence/offlinemsgengine.cpp
+++ b/src/persistence/offlinemsgengine.cpp
@@ -154,7 +154,7 @@ void OfflineMsgEngine::completeMessage(QMap<ReceiptNum, Message>::iterator msgIt
     if (QThread::currentThread() == QCoreApplication::instance()->thread()) {
         updateTimestamp(msgIt->chatMessage);
     } else {
-        QMetaObject::invokeMethod(this, "updateTimestamp", Qt::QueuedConnection, Q_ARG(ChatMessage::Ptr, msgIt->chatMessage));
+        QMetaObject::invokeMethod(this, "updateTimestamp", Qt::BlockingQueuedConnection, Q_ARG(ChatMessage::Ptr, msgIt->chatMessage));
     }
     sentSavedMessages.erase(msgIt);
     receivedReceipts.removeOne(msgIt.key());

--- a/src/persistence/offlinemsgengine.h
+++ b/src/persistence/offlinemsgengine.h
@@ -57,8 +57,10 @@ private:
 private slots:
     void completeMessage(QMap<ReceiptNum, Message>::iterator msgIt);
 
-private:
+private slots:
     void updateTimestamp(ChatMessage::Ptr msg);
+
+private:
     void checkForCompleteMessages(ReceiptNum receipt);
 
     QMutex mutex;


### PR DESCRIPTION
* cannot invoke non-slot function

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5669)
<!-- Reviewable:end -->
