### PR TITLE
fix(core): correctly relink ui/core when core is changed

### DIFF
--- a/src/nexus.cpp
+++ b/src/nexus.cpp
@@ -237,40 +237,12 @@ void Nexus::showMainGUI()
     // Connections
     connect(profile, &Profile::selfAvatarChanged, widget, &Widget::onSelfAvatarLoaded);
 
-    Core* core = profile->getCore();
-    connect(core, &Core::requestSent, profile, &Profile::onRequestSent);
+    connect(profile, &Profile::coreChanged, widget, &Widget::onCoreChanged);
 
-    connect(core, &Core::connected, widget, &Widget::onConnected);
-    connect(core, &Core::disconnected, widget, &Widget::onDisconnected);
     connect(profile, &Profile::failedToStart, widget, &Widget::onFailedToStartCore,
             Qt::BlockingQueuedConnection);
-    connect(profile, &Profile::badProxy, widget, &Widget::onBadProxyCore, Qt::BlockingQueuedConnection);
-    connect(core, &Core::statusSet, widget, &Widget::onStatusSet);
-    connect(core, &Core::usernameSet, widget, &Widget::setUsername);
-    connect(core, &Core::statusMessageSet, widget, &Widget::setStatusMessage);
-    connect(core, &Core::friendAdded, widget, &Widget::addFriend);
-    connect(core, &Core::failedToAddFriend, widget, &Widget::addFriendFailed);
-    connect(core, &Core::friendUsernameChanged, widget, &Widget::onFriendUsernameChanged);
-    connect(core, &Core::friendStatusChanged, widget, &Widget::onFriendStatusChanged);
-    connect(core, &Core::friendStatusMessageChanged, widget, &Widget::onFriendStatusMessageChanged);
-    connect(core, &Core::friendRequestReceived, widget, &Widget::onFriendRequestReceived);
-    connect(core, &Core::friendMessageReceived, widget, &Widget::onFriendMessageReceived);
-    connect(core, &Core::receiptRecieved, widget, &Widget::onReceiptReceived);
-    connect(core, &Core::groupInviteReceived, widget, &Widget::onGroupInviteReceived);
-    connect(core, &Core::groupMessageReceived, widget, &Widget::onGroupMessageReceived);
-    connect(core, &Core::groupPeerlistChanged, widget, &Widget::onGroupPeerlistChanged);
-    connect(core, &Core::groupPeerNameChanged, widget, &Widget::onGroupPeerNameChanged);
-    connect(core, &Core::groupTitleChanged, widget, &Widget::onGroupTitleChanged);
-    connect(core, &Core::groupPeerAudioPlaying, widget, &Widget::onGroupPeerAudioPlaying);
-    connect(core, &Core::emptyGroupCreated, widget, &Widget::onEmptyGroupCreated);
-    connect(core, &Core::groupJoined, widget, &Widget::onGroupJoined);
-    connect(core, &Core::friendTypingChanged, widget, &Widget::onFriendTypingChanged);
-    connect(core, &Core::groupSentFailed, widget, &Widget::onGroupSendFailed);
-    connect(core, &Core::usernameSet, widget, &Widget::refreshPeerListsLocal);
 
-    connect(widget, &Widget::statusSet, core, &Core::setStatus);
-    connect(widget, &Widget::friendRequested, core, &Core::requestFriendship);
-    connect(widget, &Widget::friendRequestAccepted, core, &Core::acceptFriendRequest);
+    connect(profile, &Profile::badProxy, widget, &Widget::onBadProxyCore, Qt::BlockingQueuedConnection);
 
     profile->startCore();
 

--- a/src/persistence/profile.cpp
+++ b/src/persistence/profile.cpp
@@ -299,6 +299,10 @@ QString Profile::getName() const
  */
 void Profile::startCore()
 {
+    // kriby: code duplication belongs in initCore, but cannot yet due to Core/Profile coupling
+    connect(core.get(), &Core::requestSent, this, &Profile::onRequestSent);
+    emit coreChanged(*core);
+
     core->start();
 
     const ToxId& selfId = core->getSelfId();
@@ -799,6 +803,11 @@ void Profile::restartCore()
             assert(audioBak != nullptr);
             initCore(savedata, Settings::getInstance(), isNewProfile);
             core->getAv()->setAudio(*audioBak);
+
+            // kriby: code duplication belongs in initCore, but cannot yet due to Core/Profile coupling
+            connect(core.get(), &Core::requestSent, this, &Profile::onRequestSent);
+            emit coreChanged(*core);
+
             core->start();
         } else {
             qCritical() << "Failed to save, not restarting core";

--- a/src/persistence/profile.h
+++ b/src/persistence/profile.h
@@ -84,6 +84,7 @@ signals:
     // TODO(sudden6): this doesn't seem to be the right place for Core errors
     void failedToStart();
     void badProxy();
+    void coreChanged(Core& core);
 
 public slots:
     void onRequestSent(const ToxPk& friendPk, const QString& message);

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -127,8 +127,10 @@ public:
     void showUpdateDownloadProgress();
     void addFriendDialog(const Friend* frnd, ContentDialog* dialog);
     void addGroupDialog(Group* group, ContentDialog* dialog);
-    bool newFriendMessageAlert(const ToxPk& friendId, const QString& text, bool sound = true, bool file = false);
-    bool newGroupMessageAlert(const GroupId& groupId, const ToxPk& authorPk, const QString& message, bool notify);
+    bool newFriendMessageAlert(const ToxPk& friendId, const QString& text, bool sound = true,
+                               bool file = false);
+    bool newGroupMessageAlert(const GroupId& groupId, const ToxPk& authorPk, const QString& message,
+                              bool notify);
     bool getIsWindowMinimized();
     void updateIcons();
 
@@ -193,6 +195,7 @@ public slots:
     void toggleFullscreen();
     void refreshPeerListsLocal(const QString& username);
     void onUpdateAvailable(QString latestVersion, QUrl link);
+    void onCoreChanged(Core& core);
 
 signals:
     void friendRequestAccepted(const ToxPk& friendPk);


### PR DESCRIPTION
Widget was only connecting the Core to itself during initialization, but the Core instance could change during a restartCore call. This commit will make Widget link the Core to itself when it changes rather than only on initialization.

Fixes #5710

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5721)
<!-- Reviewable:end -->
