### PR TITLE
refactor(startup): decouple loginscreen from model elements

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -295,7 +295,7 @@ int main(int argc, char* argv[])
         profileName = settings.getCurrentProfile();
     }
 
-    if (parser.positionalArguments().size() == 0) {
+    if (parser.positionalArguments().empty()) {
         eventType = "activate";
     } else {
         firstParam = parser.positionalArguments()[0];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,7 +18,6 @@
 */
 
 #include "src/audio/audio.h"
-#include "src/core/coreav.h"
 #include "src/ipc.h"
 #include "src/net/toxuri.h"
 #include "src/nexus.h"
@@ -194,8 +193,8 @@ int main(int argc, char* argv[])
 #endif
 
     qsrand(time(nullptr));
-    Settings::getInstance();
-    QString locale = Settings::getInstance().getTranslation();
+    Settings& settings = Settings::getInstance();
+    QString locale = settings.getTranslation();
     Translator::translate(locale);
 
     // Process arguments
@@ -215,15 +214,14 @@ int main(int argc, char* argv[])
                            QObject::tr("Starts new instance and opens the login screen.")));
     parser.process(*a);
 
-    uint32_t profileId = Settings::getInstance().getCurrentProfileId();
+    uint32_t profileId = settings.getCurrentProfileId();
     IPC ipc(profileId);
     if (!ipc.isAttached()) {
         qCritical() << "Can't init IPC";
         return EXIT_FAILURE;
     }
 
-    QObject::connect(&Settings::getInstance(), &Settings::currentProfileIdChanged, &ipc,
-                     &IPC::setProfileId);
+    QObject::connect(&settings, &Settings::currentProfileIdChanged, &ipc, &IPC::setProfileId);
 
     // For the auto-updater
     if (sodium_init() < 0) {
@@ -232,7 +230,7 @@ int main(int argc, char* argv[])
     }
 
 #ifdef LOG_TO_FILE
-    QString logFileDir = Settings::getInstance().getAppCacheDirPath();
+    QString logFileDir = settings.getAppCacheDirPath();
     QDir(logFileDir).mkpath(".");
 
     QString logfile = logFileDir + "qtox.log";
@@ -274,7 +272,7 @@ int main(int argc, char* argv[])
     qDebug() << "commit: " << GIT_VERSION;
 
     QString profileName;
-    bool autoLogin = Settings::getInstance().getAutoLogin();
+    bool autoLogin = settings.getAutoLogin();
 
     uint32_t ipcDest = 0;
     bool doIpc = true;
@@ -294,7 +292,7 @@ int main(int argc, char* argv[])
         doIpc = false;
         autoLogin = false;
     } else {
-        profileName = Settings::getInstance().getCurrentProfile();
+        profileName = settings.getCurrentProfile();
     }
 
     if (parser.positionalArguments().size() == 0) {
@@ -330,37 +328,26 @@ int main(int argc, char* argv[])
         }
     }
 
-    Profile* profile = nullptr;
+    // TODO(sudden6): remove once we get rid of Nexus
+    Nexus& nexus = Nexus::getInstance();
+    // TODO(kriby): Consider moving application initializing variables into a globalSettings object
+    //  note: Because Settings is shouldering global settings as well as model specific ones it
+    //  cannot be integrated into a central model object yet
+    nexus.setSettings(&settings);
 
     // Autologin
