### PR TITLE
fix(audio): correctly loop incoming call sound

### DIFF
--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -949,11 +949,11 @@ void Widget::playNotificationSound(IAudioSink::Sound sound, bool loop)
     connect(audioNotification.get(), &IAudioSink::finishedPlaying, this,
             &Widget::cleanupNotificationSound);
 
+    audioNotification->playMono16Sound(sound);
+
     if (loop) {
         audioNotification->startLoop();
     }
-
-    audioNotification->playMono16Sound(sound);
 }
 
 void Widget::cleanupNotificationSound()


### PR DESCRIPTION
Reordered audioNotification play/loop calls.
Fixes #5680

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5696)
<!-- Reviewable:end -->
