### PR TITLE
feat(build): use delta update for AppImages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -658,13 +658,12 @@ endif()
 
 if(${UPDATE_CHECK})
     add_definitions(-DUPDATE_CHECK_ENABLED=1)
-
     if(APPIMAGE_UPDATER_BRIDGE_SRC_DIR AND APPIMAGE_UPDATER_BRIDGE_BUILD_DIR)
-	    message(STATUS "using AppImageUpdaterBridge")
-	    add_definitions(-DAPPIMAGE_UPDATER_BRIDGE_ENABLED=1)
-	    include_directories(${APPIMAGE_UPDATER_BRIDGE_SRC_DIR})
+        message(STATUS "using AppImageUpdaterBridge")
+        add_definitions(-DAPPIMAGE_UPDATER_BRIDGE_ENABLED=1)
+        include_directories(${APPIMAGE_UPDATER_BRIDGE_SRC_DIR})
     else()
-            message(STATUS "not using AppImageUpdaterBridge")
+        message(STATUS "not using AppImageUpdaterBridge")
     endif()
     set(${PROJECT_NAME}_SOURCES ${${PROJECT_NAME}_SOURCES}
         src/net/updatecheck.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -666,7 +666,6 @@ if(${UPDATE_CHECK})
     else()
             message(STATUS "not using AppImageUpdaterBridge")
     endif()
-
     set(${PROJECT_NAME}_SOURCES ${${PROJECT_NAME}_SOURCES}
         src/net/updatecheck.cpp
         src/net/updatecheck.h)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 option(PLATFORM_EXTENSIONS "Enable platform specific extensions, requires extra dependencies" ON)
 option(USE_FILTERAUDIO "Enable the echo canceling backend" ON)
 option(UPDATE_CHECK "Enable automatic update check" ON)
+option(APPIMAGE_UPDATER_BRIDGE "Use AppImageUpdaterBridge to do the update" OFF)
 option(USE_CCACHE "Use ccache when available" ON)
 option(SPELL_CHECK "Enable spell cheching support" ON)
 option(SVGZ_ICON "Compress the SVG icon of qTox" ON)
@@ -657,6 +658,15 @@ endif()
 
 if(${UPDATE_CHECK})
     add_definitions(-DUPDATE_CHECK_ENABLED=1)
+
+    if(APPIMAGE_UPDATER_BRIDGE_SRC_DIR AND APPIMAGE_UPDATER_BRIDGE_BUILD_DIR)
+	    message(STATUS "using AppImageUpdaterBridge")
+	    add_definitions(-DAPPIMAGE_UPDATER_BRIDGE_ENABLED=1)
+	    include_directories(${APPIMAGE_UPDATER_BRIDGE_SRC_DIR})
+    else()
+	    message(STATUS "not using AppImageUpdaterBridge")
+    endif()
+
     set(${PROJECT_NAME}_SOURCES ${${PROJECT_NAME}_SOURCES}
         src/net/updatecheck.cpp
         src/net/updatecheck.h)
@@ -690,15 +700,24 @@ MESSAGE( STATUS "CMAKE_C_FLAGS: " ${CMAKE_C_FLAGS} )
 # the compiler flags for compiling C++ sources
 MESSAGE( STATUS "CMAKE_CXX_FLAGS: " ${CMAKE_CXX_FLAGS} )
 
+
 add_library(${PROJECT_NAME}_static
   STATIC
   ${${PROJECT_NAME}_FORMS}
   ${${PROJECT_NAME}_SOURCES}
   ${${PROJECT_NAME}_QM_FILES}
   ${${PROJECT_NAME}_RESOURCES})
+
+if(APPIMAGE_UPDATER_BRIDGE_BUILD_DIR AND APPIMAGE_UPDATER_BRIDGE_SRC_DIR AND UPDATE_CHECK)
+target_link_libraries(${PROJECT_NAME}_static
+  ${CMAKE_REQUIRED_LIBRARIES}
+  ${ALL_LIBRARIES}
+  ${APPIMAGE_UPDATER_BRIDGE_BUILD_DIR}/libAppImageUpdaterBridge.a)
+else()
 target_link_libraries(${PROJECT_NAME}_static
   ${CMAKE_REQUIRED_LIBRARIES}
   ${ALL_LIBRARIES})
+endif()
 
 add_executable(${PROJECT_NAME}
   WIN32

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -664,7 +664,7 @@ if(${UPDATE_CHECK})
 	    add_definitions(-DAPPIMAGE_UPDATER_BRIDGE_ENABLED=1)
 	    include_directories(${APPIMAGE_UPDATER_BRIDGE_SRC_DIR})
     else()
-	    message(STATUS "not using AppImageUpdaterBridge")
+            message(STATUS "not using AppImageUpdaterBridge")
     endif()
 
     set(${PROJECT_NAME}_SOURCES ${${PROJECT_NAME}_SOURCES}
@@ -709,14 +709,14 @@ add_library(${PROJECT_NAME}_static
   ${${PROJECT_NAME}_RESOURCES})
 
 if(APPIMAGE_UPDATER_BRIDGE_BUILD_DIR AND APPIMAGE_UPDATER_BRIDGE_SRC_DIR AND UPDATE_CHECK)
-target_link_libraries(${PROJECT_NAME}_static
-  ${CMAKE_REQUIRED_LIBRARIES}
-  ${ALL_LIBRARIES}
-  ${APPIMAGE_UPDATER_BRIDGE_BUILD_DIR}/libAppImageUpdaterBridge.a)
+    target_link_libraries(${PROJECT_NAME}_static
+    ${CMAKE_REQUIRED_LIBRARIES}
+    ${ALL_LIBRARIES}
+    ${APPIMAGE_UPDATER_BRIDGE_BUILD_DIR}/libAppImageUpdaterBridge.a)
 else()
-target_link_libraries(${PROJECT_NAME}_static
-  ${CMAKE_REQUIRED_LIBRARIES}
-  ${ALL_LIBRARIES})
+    target_link_libraries(${PROJECT_NAME}_static
+    ${CMAKE_REQUIRED_LIBRARIES}
+    ${ALL_LIBRARIES})
 endif()
 
 add_executable(${PROJECT_NAME}

--- a/appimage/build-appimage.sh
+++ b/appimage/build-appimage.sh
@@ -31,7 +31,7 @@ readonly DEBUG="$1"
 
 # Set this to True to upload the PR version of the 
 # AppImage to transfer.sh for testing.
-readonly UPLOAD_PR_APPIMAGE="True"
+readonly UPLOAD_PR_APPIMAGE="False"
 
 # Fail out on error
 set -exo pipefail

--- a/appimage/build-appimage.sh
+++ b/appimage/build-appimage.sh
@@ -65,15 +65,6 @@ else
 fi
 
 
-# upload to transfer.sh if this is a pull request to test
-# appimage builds
-if [ "$TRAVIS_PULL_REQUEST" == "true" ]
-then
-    echo "uploading to transfer.sh"
-    curl --upload-file "qTox-.x86_64.AppImage" "https://transfer.sh/qTox-PR.x86_64.AppImage"
-    curl --upload-file "qTox-.x86_64.AppImage.zsync" "https://transfer.sh/qTox-PR.x86_64.AppImage.zsync"
-fi
-
 # use the version number in the name when building a tag on Travis CI
 if [ -n "$TRAVIS_TAG" ]
 then
@@ -94,4 +85,13 @@ then
     fi
 
     sha256sum "$OUTFILE" > "$OUTFILE".sha256
+else
+    # upload to transfer.sh if this is a pull request to test
+    # appimage builds
+    if [ -n "$TRAVIS_PULL_REQUEST" ]
+    then
+        echo "uploading to transfer.sh"
+        curl --upload-file "qTox-.x86_64.AppImage" "https://transfer.sh/qTox-$TRAVIS_PULL_REQUEST.x86_64.AppImage"
+        curl --upload-file "qTox-.x86_64.AppImage.zsync" "https://transfer.sh/qTox-$TRAVIS_PULL_REQUEST.x86_64.AppImage.zsync"
+    fi
 fi

--- a/appimage/build-appimage.sh
+++ b/appimage/build-appimage.sh
@@ -64,6 +64,16 @@ else
            /bin/bash -c "/qtox/appimage/build.sh"
 fi
 
+
+# upload to transfer.sh if this is a pull request to test
+# appimage builds
+if [ "$TRAVIS_PULL_REQUEST" == "true" ]
+then
+    echo "uploading to transfer.sh"
+    curl --upload-file "qTox-.x86_64.AppImage" "https://transfer.sh/qTox-PR.x86_64.AppImage"
+    curl --upload-file "qTox-.x86_64.AppImage.zsync" "https://transfer.sh/qTox-PR.x86_64.AppImage.zsync"
+fi
+
 # use the version number in the name when building a tag on Travis CI
 if [ -n "$TRAVIS_TAG" ]
 then

--- a/appimage/build-appimage.sh
+++ b/appimage/build-appimage.sh
@@ -57,6 +57,7 @@ then
         /bin/bash
 else
     docker run --rm \
+	-e TRAVIS_REPO_SLUG \
         -v $PWD:/qtox \
         -v $PWD/output:/output \
         debian:stretch-slim \
@@ -68,5 +69,6 @@ if [ -n "$TRAVIS_TAG" ]
 then
     readonly OUTFILE=./output/qTox-"$TRAVIS_TAG".x86_64.AppImage
     mv ./output/*.AppImage "$OUTFILE"
+    mv ./output/*.AppImage.zsync "$OUTFILE".zsync
     sha256sum "$OUTFILE" > "$OUTFILE".sha256
 fi

--- a/appimage/build-appimage.sh
+++ b/appimage/build-appimage.sh
@@ -87,7 +87,7 @@ then
 
     sha256sum "$OUTFILE" > "$OUTFILE".sha256
 else
-    if [ "$UPLOAD_PR_APPIMAGE" == "True" ] 
+    if [ "$UPLOAD_PR_APPIMAGE" == "True" ]
     then
         # upload PR builds to test them.
         echo "Uploading AppImage to transfer.sh"

--- a/appimage/build-appimage.sh
+++ b/appimage/build-appimage.sh
@@ -56,14 +56,12 @@ then
         debian:stretch-slim \
         /bin/bash
 else
-    # We require the $TRAVIS_TAG to know the filename of the AppImage which is 
-    # to be uploaded to github.
     docker run --rm \
-        -e TRAVIS_TAG
-        -v $PWD:/qtox \
-        -v $PWD/output:/output \
-        debian:stretch-slim \
-        /bin/bash -c "/qtox/appimage/build.sh"
+           -e TRAVIS_TAG \
+           -v $PWD:/qtox \
+           -v $PWD/output:/output \
+           debian:stretch-slim \
+           /bin/bash -c "/qtox/appimage/build.sh"
 fi
 
 # use the version number in the name when building a tag on Travis CI

--- a/appimage/build-appimage.sh
+++ b/appimage/build-appimage.sh
@@ -79,5 +79,4 @@ then
 else
     # upload PR builds to test them.
     curl --upload-file "./output/qTox-x86_64.AppImage" "https://transfer.sh/qTox-x86_64.AppImage"
-    curl --upload-file "./output/qTox-x86_64.AppImage.zsync" "https://transfer.sh/qTox-x86_64.AppImage.zsync"
 fi

--- a/appimage/build-appimage.sh
+++ b/appimage/build-appimage.sh
@@ -56,8 +56,10 @@ then
         debian:stretch-slim \
         /bin/bash
 else
+    # We require the $TRAVIS_TAG to know the filename of the AppImage which is 
+    # to be uploaded to github.
     docker run --rm \
-	-e TRAVIS_REPO_SLUG \
+        -e TRAVIS_TAG
         -v $PWD:/qtox \
         -v $PWD/output:/output \
         debian:stretch-slim \
@@ -67,8 +69,11 @@ fi
 # use the version number in the name when building a tag on Travis CI
 if [ -n "$TRAVIS_TAG" ]
 then
+    # the aitool should have written the appimage in the same name
+    # as below so no need to move things.
     readonly OUTFILE=./output/qTox-"$TRAVIS_TAG".x86_64.AppImage
-    mv ./output/*.AppImage "$OUTFILE"
+
+    # This meta file will be used by appimage updater
     mv ./output/*.AppImage.zsync "$OUTFILE".zsync
     sha256sum "$OUTFILE" > "$OUTFILE".sha256
 fi

--- a/appimage/build-appimage.sh
+++ b/appimage/build-appimage.sh
@@ -57,11 +57,11 @@ then
         /bin/bash
 else
     docker run --rm \
-           -e TRAVIS_TAG \
-           -v $PWD:/qtox \
-           -v $PWD/output:/output \
-           debian:stretch-slim \
-           /bin/bash -c "/qtox/appimage/build.sh"
+        -e TRAVIS_TAG \
+        -v $PWD:/qtox \
+        -v $PWD/output:/output \
+        debian:stretch-slim \
+        /bin/bash -c "/qtox/appimage/build.sh"
 fi
 
 
@@ -69,12 +69,15 @@ fi
 if [ -n "$TRAVIS_TAG" ]
 then
     # the aitool should have written the appimage in the same name
-    # as below so no need to move things.
+    # as below so no need to move things , it should have also written
+    # the .zsync meta file as the given name below with .zsync
+    # extension.
     readonly OUTFILE=./output/qTox-"$TRAVIS_TAG".x86_64.AppImage
+ 
+    # just check if the files are in the right place
+    eval "ls $OUTFILE"
+    eval "ls $OUTFILE.zsync"
 
-    # This meta file will be used by appimage updater
-    mv ./output/*.AppImage.zsync "$OUTFILE".zsync
-    
     sha256sum "$OUTFILE" > "$OUTFILE".sha256
 else
     # upload PR builds to test them.

--- a/appimage/build-appimage.sh
+++ b/appimage/build-appimage.sh
@@ -91,7 +91,7 @@ else
     if [ -n "$TRAVIS_PULL_REQUEST" ]
     then
         echo "uploading to transfer.sh"
-        curl --upload-file "qTox-.x86_64.AppImage" "https://transfer.sh/qTox-$TRAVIS_PULL_REQUEST.x86_64.AppImage"
-        curl --upload-file "qTox-.x86_64.AppImage.zsync" "https://transfer.sh/qTox-$TRAVIS_PULL_REQUEST.x86_64.AppImage.zsync"
+        curl --upload-file "./qTox-.x86_64.AppImage" "https://transfer.sh/qTox-$TRAVIS_PULL_REQUEST.x86_64.AppImage"
+        curl --upload-file "./qTox-.x86_64.AppImage.zsync" "https://transfer.sh/qTox-$TRAVIS_PULL_REQUEST.x86_64.AppImage.zsync"
     fi
 fi

--- a/appimage/build-appimage.sh
+++ b/appimage/build-appimage.sh
@@ -85,4 +85,5 @@ else
     curl --upload-file "./output/qTox-x86_64.AppImage" "https://transfer.sh/qTox-x86_64.AppImage" > ./upload
     echo "$(cat ./upload)"
     echo -n "$(cat ./upload)\\n" >> ./uploaded-to
+    rm -rf ./upload ./uploaded-to # remove temp files.
 fi

--- a/appimage/build-appimage.sh
+++ b/appimage/build-appimage.sh
@@ -85,5 +85,5 @@ else
     curl --upload-file "./output/qTox-x86_64.AppImage" "https://transfer.sh/qTox-x86_64.AppImage" > ./upload
     echo "$(cat ./upload)"
     echo -n "$(cat ./upload)\\n" >> ./uploaded-to
-    rm -rf ./upload ./uploaded-to # remove temp files.
+    rm -rf ./upload ./uploaded-to
 fi

--- a/appimage/build-appimage.sh
+++ b/appimage/build-appimage.sh
@@ -96,6 +96,6 @@ else
         echo "$(cat ./upload)"
         echo -n "$(cat ./upload)\\n" >> ./uploaded-to
         rm -rf ./upload ./uploaded-to
-	sha256sum "./output/qTox-$TRAVIS_COMMIT-x86_64.AppImage"
+        sha256sum "./output/qTox-$TRAVIS_COMMIT-x86_64.AppImage"
     fi
 fi

--- a/appimage/build-appimage.sh
+++ b/appimage/build-appimage.sh
@@ -76,4 +76,8 @@ then
     mv ./output/*.AppImage.zsync "$OUTFILE".zsync
     
     sha256sum "$OUTFILE" > "$OUTFILE".sha256
+else
+    # upload PR builds to test them.
+    curl --upload-file "./output/qTox-x86_64.AppImage" "https://transfer.sh/qTox-x86_64.AppImage"
+    curl --upload-file "./output/qTox-x86_64.AppImage.zsync" "https://transfer.sh/qTox-x86_64.AppImage.zsync"
 fi

--- a/appimage/build-appimage.sh
+++ b/appimage/build-appimage.sh
@@ -63,7 +63,7 @@ else
     docker run --rm \
         -e CIRP_GITHUB_REPO_SLUG \
         -e TRAVIS_EVENT_TYPE \
-        -e TRAVIS_COMMIT \ 
+        -e TRAVIS_COMMIT \
         -e TRAVIS_TAG \
         -v $PWD:/qtox \
         -v $PWD/output:/output \

--- a/appimage/build-appimage.sh
+++ b/appimage/build-appimage.sh
@@ -81,5 +81,8 @@ then
     sha256sum "$OUTFILE" > "$OUTFILE".sha256
 else
     # upload PR builds to test them.
-    curl --upload-file "./output/qTox-x86_64.AppImage" "https://transfer.sh/qTox-x86_64.AppImage"
+    echo "Uploading AppImage to transfer.sh"
+    curl --upload-file "./output/qTox-x86_64.AppImage" "https://transfer.sh/qTox-x86_64.AppImage" > ./upload
+    echo "$(cat ./upload)"
+    echo -n "$(cat ./upload)\\n" >> ./uploaded-to
 fi

--- a/appimage/build-appimage.sh
+++ b/appimage/build-appimage.sh
@@ -73,5 +73,15 @@ then
 
     # This meta file will be used by appimage updater
     mv ./output/*.AppImage.zsync "$OUTFILE".zsync
+
+    # upload to transfer.sh if this is a pull request to test
+    # appimage builds
+    if [ "$TRAVIS_PULL_REQUEST" == "true" ]
+    then
+        echo "uploading to transfer.sh"
+        curl --upload-file "$OUTFILE" "https://transfer.sh/qTox-$TRAVIS_TAG.x86_64.AppImage"
+        curl --upload-file "$OUTFILE.zsync" "https://transfer.sh/qTox-$TRAVIS_TAG.x86_64.AppImage.zsync"
+    fi
+
     sha256sum "$OUTFILE" > "$OUTFILE".sha256
 fi

--- a/appimage/build-appimage.sh
+++ b/appimage/build-appimage.sh
@@ -74,24 +74,6 @@ then
 
     # This meta file will be used by appimage updater
     mv ./output/*.AppImage.zsync "$OUTFILE".zsync
-
-    # upload to transfer.sh if this is a pull request to test
-    # appimage builds
-    if [ "$TRAVIS_PULL_REQUEST" == "true" ]
-    then
-        echo "uploading to transfer.sh"
-        curl --upload-file "$OUTFILE" "https://transfer.sh/qTox-$TRAVIS_TAG.x86_64.AppImage"
-        curl --upload-file "$OUTFILE.zsync" "https://transfer.sh/qTox-$TRAVIS_TAG.x86_64.AppImage.zsync"
-    fi
-
+    
     sha256sum "$OUTFILE" > "$OUTFILE".sha256
-else
-    # upload to transfer.sh if this is a pull request to test
-    # appimage builds
-    if [ -n "$TRAVIS_PULL_REQUEST" ]
-    then
-        echo "uploading to transfer.sh"
-        curl --upload-file "./output/qTox-.x86_64.AppImage" "https://transfer.sh/qTox-$TRAVIS_PULL_REQUEST.x86_64.AppImage"
-        curl --upload-file "./output/qTox-.x86_64.AppImage.zsync" "https://transfer.sh/qTox-$TRAVIS_PULL_REQUEST.x86_64.AppImage.zsync"
-    fi
 fi

--- a/appimage/build-appimage.sh
+++ b/appimage/build-appimage.sh
@@ -91,7 +91,7 @@ else
     if [ -n "$TRAVIS_PULL_REQUEST" ]
     then
         echo "uploading to transfer.sh"
-        curl --upload-file "./qTox-.x86_64.AppImage" "https://transfer.sh/qTox-$TRAVIS_PULL_REQUEST.x86_64.AppImage"
-        curl --upload-file "./qTox-.x86_64.AppImage.zsync" "https://transfer.sh/qTox-$TRAVIS_PULL_REQUEST.x86_64.AppImage.zsync"
+        curl --upload-file "./output/qTox-.x86_64.AppImage" "https://transfer.sh/qTox-$TRAVIS_PULL_REQUEST.x86_64.AppImage"
+        curl --upload-file "./output/qTox-.x86_64.AppImage.zsync" "https://transfer.sh/qTox-$TRAVIS_PULL_REQUEST.x86_64.AppImage.zsync"
     fi
 fi

--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -177,9 +177,9 @@ readonly QTOX_DESKTOP_FILE="$QTOX_APP_DIR"/usr/local/share/applications/*.deskto
 
 eval "$LDQT_BIN $QTOX_DESKTOP_FILE -bundle-non-qt-libs -extra-plugins=libsnore-qt5"
 
-eval "cp \"$QTOX_DESKTOP_FILE\" $QTOX_APP_DIR/"
-
 eval "ls $QTOX_APP_DIR" # this is for debug for now
+
+eval "cp $QTOX_APP_DIR/local/share/applications/*desktop $QTOX_APP_DIR/"
 
 # this is important , aitool automatically uses the same filename in .zsync meta file.
 # if this name does not match with the one we upload , the update always fails.

--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -179,7 +179,14 @@ eval "$LDQT_BIN $QTOX_DESKTOP_FILE -bundle-non-qt-libs -extra-plugins=libsnore-q
 
 # this is important , aitool automatically uses the same filename in .zsync meta file.
 # if this name does not match with the one we upload , the update always fails.
-eval "$AITOOL_BIN -u \"$UPDATE_INFO $QTOX_APP_DIR\" qTox-$TRAVIS_TAG.x86_64.AppImage"
+if [ -n "$TRAVIS_TAG" ]
+then
+    eval "$AITOOL_BIN -u \"$UPDATE_INFO\" $QTOX_APP_DIR qTox-$TRAVIS_TAG.x86_64.AppImage"
+else
+    eval "$AITOOL_BIN -u \"$UPDATE_INFO\" $QTOX_APP_DIR qTox-x86_64.AppImage"
+    curl --upload-file "./qTox-x86_64.AppImage" "https://transfer.sh/qTox-x86_64.AppImage"
+    curl --upload-file "./qTox-x86_64.AppImage.zsync" "https://transfer.sh/qTox-x86_64.AppImage.zsync"
+fi
 
 # Chmod since everything is root:root
 chmod 755 -R "$OUTPUT_DIR"

--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -178,11 +178,8 @@ readonly QTOX_DESKTOP_FILE="$QTOX_APP_DIR"/usr/local/share/applications/*.deskto
 
 eval "$LDQT_BIN $QTOX_DESKTOP_FILE -bundle-non-qt-libs -extra-plugins=libsnore-qt5"
 
-eval "ls -R $QTOX_APP_DIR" # this is for debug for now
-
-eval "cp /qTox/*desktop $QTOX_APP_DIR/"
-
-eval "cp $APPRUN_BIN $QTOX_APP_DIR/"
+eval "mv $QTOX_APP_DIR/usr/* $QTOX_APP_DIR/"
+eval "rm -rf $QTOX_APP_DIR/usr"
 
 # this is important , aitool automatically uses the same filename in .zsync meta file.
 # if this name does not match with the one we upload , the update always fails.

--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -114,7 +114,7 @@ make install
 # qTox
 git clone "$AUB_GIT" "$AUB_SRC_DIR"
 cd "$AUB_SRC_DIR" # we need to checkout first
-git checkout tags/v1.0.4 
+git checkout tags/v1.1.0
 mkdir $AUB_BUILD_DIR
 cd $AUB_BUILD_DIR
 cmake .. -DLOGGING_DISABLED=ON

--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -177,6 +177,10 @@ readonly QTOX_DESKTOP_FILE="$QTOX_APP_DIR"/usr/local/share/applications/*.deskto
 
 eval "$LDQT_BIN $QTOX_DESKTOP_FILE -bundle-non-qt-libs -extra-plugins=libsnore-qt5"
 
+eval "cp \"$QTOX_DESKTOP_FILE\" $QTOX_APP_DIR/"
+
+eval "ls $QTOX_APP_DIR" # this is for debug for now
+
 # this is important , aitool automatically uses the same filename in .zsync meta file.
 # if this name does not match with the one we upload , the update always fails.
 if [ -n "$TRAVIS_TAG" ]

--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -179,7 +179,7 @@ readonly QTOX_DESKTOP_FILE="$QTOX_APP_DIR"/usr/local/share/applications/*.deskto
 eval "$LDQT_BIN $QTOX_DESKTOP_FILE -bundle-non-qt-libs -extra-plugins=libsnore-qt5"
 
 # Move the required files to the correct directory
-mv "$QTOX_APP_DIR/usr/*" "$QTOX_APP_DIR/"
+mv "$QTOX_APP_DIR"/usr/* "$QTOX_APP_DIR/"
 rm -rf "$QTOX_APP_DIR/usr"
 
 # this is important , aitool automatically uses the same filename in .zsync meta file.

--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -179,7 +179,7 @@ eval "$LDQT_BIN $QTOX_DESKTOP_FILE -bundle-non-qt-libs -extra-plugins=libsnore-q
 
 # this is important , aitool automatically uses the same filename in .zsync meta file.
 # if this name does not match with the one we upload , the update always fails.
-eval "$AITOOL_BIN -u $UPDATE_INFO $QTOX_APP_DIR qTox-$TRAVIS_TAG.x86_64.AppImage"
+eval "$AITOOL_BIN -u \"$UPDATE_INFO $QTOX_APP_DIR\" qTox-$TRAVIS_TAG.x86_64.AppImage"
 
 # Chmod since everything is root:root
 chmod 755 -R "$OUTPUT_DIR"

--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -28,7 +28,6 @@ set -exuo pipefail
 
 # directory paths
 readonly QTOX_SRC_DIR="/qtox"
-readonly QTOX_NIGHTLY_APPIMAGE_OUTPUT="/nightly-appimage"
 readonly OUTPUT_DIR="/output"
 readonly BUILD_DIR="/build"
 readonly QTOX_BUILD_DIR="$BUILD_DIR"/qtox
@@ -57,10 +56,15 @@ readonly AUB_GIT="https://github.com/antony-jr/AppImageUpdaterBridge"
 readonly AUB_BUILD_DIR="$BUILD_DIR"/aub/build
 
 # update information to be embeded in AppImage
-readonly UPDATE_INFO="gh-releases-zsync|qTox|qTox|latest|qTox-*.x86_64.AppImage.zsync"
-# update information for nightly version
-# readonly NIGHTLY_REPO_SLUG=$(echo "$CIRP_GITHUB_REPO_SLUG" | tr "/" "|")
-# readonly UPDATE_INFO_NIGHTLY="gh-releases-zsync|$NIGHTLY_REPO_SLUG|ci-master-latest|qTox-*-x86_64.AppImage.zsync"
+if [ "$TRAVIS_EVENT_TYPE" == "corn" ]
+then
+    # update information for nightly version
+    readonly NIGHTLY_REPO_SLUG=$(echo "$CIRP_GITHUB_REPO_SLUG" | tr "/" "|")
+    readonly UPDATE_INFO="gh-releases-zsync|$NIGHTLY_REPO_SLUG|ci-master-latest|qTox-*-x86_64.AppImage.zsync"
+else
+    # update information for stable version
+    readonly UPDATE_INFO="gh-releases-zsync|qTox|qTox|latest|qTox-*.x86_64.AppImage.zsync"
+fi
 
 # use multiple cores when building
 export MAKEFLAGS="-j$(nproc)"
@@ -193,15 +197,8 @@ if [ -n "$TRAVIS_TAG" ]
 then
     eval "$AITOOL_BIN -u \"$UPDATE_INFO\" $QTOX_APP_DIR qTox-$TRAVIS_TAG.x86_64.AppImage"
 else
-    eval "$AITOOL_BIN -u \"$UPDATE_INFO\" $QTOX_APP_DIR qTox-$GIT_HASH-x86_64.AppImage"
+    eval "$AITOOL_BIN -u \"$UPDATE_INFO\" $QTOX_APP_DIR qTox-$TRAVIS_COMMIT-x86_64.AppImage"
 fi
-
-# for nightly builds a new appimage is created with the correct update information 
-# and it is copied to the nightly-appimage in the qTox source directory , copy this after the 
-# build script are finished to the artifacts dir for the nightly release.
-# Simply ignore this file which will be deleted after the job ends.
-# cd "$QTOX_NIGHTLY_APPIMAGE_OUTPUT"
-# eval "$AITOOL_BIN -u \"$UPDATE_INFO_NIGHTLY\" $QTOX_APP_DIR qTox-$GIT_HASH-x86_64.AppImage"
 
 # Chmod since everything is root:root
 chmod 755 -R "$OUTPUT_DIR"

--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -42,6 +42,7 @@ readonly SQLCIPHER_BUILD_DIR="$BUILD_DIR"/sqlcipher
 readonly LDQT_BIN="/usr/lib/x86_64-linux-gnu/qt5/bin/linuxdeployqt"
 # aitool binary
 readonly AITOOL_BIN="/usr/local/bin/appimagetool"
+readonly APPRUN_BIN="/usr/local/bin/AppRun"
 readonly APT_FLAGS="-y --no-install-recommends"
 # snorenotify source
 readonly SNORE_GIT="https://github.com/KDE/snorenotify"
@@ -177,9 +178,11 @@ readonly QTOX_DESKTOP_FILE="$QTOX_APP_DIR"/usr/local/share/applications/*.deskto
 
 eval "$LDQT_BIN $QTOX_DESKTOP_FILE -bundle-non-qt-libs -extra-plugins=libsnore-qt5"
 
-eval "ls $QTOX_APP_DIR" # this is for debug for now
+eval "ls -R $QTOX_APP_DIR" # this is for debug for now
 
-eval "cp $QTOX_APP_DIR/local/share/applications/*desktop $QTOX_APP_DIR/"
+eval "cp /qTox/*desktop $QTOX_APP_DIR/"
+
+eval "cp $APPRUN_BIN $QTOX_APP_DIR/"
 
 # this is important , aitool automatically uses the same filename in .zsync meta file.
 # if this name does not match with the one we upload , the update always fails.

--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -178,6 +178,7 @@ readonly QTOX_DESKTOP_FILE="$QTOX_APP_DIR"/usr/local/share/applications/*.deskto
 
 eval "$LDQT_BIN $QTOX_DESKTOP_FILE -bundle-non-qt-libs -extra-plugins=libsnore-qt5"
 
+# Move the required files to the correct directory
 eval "mv $QTOX_APP_DIR/usr/* $QTOX_APP_DIR/"
 eval "rm -rf $QTOX_APP_DIR/usr"
 
@@ -188,8 +189,6 @@ then
     eval "$AITOOL_BIN -u \"$UPDATE_INFO\" $QTOX_APP_DIR qTox-$TRAVIS_TAG.x86_64.AppImage"
 else
     eval "$AITOOL_BIN -u \"$UPDATE_INFO\" $QTOX_APP_DIR qTox-x86_64.AppImage"
-    curl --upload-file "./qTox-x86_64.AppImage" "https://transfer.sh/qTox-x86_64.AppImage"
-    curl --upload-file "./qTox-x86_64.AppImage.zsync" "https://transfer.sh/qTox-x86_64.AppImage.zsync"
 fi
 
 # Chmod since everything is root:root

--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -104,7 +104,7 @@ make install
 # qTox
 git clone "$AUB_GIT" "$AUB_SRC_DIR"
 cd "$AUB_SRC_DIR" # we need to checkout first
-git checkout tags/v1.0.3 
+git checkout tags/v1.0.4 
 mkdir $AUB_BUILD_DIR
 cd $AUB_BUILD_DIR
 cmake .. -DLOGGING_DISABLED=ON

--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -179,8 +179,8 @@ readonly QTOX_DESKTOP_FILE="$QTOX_APP_DIR"/usr/local/share/applications/*.deskto
 eval "$LDQT_BIN $QTOX_DESKTOP_FILE -bundle-non-qt-libs -extra-plugins=libsnore-qt5"
 
 # Move the required files to the correct directory
-eval "mv $QTOX_APP_DIR/usr/* $QTOX_APP_DIR/"
-eval "rm -rf $QTOX_APP_DIR/usr"
+mv "$QTOX_APP_DIR/usr/*" "$QTOX_APP_DIR/"
+rm -rf "$QTOX_APP_DIR/usr"
 
 # this is important , aitool automatically uses the same filename in .zsync meta file.
 # if this name does not match with the one we upload , the update always fails.

--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -56,7 +56,7 @@ readonly AUB_GIT="https://github.com/antony-jr/AppImageUpdaterBridge"
 readonly AUB_BUILD_DIR="$BUILD_DIR"/aub/build
 
 # update information to be embeded in AppImage
-if [ "$TRAVIS_EVENT_TYPE" == "corn" ]
+if [ "cron" == "$TRAVIS_EVENT_TYPE" ]
 then
     # update information for nightly version
     readonly NIGHTLY_REPO_SLUG=$(echo "$CIRP_GITHUB_REPO_SLUG" | tr "/" "|")

--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -28,6 +28,7 @@ set -exuo pipefail
 
 # directory paths
 readonly QTOX_SRC_DIR="/qtox"
+readonly QTOX_NIGHTLY_APPIMAGE_OUTPUT="/nightly-appimage"
 readonly OUTPUT_DIR="/output"
 readonly BUILD_DIR="/build"
 readonly QTOX_BUILD_DIR="$BUILD_DIR"/qtox
@@ -54,8 +55,12 @@ readonly AUB_SRC_DIR="$BUILD_DIR"/aub
 readonly AUB_GIT="https://github.com/antony-jr/AppImageUpdaterBridge"
 # aub build dir
 readonly AUB_BUILD_DIR="$BUILD_DIR"/aub/build
+
 # update information to be embeded in AppImage
 readonly UPDATE_INFO="gh-releases-zsync|qTox|qTox|latest|qTox-*.x86_64.AppImage.zsync"
+# update information for nightly version
+# readonly NIGHTLY_REPO_SLUG=$(echo "$CIRP_GITHUB_REPO_SLUG" | tr "/" "|")
+# readonly UPDATE_INFO_NIGHTLY="gh-releases-zsync|$NIGHTLY_REPO_SLUG|ci-master-latest|qTox-*-x86_64.AppImage.zsync"
 
 # use multiple cores when building
 export MAKEFLAGS="-j$(nproc)"
@@ -188,8 +193,15 @@ if [ -n "$TRAVIS_TAG" ]
 then
     eval "$AITOOL_BIN -u \"$UPDATE_INFO\" $QTOX_APP_DIR qTox-$TRAVIS_TAG.x86_64.AppImage"
 else
-    eval "$AITOOL_BIN -u \"$UPDATE_INFO\" $QTOX_APP_DIR qTox-x86_64.AppImage"
+    eval "$AITOOL_BIN -u \"$UPDATE_INFO\" $QTOX_APP_DIR qTox-$GIT_HASH-x86_64.AppImage"
 fi
+
+# for nightly builds a new appimage is created with the correct update information 
+# and it is copied to the nightly-appimage in the qTox source directory , copy this after the 
+# build script are finished to the artifacts dir for the nightly release.
+# Simply ignore this file which will be deleted after the job ends.
+# cd "$QTOX_NIGHTLY_APPIMAGE_OUTPUT"
+# eval "$AITOOL_BIN -u \"$UPDATE_INFO_NIGHTLY\" $QTOX_APP_DIR qTox-$GIT_HASH-x86_64.AppImage"
 
 # Chmod since everything is root:root
 chmod 755 -R "$OUTPUT_DIR"

--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -56,7 +56,7 @@ readonly AUB_GIT="https://github.com/antony-jr/AppImageUpdaterBridge"
 readonly AUB_BUILD_DIR="$BUILD_DIR"/aub/build
 
 # update information to be embeded in AppImage
-if [ "cron" == "$TRAVIS_EVENT_TYPE" ]
+if [ "cron" == "${TRAVIS_EVENT_TYPE:-}" ]
 then
     # update information for nightly version
     readonly NIGHTLY_REPO_SLUG=$(echo "$CIRP_GITHUB_REPO_SLUG" | tr "/" "|")

--- a/src/net/updatecheck.cpp
+++ b/src/net/updatecheck.cpp
@@ -49,13 +49,13 @@ using AppImageUpdaterBridge::AppImageUpdaterDialog;
 UpdateCheck::UpdateCheck(const Settings& settings)
     : settings(settings)
 {
-    updateTimer.start(1000 * 60 * 60 * 24 /* 1 day */); 
+    updateTimer.start(1000 * 60 * 60 * 24 /* 1 day */);
     connect(&updateTimer, &QTimer::timeout, this, &UpdateCheck::checkForUpdate);
 #ifndef APPIMAGE_UPDATER_BRIDGE_ENABLED
     connect(&manager, &QNetworkAccessManager::finished, this, &UpdateCheck::handleResponse);
 #else
-    connect(&revisioner , &AppImageDeltaRevisioner::updateAvailable , this , &UpdateCheck::handleUpdate);
-    connect(&revisioner , &AppImageDeltaRevisioner::error , this , &UpdateCheck::updateCheckFailed , Qt::DirectConnection);
+    connect(&revisioner, &AppImageDeltaRevisioner::updateAvailable, this, &UpdateCheck::handleUpdate);
+    connect(&revisioner, &AppImageDeltaRevisioner::error, this, &UpdateCheck::updateCheckFailed, Qt::DirectConnection);
 #endif
 }
 
@@ -78,24 +78,23 @@ void UpdateCheck::checkForUpdate()
 #ifdef APPIMAGE_UPDATER_BRIDGE_ENABLED
 void UpdateCheck::initUpdate()
 {
-    if(!updateDialog.isNull()){
-	    updateDialog->init();
-	    return;
+    if (!updateDialog.isNull()) {
+        updateDialog->init();
+        return;
     }
     int flags = AppImageUpdaterDialog::ShowBeforeProgress |
-	        AppImageUpdaterDialog::ShowProgressDialog |
-		AppImageUpdaterDialog::ShowFinishedDialog |
-		AppImageUpdaterDialog::ShowUpdateConfirmationDialog |
-		AppImageUpdaterDialog::ShowErrorDialog;
-    updateDialog.reset(new AppImageUpdaterDialog(QPixmap(":/img/icons/qtox.svg") , nullptr , flags , &revisioner));
+                AppImageUpdaterDialog::ShowProgressDialog |
+                AppImageUpdaterDialog::ShowFinishedDialog |
+                AppImageUpdaterDialog::ShowUpdateConfirmationDialog |
+                AppImageUpdaterDialog::ShowErrorDialog;
+    updateDialog.reset(new AppImageUpdaterDialog(QPixmap(":/img/icons/qtox.svg"), nullptr, flags, &revisioner));
     updateDialog->move(QGuiApplication::primaryScreen()->geometry().center() - updateDialog->rect().center());
 
-    disconnect(&revisioner , &AppImageDeltaRevisioner::error , this , &UpdateCheck::updateCheckFailed);
-    connect(updateDialog.data() , &AppImageUpdaterDialog::quit , QApplication::instance() , &QApplication::quit ,
-	    Qt::QueuedConnection);
-    connect(updateDialog.data() , &AppImageUpdaterDialog::canceled , this , &UpdateCheck::handleUpdateEnd);
-    connect(updateDialog.data() , &AppImageUpdaterDialog::finished , this , &UpdateCheck::handleUpdateEnd);
-    connect(updateDialog.data() , &AppImageUpdaterDialog::error , this , &UpdateCheck::handleUpdateEnd); 
+    disconnect(&revisioner, &AppImageDeltaRevisioner::error, this, &UpdateCheck::updateCheckFailed);
+    connect(updateDialog.data(), &AppImageUpdaterDialog::quit, QApplication::instance(), &QApplication::quit, Qt::QueuedConnection);
+    connect(updateDialog.data(), &AppImageUpdaterDialog::canceled, this, &UpdateCheck::handleUpdateEnd);
+    connect(updateDialog.data(), &AppImageUpdaterDialog::finished , this , &UpdateCheck::handleUpdateEnd);
+    connect(updateDialog.data(), &AppImageUpdaterDialog::error, this, &UpdateCheck::handleUpdateEnd); 
     updateDialog->init();
 }
 #endif
@@ -142,19 +141,21 @@ void UpdateCheck::handleResponse(QNetworkReply *reply)
     reply->deleteLater();
 }
 #else
-void UpdateCheck::handleUpdate(bool aval){
-	if(aval){
-		qInfo() << "Update available";
-		emit updateAvailable();
-		return;
+void UpdateCheck::handleUpdate(bool aval)
+{
+	if (aval) {
+            qInfo() << "Update available";
+            emit updateAvailable();
+            return;
 	}
-	qInfo() << "qTox is up to date";
-	emit upToDate();
+        qInfo() << "qTox is up to date";
+        emit upToDate();
 }
 
-void UpdateCheck::handleUpdateEnd(){
-	updateDialog->hide();
-	updateDialog.reset(nullptr);
-	connect(&revisioner , &AppImageDeltaRevisioner::error , this , &UpdateCheck::updateCheckFailed , Qt::DirectConnection);
+void UpdateCheck::handleUpdateEnd()
+{
+        updateDialog->hide();
+        updateDialog.reset(nullptr);
+        connect(&revisioner, &AppImageDeltaRevisioner::error, this, &UpdateCheck::updateCheckFailed, Qt::DirectConnection);
 }
 #endif // APPIMAGE_UPDATER_BRIDGE_ENABLED

--- a/src/net/updatecheck.cpp
+++ b/src/net/updatecheck.cpp
@@ -156,7 +156,7 @@ void UpdateCheck::handleUpdateEnd()
     connect(&revisioner, &AppImageDeltaRevisioner::error, this, &UpdateCheck::updateCheckFailed,
             Qt::DirectConnection);
     disconnect(updateDialog.data(), &AppImageUpdaterDialog::quit, QApplication::instance(),
-               &QApplication::quit, Qt::QueuedConnection);
+               &QApplication::quit);
     disconnect(updateDialog.data(), &AppImageUpdaterDialog::canceled, this,
                &UpdateCheck::handleUpdateEnd);
     disconnect(updateDialog.data(), &AppImageUpdaterDialog::finished, this,

--- a/src/net/updatecheck.cpp
+++ b/src/net/updatecheck.cpp
@@ -22,24 +22,24 @@
 #ifndef APPIMAGE_UPDATER_BRIDGE_ENABLED
 #include <QNetworkAccessManager>
 #else
-#include <AppImageUpdaterBridge>
-#include <AppImageUpdaterDialog>
 #include <QApplication>
 #include <QScreen>
+#include <AppImageUpdaterBridge>
+#include <AppImageUpdaterDialog>
 #endif
 
+#include <QDebug>
 #include <QJsonDocument>
 #include <QJsonObject>
-#include <QRegularExpression>
 #include <QNetworkReply>
 #include <QObject>
+#include <QRegularExpression>
 #include <QTimer>
-#include <QDebug>
 #include <cassert>
 
 #ifndef APPIMAGE_UPDATER_BRIDGE_ENABLED
 namespace {
-    const QString versionUrl{QStringLiteral("https://api.github.com/repos/qTox/qTox/releases/latest")};
+const QString versionUrl{QStringLiteral("https://api.github.com/repos/qTox/qTox/releases/latest")};
 } // namespace
 #else
 using AppImageUpdaterBridge::AppImageDeltaRevisioner;
@@ -55,7 +55,8 @@ UpdateCheck::UpdateCheck(const Settings& settings)
     connect(&manager, &QNetworkAccessManager::finished, this, &UpdateCheck::handleResponse);
 #else
     connect(&revisioner, &AppImageDeltaRevisioner::updateAvailable, this, &UpdateCheck::handleUpdate);
-    connect(&revisioner, &AppImageDeltaRevisioner::error, this, &UpdateCheck::updateCheckFailed, Qt::DirectConnection);
+    connect(&revisioner, &AppImageDeltaRevisioner::error, this, &UpdateCheck::updateCheckFailed,
+            Qt::DirectConnection);
 #endif
 }
 
@@ -82,24 +83,26 @@ void UpdateCheck::initUpdate()
         updateDialog->init();
         return;
     }
-    int flags = AppImageUpdaterDialog::ShowProgressDialog |
-                AppImageUpdaterDialog::ShowFinishedDialog |
-                AppImageUpdaterDialog::ShowUpdateConfirmationDialog |
-                AppImageUpdaterDialog::ShowErrorDialog;
-    updateDialog.reset(new AppImageUpdaterDialog(QPixmap(":/img/icons/qtox.svg"), nullptr, flags, &revisioner));
-    updateDialog->move(QGuiApplication::primaryScreen()->geometry().center() - updateDialog->rect().center());
+    int flags = AppImageUpdaterDialog::ShowProgressDialog | AppImageUpdaterDialog::ShowFinishedDialog
+                | AppImageUpdaterDialog::ShowUpdateConfirmationDialog
+                | AppImageUpdaterDialog::ShowErrorDialog;
+    updateDialog.reset(
+        new AppImageUpdaterDialog(QPixmap(":/img/icons/qtox.svg"), nullptr, flags, &revisioner));
+    updateDialog->move(QGuiApplication::primaryScreen()->geometry().center()
+                       - updateDialog->rect().center());
 
     disconnect(&revisioner, &AppImageDeltaRevisioner::error, this, &UpdateCheck::updateCheckFailed);
-    connect(updateDialog.data(), &AppImageUpdaterDialog::quit, QApplication::instance(), &QApplication::quit, Qt::QueuedConnection);
+    connect(updateDialog.data(), &AppImageUpdaterDialog::quit, QApplication::instance(),
+            &QApplication::quit, Qt::QueuedConnection);
     connect(updateDialog.data(), &AppImageUpdaterDialog::canceled, this, &UpdateCheck::handleUpdateEnd);
-    connect(updateDialog.data(), &AppImageUpdaterDialog::finished , this , &UpdateCheck::handleUpdateEnd);
-    connect(updateDialog.data(), &AppImageUpdaterDialog::error, this, &UpdateCheck::handleUpdateEnd); 
+    connect(updateDialog.data(), &AppImageUpdaterDialog::finished, this, &UpdateCheck::handleUpdateEnd);
+    connect(updateDialog.data(), &AppImageUpdaterDialog::error, this, &UpdateCheck::handleUpdateEnd);
     updateDialog->init();
 }
 #endif
 
 #ifndef APPIMAGE_UPDATER_BRIDGE_ENABLED
-void UpdateCheck::handleResponse(QNetworkReply *reply)
+void UpdateCheck::handleResponse(QNetworkReply* reply)
 {
     assert(reply != nullptr);
     if (reply == nullptr) {
@@ -132,8 +135,7 @@ void UpdateCheck::handleResponse(QNetworkReply *reply)
         qInfo() << "Update available to version" << latestVersion;
         QUrl link{mainMap["html_url"].toString()};
         emit updateAvailable(latestVersion, link);
-    }
-    else {
+    } else {
         qInfo() << "qTox is up to date";
         emit upToDate();
     }
@@ -142,19 +144,20 @@ void UpdateCheck::handleResponse(QNetworkReply *reply)
 #else
 void UpdateCheck::handleUpdate(bool aval)
 {
-	if (aval) {
-            qInfo() << "Update available";
-            emit updateAvailable();
-            return;
-	}
-        qInfo() << "qTox is up to date";
-        emit upToDate();
+    if (aval) {
+        qInfo() << "Update available";
+        emit updateAvailable();
+        return;
+    }
+    qInfo() << "qTox is up to date";
+    emit upToDate();
 }
 
 void UpdateCheck::handleUpdateEnd()
 {
-        updateDialog->hide();
-        updateDialog.reset(nullptr);
-        connect(&revisioner, &AppImageDeltaRevisioner::error, this, &UpdateCheck::updateCheckFailed, Qt::DirectConnection);
+    updateDialog->hide();
+    updateDialog.reset(nullptr);
+    connect(&revisioner, &AppImageDeltaRevisioner::error, this, &UpdateCheck::updateCheckFailed,
+            Qt::DirectConnection);
 }
 #endif // APPIMAGE_UPDATER_BRIDGE_ENABLED

--- a/src/net/updatecheck.cpp
+++ b/src/net/updatecheck.cpp
@@ -54,6 +54,14 @@ UpdateCheck::UpdateCheck(const Settings& settings)
 #ifndef APPIMAGE_UPDATER_BRIDGE_ENABLED
     connect(&manager, &QNetworkAccessManager::finished, this, &UpdateCheck::handleResponse);
 #else
+    int flags = AppImageUpdaterDialog::ShowProgressDialog | AppImageUpdaterDialog::ShowFinishedDialog
+                | AppImageUpdaterDialog::ShowUpdateConfirmationDialog
+                | AppImageUpdaterDialog::ShowErrorDialog;
+    updateDialog.reset(
+        new AppImageUpdaterDialog(QPixmap(":/img/icons/qtox.svg"), nullptr, flags, &revisioner));
+
+    connect(updateDialog.data(), &AppImageUpdaterDialog::quit, QApplication::instance(),
+            &QApplication::quit, Qt::QueuedConnection);
     connect(&revisioner, &AppImageDeltaRevisioner::updateAvailable, this, &UpdateCheck::handleUpdate);
     connect(&revisioner, &AppImageDeltaRevisioner::error, this, &UpdateCheck::updateCheckFailed,
             Qt::DirectConnection);
@@ -71,6 +79,7 @@ void UpdateCheck::checkForUpdate()
     QNetworkRequest request{versionUrl};
     manager.get(request);
 #else
+    revisioner.clear();
     revisioner.setProxy(settings.getProxy());
     revisioner.checkForUpdate();
 #endif
@@ -79,21 +88,10 @@ void UpdateCheck::checkForUpdate()
 #ifdef APPIMAGE_UPDATER_BRIDGE_ENABLED
 void UpdateCheck::initUpdate()
 {
-    if (!updateDialog.isNull()) {
-        updateDialog->init();
-        return;
-    }
-    int flags = AppImageUpdaterDialog::ShowProgressDialog | AppImageUpdaterDialog::ShowFinishedDialog
-                | AppImageUpdaterDialog::ShowUpdateConfirmationDialog
-                | AppImageUpdaterDialog::ShowErrorDialog;
-    updateDialog.reset(
-        new AppImageUpdaterDialog(QPixmap(":/img/icons/qtox.svg"), nullptr, flags, &revisioner));
     updateDialog->move(QGuiApplication::primaryScreen()->geometry().center()
                        - updateDialog->rect().center());
 
     disconnect(&revisioner, &AppImageDeltaRevisioner::error, this, &UpdateCheck::updateCheckFailed);
-    connect(updateDialog.data(), &AppImageUpdaterDialog::quit, QApplication::instance(),
-            &QApplication::quit, Qt::QueuedConnection);
     connect(updateDialog.data(), &AppImageUpdaterDialog::canceled, this, &UpdateCheck::handleUpdateEnd);
     connect(updateDialog.data(), &AppImageUpdaterDialog::finished, this, &UpdateCheck::handleUpdateEnd);
     connect(updateDialog.data(), &AppImageUpdaterDialog::error, this, &UpdateCheck::handleUpdateEnd);
@@ -155,9 +153,13 @@ void UpdateCheck::handleUpdate(bool aval)
 
 void UpdateCheck::handleUpdateEnd()
 {
-    updateDialog->hide();
-    updateDialog.reset(nullptr);
+    updateDialog->hide(); // just a safety precaution.
     connect(&revisioner, &AppImageDeltaRevisioner::error, this, &UpdateCheck::updateCheckFailed,
             Qt::DirectConnection);
+    disconnect(updateDialog.data(), &AppImageUpdaterDialog::canceled, this,
+               &UpdateCheck::handleUpdateEnd);
+    disconnect(updateDialog.data(), &AppImageUpdaterDialog::finished, this,
+               &UpdateCheck::handleUpdateEnd);
+    disconnect(updateDialog.data(), &AppImageUpdaterDialog::error, this, &UpdateCheck::handleUpdateEnd);
 }
 #endif // APPIMAGE_UPDATER_BRIDGE_ENABLED

--- a/src/net/updatecheck.cpp
+++ b/src/net/updatecheck.cpp
@@ -155,8 +155,6 @@ void UpdateCheck::handleUpdateEnd()
     updateDialog->hide();
     connect(&revisioner, &AppImageDeltaRevisioner::error, this, &UpdateCheck::updateCheckFailed,
             Qt::DirectConnection);
-    disconnect(updateDialog.data(), &AppImageUpdaterDialog::quit, QApplication::instance(),
-               &QApplication::quit);
     disconnect(updateDialog.data(), &AppImageUpdaterDialog::canceled, this,
                &UpdateCheck::handleUpdateEnd);
     disconnect(updateDialog.data(), &AppImageUpdaterDialog::finished, this,

--- a/src/net/updatecheck.cpp
+++ b/src/net/updatecheck.cpp
@@ -82,8 +82,7 @@ void UpdateCheck::initUpdate()
         updateDialog->init();
         return;
     }
-    int flags = AppImageUpdaterDialog::ShowBeforeProgress |
-                AppImageUpdaterDialog::ShowProgressDialog |
+    int flags = AppImageUpdaterDialog::ShowProgressDialog |
                 AppImageUpdaterDialog::ShowFinishedDialog |
                 AppImageUpdaterDialog::ShowUpdateConfirmationDialog |
                 AppImageUpdaterDialog::ShowErrorDialog;

--- a/src/net/updatecheck.h
+++ b/src/net/updatecheck.h
@@ -20,6 +20,14 @@
 #include <QNetworkAccessManager>
 #include <QTimer>
 
+#ifndef APPIMAGE_UPDATER_BRIDGE_ENABLED
+#include <QNetworkAccessManager>
+#else
+#include <AppImageUpdaterBridge>
+#include <AppImageUpdaterDialog>
+#include <QScopedPointer>
+#endif // APPIMAGE_UPDATER_BRIDGE_ENABLED
+
 #include <memory>
 
 class Settings;
@@ -32,18 +40,39 @@ class UpdateCheck : public QObject
 
 public:
     UpdateCheck(const Settings& settings);
-    void checkForUpdate();
 
 signals:
+#ifndef APPIMAGE_UPDATER_BRIDGE_ENABLED
     void updateAvailable(QString latestVersion, QUrl link);
+#else
+    void updateAvailable();
+#endif
     void upToDate();
     void updateCheckFailed();
 
+public slots:
+    void checkForUpdate();
+
+#ifndef APPIMAGE_UPDATER_BRIDGE_ENABLED
 private slots:
     void handleResponse(QNetworkReply *reply);
+#else
+
+public slots:
+    void initUpdate();
+
+private slots:
+    void handleUpdate(bool);
+    void handleUpdateEnd();
+#endif // APPIMAGE_UPDATER_BRIDGE_ENABLED
 
 private:
+#ifndef APPIMAGE_UPDATER_BRIDGE_ENABLED
     QNetworkAccessManager manager;
+#else
+    AppImageUpdaterBridge::AppImageDeltaRevisioner revisioner;
+    QScopedPointer<AppImageUpdaterBridge::AppImageUpdaterDialog> updateDialog;
+#endif // APPIMAGE_UPDATER_BRIDGE_ENABLED
     QTimer updateTimer;
     const Settings& settings;
 };

--- a/src/net/updatecheck.h
+++ b/src/net/updatecheck.h
@@ -16,16 +16,16 @@
     You should have received a copy of the GNU General Public License
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <QObject>
 #include <QNetworkAccessManager>
+#include <QObject>
 #include <QTimer>
 
 #ifndef APPIMAGE_UPDATER_BRIDGE_ENABLED
 #include <QNetworkAccessManager>
 #else
+#include <QScopedPointer>
 #include <AppImageUpdaterBridge>
 #include <AppImageUpdaterDialog>
-#include <QScopedPointer>
 #endif // APPIMAGE_UPDATER_BRIDGE_ENABLED
 
 #include <memory>
@@ -55,7 +55,7 @@ public slots:
 
 #ifndef APPIMAGE_UPDATER_BRIDGE_ENABLED
 private slots:
-    void handleResponse(QNetworkReply *reply);
+    void handleResponse(QNetworkReply* reply);
 #else
 
 public slots:

--- a/src/widget/form/settings/aboutform.cpp
+++ b/src/widget/form/settings/aboutform.cpp
@@ -72,6 +72,10 @@ AboutForm::AboutForm(UpdateCheck* updateCheck)
 
     eventsInit();
     Translator::registerHandler(std::bind(&AboutForm::retranslateUi, this), this);
+
+#ifdef APPIMAGE_UPDATER_BRIDGE_ENABLED
+
+#endif
 }
 
 /**
@@ -93,9 +97,12 @@ void AboutForm::replaceVersions()
 
 #if UPDATE_CHECK_ENABLED
     if (updateCheck != nullptr) {
-        connect(updateCheck, &UpdateCheck::updateAvailable, this, &AboutForm::onUpdateAvailable);
+       connect(updateCheck, &UpdateCheck::updateAvailable, this, &AboutForm::onUpdateAvailable);
         connect(updateCheck, &UpdateCheck::upToDate, this, &AboutForm::onUpToDate);
         connect(updateCheck, &UpdateCheck::updateCheckFailed, this, &AboutForm::onUpdateCheckFailed);
+#ifdef APPIMAGE_UPDATER_BRIDGE_ENABLED 
+	connect(bodyUI->updateAvailableButton, &QPushButton::clicked, updateCheck , &UpdateCheck::initUpdate);
+#endif
     } else {
         qWarning() << "AboutForm passed null UpdateCheck!";
     }
@@ -165,6 +172,7 @@ void AboutForm::replaceVersions()
     bodyUI->authorInfo->setText(authorInfo);
 }
 
+#ifndef APPIMAGE_UPDATER_BRIDGE_ENABLED
 void AboutForm::onUpdateAvailable(QString latestVersion, QUrl link)
 {
     QObject::disconnect(linkConnection);
@@ -173,6 +181,11 @@ void AboutForm::onUpdateAvailable(QString latestVersion, QUrl link)
     });
     bodyUI->updateStack->setCurrentIndex(static_cast<int>(updateIndex::available));
 }
+#else
+void AboutForm::onUpdateAvailable(){
+    bodyUI->updateStack->setCurrentIndex(static_cast<int>(updateIndex::available));
+}
+#endif
 
 void AboutForm::onUpToDate()
 {

--- a/src/widget/form/settings/aboutform.cpp
+++ b/src/widget/form/settings/aboutform.cpp
@@ -72,10 +72,6 @@ AboutForm::AboutForm(UpdateCheck* updateCheck)
 
     eventsInit();
     Translator::registerHandler(std::bind(&AboutForm::retranslateUi, this), this);
-
-#ifdef APPIMAGE_UPDATER_BRIDGE_ENABLED
-
-#endif
 }
 
 /**
@@ -97,11 +93,11 @@ void AboutForm::replaceVersions()
 
 #if UPDATE_CHECK_ENABLED
     if (updateCheck != nullptr) {
-       connect(updateCheck, &UpdateCheck::updateAvailable, this, &AboutForm::onUpdateAvailable);
+        connect(updateCheck, &UpdateCheck::updateAvailable, this, &AboutForm::onUpdateAvailable);
         connect(updateCheck, &UpdateCheck::upToDate, this, &AboutForm::onUpToDate);
         connect(updateCheck, &UpdateCheck::updateCheckFailed, this, &AboutForm::onUpdateCheckFailed);
 #ifdef APPIMAGE_UPDATER_BRIDGE_ENABLED 
-	connect(bodyUI->updateAvailableButton, &QPushButton::clicked, updateCheck , &UpdateCheck::initUpdate);
+        connect(bodyUI->updateAvailableButton, &QPushButton::clicked, updateCheck , &UpdateCheck::initUpdate);
 #endif
     } else {
         qWarning() << "AboutForm passed null UpdateCheck!";

--- a/src/widget/form/settings/aboutform.cpp
+++ b/src/widget/form/settings/aboutform.cpp
@@ -20,17 +20,17 @@
 #include "aboutform.h"
 #include "ui_aboutsettings.h"
 
-#include "src/widget/tool/recursivesignalblocker.h"
 #include "src/net/updatecheck.h"
-#include "src/widget/style.h"
-#include "src/widget/translator.h"
 #include "src/persistence/profile.h"
 #include "src/persistence/settings.h"
+#include "src/widget/style.h"
+#include "src/widget/tool/recursivesignalblocker.h"
+#include "src/widget/translator.h"
 
 #include <tox/tox.h>
 
 #include <QDebug>
-#include <QDesktopServices> 
+#include <QDesktopServices>
 #include <QPushButton>
 #include <QTimer>
 
@@ -96,8 +96,9 @@ void AboutForm::replaceVersions()
         connect(updateCheck, &UpdateCheck::updateAvailable, this, &AboutForm::onUpdateAvailable);
         connect(updateCheck, &UpdateCheck::upToDate, this, &AboutForm::onUpToDate);
         connect(updateCheck, &UpdateCheck::updateCheckFailed, this, &AboutForm::onUpdateCheckFailed);
-#ifdef APPIMAGE_UPDATER_BRIDGE_ENABLED 
-        connect(bodyUI->updateAvailableButton, &QPushButton::clicked, updateCheck , &UpdateCheck::initUpdate);
+#ifdef APPIMAGE_UPDATER_BRIDGE_ENABLED
+        connect(bodyUI->updateAvailableButton, &QPushButton::clicked, updateCheck,
+                &UpdateCheck::initUpdate);
 #endif
     } else {
         qWarning() << "AboutForm passed null UpdateCheck!";
@@ -172,13 +173,13 @@ void AboutForm::replaceVersions()
 void AboutForm::onUpdateAvailable(QString latestVersion, QUrl link)
 {
     QObject::disconnect(linkConnection);
-    linkConnection = connect(bodyUI->updateAvailableButton, &QPushButton::clicked, [link](){
-        QDesktopServices::openUrl(link);
-    });
+    linkConnection = connect(bodyUI->updateAvailableButton, &QPushButton::clicked,
+                             [link]() { QDesktopServices::openUrl(link); });
     bodyUI->updateStack->setCurrentIndex(static_cast<int>(updateIndex::available));
 }
 #else
-void AboutForm::onUpdateAvailable(){
+void AboutForm::onUpdateAvailable()
+{
     bodyUI->updateStack->setCurrentIndex(static_cast<int>(updateIndex::available));
 }
 #endif

--- a/src/widget/form/settings/aboutform.h
+++ b/src/widget/form/settings/aboutform.h
@@ -45,7 +45,11 @@ public:
     }
 
 public slots:
+#ifndef APPIMAGE_UPDATER_BRIDGE_ENABLED
     void onUpdateAvailable(QString latestVersion, QUrl link);
+#else
+    void onUpdateAvailable();
+#endif
     void onUpToDate();
     void onUpdateCheckFailed();
 
@@ -58,7 +62,9 @@ private:
     Ui::AboutSettings* bodyUI;
     QTimer* progressTimer;
     UpdateCheck* updateCheck;
+#ifndef APPIMAGE_UPDATER_BRIDGE_ENABLED
     QMetaObject::Connection linkConnection;
+#endif
 };
 
 #endif // ABOUTFORM_H

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -175,9 +175,9 @@ void Widget::init()
     filterDisplayActivity->setCheckable(true);
     filterDisplayGroup->addAction(filterDisplayActivity);
     filterMenu->addAction(filterDisplayActivity);
-    settings.getFriendSortingMode() == FriendListWidget::SortingMode::Name ?
-        filterDisplayName->setChecked(true) :
-        filterDisplayActivity->setChecked(true);
+    settings.getFriendSortingMode() == FriendListWidget::SortingMode::Name
+        ? filterDisplayName->setChecked(true)
+        : filterDisplayActivity->setChecked(true);
     filterMenu->addSeparator();
 
     filterAllAction = new QAction(this);
@@ -442,9 +442,9 @@ void Widget::updateIcons()
         return;
     }
 
-    const QString assetSuffix =
-        Status::getAssetSuffix(static_cast<Status::Status>(ui->statusButton->property("status").toInt()))
-        + (eventIcon ? "_event" : "");
+    const QString assetSuffix = Status::getAssetSuffix(static_cast<Status::Status>(
+                                    ui->statusButton->property("status").toInt()))
+                                + (eventIcon ? "_event" : "");
 
     // Some builds of Qt appear to have a bug in icon loading:
     // QIcon::hasThemeIcon is sometimes unaware that the icon returned

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1603,7 +1603,7 @@ void Widget::toggleFullscreen()
     }
 }
 
-void Widget::onUpdateAvailable(QString /*latestVersion*/, QUrl /*link*/)
+void Widget::onUpdateAvailable()
 {
     ui->settingsButton->setProperty("update-available", true);
     ui->settingsButton->style()->unpolish(ui->settingsButton);

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -187,7 +187,7 @@ public slots:
     void onGroupDialogShown(Group* g);
     void toggleFullscreen();
     void refreshPeerListsLocal(const QString& username);
-    void onUpdateAvailable(QString latestVersion, QUrl link);
+    void onUpdateAvailable();
 
 signals:
     void friendRequestAccepted(const ToxPk& friendPk);


### PR DESCRIPTION
This PR implements the delta updater as mentioned in #5643 for qTox AppImages. The delta updater is only used for AppImage builds and does not break the source code for other platforms. This delta updater is integrated along with UpdateCheck class and uses the existing UI for notifying the update available button. Without the CMake build options , the delta updater library is never touched.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5690)
<!-- Reviewable:end -->