+    // TODO (kriby): Shift responsibility of linking views to model objects from nexus
+    // Further: generate view instances separately (loginScreen, mainGUI, audio)
     if (autoLogin && Profile::exists(profileName) && !Profile::isEncrypted(profileName)) {
-        profile = Profile::loadProfile(profileName);
+        Profile* profile = Profile::loadProfile(profileName);
+        settings.updateProfileData(profile);
+        nexus.bootstrapWithProfile(profile);
     } else {
-        LoginScreen loginScreen{profileName};
-        loginScreen.exec();
-        profile = loginScreen.getProfile();
-        if (profile) {
-            profileName = profile->getName();
+        int returnval = nexus.showLogin(profileName);
+        if (returnval != 0) {
+            return returnval;
         }
     }
-
-    if (!profile) {
-        return EXIT_FAILURE;
-    }
-
-    Nexus::getInstance().setProfile(profile);
-    Settings& s = Settings::getInstance();
-    s.setCurrentProfile(profileName);
-
-    auto audio = Audio::makeAudio(s);
-    assert(audio != nullptr);
-    // TODO(sudden6): init CoreAV audio backend somewhere else so main doesn't depend on coreav.h
-    profile->getCore()->getAv()->setAudio(*audio);
-
-    Nexus& nexus = Nexus::getInstance();
-    // TODO(sudden6): remove once we get rid of Nexus
-    nexus.audio = audio.get();
-    nexus.start();
 
     // Start to accept Inter-process communication
     ipc.registerEventHandler("uri", &toxURIEventHandler);

--- a/src/model/profile/profileinfo.cpp
+++ b/src/model/profile/profileinfo.cpp
@@ -342,8 +342,8 @@ IProfileInfo::SetAvatarResult ProfileInfo::byteArrayToPng(QByteArray inData, QBy
     }
 
     if (format == "png") {
-        // FIXME: re-encode the png even though inData is already valid. This strips the metadata since
-        // we don't have a good png metadata stripping method currently.
+        // FIXME: re-encode the png even though inData is already valid. This strips the metadata
+        // since we don't have a good png metadata stripping method currently.
         outPng = picToPng(image);
     } else {
         outPng = picToPng(image);

--- a/src/model/profile/profileinfo.cpp
+++ b/src/model/profile/profileinfo.cpp
@@ -226,8 +226,10 @@ QStringList ProfileInfo::removeProfile()
  */
 void ProfileInfo::logout()
 {
+    // TODO(kriby): Refactor all of these invokeMethod calls with connect() properly when possible
     Settings::getInstance().saveGlobal();
-    QMetaObject::invokeMethod(&Nexus::getInstance(), "showLogin");
+    QMetaObject::invokeMethod(&Nexus::getInstance(), "showLogin",
+                              Q_ARG(QString, Settings::getInstance().getCurrentProfile()));
 }
 
 /**

--- a/src/nexus.cpp
+++ b/src/nexus.cpp
@@ -209,7 +209,8 @@ void Nexus::connectLoginScreen(const LoginScreen& loginScreen)
     QObject::connect(&loginScreen, &LoginScreen::createNewProfile, this, &Nexus::onCreateNewProfile);
     QObject::connect(&loginScreen, &LoginScreen::loadProfile, this, &Nexus::onLoadProfile);
     // LoginScreen -> Settings
-    QObject::connect(&loginScreen, &LoginScreen::autoLoginChanged, settings, &Settings::onSetAutoLogin);
+    QObject::connect(&loginScreen, &LoginScreen::autoLoginChanged, settings, &Settings::setAutoLogin);
+    QObject::connect(&loginScreen, &LoginScreen::autoLoginChanged, settings, &Settings::saveGlobal);
     // Settings -> LoginScreen
     QObject::connect(settings, &Settings::autoLoginChanged, &loginScreen,
                      &LoginScreen::onAutoLoginChanged);

--- a/src/nexus.cpp
+++ b/src/nexus.cpp
@@ -35,6 +35,7 @@
 #include <QThread>
 #include <cassert>
 #include <vpx/vpx_image.h>
+#include <src/audio/audio.h>
 
 #ifdef Q_OS_MAC
 #include <QActionGroup>
@@ -67,7 +68,7 @@ Nexus::~Nexus()
     widget = nullptr;
     delete profile;
     profile = nullptr;
-    Settings::getInstance().saveGlobal();
+    emit saveGlobal();
 #ifdef Q_OS_MAC
     delete globalMenuBar;
 #endif
@@ -148,7 +149,7 @@ void Nexus::start()
 /**
  * @brief Hides the main GUI, delete the profile, and shows the login screen
  */
-void Nexus::showLogin()
+int Nexus::showLogin(const QString& profileName)
 {
     delete widget;
     widget = nullptr;
@@ -156,26 +157,71 @@ void Nexus::showLogin()
     delete profile;
     profile = nullptr;
 
-    LoginScreen loginScreen;
-    loginScreen.exec();
+    LoginScreen loginScreen{profileName};
+    connectLoginScreen(loginScreen);
 
-    profile = loginScreen.getProfile();
+    // TODO(kriby): Move core out of profile
+    // This is awkward because the core is in the profile
+    // The connection order ensures profile will be ready for bootstrap for now
+    connect(this, &Nexus::currentProfileChanged, this, &Nexus::bootstrapWithProfile);
+    int returnval = loginScreen.exec();
+    disconnect(this, &Nexus::currentProfileChanged, this, &Nexus::bootstrapWithProfile);
+    return returnval;
+}
+
+void Nexus::bootstrapWithProfile(Profile *p)
+{
+    // kriby: This is a hack until a proper controller is written
+
+    profile = p;
 
     if (profile) {
-        Nexus::getInstance().setProfile(profile);
-        Settings::getInstance().setCurrentProfile(profile->getName());
-        showMainGUI();
-    } else {
-        qApp->quit();
+        audioControl = std::unique_ptr<IAudioControl>(Audio::makeAudio(*settings));
+        assert(audioControl != nullptr);
+        profile->getCore()->getAv()->setAudio(*audioControl);
+        start();
     }
+}
+
+void Nexus::setSettings(Settings* settings)
+{
+    if (this->settings) {
+        QObject::disconnect(this, &Nexus::currentProfileChanged, this->settings,
+                            &Settings::updateProfileData);
+        QObject::disconnect(this, &Nexus::saveGlobal, this->settings, &Settings::saveGlobal);
+    }
+    this->settings = settings;
+    if (this->settings) {
+        QObject::connect(this, &Nexus::currentProfileChanged, this->settings,
+                         &Settings::updateProfileData);
+        QObject::connect(this, &Nexus::saveGlobal, this->settings, &Settings::saveGlobal);
+    }
+}
+
+void Nexus::connectLoginScreen(const LoginScreen& loginScreen)
+{
+    // TODO(kriby): Move connect sequences to a controller class object instead
+
+    // Nexus -> LoginScreen
+    QObject::connect(this, &Nexus::profileLoaded, &loginScreen, &LoginScreen::onProfileLoaded);
+    QObject::connect(this, &Nexus::profileLoadFailed, &loginScreen, &LoginScreen::onProfileLoadFailed);
+    // LoginScreen -> Nexus
+    QObject::connect(&loginScreen, &LoginScreen::createNewProfile, this, &Nexus::onCreateNewProfile);
+    QObject::connect(&loginScreen, &LoginScreen::loadProfile, this, &Nexus::onLoadProfile);
+    // LoginScreen -> Settings
+    QObject::connect(&loginScreen, &LoginScreen::autoLoginChanged, settings, &Settings::onSetAutoLogin);
+    // Settings -> LoginScreen
+    QObject::connect(settings, &Settings::autoLoginChanged, &loginScreen,
+                     &LoginScreen::onAutoLoginChanged);
 }
 
 void Nexus::showMainGUI()
 {
+    // TODO(kriby): Rewrite as view-model connect sequence only, add to a controller class object
     assert(profile);
 
     // Create GUI
-    widget = Widget::getInstance(audio);
+    widget = Widget::getInstance(audioControl.get());
 
     // Start GUI
     widget->init();
@@ -270,14 +316,36 @@ Profile* Nexus::getProfile()
 }
 
 /**
- * @brief Unload the current profile, if any, and replaces it.
- * @param profile Profile to set.
+ * @brief Creates a new profile and replaces the current one.
+ * @param name New username
+ * @param pass New password
  */
-void Nexus::setProfile(Profile* profile)
+void Nexus::onCreateNewProfile(const QString& name, const QString& pass)
 {
-    getInstance().profile = profile;
-    if (profile)
-        Settings::getInstance().loadPersonal(profile->getName(), profile->getPasskey());
+    setProfile(Profile::createProfile(name, pass));
+}
+
+/**
+ * Loads an existing profile and replaces the current one.
+ */
+void Nexus::onLoadProfile(const QString& name, const QString& pass)
+{
+    setProfile(Profile::loadProfile(name, pass));
+}
+/**
+ * Changes the loaded profile and notifies listeners.
+ * @param p
+ */
+void Nexus::setProfile(Profile* p) {
+    if (!p) {
+        emit profileLoadFailed();
+        // Warnings are issued during respective createNew/load calls
+        return;
+    } else {
+        emit profileLoaded();
+    }
+
+    emit currentProfileChanged(p);
 }
 
 /**

--- a/src/nexus.h
+++ b/src/nexus.h
@@ -27,6 +27,8 @@
 
 class Widget;
 class Profile;
+class Settings;
+class LoginScreen;
 class Core;
 
 #ifdef Q_OS_MAC
@@ -44,16 +46,13 @@ class Nexus : public QObject
 public:
     void start();
     void showMainGUI();
-
+    void setSettings(Settings* settings);
     static Nexus& getInstance();
     static void destroyInstance();
     static Core* getCore();
     static Profile* getProfile();
-    static void setProfile(Profile* profile);
     static Widget* getDesktopGUI();
 
-public slots:
-    void showLogin();
 
 #ifdef Q_OS_MAC
 public:
@@ -81,17 +80,29 @@ private:
     QSignalMapper* windowMapper;
     QActionGroup* windowActions = nullptr;
 #endif
-public:
-    // TODO(sudden6): hack to pass the audio instance
-    IAudioControl* audio = nullptr;
+signals:
+    void currentProfileChanged(Profile* Profile);
+    void profileLoaded();
+    void profileLoadFailed();
+    void saveGlobal();
+
+public slots:
+    void onCreateNewProfile(const QString& name, const QString& pass);
+    void onLoadProfile(const QString& name, const QString& pass);
+    int showLogin(const QString& profileName = QString());
+    void bootstrapWithProfile(Profile *p);
 
 private:
     explicit Nexus(QObject* parent = nullptr);
+    void connectLoginScreen(const LoginScreen& loginScreen);
+    void setProfile(Profile* p);
     ~Nexus();
 
 private:
     Profile* profile;
+    Settings* settings;
     Widget* widget;
+    std::unique_ptr<IAudioControl> audioControl;
 };
 
 #endif // NEXUS_H

--- a/src/persistence/profile.cpp
+++ b/src/persistence/profile.cpp
@@ -105,9 +105,6 @@ Profile::Profile(QString name, const QString& password, bool isNewProfile,
     , encrypted{this->passkey != nullptr}
 {
     Settings& s = Settings::getInstance();
-    s.setCurrentProfile(name);
-    s.saveGlobal();
-    s.loadPersonal(name, this->passkey.get());
     initCore(toxsave, s, isNewProfile);
 
     const ToxId& selfId = core->getSelfId();

--- a/src/persistence/profile.cpp
+++ b/src/persistence/profile.cpp
@@ -269,21 +269,17 @@ QStringList Profile::getFilesByExt(QString extension)
  * @brief Scan for profile, automatically importing them if needed.
  * @warning NOT thread-safe.
  */
-void Profile::scanProfiles()
+const QStringList Profile::getAllProfileNames()
 {
     profiles.clear();
     QStringList toxfiles = getFilesByExt("tox"), inifiles = getFilesByExt("ini");
-    for (QString toxfile : toxfiles) {
+    for (const QString& toxfile : toxfiles) {
         if (!inifiles.contains(toxfile)) {
             Settings::getInstance().createPersonal(toxfile);
         }
 
         profiles.append(toxfile);
     }
-}
-
-QStringList Profile::getProfiles()
-{
     return profiles;
 }
 

--- a/src/persistence/profile.cpp
+++ b/src/persistence/profile.cpp
@@ -105,10 +105,11 @@ Profile::Profile(QString name, const QString& password, bool isNewProfile,
     , encrypted{this->passkey != nullptr}
 {
     Settings& s = Settings::getInstance();
+    // TODO(kriby): Move/refactor core initialization to remove settings dependency
+    //  note to self: use slots/signals for this?
     initCore(toxsave, s, isNewProfile);
 
-    const ToxId& selfId = core->getSelfId();
-    loadDatabase(selfId, password);
+    loadDatabase(password);
 }
 
 /**
@@ -470,14 +471,16 @@ QByteArray Profile::loadAvatarData(const ToxPk& owner)
     return pic;
 }
 
-void Profile::loadDatabase(const ToxId& id, QString password)
+void Profile::loadDatabase(QString password)
 {
+    assert(core);
+
     if (isRemoved) {
         qDebug() << "Can't load database of removed profile";
         return;
     }
 
-    QByteArray salt = id.getPublicKey().getByteArray();
+    QByteArray salt = core->getSelfId().getPublicKey().getByteArray();
     if (salt.size() != TOX_PASS_SALT_LENGTH) {
         qWarning() << "Couldn't compute salt from public key" << name;
         GUI::showError(QObject::tr("Error"),

--- a/src/persistence/profile.h
+++ b/src/persistence/profile.h
@@ -97,7 +97,8 @@ private slots:
     void onAvatarOfferReceived(uint32_t friendId, uint32_t fileId, const QByteArray& avatarHash);
 
 private:
-    Profile(QString name, const QString& password, bool newProfile, const QByteArray& toxsave, std::unique_ptr<ToxEncrypt> passKey);
+    Profile(QString name, const QString& password, bool newProfile, const QByteArray& toxsave,
+            std::unique_ptr<ToxEncrypt> passKey);
     static QStringList getFilesByExt(QString extension);
     QString avatarPath(const ToxPk& owner, bool forceUnencrypted = false);
     bool saveToxSave(QByteArray data);

--- a/src/persistence/profile.h
+++ b/src/persistence/profile.h
@@ -67,8 +67,7 @@ public:
 
     bool rename(QString newName);
 
-    static void scanProfiles();
-    static QStringList getProfiles();
+    static const QStringList getAllProfileNames();
 
     static bool exists(QString name);
     static bool isEncrypted(QString name);

--- a/src/persistence/profile.h
+++ b/src/persistence/profile.h
@@ -90,7 +90,7 @@ public slots:
     void onRequestSent(const ToxPk& friendPk, const QString& message);
 
 private slots:
-    void loadDatabase(const ToxId& id, QString password);
+    void loadDatabase(QString password);
     void saveAvatar(const ToxPk& owner, const QByteArray& avatar);
     void removeAvatar(const ToxPk& owner);
     void onSaveToxSave();

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -273,6 +273,19 @@ void Settings::loadGlobal()
     loaded = true;
 }
 
+void Settings::updateProfileData(Profile *profile)
+{
+    QMutexLocker locker{&bigLock};
+
+    if (profile == nullptr) {
+        qWarning() << QString("Could not load new settings (profile change to nullptr)");
+        return;
+    }
+    setCurrentProfile(profile->getName());
+    saveGlobal();
+    loadPersonal(profile->getName(), profile->getPasskey());
+}
+
 void Settings::loadPersonal(QString profileName, const ToxEncrypt* passKey)
 {
     QMutexLocker locker{&bigLock};
@@ -1281,7 +1294,7 @@ void Settings::setCurrentProfile(const QString& profile)
     if (profile != currentProfile) {
         currentProfile = profile;
         currentProfileId = makeProfileId(currentProfile);
-        emit currentProfileChanged(currentProfile);
+
         emit currentProfileIdChanged(currentProfileId);
     }
 }

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -143,9 +143,11 @@ void Settings::loadGlobal()
         }
         autoAwayTime = s.value("autoAwayTime", 10).toInt();
         checkUpdates = s.value("checkUpdates", true).toBool();
-        notifySound = s.value("notifySound", true).toBool(); // note: notifySound and busySound UI elements are now under UI settings
+        // note: notifySound and busySound UI elements are now under UI settings
+        // page, but kept under General in settings file to be backwards compatible
+        notifySound = s.value("notifySound", true).toBool();
         notifyHide = s.value("notifyHide", false).toBool();
-        busySound = s.value("busySound", false).toBool();    // page, but kept under General in settings file to be backwards compatible
+        busySound = s.value("busySound", false).toBool();
         autoSaveEnabled = s.value("autoSaveEnabled", false).toBool();
         globalAutoAcceptDir = s.value("globalAutoAcceptDir",
                                       QStandardPaths::locate(QStandardPaths::HomeLocation, QString(),
@@ -338,7 +340,7 @@ void Settings::loadPersonal(QString profileName, const ToxEncrypt* passKey)
             fp.circleID = ps.value("circle", -1).toInt();
 
             if (getEnableLogging())
-                fp.activity = ps.value("activity",  QDateTime()).toDateTime();
+                fp.activity = ps.value("activity", QDateTime()).toDateTime();
             friendLst.insert(ToxId(fp.addr).getPublicKey().getByteArray(), fp);
         }
         ps.endArray();
@@ -365,7 +367,8 @@ void Settings::loadPersonal(QString profileName, const ToxEncrypt* passKey)
     ps.beginGroup("GUI");
     {
         compactLayout = ps.value("compactLayout", true).toBool();
-        sortingMode = static_cast<FriendListSortingMode>(ps.value("friendSortingMethod", static_cast<int>(FriendListSortingMode::Name)).toInt());
+        sortingMode = static_cast<FriendListSortingMode>(
+            ps.value("friendSortingMethod", static_cast<int>(FriendListSortingMode::Name)).toInt());
     }
     ps.endGroup();
 

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -268,17 +268,15 @@ void Settings::loadGlobal()
 bool Settings::isToxPortable()
 {
     QString localSettingsPath = qApp->applicationDirPath() + QDir::separator() + globalSettingsFile;
-    bool result;
-
-    if (QFile(localSettingsPath).exists()) {
-        QSettings ps(localSettingsPath, QSettings::IniFormat);
-        ps.setIniCodec("UTF-8");
-        ps.beginGroup("Advanced");
-        result = ps.value("makeToxPortable", false).toBool();
-        ps.endGroup();
-        return result;
+    if (!QFile(localSettingsPath).exists()) {
+        return false;
     }
-    return false;
+    QSettings ps(localSettingsPath, QSettings::IniFormat);
+    ps.setIniCodec("UTF-8");
+    ps.beginGroup("Advanced");
+    bool result = ps.value("makeToxPortable", false).toBool();
+    ps.endGroup();
+    return result;
 }
 
 void Settings::updateProfileData(Profile *profile)

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -109,17 +109,7 @@ void Settings::loadGlobal()
 
     createSettingsDir();
 
-    QString localSettingsPath = qApp->applicationDirPath() + QDir::separator() + globalSettingsFile;
-
-    if (QFile(localSettingsPath).exists()) {
-        QSettings ps(localSettingsPath, QSettings::IniFormat);
-        ps.setIniCodec("UTF-8");
-        ps.beginGroup("Advanced");
-        makeToxPortable = ps.value("makeToxPortable", false).toBool();
-        ps.endGroup();
-    } else {
-        makeToxPortable = false;
-    }
+    makeToxPortable = Settings::isToxPortable();
 
     QDir dir(getSettingsDirPath());
     QString filePath = dir.filePath(globalSettingsFile);
@@ -271,6 +261,22 @@ void Settings::loadGlobal()
     s.endGroup();
 
     loaded = true;
+}
+
+bool Settings::isToxPortable()
+{
+    QString localSettingsPath = qApp->applicationDirPath() + QDir::separator() + globalSettingsFile;
+    bool result;
+
+    if (QFile(localSettingsPath).exists()) {
+        QSettings ps(localSettingsPath, QSettings::IniFormat);
+        ps.setIniCodec("UTF-8");
+        ps.beginGroup("Advanced");
+        result = ps.value("makeToxPortable", false).toBool();
+        ps.endGroup();
+        return result;
+    }
+    return false;
 }
 
 void Settings::updateProfileData(Profile *profile)

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -169,7 +169,7 @@ public:
 public slots:
     void saveGlobal();
     void sync();
-    void onSetAutoLogin(bool state);
+    void setAutoLogin(bool state);
     void updateProfileData(Profile *profile);
 
 signals:
@@ -543,7 +543,6 @@ public:
     void setShowIdenticons(bool value);
 
     bool getAutoLogin() const;
-    void setAutoLogin(bool state);
     void setEnableGroupChatsColor(bool state);
     bool getEnableGroupChatsColor() const;
 

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -168,6 +168,8 @@ public:
 public slots:
     void saveGlobal();
     void sync();
+    void onSetAutoLogin(bool state);
+    void updateProfileData(Profile *profile);
 
 signals:
     // General
@@ -190,7 +192,6 @@ signals:
     void toxmeBioChanged(const QString& bio);
     void toxmePrivChanged(bool priv);
     void toxmePassChanged();
-    void currentProfileChanged(const QString& profile);
     void currentProfileIdChanged(quint32 id);
     void enableLoggingChanged(bool enabled);
     void autoAwayTimeChanged(int minutes);

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -154,6 +154,7 @@ public:
     void savePersonal();
 
     void loadGlobal();
+    bool isToxPortable();
     void loadPersonal(QString profileName, const ToxEncrypt* passKey);
 
     void resetToDefault();

--- a/src/widget/loginscreen.cpp
+++ b/src/widget/loginscreen.cpp
@@ -245,10 +245,8 @@ void LoginScreen::retranslateUi()
 
 void LoginScreen::onImportProfile()
 {
-    ProfileImporter* pi = new ProfileImporter(this);
-
-    if (pi->importProfile())
+    ProfileImporter pi(this);
+    if (pi.importProfile()) {
         reset();
-
-    delete pi;
+    }
 }

--- a/src/widget/loginscreen.cpp
+++ b/src/widget/loginscreen.cpp
@@ -59,7 +59,7 @@ LoginScreen::LoginScreen(const QString& initialProfileName, QWidget* parent)
     connect(ui->autoLoginCB, &QCheckBox::stateChanged, this, &LoginScreen::onAutoLoginToggled);
     connect(ui->importButton, &QPushButton::clicked, this, &LoginScreen::onImportProfile);
 
-    reset(initialProfile);
+    reset(initialProfileName);
     this->setStyleSheet(Style::getStylesheet("loginScreen/loginScreen.css"));
 
     retranslateUi();
@@ -84,7 +84,7 @@ void LoginScreen::closeEvent(QCloseEvent* event)
 /**
  * @brief Resets the UI, clears all fields.
  */
-void LoginScreen::reset(QString initialProfile)
+void LoginScreen::reset(const QString& initialProfileName)
 {
     ui->newUsername->clear();
     ui->newPass->clear();
@@ -92,25 +92,26 @@ void LoginScreen::reset(QString initialProfile)
     ui->loginPassword->clear();
     ui->loginUsernames->clear();
 
-    Profile::scanProfiles();
-    if (initialProfile.isEmpty()) {
-        initialProfile = Settings::getInstance().getCurrentProfile();
-    }
-    QStringList profiles = Profile::getProfiles();
-    for (QString profile : profiles) {
-        ui->loginUsernames->addItem(profile);
-        if (profile == initialProfile) {
-            ui->loginUsernames->setCurrentIndex(ui->loginUsernames->count() - 1);
-        }
-    }
+    QStringList allProfileNames = Profile::getAllProfileNames();
 
-    if (profiles.isEmpty()) {
+    if (allProfileNames.isEmpty()) {
         ui->stackedWidget->setCurrentIndex(0);
         ui->newUsername->setFocus();
     } else {
+        for (const QString& profileName : allProfileNames) {
+            ui->loginUsernames->addItem(profileName);
+        }
+
+        ui->loginUsernames->setCurrentText(initialProfileName);
         ui->stackedWidget->setCurrentIndex(1);
         ui->loginPassword->setFocus();
     }
+}
+
+void LoginScreen::onProfileLoaded()
+{
+    done(0);
+}
 
 void LoginScreen::onProfileLoadFailed() {
     QMessageBox::critical(this, tr("Couldn't load this profile"), tr("Wrong password."));

--- a/src/widget/loginscreen.cpp
+++ b/src/widget/loginscreen.cpp
@@ -56,7 +56,7 @@ LoginScreen::LoginScreen(const QString& initialProfileName, QWidget* parent)
     connect(ui->loginPassword, &QLineEdit::returnPressed, this, &LoginScreen::onLogin);
     connect(ui->newPass, &QLineEdit::textChanged, this, &LoginScreen::onPasswordEdited);
     connect(ui->newPassConfirm, &QLineEdit::textChanged, this, &LoginScreen::onPasswordEdited);
-    connect(ui->autoLoginCB, &QCheckBox::stateChanged, this, &LoginScreen::onAutoLoginToggled);
+    connect(ui->autoLoginCB, &QCheckBox::stateChanged, this, &LoginScreen::onAutoLoginCheckboxChanged);
     connect(ui->importButton, &QPushButton::clicked, this, &LoginScreen::onImportProfile);
 
     reset(initialProfileName);
@@ -232,15 +232,10 @@ void LoginScreen::onPasswordEdited()
     ui->passStrengthMeter->setValue(SetPasswordDialog::getPasswordStrength(ui->newPass->text()));
 }
 
-void LoginScreen::onAutoLoginToggled(int state)
+void LoginScreen::onAutoLoginCheckboxChanged(int state)
 {
-    Qt::CheckState cstate = static_cast<Qt::CheckState>(state);
-    if (cstate == Qt::CheckState::Unchecked)
-        Settings::getInstance().setAutoLogin(false);
-    else
-        Settings::getInstance().setAutoLogin(true);
-
-    Settings::getInstance().saveGlobal();
+    auto cstate = static_cast<Qt::CheckState>(state);
+    emit autoLoginChanged(cstate == Qt::CheckState::Checked);
 }
 
 void LoginScreen::retranslateUi()

--- a/src/widget/loginscreen.h
+++ b/src/widget/loginscreen.h
@@ -36,19 +36,22 @@ class LoginScreen : public QDialog
     Q_OBJECT
 
 public:
-    LoginScreen(QString selectedProfile = QString(), QWidget* parent = nullptr);
+    LoginScreen(const QString& initialProfileName = QString(), QWidget* parent = nullptr);
     ~LoginScreen();
-    void reset(QString selectedProfile = QString());
-    Profile* getProfile() const;
-
     bool event(QEvent* event) final override;
 
 signals:
+
     void windowStateChanged(Qt::WindowStates states);
-    void closed();
+    void createNewProfile(QString name, const QString& pass);
+    void loadProfile(QString name, const QString& pass);
 
 protected:
     virtual void closeEvent(QCloseEvent* event) final override;
+
+public slots:
+    void onProfileLoaded();
+    void onProfileLoadFailed();
 
 private slots:
     void onAutoLoginToggled(int state);
@@ -63,6 +66,7 @@ private slots:
     void onImportProfile();
 
 private:
+    void reset(const QString& initialProfileName = QString());
     void retranslateUi();
     void showCapsIndicator();
     void hideCapsIndicator();
@@ -71,7 +75,6 @@ private:
 private:
     Ui::LoginScreen* ui;
     QShortcut quitShortcut;
-    Profile* profile{nullptr};
 };
 
 #endif // LOGINSCREEN_H

--- a/src/widget/loginscreen.h
+++ b/src/widget/loginscreen.h
@@ -43,6 +43,7 @@ public:
 signals:
 
     void windowStateChanged(Qt::WindowStates states);
+    void autoLoginChanged(bool state);
     void createNewProfile(QString name, const QString& pass);
     void loadProfile(QString name, const QString& pass);
 
@@ -52,9 +53,10 @@ protected:
 public slots:
     void onProfileLoaded();
     void onProfileLoadFailed();
+    void onAutoLoginChanged(bool state);
 
 private slots:
-    void onAutoLoginToggled(int state);
+    void onAutoLoginCheckboxChanged(int state);
     void onLoginUsernameSelected(const QString& name);
     void onPasswordEdited();
     // Buttons to change page


### PR DESCRIPTION
LoginScreen was directly modifying Profile, and the overall startup process of qTox was confusing. This commit aims to simplify the code and reduce overall singleton dependency during startup. The scope of the commit could not be allowed to grow too large; as such there are awkward compromises in places due to the structure of singletons that could not be changed at this time. These should not be any worse than what was already in place.

Moved audio instance into Nexus instance. This was a necessary evil to concentrate related logic and facilitate a future shifting of the Nexus object responsibilities elsewhere.

Stop treating singleton instances of Nexus, Profile and Settings as singletons during main.cpp and related processes as much as possible. This does not break Singleton functionality elsewhere, but starts the process of replacing Singleton reliance with a central model object:

- If getInstance() for a singleton is used, keep and use that pointer during function call. This enables passing the object by reference easily later.

-  If getInstance() calls are used to manipulate singleton variables, prefer an emit-to-slot solution whenever possible. Due to deep nesting preventing connect() calls or heavily singleton dependent existing solution this may be non-trivial, but this should become simpler as changes propagate through the project elsewhere.

Remove code duplication related to initial LoginScreen vs. returning to LoginScreen later. This favored the Nexus solution because it is called in code elsewhere, but as above this concentration of logic should simplify moving out of the Nexus design pattern in the long term.

Made Logout action select logged out profile by default.

Profile creation and loading is now performed using signal emits rather than immediate singleton access. This means LoginScreen no longer modifies Profile instance directly.

Made AutoLogin checkbox during LoginScreen use signals instead.

Lifted makeToxPortable initialization logic into separate utility function for future decoupling of global settings vs. profile (eg. model specific) settings. This decoupling would simplify startup behavior as a Settings instance would not be required for initial file reading.

Tests performed:
 Login (default)
 Login (-l)
 Login (-p <profile>)
 Login (create new profile)
 Login (load profile)
 Login (no existing profiles)
 Login (import profile)
 Login (autologin)
 Login (autologin checkbox)
 Login (locale translation)
 Login (quit)

 MainGUI (connect)
 MainGUI (add friend)
 MainGUI (remove friend)
 MainGUI (create group)
 MainGUI (leave group)
 MainGUI (chat)
 MainGUI (separate friend chat window)
 MainGUI (logout)
 MainGUI (quit)
 MainGUI (change profile settings)
 MainGUI (change global settings)

Concerns:
 Mac OSX compatability due to moving Mac specific logic out of Nexus and changing call order. I have not been able to test those changes.

Fixes #5707

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5711)
<!-- Reviewable:end -->
