### PR TITLE
edit load history (close #5501)

### DIFF
--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -49,8 +49,8 @@ T clamp(T x, T min, T max)
     return x;
 }
 
-ChatLog::ChatLog(QWidget* parent)
-    : QGraphicsView(parent)
+ChatLog::ChatLog(const bool canRemove, QWidget* parent)
+    : QGraphicsView(parent), canRemove(canRemove)
 {
     // Create the scene
     busyScene = new QGraphicsScene(this);
@@ -391,7 +391,7 @@ void ChatLog::insertChatlineAtBottom(const QList<ChatLine::Ptr>& newLines)
     if (newLines.isEmpty())
         return;
 
-    if (lines.size() + DEF_NUM_MSG_TO_LOAD >= maxMessages) {
+    if (canRemove && lines.size() + DEF_NUM_MSG_TO_LOAD >= maxMessages) {
         removeFirsts(DEF_NUM_MSG_TO_LOAD);
     }
 
@@ -442,7 +442,7 @@ void ChatLog::insertChatlinesOnTop(const QList<ChatLine::Ptr>& newLines)
         combLines.push_back(l);
     }
 
-    if (lines.size() + DEF_NUM_MSG_TO_LOAD >= maxMessages) {
+    if (canRemove && lines.size() + DEF_NUM_MSG_TO_LOAD >= maxMessages) {
         removeLasts(DEF_NUM_MSG_TO_LOAD);
     }
 
@@ -804,7 +804,6 @@ void ChatLog::checkVisibility(bool causedWheelEvent)
     }
 
     if (causedWheelEvent) {
-        qDebug() << "causedWheelEvent";
         if (lowerBound != lines.cend() && lowerBound->get()->row == 0) {
             emit loadHistoryLower();
         } else if (upperBound == lines.cend()) {

--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -677,7 +677,7 @@ void ChatLog::forceRelayout()
     startResizeWorker();
 }
 
-void ChatLog::checkVisibility()
+void ChatLog::checkVisibility(bool causedByScroll)
 {
     if (lines.empty())
         return;
@@ -717,12 +717,16 @@ void ChatLog::checkVisibility()
     if (!visibleLines.isEmpty()) {
         emit firstVisibleLineChanged(visibleLines.at(0));
     }
+
+    if (causedByScroll && lowerBound != lines.cend() && lowerBound->get()->row == 0) {
+        emit loadHistoryLower();
+    }
 }
 
 void ChatLog::scrollContentsBy(int dx, int dy)
 {
     QGraphicsView::scrollContentsBy(dx, dy);
-    checkVisibility();
+    checkVisibility(true);
 }
 
 void ChatLog::resizeEvent(QResizeEvent* ev)

--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -688,6 +688,28 @@ void ChatLog::reloadTheme()
     }
 }
 
+void ChatLog::removeFirsts(const int num)
+{
+    if (lines.size() > num) {
+        lines.erase(lines.begin(), lines.begin()+num);
+    } else {
+        lines.clear();
+    }
+
+    for (int i = 0; i < lines.size(); ++i) {
+        lines[i]->setRow(i);
+    }
+}
+
+void ChatLog::removeLasts(const int num)
+{
+    if (lines.size() > num) {
+        lines.erase(lines.end()-num, lines.end());
+    } else {
+        lines.clear();
+    }
+}
+
 void ChatLog::forceRelayout()
 {
     startResizeWorker();

--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -382,6 +382,22 @@ void ChatLog::insertChatlineAtBottom(ChatLine::Ptr l)
     updateTypingNotification();
 }
 
+void ChatLog::insertChatlineAtBottom(const QList<ChatLine::Ptr>& newLines)
+{
+    if (newLines.isEmpty())
+        return;
+
+    for (ChatLine::Ptr l : newLines) {
+        l->setRow(lines.size());
+        l->addToScene(scene);
+        l->visibilityChanged(false);
+        lines.append(l);
+    }
+
+    layout(lines.last()->getRow(), lines.size(), useableWidth());
+    startResizeWorker();
+}
+
 void ChatLog::insertChatlineOnTop(ChatLine::Ptr l)
 {
     if (!l.get())
@@ -718,8 +734,12 @@ void ChatLog::checkVisibility(bool causedByScroll)
         emit firstVisibleLineChanged(visibleLines.at(0));
     }
 
-    if (causedByScroll && lowerBound != lines.cend() && lowerBound->get()->row == 0) {
-        emit loadHistoryLower();
+    if (causedByScroll) {
+        if (lowerBound != lines.cend() && lowerBound->get()->row == 0) {
+            emit loadHistoryLower();
+        } else if (upperBound != lines.cend() && upperBound->get()->row >= lines.size() - 10) {
+            emit loadHistoryUpper();
+        }
     }
 }
 

