### PR TITLE
fix(group): always retain own name when updating group peer list

### DIFF
--- a/src/model/group.cpp
+++ b/src/model/group.cpp
@@ -95,9 +95,11 @@ void Group::regeneratePeerList()
     const int nPeers = peers.size();
     for (int i = 0; i < nPeers; ++i) {
         const auto pk = core->getGroupPeerPk(toxGroupNum, i);
-        if (pk == core->getSelfPublicKey())
+        if (pk == core->getSelfPublicKey()) {
             peerDisplayNames[pk] = core->getUsername();
-        peerDisplayNames[pk] = FriendList::decideNickname(pk, peers[i]);
+        } else {
+            peerDisplayNames[pk] = FriendList::decideNickname(pk, peers[i]);
+        }
     }
     for (const auto& pk : oldPeerNames.keys()) {
         if (!peerDisplayNames.contains(pk)) {


### PR DESCRIPTION
Adds special case for updating our own PK in regeneratePeerList
Format according to format-code.sh

Fixes #5686

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5698)
<!-- Reviewable:end -->
