### PR TITLE
fix(settings): apply toxcore settings for encrypted profiles

### DIFF
--- a/src/persistence/profile.cpp
+++ b/src/persistence/profile.cpp
@@ -107,7 +107,7 @@ Profile::Profile(QString name, const QString& password, bool isNewProfile,
     Settings& s = Settings::getInstance();
     s.setCurrentProfile(name);
     s.saveGlobal();
-    s.loadPersonal(name, passkey.get());
+    s.loadPersonal(name, this->passkey.get());
     initCore(toxsave, s, isNewProfile);
 
     const ToxId& selfId = core->getSelfId();


### PR DESCRIPTION
Fix #5682

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5687)
<!-- Reviewable:end -->
