### PR TITLE
chore(nightlies): enable windows for nightlies too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,11 @@ branches:
 stages:
   - Linux
   - name: "Windows Stage 1: Dependencies (OpenSSL, Qt)"
-    if: type = push
+    if: type = push OR type = cron
   - name: "Windows Stage 2: Dependencies (other)"
-    if: type = push
+    if: type = push OR type = cron
   - name: "Windows Stage 3: qTox"
-    if: type = push
+    if: type = push OR type = cron
 
 env:
   global:


### PR DESCRIPTION
- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

This fixes a mistake disabling windows nightly builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5699)
<!-- Reviewable:end -->