--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -168,8 +168,9 @@ void ChatLog::updateSceneRect()
 
 void ChatLog::layout(int start, int end, qreal width)
 {
-    if (lines.empty())
+    if (lines.empty()) {
         return;
+    }
 
     qreal h = 0.0;
 
@@ -312,8 +313,9 @@ void ChatLog::mouseMoveEvent(QMouseEvent* ev)
 // Much faster than QGraphicsScene::itemAt()!
 ChatLineContent* ChatLog::getContentFromPos(QPointF scenePos) const
 {
-    if (lines.empty())
+    if (lines.empty()) {
         return nullptr;
+    }
 
     auto itr =
         std::lower_bound(lines.cbegin(), lines.cend(), scenePos.y(), ChatLine::lessThanBSRectBottom);
@@ -454,8 +456,9 @@ void ChatLog::scrollToBottom()
 
 void ChatLog::startResizeWorker()
 {
-    if (lines.empty())
+    if (lines.empty()) {
         return;
+    }
 
     // (re)start the worker
     if (!workerTimer->isActive()) {
@@ -656,8 +659,9 @@ void ChatLog::scrollToLine(ChatLine::Ptr line)
 
 void ChatLog::selectAll()
 {
-    if (lines.empty())
+    if (lines.empty()) {
         return;
+    }
 
     clearSelection();
 
@@ -717,8 +721,9 @@ void ChatLog::forceRelayout()
 
 void ChatLog::checkVisibility(bool causedWheelEvent)
 {
-    if (lines.empty())
+    if (lines.empty()) {
         return;
+    }
 
     // find first visible line
     auto lowerBound = std::lower_bound(lines.cbegin(), lines.cend(), getVisibleRect().top(),
@@ -813,8 +818,9 @@ void ChatLog::updateTypingNotification()
 
     qreal posY = 0.0;
 
-    if (!lines.empty())
+    if (!lines.empty()) {
         posY = lines.last()->sceneBoundingRect().bottom() + lineSpacing;
+    }
 
     notification->layout(useableWidth(), QPointF(0.0, posY));
 }

--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -363,6 +363,7 @@ void ChatLog::reposition(int start, int end, qreal deltaY)
 
 void ChatLog::insertChatlineAtBottom(ChatLine::Ptr l)
 {
+    numRemove = 0;
     if (!l.get())
         return;
 
@@ -386,8 +387,13 @@ void ChatLog::insertChatlineAtBottom(ChatLine::Ptr l)
 
 void ChatLog::insertChatlineAtBottom(const QList<ChatLine::Ptr>& newLines)
 {
+    numRemove = 0;
     if (newLines.isEmpty())
         return;
+
+    if (lines.size() + DEF_NUM_MSG_TO_LOAD >= maxMessages) {
+        removeFirsts(DEF_NUM_MSG_TO_LOAD);
+    }
 
     for (ChatLine::Ptr l : newLines) {
         l->setRow(lines.size());
@@ -397,11 +403,17 @@ void ChatLog::insertChatlineAtBottom(const QList<ChatLine::Ptr>& newLines)
     }
 
     layout(lines.last()->getRow(), lines.size(), useableWidth());
-    startResizeWorker();
+
+    if (visibleLines.size() > 1) {
+        startResizeWorker(visibleLines[1]);
+    } else {
+        startResizeWorker();
+    }
 }
 
 void ChatLog::insertChatlineOnTop(ChatLine::Ptr l)
 {
+    numRemove = 0;
     if (!l.get())
         return;
 
@@ -410,6 +422,7 @@ void ChatLog::insertChatlineOnTop(ChatLine::Ptr l)
 
 void ChatLog::insertChatlinesOnTop(const QList<ChatLine::Ptr>& newLines)
 {
+    numRemove = 0;
     if (newLines.isEmpty())
         return;
 
@@ -429,6 +442,10 @@ void ChatLog::insertChatlinesOnTop(const QList<ChatLine::Ptr>& newLines)
         combLines.push_back(l);
     }
 
+    if (lines.size() + DEF_NUM_MSG_TO_LOAD >= maxMessages) {
+        removeLasts(DEF_NUM_MSG_TO_LOAD);
+    }
+
     // add the old lines
     for (ChatLine::Ptr l : lines) {
         l->setRow(i++);
@@ -440,7 +457,12 @@ void ChatLog::insertChatlinesOnTop(const QList<ChatLine::Ptr>& newLines)
     scene->setItemIndexMethod(oldIndexMeth);
 
     // redo layout
-    startResizeWorker();
+    if (visibleLines.size() > 1) {
+        startResizeWorker(visibleLines[1]);
+    } else {
+        startResizeWorker();
+    }
+
 }
 
 bool ChatLog::stickToBottom() const
@@ -454,19 +476,22 @@ void ChatLog::scrollToBottom()
     verticalScrollBar()->setValue(verticalScrollBar()->maximum());
 }
 
-void ChatLog::startResizeWorker()
+void ChatLog::startResizeWorker(ChatLine::Ptr anchorLine)
 {
     if (lines.empty()) {
+        isScroll = true;
         return;
     }
 
     // (re)start the worker
     if (!workerTimer->isActive()) {
         // these values must not be reevaluated while the worker is running
-        workerStb = stickToBottom();
-
-        if (!visibleLines.empty())
-            workerAnchorLine = visibleLines.first();
+        if (anchorLine) {
+            workerAnchorLine = anchorLine;
+            workerStb = false;
+        } else {
+            workerStb = stickToBottom();
+        }
     }
 
     // switch to busy scene displaying the busy notification if there is a lot
@@ -653,8 +678,13 @@ void ChatLog::scrollToLine(ChatLine::Ptr line)
     if (!line.get())
         return;
 
-    updateSceneRect();
-    verticalScrollBar()->setValue(line->sceneBoundingRect().top());
+    if (workerTimer->isActive()) {
+        workerAnchorLine = line;
+        workerStb = false;
+    } else {
+        updateSceneRect();
+        verticalScrollBar()->setValue(line->sceneBoundingRect().top()); // NOTE: start here
+    }
 }
 
 void ChatLog::selectAll()
@@ -696,6 +726,7 @@ void ChatLog::removeFirsts(const int num)
 {
     if (lines.size() > num) {
         lines.erase(lines.begin(), lines.begin()+num);
+        numRemove = num;
     } else {
         lines.clear();
     }
@@ -709,9 +740,20 @@ void ChatLog::removeLasts(const int num)
 {
     if (lines.size() > num) {
         lines.erase(lines.end()-num, lines.end());
+        numRemove = num;
     } else {
         lines.clear();
     }
+}
+
+void ChatLog::setScroll(const bool scroll)
+{
+    isScroll = scroll;
+}
+
+int ChatLog::getNumRemove() const
+{
+    return numRemove;
 }
 
 void ChatLog::forceRelayout()
@@ -762,6 +804,7 @@ void ChatLog::checkVisibility(bool causedWheelEvent)
     }
 
     if (causedWheelEvent) {
+        qDebug() << "causedWheelEvent";
         if (lowerBound != lines.cend() && lowerBound->get()->row == 0) {
             emit loadHistoryLower();
         } else if (upperBound == lines.cend()) {
@@ -905,7 +948,8 @@ void ChatLog::onWorkerTimeout()
         // hidden during busy screen
         verticalScrollBar()->show();
 
-        emit workerTimeoutFinished();
+        isScroll = true;
+        emit workerTimeoutFinished();   
     }
 }
 
@@ -972,6 +1016,10 @@ void ChatLog::focusOutEvent(QFocusEvent* ev)
 
 void ChatLog::wheelEvent(QWheelEvent *event)
 {
+    if (!isScroll) {
+        return;
+    }
+
     QGraphicsView::wheelEvent(event);
     checkVisibility(true);
 }

--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -693,7 +693,7 @@ void ChatLog::forceRelayout()
     startResizeWorker();
 }
 
-void ChatLog::checkVisibility(bool causedByScroll)
+void ChatLog::checkVisibility(bool causedWheelEvent)
 {
     if (lines.empty())
         return;
@@ -734,10 +734,10 @@ void ChatLog::checkVisibility(bool causedByScroll)
         emit firstVisibleLineChanged(visibleLines.at(0));
     }
 
-    if (causedByScroll) {
+    if (causedWheelEvent) {
         if (lowerBound != lines.cend() && lowerBound->get()->row == 0) {
             emit loadHistoryLower();
-        } else if (upperBound != lines.cend() && upperBound->get()->row >= lines.size() - 10) {
+        } else if (upperBound == lines.cend()) {
             emit loadHistoryUpper();
         }
     }
@@ -746,7 +746,7 @@ void ChatLog::checkVisibility(bool causedByScroll)
 void ChatLog::scrollContentsBy(int dx, int dy)
 {
     QGraphicsView::scrollContentsBy(dx, dy);
-    checkVisibility(true);
+    checkVisibility();
 }
 
 void ChatLog::resizeEvent(QResizeEvent* ev)
@@ -940,6 +940,12 @@ void ChatLog::focusOutEvent(QFocusEvent* ev)
         for (int i = selFirstRow; i <= selLastRow; ++i)
             lines[i]->selectionFocusChanged(false);
     }
+}
+
+void ChatLog::wheelEvent(QWheelEvent *event)
+{
+    QGraphicsView::wheelEvent(event);
+    checkVisibility(true);
 }
 
 void ChatLog::retranslateUi()

--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -41,7 +41,7 @@ class ChatLog : public QGraphicsView
 {
     Q_OBJECT
 public:
-    explicit ChatLog(QWidget* parent = nullptr);
+    explicit ChatLog(const bool canRemove, QWidget* parent = nullptr);
     virtual ~ChatLog();
 
     void insertChatlineAtBottom(ChatLine::Ptr l);
@@ -182,6 +182,7 @@ private:
 
     int numRemove{0};
     const int maxMessages{300};
+    bool canRemove;
 };
 
 #endif // CHATLOG_H

--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -56,6 +56,8 @@ public:
     void selectAll();
     void fontChanged(const QFont& font);
     void reloadTheme();
+    void removeFirsts(const int num);
+    void removeLasts(const int num);
 
     QString getSelectedText() const;
 

--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -97,7 +97,7 @@ protected:
 
     void reposition(int start, int end, qreal deltaY);
     void updateSceneRect();
-    void checkVisibility(bool causedByScroll = false);
+    void checkVisibility(bool causedWheelEvent = false);
     void scrollToBottom();
     void startResizeWorker();
 
@@ -110,6 +110,7 @@ protected:
     virtual void showEvent(QShowEvent*) final override;
     virtual void focusInEvent(QFocusEvent* ev) final override;
     virtual void focusOutEvent(QFocusEvent* ev) final override;
+    virtual void wheelEvent(QWheelEvent *event) final override;
 
     void updateMultiSelectionRect();
     void updateTypingNotification();

--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -72,6 +72,7 @@ signals:
     void selectionChanged();
     void workerTimeoutFinished();
     void firstVisibleLineChanged(const ChatLine::Ptr&);
+    void loadHistoryLower();
 
 public slots:
     void forceRelayout();
@@ -94,7 +95,7 @@ protected:
 
     void reposition(int start, int end, qreal deltaY);
     void updateSceneRect();
-    void checkVisibility();
+    void checkVisibility(bool causedByScroll = false);
     void scrollToBottom();
     void startResizeWorker();
 

--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -43,6 +43,7 @@ public:
     virtual ~ChatLog();
 
     void insertChatlineAtBottom(ChatLine::Ptr l);
+    void insertChatlineAtBottom(const QList<ChatLine::Ptr>& newLines);
     void insertChatlineOnTop(ChatLine::Ptr l);
     void insertChatlinesOnTop(const QList<ChatLine::Ptr>& newLines);
     void clearSelection();
@@ -73,6 +74,7 @@ signals:
     void workerTimeoutFinished();
     void firstVisibleLineChanged(const ChatLine::Ptr&);
     void loadHistoryLower();
+    void loadHistoryUpper();
 
 public slots:
     void forceRelayout();

--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -35,6 +35,8 @@ class QTimer;
 class ChatLineContent;
 struct ToxFile;
 
+static const auto DEF_NUM_MSG_TO_LOAD = 100;
+
 class ChatLog : public QGraphicsView
 {
     Q_OBJECT
@@ -58,6 +60,8 @@ public:
     void reloadTheme();
     void removeFirsts(const int num);
     void removeLasts(const int num);
+    void setScroll(const bool scroll);
+    int getNumRemove() const;
 
     QString getSelectedText() const;
 
@@ -101,7 +105,7 @@ protected:
     void updateSceneRect();
     void checkVisibility(bool causedWheelEvent = false);
     void scrollToBottom();
-    void startResizeWorker();
+    void startResizeWorker(ChatLine::Ptr anchorLine = nullptr);
 
     virtual void mouseDoubleClickEvent(QMouseEvent* ev) final override;
     virtual void mousePressEvent(QMouseEvent* ev) final override;
@@ -165,6 +169,7 @@ private:
     int clickCount = 0;
     QPoint lastClickPos;
     Qt::MouseButton lastClickButton;
+    bool isScroll{true};
 
     // worker vars
     int workerLastIndex = 0;
@@ -174,6 +179,9 @@ private:
     // layout
     QMargins margins = QMargins(10, 10, 10, 10);
     qreal lineSpacing = 5.0f;
+
+    int numRemove{0};
+    const int maxMessages{300};
 };
 
 #endif // CHATLOG_H

--- a/src/chatlog/content/text.cpp
+++ b/src/chatlog/content/text.cpp
@@ -66,9 +66,11 @@ void Text::selectText(const QString& txt, const std::pair<int, int>& point)
         return;
     }
 
-    auto cursor = doc->find(txt, point.first);
+    selectCursor = doc->find(txt, point.first);
+    selectPoint = point;
 
-    selectText(cursor, point);
+    regenerate();
+    update();
 }
 
 void Text::selectText(const QRegularExpression &exp, const std::pair<int, int>& point)
@@ -79,14 +81,20 @@ void Text::selectText(const QRegularExpression &exp, const std::pair<int, int>& 
         return;
     }
 
-    auto cursor = doc->find(exp, point.first);
+    selectCursor = doc->find(exp, point.first);
+    selectPoint = point;
 
-    selectText(cursor, point);
+    regenerate();
+    update();
 }
 
 void Text::deselectText()
 {
     dirty = true;
+
+    selectCursor = QTextCursor();
+    selectPoint = {0, 0};
+
     regenerate();
     update();
 }
@@ -355,6 +363,10 @@ void Text::regenerate()
         dirty = false;
     }
 
+    if (!selectCursor.isNull()) {
+        selectText(selectCursor, selectPoint);
+    }
+
     // if we are not visible -> free mem
     if (!keepInMemory)
         freeResources();
@@ -462,9 +474,6 @@ void Text::selectText(QTextCursor& cursor, const std::pair<int, int>& point)
         QTextCharFormat format;
         format.setBackground(QBrush(Style::getColor(Style::SearchHighlighted)));
         cursor.mergeCharFormat(format);
-
-        regenerate();
-        update();
     }
 }
 

