### PR TITLE
refactor(audio): Remove Audio singleton

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,6 +243,7 @@ set(${PROJECT_NAME}_SOURCES
   src/audio/backend/openal.cpp
   src/audio/backend/openal.h
   src/audio/iaudiosettings.h
+  src/audio/iaudiocontrol.h
   src/audio/iaudiosink.h
   src/audio/iaudiosource.h
   src/chatlog/chatlinecontent.cpp

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -17,109 +17,30 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "audio.h"
+#include <memory>
+
+#include "src/audio/audio.h"
+#include "src/audio/iaudiosettings.h"
 #include "src/audio/backend/openal.h"
 #ifdef USE_FILTERAUDIO
 #include "src/audio/backend/openal2.h"
 #endif
-#include "src/persistence/settings.h"
 
 /**
- * @class Audio
- *
- * @var Audio::AUDIO_SAMPLE_RATE
- * @brief The next best Opus would take is 24k
- *
- * @var Audio::AUDIO_FRAME_DURATION
- * @brief In milliseconds
- *
- * @var Audio::AUDIO_FRAME_SAMPLE_COUNT
- * @brief Frame sample count
- *
- * @fn qreal Audio::outputVolume() const
- * @brief Returns the current output volume (between 0 and 1)
- *
- * @fn void Audio::setOutputVolume(qreal volume)
- * @brief Set the master output volume.
- *
- * @param[in] volume   the master volume (between 0 and 1)
- *
- * @fn qreal Audio::minInputGain() const
- * @brief The minimum gain value for an input device.
- *
- * @return minimum gain value in dB
- *
- * @fn void Audio::setMinInputGain(qreal dB)
- * @brief Set the minimum allowed gain value in dB.
- *
- * @note Default is -30dB; usually you don't need to alter this value;
- *
- * @fn qreal Audio::maxInputGain() const
- * @brief The maximum gain value for an input device.
- *
- * @return maximum gain value in dB
- *
- * @fn void Audio::setMaxInputGain(qreal dB)
- * @brief Set the maximum allowed gain value in dB.
- *
- * @note Default is 30dB; usually you don't need to alter this value.
- *
- * @fn bool Audio::isOutputReady() const
- * @brief check if the output is ready to play audio
- *
- * @return true if the output device is open, false otherwise
- *
- * @fn QStringList Audio::outDeviceNames()
- * @brief Get the names of available output devices
- *
- * @return list of output devices
- *
- * @fn QStringList Audio::inDeviceNames()
- * @brief Get the names of available input devices
- *
- * @return list of input devices
- *
- * @fn qreal Audio::inputGain() const
- * @brief get the current input gain
- *
- * @return current input gain in dB
- *
- * @fn void Audio::setInputGain(qreal dB)
- * @brief set the input gain
- *
- * @fn void Audio::getInputThreshold()
- * @brief get the current input threshold
- *
- * @return current input threshold percentage
- *
- * @fn void Audio::setInputThreshold(qreal percent)
- * @brief set the input threshold
- *
- * @param[in] percent the new input threshold percentage
+ * @brief Select the audio backend
+ * @param settings Audio settings to use
+ * @return Audio backend selection based on settings
  */
-
-/**
- * @brief Returns the singleton instance.
- */
-Audio& Audio::getInstance()
+std::unique_ptr<IAudioControl> Audio::makeAudio(IAudioSettings& settings)
 {
-    // TODO: replace backend selection by inversion of control
 #ifdef USE_FILTERAUDIO
-    static bool initialized = false;
-    static bool Backend2 = false;
-
-    if (!initialized) {
-        Backend2 = Settings::getInstance().getEnableBackend2();
-        initialized = true;
-    }
+    const bool Backend2 = settings.getEnableBackend2();
 
     if (Backend2) {
-        static OpenAL2 instance;
-        return instance;
+        return std::unique_ptr<IAudioControl>(new OpenAL2());
     } else
 #endif
     {
-        static OpenAL instance;
-        return instance;
+        return std::unique_ptr<IAudioControl>(new OpenAL());
     }
 }

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -21,57 +21,14 @@
 #ifndef AUDIO_H
 #define AUDIO_H
 
-#include <QObject>
 #include <memory>
 
-class IAudioSink;
-class IAudioSource;
-class Audio : public QObject
+class IAudioControl;
+class IAudioSettings;
+class Audio
 {
-    Q_OBJECT
-
 public:
-    static Audio& getInstance();
-
-    virtual qreal outputVolume() const = 0;
-    virtual void setOutputVolume(qreal volume) = 0;
-    virtual qreal maxOutputVolume() const = 0;
-    virtual qreal minOutputVolume() const = 0;
-
-    virtual qreal minInputGain() const = 0;
-    virtual void setMinInputGain(qreal dB) = 0;
-
-    virtual qreal maxInputGain() const = 0;
-    virtual void setMaxInputGain(qreal dB) = 0;
-
-    virtual qreal inputGain() const = 0;
-    virtual void setInputGain(qreal dB) = 0;
-
-    virtual qreal minInputThreshold() const = 0;
-    virtual qreal maxInputThreshold() const = 0;
-
-    virtual qreal getInputThreshold() const = 0;
-    virtual void setInputThreshold(qreal percent) = 0;
-
-    virtual void reinitInput(const QString& inDevDesc) = 0;
-    virtual bool reinitOutput(const QString& outDevDesc) = 0;
-
-    virtual bool isOutputReady() const = 0;
-
-    virtual QStringList outDeviceNames() = 0;
-    virtual QStringList inDeviceNames() = 0;
-
-    virtual std::unique_ptr<IAudioSink> makeSink() = 0;
-    virtual std::unique_ptr<IAudioSource> makeSource() = 0;
-
-protected:
-    // Public default audio settings
-    // Samplerate for Tox calls and sounds
-    static constexpr uint32_t AUDIO_SAMPLE_RATE = 48000;
-    static constexpr uint32_t AUDIO_FRAME_DURATION = 20;
-    static constexpr uint32_t AUDIO_FRAME_SAMPLE_COUNT_PER_CHANNEL =
-        AUDIO_FRAME_DURATION * AUDIO_SAMPLE_RATE / 1000;
-    uint32_t AUDIO_FRAME_SAMPLE_COUNT_TOTAL = 0;
+    static std::unique_ptr<IAudioControl> makeAudio(IAudioSettings& settings);
 };
 
 #endif // AUDIO_H

--- a/src/audio/backend/openal.h
+++ b/src/audio/backend/openal.h
@@ -21,7 +21,7 @@
 #ifndef OPENAL_H
 #define OPENAL_H
 
-#include "src/audio/audio.h"
+#include "src/audio/iaudiocontrol.h"
 #include "src/audio/backend/alsink.h"
 #include "src/audio/backend/alsource.h"
 
@@ -45,7 +45,7 @@
 #include <AL/alext.h>
 #endif
 
-class OpenAL : public Audio
+class OpenAL : public IAudioControl
 {
     Q_OBJECT
 

--- a/src/audio/backend/openal2.cpp
+++ b/src/audio/backend/openal2.cpp
@@ -159,7 +159,7 @@ bool OpenAL2::initOutputEchoCancel()
                       ALC_FORMAT_TYPE_SOFT,
                       ALC_SHORT_SOFT,
                       ALC_FREQUENCY,
-                      Audio::AUDIO_SAMPLE_RATE,
+                      IAudioControl::AUDIO_SAMPLE_RATE,
                       0}; // End of List
 
     alProxyDev = alcLoopbackOpenDeviceSOFT(nullptr);

--- a/src/audio/backend/openal2.h
+++ b/src/audio/backend/openal2.h
@@ -21,7 +21,7 @@
 #ifndef OPENAL2_H
 #define OPENAL2_H
 
-#include "src/audio/audio.h"
+#include "src/audio/iaudiocontrol.h"
 #include "src/audio/backend/openal.h"
 
 #include <atomic>

--- a/src/audio/iaudiocontrol.h
+++ b/src/audio/iaudiocontrol.h
@@ -1,0 +1,131 @@
+#ifndef IAUDIOCONTROL_H
+#define IAUDIOCONTROL_H
+
+#include <QObject>
+#include <QStringList>
+#include <memory>
+
+/**
+ * @class IAudioControl
+ *
+ * @var IAudioControl::AUDIO_SAMPLE_RATE
+ * @brief The next best Opus would take is 24k
+ *
+ * @var IAudioControl::AUDIO_FRAME_DURATION
+ * @brief In milliseconds
+ *
+ * @var IAudioControl::AUDIO_FRAME_SAMPLE_COUNT
+ * @brief Frame sample count
+ *
+ * @fn qreal IAudioControl::outputVolume() const
+ * @brief Returns the current output volume (between 0 and 1)
+ *
+ * @fn void IAudioControl::setOutputVolume(qreal volume)
+ * @brief Set the master output volume.
+ *
+ * @param[in] volume   the master volume (between 0 and 1)
+ *
+ * @fn qreal IAudioControl::minInputGain() const
+ * @brief The minimum gain value for an input device.
+ *
+ * @return minimum gain value in dB
+ *
+ * @fn void IAudioControl::setMinInputGain(qreal dB)
+ * @brief Set the minimum allowed gain value in dB.
+ *
+ * @note Default is -30dB; usually you don't need to alter this value;
+ *
+ * @fn qreal IAudioControl::maxInputGain() const
+ * @brief The maximum gain value for an input device.
+ *
+ * @return maximum gain value in dB
+ *
+ * @fn void IAudioControl::setMaxInputGain(qreal dB)
+ * @brief Set the maximum allowed gain value in dB.
+ *
+ * @note Default is 30dB; usually you don't need to alter this value.
+ *
+ * @fn bool IAudioControl::isOutputReady() const
+ * @brief check if the output is ready to play audio
+ *
+ * @return true if the output device is open, false otherwise
+ *
+ * @fn QStringList IAudioControl::outDeviceNames()
+ * @brief Get the names of available output devices
+ *
+ * @return list of output devices
+ *
+ * @fn QStringList IAudioControl::inDeviceNames()
+ * @brief Get the names of available input devices
+ *
+ * @return list of input devices
+ *
+ * @fn qreal IAudioControl::inputGain() const
+ * @brief get the current input gain
+ *
+ * @return current input gain in dB
+ *
+ * @fn void IAudioControl::setInputGain(qreal dB)
+ * @brief set the input gain
+ *
+ * @fn void IAudioControl::getInputThreshold()
+ * @brief get the current input threshold
+ *
+ * @return current input threshold percentage
+ *
+ * @fn void IAudioControl::setInputThreshold(qreal percent)
+ * @brief set the input threshold
+ *
+ * @param[in] percent the new input threshold percentage
+ */
+
+class IAudioSink;
+class IAudioSource;
+class IAudioControl : public QObject
+{
+    Q_OBJECT
+
+public:
+    virtual qreal outputVolume() const = 0;
+    virtual void setOutputVolume(qreal volume) = 0;
+    virtual qreal maxOutputVolume() const = 0;
+    virtual qreal minOutputVolume() const = 0;
+
+    virtual qreal minInputGain() const = 0;
+    virtual void setMinInputGain(qreal dB) = 0;
+
+    virtual qreal maxInputGain() const = 0;
+    virtual void setMaxInputGain(qreal dB) = 0;
+
+    virtual qreal inputGain() const = 0;
+    virtual void setInputGain(qreal dB) = 0;
+
+    virtual qreal minInputThreshold() const = 0;
+    virtual qreal maxInputThreshold() const = 0;
+
+    virtual qreal getInputThreshold() const = 0;
+    virtual void setInputThreshold(qreal percent) = 0;
+
+    virtual void reinitInput(const QString& inDevDesc) = 0;
+    virtual bool reinitOutput(const QString& outDevDesc) = 0;
+
+    virtual bool isOutputReady() const = 0;
+
+    virtual QStringList outDeviceNames() = 0;
+    virtual QStringList inDeviceNames() = 0;
+
+    virtual std::unique_ptr<IAudioSink> makeSink() = 0;
+    virtual std::unique_ptr<IAudioSource> makeSource() = 0;
+
+protected:
+    // Public default audio settings
+    // Samplerate for Tox calls and sounds
+    static constexpr uint32_t AUDIO_SAMPLE_RATE = 48000;
+    static constexpr uint32_t AUDIO_FRAME_DURATION = 20;
+    static constexpr uint32_t AUDIO_FRAME_SAMPLE_COUNT_PER_CHANNEL =
+        AUDIO_FRAME_DURATION * AUDIO_SAMPLE_RATE / 1000;
+    uint32_t AUDIO_FRAME_SAMPLE_COUNT_TOTAL = 0;
+};
+
+
+#endif // IAUDIOCONTROL_H

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -281,6 +281,7 @@ ToxCorePtr Core::makeToxCore(const QByteArray& savedata, const ICoreSettings* co
     assert(core->tox != nullptr);
 
     // toxcore is successfully created, create toxav
+    // TODO(sudden6): don't create CoreAv here, Core should be usable without CoreAV
     core->av = CoreAV::makeCoreAV(core->tox.get());
     if (!core->av) {
         qCritical() << "Toxav failed to start";

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -40,6 +40,7 @@
 
 class CoreAV;
 class CoreFile;
+class IAudioControl;
 class ICoreSettings;
 class GroupInvite;
 class Profile;

--- a/src/core/coreav.h
+++ b/src/core/coreav.h
@@ -29,6 +29,7 @@
 
 class Friend;
 class Group;
+class IAudioControl;
 class QThread;
 class QTimer;
 class CoreVideoSource;
@@ -43,9 +44,11 @@ class CoreAV : public QObject
     Q_OBJECT
 
 public:
-
     using CoreAVPtr = std::unique_ptr<CoreAV>;
     static CoreAVPtr makeCoreAV(Tox* core);
+
+    void setAudio(IAudioControl& newAudio);
+    IAudioControl* getAudio();
 
     ~CoreAV();
 
@@ -124,7 +127,8 @@ private:
     static constexpr uint32_t VIDEO_DEFAULT_BITRATE = 2500;
 
 private:
-
+    // atomic because potentially accessed by different threads
+    std::atomic<IAudioControl*> audio;
     std::unique_ptr<ToxAV, ToxAVDeleter> toxav;
     std::unique_ptr<QThread> coreavThread;
     QTimer* iterateTimer = nullptr;
@@ -133,8 +137,6 @@ private:
     using ToxGroupCallPtr = std::unique_ptr<ToxGroupCall>;
     static std::map<int, ToxGroupCallPtr> groupCalls;
     std::atomic_flag threadSwitchLock;
-
-    friend class Audio;
 };
 
 #endif // COREAV_H

--- a/src/core/toxcall.h
+++ b/src/core/toxcall.h
@@ -1,6 +1,7 @@
 #ifndef TOXCALL_H
 #define TOXCALL_H
 
+#include "src/audio/iaudiocontrol.h"
 #include "src/audio/iaudiosink.h"
 #include "src/audio/iaudiosource.h"
 #include <src/core/toxpk.h>
@@ -22,7 +23,7 @@ class ToxCall
 {
 protected:
     ToxCall() = delete;
-    ToxCall(bool VideoEnabled, CoreAV& av);
+    ToxCall(bool VideoEnabled, CoreAV& av, IAudioControl& audio);
     ~ToxCall();
 
 public:
@@ -53,6 +54,7 @@ protected:
     bool active{false};
     CoreAV* av{nullptr};
     // audio
+    IAudioControl& audio;
     QMetaObject::Connection audioInConn;
     bool muteMic{false};
     bool muteVol{false};
@@ -69,7 +71,7 @@ class ToxFriendCall : public ToxCall
 {
 public:
     ToxFriendCall() = delete;
-    ToxFriendCall(uint32_t friendId, bool VideoEnabled, CoreAV& av);
+    ToxFriendCall(uint32_t friendId, bool VideoEnabled, CoreAV& av, IAudioControl& audio);
     ToxFriendCall(ToxFriendCall&& other) = delete;
     ToxFriendCall& operator=(ToxFriendCall&& other) = delete;
     ~ToxFriendCall();
@@ -101,7 +103,7 @@ class ToxGroupCall : public ToxCall
 {
 public:
     ToxGroupCall() = delete;
-    ToxGroupCall(int GroupNum, CoreAV& av);
+    ToxGroupCall(int GroupNum, CoreAV& av, IAudioControl& audio);
     ToxGroupCall(ToxGroupCall&& other) = delete;
     ~ToxGroupCall();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,11 +17,13 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "persistence/settings.h"
+#include "src/audio/audio.h"
+#include "src/core/coreav.h"
 #include "src/ipc.h"
 #include "src/net/toxuri.h"
 #include "src/nexus.h"
 #include "src/persistence/profile.h"
+#include "src/persistence/settings.h"
 #include "src/persistence/toxsave.h"
 #include "src/video/camerasource.h"
 #include "src/widget/loginscreen.h"
@@ -347,9 +349,17 @@ int main(int argc, char* argv[])
     }
 
     Nexus::getInstance().setProfile(profile);
-    Settings::getInstance().setCurrentProfile(profileName);
+    Settings& s = Settings::getInstance();
+    s.setCurrentProfile(profileName);
+
+    auto audio = Audio::makeAudio(s);
+    assert(audio != nullptr);
+    // TODO(sudden6): init CoreAV audio backend somewhere else so main doesn't depend on coreav.h
+    profile->getCore()->getAv()->setAudio(*audio);
 
     Nexus& nexus = Nexus::getInstance();
+    // TODO(sudden6): remove once we get rid of Nexus
+    nexus.audio = audio.get();
     nexus.start();
 
     // Start to accept Inter-process communication

--- a/src/nexus.cpp
+++ b/src/nexus.cpp
@@ -175,7 +175,7 @@ void Nexus::showMainGUI()
     assert(profile);
 
     // Create GUI
-    widget = Widget::getInstance();
+    widget = Widget::getInstance(audio);
 
     // Start GUI
     widget->init();

--- a/src/nexus.h
+++ b/src/nexus.h
@@ -23,6 +23,8 @@
 
 #include <QObject>
 
+#include "src/audio/iaudiocontrol.h"
+
 class Widget;
 class Profile;
 class Core;
@@ -79,6 +81,9 @@ private:
     QSignalMapper* windowMapper;
     QActionGroup* windowActions = nullptr;
 #endif
+public:
+    // TODO(sudden6): hack to pass the audio instance
+    IAudioControl* audio = nullptr;
 
 private:
     explicit Nexus(QObject* parent = nullptr);

--- a/src/persistence/profile.cpp
+++ b/src/persistence/profile.cpp
@@ -32,6 +32,7 @@
 #include "profilelocker.h"
 #include "settings.h"
 #include "src/core/core.h"
+#include "src/core/coreav.h"
 #include "src/core/corefile.h"
 #include "src/net/avatarbroadcaster.h"
 #include "src/nexus.h"
@@ -96,7 +97,8 @@ void Profile::initCore(const QByteArray& toxsave, ICoreSettings& s, bool isNewPr
             Qt::ConnectionType::QueuedConnection);
 }
 
-Profile::Profile(QString name, const QString& password, bool isNewProfile, const QByteArray& toxsave, std::unique_ptr<ToxEncrypt> passkey)
+Profile::Profile(QString name, const QString& password, bool isNewProfile,
+                 const QByteArray& toxsave, std::unique_ptr<ToxEncrypt> passkey)
     : name{name}
     , passkey{std::move(passkey)}
     , isRemoved{false}
@@ -797,7 +799,10 @@ void Profile::restartCore()
         if (saveToxSave(savedata)) {
             qDebug() << "Restarting Core";
             const bool isNewProfile{false};
+            IAudioControl* audioBak = core->getAv()->getAudio();
+            assert(audioBak != nullptr);
             initCore(savedata, Settings::getInstance(), isNewProfile);
+            core->getAv()->setAudio(*audioBak);
             core->start();
         } else {
             qCritical() << "Failed to save, not restarting core";

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -44,10 +44,10 @@
 #define ALC_ALL_DEVICES_SPECIFIER ALC_DEVICE_SPECIFIER
 #endif
 
-AVForm::AVForm(Audio* audio, CoreAV* coreAV, CameraSource& camera, IAudioSettings* audioSettings,
-               IVideoSettings* videoSettings)
+AVForm::AVForm(IAudioControl& audio, CoreAV* coreAV, CameraSource& camera,
+               IAudioSettings* audioSettings, IVideoSettings* videoSettings)
     : GenericForm(QPixmap(":/img/settings/av.png"))
-    , audio{audio}
+    , audio(audio)
     , coreAV{coreAV}
     , audioSettings{audioSettings}
     , videoSettings{videoSettings}
@@ -78,8 +78,8 @@ AVForm::AVForm(Audio* audio, CoreAV* coreAV, CameraSource& camera, IAudioSetting
 
     microphoneSlider->setToolTip(tr("Use slider to set the gain of your input device ranging"
                                     " from %1dB to %2dB.")
-                                     .arg(audio->minInputGain())
-                                     .arg(audio->maxInputGain()));
+                                     .arg(audio.minInputGain())
+                                     .arg(audio.maxInputGain()));
     microphoneSlider->setMaximum(totalSliderSteps);
     microphoneSlider->setTickPosition(QSlider::TicksBothSides);
     static const int numTicks = 4;
@@ -87,14 +87,14 @@ AVForm::AVForm(Audio* audio, CoreAV* coreAV, CameraSource& camera, IAudioSetting
     microphoneSlider->setTracking(false);
     microphoneSlider->installEventFilter(this);
     microphoneSlider->setValue(
-        getStepsFromValue(audio->inputGain(), audio->minInputGain(), audio->maxInputGain()));
+        getStepsFromValue(audio.inputGain(), audio.minInputGain(), audio.maxInputGain()));
 
     audioThresholdSlider->setToolTip(tr("Use slider to set the activation volume for your"
                                         " input device."));
     audioThresholdSlider->setMaximum(totalSliderSteps);
     audioThresholdSlider->setValue(getStepsFromValue(audioSettings->getAudioThreshold(),
-                                                     audio->minInputThreshold(),
-                                                     audio->maxInputThreshold()));
+                                                     audio.minInputThreshold(),
+                                                     audio.maxInputThreshold()));
     audioThresholdSlider->setTracking(false);
     audioThresholdSlider->installEventFilter(this);
 
@@ -139,12 +139,12 @@ void AVForm::showEvent(QShowEvent* event)
     getVideoDevices();
 
     if (audioSrc == nullptr) {
-        audioSrc = audio->makeSource();
+        audioSrc = audio.makeSource();
         connect(audioSrc.get(), &IAudioSource::volumeAvailable, this, &AVForm::setVolume);
     }
 
     if (audioSink == nullptr) {
-        audioSink = audio->makeSink();
+        audioSink = audio.makeSink();
     }
 
     GenericForm::showEvent(event);
@@ -167,8 +167,7 @@ void AVForm::rescanDevices()
 
 void AVForm::setVolume(float value)
 {
-    volumeDisplay->setValue(
-        getStepsFromValue(value, audio->minOutputVolume(), audio->maxOutputVolume()));
+    volumeDisplay->setValue(getStepsFromValue(value, audio.minOutputVolume(), audio.maxOutputVolume()));
 }
 
 void AVForm::on_cbEnableBackend2_stateChanged()
@@ -493,7 +492,7 @@ int AVForm::getModeSize(VideoMode mode)
 void AVForm::getAudioInDevices()
 {
     QStringList deviceNames;
-    deviceNames << tr("Disabled") << audio->inDeviceNames();
+    deviceNames << tr("Disabled") << audio.inDeviceNames();
 
     inDevCombobox->blockSignals(true);
     inDevCombobox->clear();
@@ -512,7 +511,7 @@ void AVForm::getAudioInDevices()
 void AVForm::getAudioOutDevices()
 {
     QStringList deviceNames;
-    deviceNames << tr("Disabled") << audio->outDeviceNames();
+    deviceNames << tr("Disabled") << audio.outDeviceNames();
 
     outDevCombobox->blockSignals(true);
     outDevCombobox->clear();
@@ -541,8 +540,8 @@ void AVForm::on_inDevCombobox_currentIndexChanged(int deviceIndex)
     const QString oldName = audioSettings->getInDev();
     if (oldName != deviceName) {
         audioSettings->setInDev(deviceName);
-        audio->reinitInput(deviceName);
-        audioSrc = audio->makeSource();
+        audio.reinitInput(deviceName);
+        audioSrc = audio.makeSource();
         connect(audioSrc.get(), &IAudioSource::volumeAvailable, this, &AVForm::setVolume);
     }
 
@@ -566,8 +565,8 @@ void AVForm::on_outDevCombobox_currentIndexChanged(int deviceIndex)
 
     if (oldName != deviceName) {
         audioSettings->setOutDev(deviceName);
-        audio->reinitOutput(deviceName);
-        audioSink = Audio::getInstance().makeSink();
+        audio.reinitOutput(deviceName);
+        audioSink = audio.makeSink();
     }
 
     playbackSlider->setEnabled(outputEnabled);
@@ -579,10 +578,10 @@ void AVForm::on_playbackSlider_valueChanged(int sliderSteps)
                                                  audioSettings->getOutVolumeMax());
     audioSettings->setOutVolume(settingsVolume);
 
-    if (audio->isOutputReady()) {
+    if (audio.isOutputReady()) {
         const qreal volume =
-            getValueFromSteps(sliderSteps, audio->minOutputVolume(), audio->maxOutputVolume());
-        audio->setOutputVolume(volume);
+            getValueFromSteps(sliderSteps, audio.minOutputVolume(), audio.maxOutputVolume());
+        audio.setOutputVolume(volume);
 
         if (cbEnableTestSound->isChecked() && audioSink) {
             audioSink->playMono16Sound(IAudioSink::Sound::Test);
@@ -594,24 +593,24 @@ void AVForm::on_cbEnableTestSound_stateChanged()
 {
     audioSettings->setEnableTestSound(cbEnableTestSound->isChecked());
 
-    if (cbEnableTestSound->isChecked() && audio->isOutputReady() && audioSink) {
+    if (cbEnableTestSound->isChecked() && audio.isOutputReady() && audioSink) {
         audioSink->playMono16Sound(IAudioSink::Sound::Test);
     }
 }
 
 void AVForm::on_microphoneSlider_valueChanged(int sliderSteps)
 {
-    const qreal dB = getValueFromSteps(sliderSteps, audio->minInputGain(), audio->maxInputGain());
+    const qreal dB = getValueFromSteps(sliderSteps, audio.minInputGain(), audio.maxInputGain());
     audioSettings->setAudioInGainDecibel(dB);
-    audio->setInputGain(dB);
+    audio.setInputGain(dB);
 }
 
 void AVForm::on_audioThresholdSlider_valueChanged(int sliderSteps)
 {
     const qreal normThreshold =
-        getValueFromSteps(sliderSteps, audio->minInputThreshold(), audio->maxInputThreshold());
+        getValueFromSteps(sliderSteps, audio.minInputThreshold(), audio.maxInputThreshold());
     audioSettings->setAudioThreshold(normThreshold);
-    Audio::getInstance().setInputThreshold(normThreshold);
+    audio.setInputThreshold(normThreshold);
 }
 void AVForm::createVideoSurface()
 {

--- a/src/widget/form/settings/avform.h
+++ b/src/widget/form/settings/avform.h
@@ -30,7 +30,7 @@
 
 #include <memory>
 
-class Audio;
+class IAudioControl;
 class IAudioSettings;
 class IAudioSink;
 class IAudioSource;
@@ -42,8 +42,8 @@ class AVForm : public GenericForm, private Ui::AVForm
 {
     Q_OBJECT
 public:
-    AVForm(Audio* audio, CoreAV* coreAV, CameraSource& camera, IAudioSettings* audioSettings,
-           IVideoSettings* videoSettings);
+    AVForm(IAudioControl& audio, CoreAV* coreAV, CameraSource& camera,
+           IAudioSettings* audioSettings, IVideoSettings* videoSettings);
     ~AVForm() override;
     QString getFormName() final override
     {
@@ -97,7 +97,7 @@ private:
     qreal getValueFromSteps(int steps, qreal valMin, qreal valMax);
 
 private:
-    Audio* audio;
+    IAudioControl& audio;
     CoreAV* coreAV;
     IAudioSettings* audioSettings;
     IVideoSettings* videoSettings;

--- a/src/widget/form/settingswidget.cpp
+++ b/src/widget/form/settingswidget.cpp
@@ -20,8 +20,8 @@
 #include "settingswidget.h"
 
 #include "src/audio/audio.h"
-#include "src/core/coreav.h"
 #include "src/core/core.h"
+#include "src/core/coreav.h"
 #include "src/net/updatecheck.h"
 #include "src/persistence/settings.h"
 #include "src/video/camerasource.h"
@@ -41,10 +41,9 @@
 
 #include <memory>
 
-SettingsWidget::SettingsWidget(UpdateCheck* updateCheck, QWidget* parent)
+SettingsWidget::SettingsWidget(UpdateCheck* updateCheck, IAudioControl& audio, QWidget* parent)
     : QWidget(parent, Qt::Window)
 {
-    Audio* audio = &Audio::getInstance();
     CoreAV* coreAV = Core::getInstance()->getAv();
     IAudioSettings* audioSettings = &Settings::getInstance();
     IVideoSettings* videoSettings = &Settings::getInstance();
@@ -74,7 +73,8 @@ SettingsWidget::SettingsWidget(UpdateCheck* updateCheck, QWidget* parent)
     }
 #endif
 
-    cfgForms = {{std::move(gfrm), std::move(uifrm), std::move(pfrm), std::move(avfrm), std::move(expfrm), std::move(abtfrm)}};
+    cfgForms = {{std::move(gfrm), std::move(uifrm), std::move(pfrm), std::move(avfrm),
+                 std::move(expfrm), std::move(abtfrm)}};
     for (auto& cfgForm : cfgForms)
         settingsWidgets->addTab(cfgForm.get(), cfgForm->getFormIcon(), cfgForm->getFormName());
 

--- a/src/widget/form/settingswidget.h
+++ b/src/widget/form/settingswidget.h
@@ -30,6 +30,7 @@
 class Camera;
 class GenericForm;
 class GeneralForm;
+class IAudioControl;
 class PrivacyForm;
 class AVForm;
 class QLabel;
@@ -41,7 +42,7 @@ class SettingsWidget : public QWidget
 {
     Q_OBJECT
 public:
-    SettingsWidget(UpdateCheck* updateCheck, QWidget* parent = nullptr);
+    SettingsWidget(UpdateCheck* updateCheck, IAudioControl& audio, QWidget* parent = nullptr);
     ~SettingsWidget();
 
     bool isShown() const;

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -29,12 +29,13 @@
 
 #include "genericchatitemwidget.h"
 
+#include "src/audio/iaudiocontrol.h"
 #include "src/audio/iaudiosink.h"
 #include "src/core/core.h"
-#include "src/core/toxfile.h"
 #include "src/core/groupid.h"
-#include "src/core/toxpk.h"
+#include "src/core/toxfile.h"
 #include "src/core/toxid.h"
+#include "src/core/toxpk.h"
 #if DESKTOP_NOTIFICATIONS
 #include "src/platform/desktop_notifications/desktopnotify.h"
 #endif
@@ -112,13 +113,13 @@ private:
     };
 
 public:
-    explicit Widget(QWidget* parent = nullptr);
+    explicit Widget(IAudioControl& audio, QWidget* parent = nullptr);
     ~Widget() override;
     void init();
     void setCentralWidget(QWidget* widget, const QString& widgetName);
     QString getUsername();
     Camera* getCamera();
-    static Widget* getInstance();
+    static Widget* getInstance(IAudioControl* audio = nullptr);
     void showUpdateDownloadProgress();
     void addFriendDialog(const Friend* frnd, ContentDialog* dialog);
     void addGroupDialog(Group* group, ContentDialog* dialog);
@@ -185,7 +186,7 @@ public slots:
     void onFriendDialogShown(const Friend* f);
     void onGroupDialogShown(Group* g);
     void toggleFullscreen();
-    void refreshPeerListsLocal(const QString &username);
+    void refreshPeerListsLocal(const QString& username);
     void onUpdateAvailable(QString latestVersion, QUrl link);
 
 signals:
@@ -312,6 +313,8 @@ private:
     QPushButton* groupInvitesButton;
     unsigned int unreadGroupInvites;
     int icon_size;
+
+    IAudioControl& audio;
     std::unique_ptr<IAudioSink> audioNotification = nullptr;
     Settings& settings;
 


### PR DESCRIPTION
This commit finally removes the Audio singleton and allocates the audio
backend in main.cpp.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelin

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5671)
<!-- Reviewable:end -->