--- a/src/chatlog/content/text.h
+++ b/src/chatlog/content/text.h
@@ -24,6 +24,7 @@
 #include "src/widget/style.h"
 
 #include <QFont>
+#include <QTextCursor>
 
 class QTextDocument;
 
@@ -110,6 +111,9 @@ private:
     TextType textType;
     QColor color;
     QColor customColor;
+
+    QTextCursor selectCursor;
+    std::pair<int, int> selectPoint{0, 0};
 };
 
 #endif // TEXT_H

--- a/src/model/chathistory.cpp
+++ b/src/model/chathistory.cpp
@@ -110,10 +110,9 @@ ChatHistory::ChatHistory(Friend& f_, History* history_, const ICoreIdHandler& co
 
     // NOTE: this has to be done _after_ sending all sent messages since initial
     // state of the message has to be marked according to our dispatch state
-    constexpr auto defaultNumMessagesToLoad = 100;
-    auto firstChatLogIdx = sessionChatLog.getFirstIdx().get() < defaultNumMessagesToLoad
+    auto firstChatLogIdx = sessionChatLog.getFirstIdx().get() < DEF_NUM_MSG_TO_LOAD
                                ? ChatLogIdx(0)
-                               : sessionChatLog.getFirstIdx() - defaultNumMessagesToLoad;
+                               : sessionChatLog.getFirstIdx() - DEF_NUM_MSG_TO_LOAD;
 
     if (canUseHistory()) {
         loadHistoryIntoSessionChatLog(firstChatLogIdx);

--- a/src/model/chathistory.cpp
+++ b/src/model/chathistory.cpp
@@ -220,6 +220,15 @@ std::vector<IChatLog::DateChatLogIdxPair> ChatHistory::getDateIdxs(const QDate& 
     }
 }
 
+std::size_t ChatHistory::size() const
+{
+    if (canUseHistory()) {
+        return history->getNumMessagesForFriend(f.getPublicKey());
+    }
+
+    return sessionChatLog.size();
+}
+
 void ChatHistory::onFileUpdated(const ToxPk& sender, const ToxFile& file)
 {
     if (canUseHistory()) {

--- a/src/model/chathistory.cpp
+++ b/src/model/chathistory.cpp
@@ -110,9 +110,10 @@ ChatHistory::ChatHistory(Friend& f_, History* history_, const ICoreIdHandler& co
 
     // NOTE: this has to be done _after_ sending all sent messages since initial
     // state of the message has to be marked according to our dispatch state
-    auto firstChatLogIdx = sessionChatLog.getFirstIdx().get() < DEF_NUM_MSG_TO_LOAD
+    constexpr auto defaultNumMessagesToLoad = 100;
+    auto firstChatLogIdx = sessionChatLog.getFirstIdx().get() < defaultNumMessagesToLoad
                                ? ChatLogIdx(0)
-                               : sessionChatLog.getFirstIdx() - DEF_NUM_MSG_TO_LOAD;
+                               : sessionChatLog.getFirstIdx() - defaultNumMessagesToLoad;
 
     if (canUseHistory()) {
         loadHistoryIntoSessionChatLog(firstChatLogIdx);

--- a/src/model/chathistory.h
+++ b/src/model/chathistory.h
@@ -42,6 +42,7 @@ public:
     ChatLogIdx getFirstIdx() const override;
     ChatLogIdx getNextIdx() const override;
     std::vector<DateChatLogIdxPair> getDateIdxs(const QDate& startDate, size_t maxDates) const override;
+    std::size_t size() const override;
 
 public slots:
     void onFileUpdated(const ToxPk& sender, const ToxFile& file);

--- a/src/model/contact.h
+++ b/src/model/contact.h
@@ -37,6 +37,8 @@ public:
     virtual void setEventFlag(bool flag) = 0;
     virtual bool getEventFlag() const = 0;
 
+    virtual bool useHistory() const = 0; // TODO: remove after added history in group chat
+
 signals:
     void displayedNameChanged(const QString& newName);
 };

--- a/src/model/friend.cpp
+++ b/src/model/friend.cpp
@@ -166,3 +166,8 @@ bool Friend::isOnline() const
 {
     return friendStatus != Status::Status::Offline && friendStatus != Status::Status::Blocked;
 }
+
+bool Friend::useHistory() const
+{
+    return true;
+}

--- a/src/model/friend.h
+++ b/src/model/friend.h
@@ -55,6 +55,8 @@ public:
     Status::Status getStatus() const;
     bool isOnline() const;
 
+    bool useHistory() const override final;
+
 signals:
     void nameChanged(const ToxPk& friendId, const QString& name);
     void aliasChanged(const ToxPk& friendId, QString alias);

--- a/src/model/group.cpp
+++ b/src/model/group.cpp
@@ -205,6 +205,11 @@ QString Group::getSelfName() const
     return selfName;
 }
 
+bool Group::useHistory() const
+{
+    return false;
+}
+
 void Group::stopAudioOfDepartedPeers(const ToxPk& peerPk)
 {
     if (avGroupchat) {

--- a/src/model/group.h
+++ b/src/model/group.h
@@ -61,6 +61,8 @@ public:
     void setSelfName(const QString& name);
     QString getSelfName() const;
 
+    bool useHistory() const override final;
+
 signals:
     void titleChangedByUser(const QString& title);
     void titleChanged(const QString& author, const QString& title);

--- a/src/model/ichatlog.h
+++ b/src/model/ichatlog.h
@@ -35,8 +35,6 @@
 
 #include <cassert>
 
-static const auto DEF_NUM_MSG_TO_LOAD = 100;
-
 using ChatLogIdx =
     NamedType<size_t, struct ChatLogIdxTag, Orderable, UnderlyingAddable, UnitlessDifferencable, Incrementable>;
 Q_DECLARE_METATYPE(ChatLogIdx);

--- a/src/model/ichatlog.h
+++ b/src/model/ichatlog.h
@@ -138,6 +138,8 @@ public:
     virtual std::vector<DateChatLogIdxPair> getDateIdxs(const QDate& startDate,
                                                         size_t maxDates) const = 0;
 
+    virtual std::size_t size() const = 0;
+
 signals:
     void itemUpdated(ChatLogIdx idx);
 };

--- a/src/model/ichatlog.h
+++ b/src/model/ichatlog.h
@@ -35,6 +35,8 @@
 
 #include <cassert>
 
+static const auto DEF_NUM_MSG_TO_LOAD = 100;
+
 using ChatLogIdx =
     NamedType<size_t, struct ChatLogIdxTag, Orderable, UnderlyingAddable, UnitlessDifferencable, Incrementable>;
 Q_DECLARE_METATYPE(ChatLogIdx);

--- a/src/model/sessionchatlog.cpp
+++ b/src/model/sessionchatlog.cpp
@@ -289,6 +289,11 @@ std::vector<IChatLog::DateChatLogIdxPair> SessionChatLog::getDateIdxs(const QDat
     return ret;
 }
 
+std::size_t SessionChatLog::size() const
+{
+    return items.size();
+}
+
 void SessionChatLog::insertMessageAtIdx(ChatLogIdx idx, ToxPk sender, QString senderName,
                                         ChatLogMessage message)
 {

--- a/src/model/sessionchatlog.h
+++ b/src/model/sessionchatlog.h
@@ -45,6 +45,7 @@ public:
     ChatLogIdx getFirstIdx() const override;
     ChatLogIdx getNextIdx() const override;
     std::vector<DateChatLogIdxPair> getDateIdxs(const QDate& startDate, size_t maxDates) const override;
+    std::size_t size() const override;
 
     void insertMessageAtIdx(ChatLogIdx idx, ToxPk sender, QString senderName, ChatLogMessage message);
     void insertFileAtIdx(ChatLogIdx idx, ToxPk sender, QString senderName, ChatLogFile file);

--- a/src/persistence/history.cpp
+++ b/src/persistence/history.cpp
@@ -681,14 +681,14 @@ QDateTime History::getDateWhereFindPhrase(const QString& friendPk, const QDateTi
         break;
     }
 
-    QDateTime date = from;
+    QDateTime time = from;
 
-    if (!date.isValid()) {
-        date = QDateTime::currentDateTime();
+    if (!time.isValid()) {
+        time = QDateTime::currentDateTime();
     }
 
     if (parameter.period == PeriodSearch::AfterDate || parameter.period == PeriodSearch::BeforeDate) {
-        date = QDateTime(parameter.date);
+        time = parameter.time;
     }
 
     QString period;
@@ -698,15 +698,15 @@ QDateTime History::getDateWhereFindPhrase(const QString& friendPk, const QDateTi
         break;
     case PeriodSearch::AfterDate:
         period = QStringLiteral("AND timestamp > '%1' ORDER BY timestamp ASC LIMIT 1;")
-                     .arg(date.toMSecsSinceEpoch());
+                     .arg(time.toMSecsSinceEpoch());
         break;
     case PeriodSearch::BeforeDate:
         period = QStringLiteral("AND timestamp < '%1' ORDER BY timestamp DESC LIMIT 1;")
-                     .arg(date.toMSecsSinceEpoch());
+                     .arg(time.toMSecsSinceEpoch());
         break;
     default:
         period = QStringLiteral("AND timestamp < '%1' ORDER BY timestamp DESC LIMIT 1;")
-                     .arg(date.toMSecsSinceEpoch());
+                     .arg(time.toMSecsSinceEpoch());
         break;
     }
 

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -811,12 +811,22 @@ void GenericChatForm::onLoadHistory()
 {
     LoadHistoryDialog dlg(&chatLog);
     if (dlg.exec()) {
-        QDateTime time = dlg.getFromDate();
-        auto idx = firstItemAfterDate(dlg.getFromDate().date(), chatLog);
-        auto end = ChatLogIdx(idx.get() + 100);
         chatWidget->clear();
         messages.clear();
-        renderMessages(idx, end);
+
+        QDateTime time = dlg.getFromDate();
+        auto type = dlg.getLoadType();
+
+        auto begin = firstItemAfterDate(dlg.getFromDate().date(), chatLog);
+        auto end = ChatLogIdx(begin.get() + 1);
+
+        renderMessages(begin, end);
+
+        if (type == LoadHistoryDialog::from) {
+            loadHistoryUpper();
+        } else {
+            loadHistoryLower();
+        }
     }
 }
 
@@ -986,15 +996,13 @@ void GenericChatForm::renderMessages(ChatLogIdx begin, ChatLogIdx end,
 
 void GenericChatForm::loadHistoryLower()
 {
-    auto begin = messages.begin()->first;
-
-    if (begin.get() > 100) {
-        begin = ChatLogIdx(begin.get() - 100);
-    } else {
-        begin = ChatLogIdx(0);
+    auto end = messages.begin()->first;
+    auto begin = ChatLogIdx(0);
+    if (end.get() > 100) {
+        begin = ChatLogIdx(end.get() - 100);
     }
 
-    renderMessages(begin, chatLog.getNextIdx());
+    renderMessages(begin, end);
 }
 
 void GenericChatForm::loadHistoryUpper()

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -261,7 +261,7 @@ GenericChatForm::GenericChatForm(const Contact* contact, IChatLog& chatLog,
     headWidget = new ChatFormHeader();
     searchForm = new SearchForm();
     dateInfo = new QLabel(this);
-    chatWidget = new ChatLog(this);
+    chatWidget = new ChatLog(contact->useHistory(), this);
     chatWidget->setBusyNotification(ChatMessage::createBusyNotification());
     searchForm->hide();
     dateInfo->setAlignment(Qt::AlignHCenter);
@@ -703,7 +703,6 @@ void GenericChatForm::loadHistoryFrom(const QDateTime &time)
 
     int add = DEF_NUM_MSG_TO_LOAD;
     if (begin.get() + DEF_NUM_MSG_TO_LOAD > chatLog.getNextIdx().get()) {
-        auto aTest = chatLog.getNextIdx().get();
         add = chatLog.getNextIdx().get() - begin.get();
     }
     auto end = ChatLogIdx(begin.get() + add);

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -670,7 +670,13 @@ void GenericChatForm::loadHistoryTo(const QDateTime &time)
 {
     auto end = ChatLogIdx(0);
     if (time.isNull()) {
-        end = messages.begin()->first;
+        if (messages.size() + 100 >= maxMessages) {
+            end = ChatLogIdx(messages.rbegin()->first.get() - 100);
+            chatWidget->removeLasts(100);
+            removeLastsMessages(100);
+        } else {
+            end = messages.begin()->first;
+        }
     } else {
         end = firstItemAfterDate(time.date(), chatLog);
     }
@@ -687,7 +693,14 @@ void GenericChatForm::loadHistoryFrom(const QDateTime &time)
 {
     auto begin = ChatLogIdx(0);
     if (time.isNull()) {
-        begin = messages.rbegin()->first;
+        if (messages.size() + 100 >= maxMessages) {
+            begin = ChatLogIdx(messages.rbegin()->first.get() + 100);
+            chatWidget->removeFirsts(100);
+            removeFirstsMessages(100);
+        } else {
+            begin = messages.rbegin()->first;
+        }
+
     } else {
         begin = firstItemAfterDate(time.date(), chatLog);
     }
@@ -698,6 +711,24 @@ void GenericChatForm::loadHistoryFrom(const QDateTime &time)
     }
     auto end = ChatLogIdx(begin.get() + add);
     renderMessages(begin, end);
+}
+
+void GenericChatForm::removeFirstsMessages(const int num)
+{
+    if (messages.size() > num) {
+        messages.erase(messages.begin(), std::next(messages.begin(), num));
+    } else {
+        messages.clear();
+    }
+}
+
+void GenericChatForm::removeLastsMessages(const int num)
+{
+    if (messages.size() > 100) {
+        messages.erase(std::next(messages.end(), -100), messages.end());
+    } else {
+        messages.clear();
+    }
 }
 
 
@@ -993,6 +1024,10 @@ void GenericChatForm::handleSearchResult(SearchResult result, SearchDirection di
 
 void GenericChatForm::renderMessage(ChatLogIdx idx)
 {
+    if (chatWidget->getLines().size() >= maxMessages) {
+        chatWidget->removeFirsts(optimalRemove);
+        removeFirstsMessages(optimalRemove);
+    }
     renderMessages(idx, idx + 1);
 }
 

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -37,7 +37,6 @@
 #include "src/widget/contentlayout.h"
 #include "src/widget/emoticonswidget.h"
 #include "src/widget/form/chatform.h"
-#include "src/widget/form/loadhistorydialog.h"
 #include "src/widget/maskablepixmapwidget.h"
 #include "src/widget/searchform.h"
 #include "src/widget/style.h"
@@ -646,6 +645,23 @@ QDateTime GenericChatForm::getTime(const ChatLine::Ptr &chatLine) const
     return QDateTime();
 }
 
+void GenericChatForm::loadHistory(const QDateTime &time, const LoadHistoryDialog::LoadType type)
+{
+    chatWidget->clear();
+    messages.clear();
+
+    auto begin = firstItemAfterDate(time.date(), chatLog);
+    auto end = ChatLogIdx(begin.get() + 1);
+
+    renderMessages(begin, end);
+
+    if (type == LoadHistoryDialog::from) {
+        loadHistoryUpper();
+    } else {
+        loadHistoryLower();
+    }
+}
+
 
 void GenericChatForm::disableSearchText()
 {
@@ -811,22 +827,10 @@ void GenericChatForm::onLoadHistory()
 {
     LoadHistoryDialog dlg(&chatLog);
     if (dlg.exec()) {
-        chatWidget->clear();
-        messages.clear();
-
         QDateTime time = dlg.getFromDate();
         auto type = dlg.getLoadType();
 
-        auto begin = firstItemAfterDate(dlg.getFromDate().date(), chatLog);
-        auto end = ChatLogIdx(begin.get() + 1);
-
-        renderMessages(begin, end);
-
-        if (type == LoadHistoryDialog::from) {
-            loadHistoryUpper();
-        } else {
-            loadHistoryLower();
-        }
+        loadHistory(time, type);
     }
 }
 
@@ -873,6 +877,12 @@ void GenericChatForm::searchInBegin(const QString& phrase, const ParameterSearch
 {
     disableSearchText();
 
+    if (!parameter.time.isNull()) {
+        LoadHistoryDialog::LoadType type = (parameter.period == PeriodSearch::BeforeDate)
+                ? LoadHistoryDialog::to : LoadHistoryDialog::from;
+        loadHistory(parameter.time, type);
+    }
+
     bool bForwardSearch = false;
     switch (parameter.period) {
     case PeriodSearch::WithTheFirst: {
@@ -890,13 +900,13 @@ void GenericChatForm::searchInBegin(const QString& phrase, const ParameterSearch
     }
     case PeriodSearch::AfterDate: {
         bForwardSearch = true;
-        searchPos.logIdx = firstItemAfterDate(parameter.date, chatLog);
+        searchPos.logIdx = firstItemAfterDate(parameter.time.date(), chatLog);
         searchPos.numMatches = 0;
         break;
     }
     case PeriodSearch::BeforeDate: {
         bForwardSearch = false;
-        searchPos.logIdx = firstItemAfterDate(parameter.date, chatLog);
+        searchPos.logIdx = firstItemAfterDate(parameter.time.date(), chatLog);
         searchPos.numMatches = 0;
         break;
     }
@@ -1007,7 +1017,7 @@ void GenericChatForm::loadHistoryLower()
 
 void GenericChatForm::loadHistoryUpper()
 {
-    auto begin = messages.end()->first;
+    auto begin = messages.rbegin()->first;
 
     int add = 100;
     if (begin.get() + 100 > chatLog.getNextIdx().get()) {

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -355,6 +355,7 @@ GenericChatForm::GenericChatForm(const Contact* contact, IChatLog& chatLog,
     connect(chatWidget, &ChatLog::customContextMenuRequested, this,
             &GenericChatForm::onChatContextMenuRequested);
     connect(chatWidget, &ChatLog::firstVisibleLineChanged, this, &GenericChatForm::updateShowDateInfo);
+    connect(chatWidget, &ChatLog::loadHistoryLower, this, &GenericChatForm::loadHistoryLower);
 
     connect(searchForm, &SearchForm::searchInBegin, this, &GenericChatForm::searchInBegin);
     connect(searchForm, &SearchForm::searchUp, this, &GenericChatForm::onSearchUp);
@@ -977,6 +978,19 @@ void GenericChatForm::renderMessages(ChatLogIdx begin, ChatLogIdx end,
     } else if (onCompletion) {
         onCompletion();
     }
+}
+
+void GenericChatForm::loadHistoryLower()
+{
+    auto begin = messages.begin()->first;
+
+    if (begin.get() > 100) {
+        begin = ChatLogIdx(begin.get() - 100);
+    } else {
+        begin = ChatLogIdx(0);
+    }
+
+    renderMessages(begin, chatLog.getNextIdx());
 }
 
 void GenericChatForm::updateShowDateInfo(const ChatLine::Ptr& line)

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -657,16 +657,47 @@ void GenericChatForm::loadHistory(const QDateTime &time, const LoadHistoryDialog
     chatWidget->clear();
     messages.clear();
 
-    auto begin = firstItemAfterDate(time.date(), chatLog);
-    auto end = ChatLogIdx(begin.get() + 1);
+    if (type == LoadHistoryDialog::from) {
+        loadHistoryFrom(time);
+        auto msg = messages.cbegin()->second;
+        chatWidget->scrollToLine(msg);
+    } else {
+        loadHistoryTo(time);
+    }
+}
+
+void GenericChatForm::loadHistoryTo(const QDateTime &time)
+{
+    auto end = ChatLogIdx(0);
+    if (time.isNull()) {
+        end = messages.begin()->first;
+    } else {
+        end = firstItemAfterDate(time.date(), chatLog);
+    }
+
+    auto begin = ChatLogIdx(0);
+    if (end.get() > 100) {
+        begin = ChatLogIdx(end.get() - 100);
+    }
 
     renderMessages(begin, end);
+}
 
-    if (type == LoadHistoryDialog::from) {
-        loadHistoryUpper();
+void GenericChatForm::loadHistoryFrom(const QDateTime &time)
+{
+    auto begin = ChatLogIdx(0);
+    if (time.isNull()) {
+        begin = messages.rbegin()->first;
     } else {
-        loadHistoryLower();
+        begin = firstItemAfterDate(time.date(), chatLog);
     }
+
+    int add = 100;
+    if (begin.get() + 100 > chatLog.getNextIdx().get()) {
+        add = chatLog.getNextIdx().get() - (begin.get() + 100);
+    }
+    auto end = ChatLogIdx(begin.get() + add);
+    renderMessages(begin, end);
 }
 
 
@@ -1023,25 +1054,14 @@ void GenericChatForm::goToCurrentDate()
 
 void GenericChatForm::loadHistoryLower()
 {
-    auto end = messages.begin()->first;
-    auto begin = ChatLogIdx(0);
-    if (end.get() > 100) {
-        begin = ChatLogIdx(end.get() - 100);
-    }
-
-    renderMessages(begin, end);
+    loadHistoryTo(QDateTime());
 }
 
 void GenericChatForm::loadHistoryUpper()
 {
-    auto begin = messages.rbegin()->first;
-
-    int add = 100;
-    if (begin.get() + 100 > chatLog.getNextIdx().get()) {
-        add = chatLog.getNextIdx().get() - (begin.get() + 100);
-    }
-    auto end = ChatLogIdx(begin.get() + add);
-    renderMessages(begin, end);
+    auto msg = messages.crbegin()->second;
+    loadHistoryFrom(QDateTime());
+    chatWidget->scrollToLine(msg);
 }
 
 void GenericChatForm::updateShowDateInfo(const ChatLine::Ptr& line)

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -388,7 +388,7 @@ GenericChatForm::GenericChatForm(const Contact* contact, IChatLog& chatLog,
     connect(contact, &Contact::displayedNameChanged, this, &GenericChatForm::setName);
 
     auto chatLogIdxRange = chatLog.getNextIdx() - chatLog.getFirstIdx();
-    auto firstChatLogIdx = (chatLogIdxRange < 100) ? chatLog.getFirstIdx() : chatLog.getNextIdx() - 100;
+    auto firstChatLogIdx = (chatLogIdxRange < DEF_NUM_MSG_TO_LOAD) ? chatLog.getFirstIdx() : chatLog.getNextIdx() - DEF_NUM_MSG_TO_LOAD;
 
     renderMessages(firstChatLogIdx, chatLog.getNextIdx());
 
@@ -670,10 +670,10 @@ void GenericChatForm::loadHistoryTo(const QDateTime &time)
 {
     auto end = ChatLogIdx(0);
     if (time.isNull()) {
-        if (messages.size() + 100 >= maxMessages) {
-            end = ChatLogIdx(messages.rbegin()->first.get() - 100);
-            chatWidget->removeLasts(100);
-            removeLastsMessages(100);
+        if (messages.size() + DEF_NUM_MSG_TO_LOAD >= maxMessages) {
+            end = ChatLogIdx(messages.rbegin()->first.get() - DEF_NUM_MSG_TO_LOAD);
+            chatWidget->removeLasts(DEF_NUM_MSG_TO_LOAD);
+            removeLastsMessages(DEF_NUM_MSG_TO_LOAD);
         } else {
             end = messages.begin()->first;
         }
@@ -682,8 +682,8 @@ void GenericChatForm::loadHistoryTo(const QDateTime &time)
     }
 
     auto begin = ChatLogIdx(0);
-    if (end.get() > 100) {
-        begin = ChatLogIdx(end.get() - 100);
+    if (end.get() > DEF_NUM_MSG_TO_LOAD) {
+        begin = ChatLogIdx(end.get() - DEF_NUM_MSG_TO_LOAD);
     }
 
     renderMessages(begin, end);
@@ -693,10 +693,10 @@ void GenericChatForm::loadHistoryFrom(const QDateTime &time)
 {
     auto begin = ChatLogIdx(0);
     if (time.isNull()) {
-        if (messages.size() + 100 >= maxMessages) {
-            begin = ChatLogIdx(messages.rbegin()->first.get() + 100);
-            chatWidget->removeFirsts(100);
-            removeFirstsMessages(100);
+        if (messages.size() + DEF_NUM_MSG_TO_LOAD >= maxMessages) {
+            begin = ChatLogIdx(messages.rbegin()->first.get() + DEF_NUM_MSG_TO_LOAD);
+            chatWidget->removeFirsts(DEF_NUM_MSG_TO_LOAD);
+            removeFirstsMessages(DEF_NUM_MSG_TO_LOAD);
         } else {
             begin = messages.rbegin()->first;
         }
@@ -705,9 +705,9 @@ void GenericChatForm::loadHistoryFrom(const QDateTime &time)
         begin = firstItemAfterDate(time.date(), chatLog);
     }
 
-    int add = 100;
-    if (begin.get() + 100 > chatLog.getNextIdx().get()) {
-        add = chatLog.getNextIdx().get() - (begin.get() + 100);
+    int add = DEF_NUM_MSG_TO_LOAD;
+    if (begin.get() + DEF_NUM_MSG_TO_LOAD > chatLog.getNextIdx().get()) {
+        add = chatLog.getNextIdx().get() - (begin.get() + DEF_NUM_MSG_TO_LOAD);
     }
     auto end = ChatLogIdx(begin.get() + add);
     renderMessages(begin, end);
@@ -724,8 +724,8 @@ void GenericChatForm::removeFirstsMessages(const int num)
 
 void GenericChatForm::removeLastsMessages(const int num)
 {
-    if (messages.size() > 100) {
-        messages.erase(std::next(messages.end(), -100), messages.end());
+    if (messages.size() > num) {
+        messages.erase(std::next(messages.end(), -num), messages.end());
     } else {
         messages.clear();
     }
@@ -1082,7 +1082,7 @@ void GenericChatForm::goToCurrentDate()
     chatWidget->clear();
     messages.clear();
     auto end = ChatLogIdx(chatLog.size() - 1);
-    auto begin = end.get() > 100 ? ChatLogIdx(end.get() - 100) : ChatLogIdx(0);
+    auto begin = end.get() > DEF_NUM_MSG_TO_LOAD ? ChatLogIdx(end.get() - DEF_NUM_MSG_TO_LOAD) : ChatLogIdx(0);
 
     renderMessages(begin, end);
 }

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -356,6 +356,7 @@ GenericChatForm::GenericChatForm(const Contact* contact, IChatLog& chatLog,
             &GenericChatForm::onChatContextMenuRequested);
     connect(chatWidget, &ChatLog::firstVisibleLineChanged, this, &GenericChatForm::updateShowDateInfo);
     connect(chatWidget, &ChatLog::loadHistoryLower, this, &GenericChatForm::loadHistoryLower);
+    connect(chatWidget, &ChatLog::loadHistoryUpper, this, &GenericChatForm::loadHistoryUpper);
 
     connect(searchForm, &SearchForm::searchInBegin, this, &GenericChatForm::searchInBegin);
     connect(searchForm, &SearchForm::searchUp, this, &GenericChatForm::onSearchUp);
@@ -812,7 +813,10 @@ void GenericChatForm::onLoadHistory()
     if (dlg.exec()) {
         QDateTime time = dlg.getFromDate();
         auto idx = firstItemAfterDate(dlg.getFromDate().date(), chatLog);
-        renderMessages(idx, chatLog.getNextIdx());
+        auto end = ChatLogIdx(idx.get() + 100);
+        chatWidget->clear();
+        messages.clear();
+        renderMessages(idx, end);
     }
 }
 
@@ -991,6 +995,18 @@ void GenericChatForm::loadHistoryLower()
     }
 
     renderMessages(begin, chatLog.getNextIdx());
+}
+
+void GenericChatForm::loadHistoryUpper()
+{
+    auto begin = messages.end()->first;
+
+    int add = 100;
+    if (begin.get() + 100 > chatLog.getNextIdx().get()) {
+        add = chatLog.getNextIdx().get() - (begin.get() + 100);
+    }
+    auto end = ChatLogIdx(begin.get() + add);
+    renderMessages(begin, end);
 }
 
 void GenericChatForm::updateShowDateInfo(const ChatLine::Ptr& line)

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -328,6 +328,13 @@ GenericChatForm::GenericChatForm(const Contact* contact, IChatLog& chatLog,
     quoteAction = menu.addAction(QIcon(), QString(), this, SLOT(quoteSelectedText()),
                                  QKeySequence(Qt::ALT + Qt::Key_Q));
     addAction(quoteAction);
+
+    menu.addSeparator();
+
+    goCurrentDateAction = menu.addAction(QIcon(), QString(), this, SLOT(goToCurrentDate()),
+                                  QKeySequence(Qt::CTRL + Qt::Key_G));
+    addAction(goCurrentDateAction);
+
     menu.addSeparator();
 
     searchAction = menu.addAction(QIcon(), QString(), this, SLOT(searchFormShow()),
@@ -1004,6 +1011,16 @@ void GenericChatForm::renderMessages(ChatLogIdx begin, ChatLogIdx end,
     }
 }
 
+void GenericChatForm::goToCurrentDate()
+{
+    chatWidget->clear();
+    messages.clear();
+    auto end = ChatLogIdx(chatLog.size() - 1);
+    auto begin = end.get() > 100 ? ChatLogIdx(end.get() - 100) : ChatLogIdx(0);
+
+    renderMessages(begin, end);
+}
+
 void GenericChatForm::loadHistoryLower()
 {
     auto end = messages.begin()->first;
@@ -1050,6 +1067,7 @@ void GenericChatForm::retranslateUi()
     quoteAction->setText(tr("Quote selected text"));
     copyLinkAction->setText(tr("Copy link address"));
     searchAction->setText(tr("Search in text"));
+    goCurrentDateAction->setText(tr("Go to current date"));
     loadHistoryAction->setText(tr("Load chat history..."));
     exportChatAction->setText(tr("Export to file"));
 }

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -127,6 +127,7 @@ protected slots:
                         std::function<void(void)> onCompletion = std::function<void(void)>());
 
     void loadHistoryLower();
+    void loadHistoryUpper();
 
 private:
     void retranslateUi();

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -126,6 +126,8 @@ protected slots:
     void renderMessages(ChatLogIdx begin, ChatLogIdx end,
                         std::function<void(void)> onCompletion = std::function<void(void)>());
 
+    void loadHistoryLower();
+
 private:
     void retranslateUi();
     void addSystemDateMessage(const QDate& date);

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -136,6 +136,8 @@ private:
     void addSystemDateMessage(const QDate& date);
     QDateTime getTime(const ChatLine::Ptr& chatLine) const;
     void loadHistory(const QDateTime& time, const LoadHistoryDialog::LoadType type);
+    void loadHistoryTo(const QDateTime& time);
+    void loadHistoryFrom(const QDateTime& time);
 
 protected:
     ChatMessage::Ptr createMessage(const ToxPk& author, const QString& message,

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -201,10 +201,6 @@ protected:
     SearchPos searchPos;
     std::map<ChatLogIdx, ChatMessage::Ptr> messages;
     bool colorizeNames = false;
-
-private:
-    const int maxMessages{300};
-    const int optimalRemove{50};
 };
 
 #endif // GENERICCHATFORM_H

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -23,6 +23,7 @@
 #include "src/chatlog/chatmessage.h"
 #include "src/core/toxpk.h"
 #include "src/model/ichatlog.h"
+#include "src/widget/form/loadhistorydialog.h"
 #include "src/widget/searchtypes.h"
 
 #include <QMenu>
@@ -133,6 +134,7 @@ private:
     void retranslateUi();
     void addSystemDateMessage(const QDate& date);
     QDateTime getTime(const ChatLine::Ptr& chatLine) const;
+    void loadHistory(const QDateTime& time, const LoadHistoryDialog::LoadType type);
 
 protected:
     ChatMessage::Ptr createMessage(const ToxPk& author, const QString& message,
@@ -165,8 +167,6 @@ protected:
     QAction* exportChatAction;
 
     ToxPk previousId;
-
-    QDateTime earliestMessage;
 
     QMenu menu;
 

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -126,6 +126,7 @@ protected slots:
     void renderMessage(ChatLogIdx idx);
     void renderMessages(ChatLogIdx begin, ChatLogIdx end,
                         std::function<void(void)> onCompletion = std::function<void(void)>());
+    void goToCurrentDate();
 
     void loadHistoryLower();
     void loadHistoryUpper();
@@ -165,6 +166,7 @@ protected:
     QAction* searchAction;
     QAction* loadHistoryAction;
     QAction* exportChatAction;
+    QAction* goCurrentDateAction;
 
     ToxPk previousId;
 

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -138,6 +138,8 @@ private:
     void loadHistory(const QDateTime& time, const LoadHistoryDialog::LoadType type);
     void loadHistoryTo(const QDateTime& time);
     void loadHistoryFrom(const QDateTime& time);
+    void removeFirstsMessages(const int num);
+    void removeLastsMessages(const int num);
 
 protected:
     ChatMessage::Ptr createMessage(const ToxPk& author, const QString& message,
@@ -199,6 +201,10 @@ protected:
     SearchPos searchPos;
     std::map<ChatLogIdx, ChatMessage::Ptr> messages;
     bool colorizeNames = false;
+
+private:
+    const int maxMessages{300};
+    const int optimalRemove{50};
 };
 
 #endif // GENERICCHATFORM_H

--- a/src/widget/form/loadhistorydialog.cpp
+++ b/src/widget/form/loadhistorydialog.cpp
@@ -62,6 +62,15 @@ QDateTime LoadHistoryDialog::getFromDate()
     return res;
 }
 
+LoadHistoryDialog::LoadType LoadHistoryDialog::getLoadType()
+{
+    if (ui->loadTypeComboBox->currentIndex() == 0) {
+        return LoadType::from;
+    }
+
+    return LoadType::to;
+}
+
 void LoadHistoryDialog::setTitle(const QString& title)
 {
     setWindowTitle(title);

--- a/src/widget/form/loadhistorydialog.cpp
+++ b/src/widget/form/loadhistorydialog.cpp
@@ -71,14 +71,12 @@ LoadHistoryDialog::LoadType LoadHistoryDialog::getLoadType()
     return LoadType::to;
 }
 
-void LoadHistoryDialog::setTitle(const QString& title)
+void LoadHistoryDialog::turnSearchMode()
 {
-    setWindowTitle(title);
-}
-
-void LoadHistoryDialog::setInfoLabel(const QString& info)
-{
-    ui->fromLabel->setText(info);
+    setWindowTitle(tr("Select Date Dialog"));
+    ui->fromLabel->setText(tr("Select a date"));
+    ui->loadTypeComboBox->setVisible(false);
+    ui->infoLabel->setVisible(false);
 }
 
 void LoadHistoryDialog::highlightDates(int year, int month)

--- a/src/widget/form/loadhistorydialog.cpp
+++ b/src/widget/form/loadhistorydialog.cpp
@@ -38,11 +38,15 @@ LoadHistoryDialog::LoadHistoryDialog(const IChatLog* chatLog, QWidget* parent)
             &LoadHistoryDialog::highlightDates);
 }
 
-LoadHistoryDialog::LoadHistoryDialog(QWidget* parent)
+LoadHistoryDialog::LoadHistoryDialog(Mode mode, QWidget* parent)
     : QDialog(parent)
     , ui(new Ui::LoadHistoryDialog)
 {
     ui->setupUi(this);
+
+    if (mode == Mode::search) {
+        enableSearchMode();
+    }
 }
 
 LoadHistoryDialog::~LoadHistoryDialog()
@@ -71,7 +75,7 @@ LoadHistoryDialog::LoadType LoadHistoryDialog::getLoadType()
     return LoadType::to;
 }
 
-void LoadHistoryDialog::turnSearchMode()
+void LoadHistoryDialog::enableSearchMode()
 {
     setWindowTitle(tr("Select Date Dialog"));
     ui->fromLabel->setText(tr("Select a date"));

--- a/src/widget/form/loadhistorydialog.h
+++ b/src/widget/form/loadhistorydialog.h
@@ -45,8 +45,7 @@ public:
 
     QDateTime getFromDate();
     LoadType getLoadType();
-    void setTitle(const QString& title);
-    void setInfoLabel(const QString& info);
+    void turnSearchMode();
 
 public slots:
     void highlightDates(int year, int month);

--- a/src/widget/form/loadhistorydialog.h
+++ b/src/widget/form/loadhistorydialog.h
@@ -34,11 +34,17 @@ class LoadHistoryDialog : public QDialog
     Q_OBJECT
 
 public:
+    enum LoadType {
+        from,
+        to
+    };
+
     explicit LoadHistoryDialog(const IChatLog* chatLog, QWidget* parent = nullptr);
     explicit LoadHistoryDialog(QWidget* parent = nullptr);
     ~LoadHistoryDialog();
 
     QDateTime getFromDate();
+    LoadType getLoadType();
     void setTitle(const QString& title);
     void setInfoLabel(const QString& info);
 

--- a/src/widget/form/loadhistorydialog.h
+++ b/src/widget/form/loadhistorydialog.h
@@ -39,18 +39,24 @@ public:
         to
     };
 
+    enum Mode {
+        common,
+        search
+    };
+
     explicit LoadHistoryDialog(const IChatLog* chatLog, QWidget* parent = nullptr);
-    explicit LoadHistoryDialog(QWidget* parent = nullptr);
+    explicit LoadHistoryDialog(Mode mode, QWidget* parent = nullptr);
     ~LoadHistoryDialog();
 
     QDateTime getFromDate();
     LoadType getLoadType();
-    void turnSearchMode();
 
 public slots:
     void highlightDates(int year, int month);
 
 private:
+    void enableSearchMode();
+
     Ui::LoadHistoryDialog* ui;
     const IChatLog* chatLog;
 };

--- a/src/widget/form/loadhistorydialog.ui
+++ b/src/widget/form/loadhistorydialog.ui
@@ -41,7 +41,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="label">
+      <widget class="QLabel" name="infoLabel">
        <property name="text">
         <string>(about 100 messages are loaded)</string>
        </property>

--- a/src/widget/form/loadhistorydialog.ui
+++ b/src/widget/form/loadhistorydialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>347</width>
-    <height>264</height>
+    <width>410</width>
+    <height>332</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,22 +16,60 @@
   <property name="modal">
    <bool>true</bool>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_3">
-   <item>
-    <widget class="QLabel" name="fromLabel">
-     <property name="text">
-      <string>Load history from:</string>
-     </property>
-    </widget>
+  <layout class="QFormLayout" name="formLayout">
+   <item row="0" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="fromLabel">
+       <property name="text">
+        <string>Load history</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="loadTypeComboBox">
+       <item>
+        <property name="text">
+         <string>from</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>to</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>(about 100 messages are loaded)</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>17</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
    </item>
-   <item>
+   <item row="1" column="0">
     <widget class="QCalendarWidget" name="fromDate">
      <property name="gridVisible">
       <bool>false</bool>
      </property>
     </widget>
    </item>
-   <item>
+   <item row="2" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>

--- a/src/widget/form/searchsettingsform.cpp
+++ b/src/widget/form/searchsettingsform.cpp
@@ -86,7 +86,7 @@ ParameterSearch SearchSettingsForm::getParameterSearch()
         break;
     }
 
-    ps.date = startDate;
+    ps.time = startTime;
     ps.isUpdate = isUpdate;
     isUpdate = false;
 
@@ -101,7 +101,7 @@ void SearchSettingsForm::reloadTheme()
 
 void SearchSettingsForm::updateStartDateLabel()
 {
-    ui->startDateLabel->setText(startDate.toString(Settings::getInstance().getDateFormat()));
+    ui->startDateLabel->setText(startTime.toString(Settings::getInstance().getDateFormat()));
 }
 
 void SearchSettingsForm::setUpdate(const bool isUpdate)
@@ -119,8 +119,8 @@ void SearchSettingsForm::onStartSearchSelected(const int index)
         ui->choiceDateButton->setProperty("state", QStringLiteral("green"));
         ui->choiceDateButton->setStyleSheet(Style::getStylesheet(QStringLiteral("chatForm/buttons.css")));
 
-        if (startDate.isNull()) {
-            startDate = QDate::currentDate();
+        if (startTime.isNull()) {
+            startTime = QDateTime::currentDateTime();
             updateStartDateLabel();
         }
 
@@ -162,10 +162,9 @@ void SearchSettingsForm::onRegularClicked(const bool checked)
 void SearchSettingsForm::onChoiceDate()
 {
     LoadHistoryDialog dlg;
-    dlg.setTitle(tr("Select Date Dialog"));
-    dlg.setInfoLabel(tr("Select a date"));
+    dlg.turnSearchMode();
     if (dlg.exec()) {
-        startDate = dlg.getFromDate().date();
+        startTime = dlg.getFromDate();
         updateStartDateLabel();
     }
 

--- a/src/widget/form/searchsettingsform.cpp
+++ b/src/widget/form/searchsettingsform.cpp
@@ -161,8 +161,7 @@ void SearchSettingsForm::onRegularClicked(const bool checked)
 
 void SearchSettingsForm::onChoiceDate()
 {
-    LoadHistoryDialog dlg;
-    dlg.turnSearchMode();
+    LoadHistoryDialog dlg(LoadHistoryDialog::search);
     if (dlg.exec()) {
         startTime = dlg.getFromDate();
         updateStartDateLabel();

--- a/src/widget/form/searchsettingsform.h
+++ b/src/widget/form/searchsettingsform.h
@@ -40,7 +40,7 @@ public:
 
 private:
     Ui::SearchSettingsForm *ui;
-    QDate startDate;
+    QDateTime startTime;
     bool isUpdate{false};
 
     void updateStartDateLabel();

--- a/src/widget/searchtypes.h
+++ b/src/widget/searchtypes.h
@@ -48,13 +48,13 @@ enum class SearchDirection {
 struct ParameterSearch {
     FilterSearch filter{FilterSearch::None};
     PeriodSearch period{PeriodSearch::None};
-    QDate date;
+    QDateTime time;
     bool isUpdate{false};
 
     bool operator ==(const ParameterSearch& other) {
         return filter == other.filter &&
             period == other.period &&
-            date == other.date;
+            time == other.time;
     }
 
     bool operator !=(const ParameterSearch& other) {


### PR DESCRIPTION
- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

1. load history at scrolling chat
2. edit function "Load chat history..."

![Screenshot_20190525_224634](https://user-images.githubusercontent.com/2956022/58374034-a3d7b200-7f3f-11e9-94ae-897c92e7c443.png)
![Screenshot_20190520_003023](https://user-images.githubusercontent.com/2956022/57988422-c9277480-7a96-11e9-9a34-3571397a5659.png)
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5672)
<!-- Reviewable:end -->
