### PR TITLE
refactor(Widget): remove Widget::getInstance

### DIFF
--- a/src/nexus.cpp
+++ b/src/nexus.cpp
@@ -34,8 +34,8 @@
 #include <QDesktopWidget>
 #include <QThread>
 #include <cassert>
-#include <vpx/vpx_image.h>
 #include <src/audio/audio.h>
+#include <vpx/vpx_image.h>
 
 #ifdef Q_OS_MAC
 #include <QActionGroup>
@@ -169,7 +169,7 @@ int Nexus::showLogin(const QString& profileName)
     return returnval;
 }
 
-void Nexus::bootstrapWithProfile(Profile *p)
+void Nexus::bootstrapWithProfile(Profile* p)
 {
     // kriby: This is a hack until a proper controller is written
 
@@ -222,7 +222,7 @@ void Nexus::showMainGUI()
     assert(profile);
 
     // Create GUI
-    widget = Widget::getInstance(audioControl.get());
+    widget = new Widget(*audioControl);
 
     // Start GUI
     widget->init();
@@ -309,7 +309,8 @@ void Nexus::onLoadProfile(const QString& name, const QString& pass)
  * Changes the loaded profile and notifies listeners.
  * @param p
  */
-void Nexus::setProfile(Profile* p) {
+void Nexus::setProfile(Profile* p)
+{
     if (!p) {
         emit profileLoadFailed();
         // Warnings are issued during respective createNew/load calls

--- a/src/widget/circlewidget.cpp
+++ b/src/widget/circlewidget.cpp
@@ -113,8 +113,8 @@ void CircleWidget::contextMenuEvent(QContextMenuEvent* event)
 
             circleList.remove(replacedCircle);
         } else if (selectedItem == openAction) {
-            ContentDialog* dialog = Widget::getInstance()->createContentDialog();
-
+            ContentDialog* dialog = new ContentDialog();
+            emit newContentDialog(*dialog);
             for (int i = 0; i < friendOnlineLayout()->count(); ++i) {
                 QWidget* const widget = friendOnlineLayout()->itemAt(i)->widget();
                 FriendWidget* const friendWidget = qobject_cast<FriendWidget*>(widget);

--- a/src/widget/circlewidget.cpp
+++ b/src/widget/circlewidget.cpp
@@ -33,8 +33,8 @@
 #include "widget.h"
 #include "tool/croppinglabel.h"
 
-#include "src/model/friend.h"
 #include "src/friendlist.h"
+#include "src/model/friend.h"
 #include "src/persistence/settings.h"
 #include "src/widget/form/chatform.h"
 
@@ -142,7 +142,7 @@ void CircleWidget::contextMenuEvent(QContextMenuEvent* event)
 
 void CircleWidget::dragEnterEvent(QDragEnterEvent* event)
 {
-    if(!event->mimeData()->hasFormat("toxPk")) {
+    if (!event->mimeData()->hasFormat("toxPk")) {
         return;
     }
     ToxPk toxPk(event->mimeData()->data("toxPk"));
@@ -186,7 +186,7 @@ void CircleWidget::dropEvent(QDropEvent* event)
 
     if (circleWidget != nullptr) {
         circleWidget->updateStatus();
-        Widget::getInstance()->searchCircle(circleWidget);
+        emit searchCircle(*circleWidget);
     }
 
     setContainerAttribute(Qt::WA_UnderMouse, false);

--- a/src/widget/circlewidget.h
+++ b/src/widget/circlewidget.h
@@ -34,6 +34,7 @@ public:
 
 signals:
     void renameRequested(CircleWidget* circleWidget, const QString& newName);
+    void searchCircle(CircleWidget& circletWidget);
 
 protected:
     void contextMenuEvent(QContextMenuEvent* event) final override;

--- a/src/widget/circlewidget.h
+++ b/src/widget/circlewidget.h
@@ -22,6 +22,8 @@
 
 #include "categorywidget.h"
 
+class ContentDialog;
+
 class CircleWidget final : public CategoryWidget
 {
     Q_OBJECT
@@ -35,6 +37,7 @@ public:
 signals:
     void renameRequested(CircleWidget* circleWidget, const QString& newName);
     void searchCircle(CircleWidget& circletWidget);
+    void newContentDialog(ContentDialog& contentDialog);
 
 protected:
     void contextMenuEvent(QContextMenuEvent* event) final override;

--- a/src/widget/contentdialog.cpp
+++ b/src/widget/contentdialog.cpp
@@ -37,10 +37,10 @@
 #include "src/model/status.h"
 #include "src/persistence/settings.h"
 #include "src/widget/contentlayout.h"
-#include "src/widget/friendwidget.h"
-#include "src/widget/groupwidget.h"
 #include "src/widget/form/chatform.h"
 #include "src/widget/friendlistlayout.h"
+#include "src/widget/friendwidget.h"
+#include "src/widget/groupwidget.h"
 #include "src/widget/style.h"
 #include "src/widget/tool/adjustingscrollarea.h"
 #include "src/widget/translator.h"
@@ -141,7 +141,7 @@ ContentDialog::~ContentDialog()
     Translator::unregister(this);
 }
 
-void ContentDialog::closeEvent(QCloseEvent *event)
+void ContentDialog::closeEvent(QCloseEvent* event)
 {
     emit willClose();
     event->accept();
@@ -499,7 +499,7 @@ void ContentDialog::dropEvent(QDropEvent* event)
             return;
         }
 
-        Widget::getInstance()->addFriendDialog(contact, this);
+        emit addFriendDialog(contact, this);
         ensureSplitterVisible();
     } else if (group) {
         assert(event->mimeData()->hasFormat("groupId"));
@@ -509,7 +509,7 @@ void ContentDialog::dropEvent(QDropEvent* event)
             return;
         }
 
-        Widget::getInstance()->addGroupDialog(contact, this);
+        emit addGroupDialog(contact, this);
         ensureSplitterVisible();
     }
 }

--- a/src/widget/contentdialog.cpp
+++ b/src/widget/contentdialog.cpp
@@ -153,6 +153,7 @@ FriendWidget* ContentDialog::addFriend(std::shared_ptr<FriendChatroom> chatroom,
     auto frnd = chatroom->getFriend();
     auto friendPk = frnd->getPublicKey();
     auto friendWidget = new FriendWidget(chatroom, compact);
+    emit connectFriendWidget(*friendWidget);
     contactWidgets[friendPk] = friendWidget;
     friendLayout->addFriendWidget(friendWidget, frnd->getStatus());
     contactChatForms[friendPk] = form;

--- a/src/widget/contentdialog.h
+++ b/src/widget/contentdialog.h
@@ -20,12 +20,12 @@
 #ifndef CONTENTDIALOG_H
 #define CONTENTDIALOG_H
 
-#include "src/model/dialogs/idialogs.h"
-#include "src/widget/genericchatitemlayout.h"
-#include "src/widget/tool/activatedialog.h"
-#include "src/model/status.h"
 #include "src/core/groupid.h"
 #include "src/core/toxpk.h"
+#include "src/model/dialogs/idialogs.h"
+#include "src/model/status.h"
+#include "src/widget/genericchatitemlayout.h"
+#include "src/widget/tool/activatedialog.h"
 
 #include <memory>
 
@@ -79,6 +79,8 @@ public:
 signals:
     void friendDialogShown(const Friend* f);
     void groupDialogShown(Group* g);
+    void addFriendDialog(Friend* frnd, ContentDialog* contentDialog);
+    void addGroupDialog(Group* group, ContentDialog* contentDialog);
     void activated();
     void willClose();
 
@@ -116,7 +118,6 @@ private:
     void focusCommon(const ContactId& id, QHash<const ContactId&, GenericChatroomWidget*> list);
 
 private:
-
     QList<QLayout*> layouts;
     QSplitter* splitter;
     FriendListLayout* friendLayout;

--- a/src/widget/contentdialog.h
+++ b/src/widget/contentdialog.h
@@ -83,6 +83,7 @@ signals:
     void addGroupDialog(Group* group, ContentDialog* contentDialog);
     void activated();
     void willClose();
+    void connectFriendWidget(FriendWidget& friendWidget);
 
 public slots:
     void reorderLayouts(bool newGroupOnTop);

--- a/src/widget/contentdialogmanager.cpp
+++ b/src/widget/contentdialogmanager.cpp
@@ -19,17 +19,16 @@
 
 #include "contentdialogmanager.h"
 
-#include "src/widget/friendwidget.h"
-#include "src/widget/groupwidget.h"
 #include "src/friendlist.h"
 #include "src/grouplist.h"
 #include "src/model/friend.h"
 #include "src/model/group.h"
+#include "src/widget/friendwidget.h"
+#include "src/widget/groupwidget.h"
 
 #include <tuple>
 
-namespace
-{
+namespace {
 void removeDialog(ContentDialog* dialog, QHash<const ContactId&, ContentDialog*>& dialogs)
 {
     for (auto it = dialogs.begin(); it != dialogs.end();) {
@@ -40,7 +39,7 @@ void removeDialog(ContentDialog* dialog, QHash<const ContactId&, ContentDialog*>
         }
     }
 }
-}
+} // namespace
 
 ContentDialogManager* ContentDialogManager::instance;
 
@@ -60,7 +59,8 @@ bool ContentDialogManager::contactWidgetExists(const ContactId& contactId)
 }
 
 FriendWidget* ContentDialogManager::addFriendToDialog(ContentDialog* dialog,
-    std::shared_ptr<FriendChatroom> chatroom, GenericChatForm* form)
+                                                      std::shared_ptr<FriendChatroom> chatroom,
+                                                      GenericChatForm* form)
 {
     auto friendWidget = dialog->addFriend(chatroom, form);
     const auto friendPk = friendWidget->getFriend()->getPublicKey();
@@ -75,7 +75,8 @@ FriendWidget* ContentDialogManager::addFriendToDialog(ContentDialog* dialog,
 }
 
 GroupWidget* ContentDialogManager::addGroupToDialog(ContentDialog* dialog,
-    std::shared_ptr<GroupChatroom> chatroom, GenericChatForm* form)
+                                                    std::shared_ptr<GroupChatroom> chatroom,
+                                                    GenericChatForm* form)
 {
     auto groupWidget = dialog->addGroup(chatroom, form);
     const auto& groupId = groupWidget->getGroup()->getPersistentId();
@@ -103,7 +104,8 @@ void ContentDialogManager::focusContact(const ContactId& contactId)
  * @param list List with dialogs
  * @return ContentDialog if found, nullptr otherwise
  */
-ContentDialog* ContentDialogManager::focusDialog(const ContactId& id, const QHash<const ContactId&, ContentDialog*>& list)
+ContentDialog* ContentDialogManager::focusDialog(const ContactId& id,
+                                                 const QHash<const ContactId&, ContentDialog*>& list)
 {
     auto iter = list.find(id);
     if (iter == list.end()) {
@@ -178,11 +180,11 @@ ContentDialogManager* ContentDialogManager::getInstance()
     return instance;
 }
 
-void ContentDialogManager::addContentDialog(ContentDialog* dialog)
+void ContentDialogManager::addContentDialog(ContentDialog& dialog)
 {
-    currentDialog = dialog;
-    connect(dialog, &ContentDialog::willClose, this, &ContentDialogManager::onDialogClose);
-    connect(dialog, &ContentDialog::activated, this, &ContentDialogManager::onDialogActivate);
+    currentDialog = &dialog;
+    connect(&dialog, &ContentDialog::willClose, this, &ContentDialogManager::onDialogClose);
+    connect(&dialog, &ContentDialog::activated, this, &ContentDialogManager::onDialogActivate);
 }
 
 void ContentDialogManager::onDialogActivate()
@@ -203,10 +205,10 @@ void ContentDialogManager::onDialogClose()
 
 IDialogs* ContentDialogManager::getFriendDialogs(const ToxPk& friendPk) const
 {
-  return getFriendDialog(friendPk);
+    return getFriendDialog(friendPk);
 }
 
 IDialogs* ContentDialogManager::getGroupDialogs(const GroupId& groupId) const
 {
-  return getGroupDialog(groupId);
+    return getGroupDialog(groupId);
 }

--- a/src/widget/contentdialogmanager.h
+++ b/src/widget/contentdialogmanager.h
@@ -20,11 +20,11 @@
 #ifndef _CONTENT_DIALOG_MANAGER_H_
 #define _CONTENT_DIALOG_MANAGER_H_
 
-#include "src/core/contactid.h"
-#include "src/core/toxpk.h"
-#include "src/core/groupid.h"
-#include "src/model/dialogs/idialogsmanager.h"
 #include "contentdialog.h"
+#include "src/core/contactid.h"
+#include "src/core/groupid.h"
+#include "src/core/toxpk.h"
+#include "src/model/dialogs/idialogsmanager.h"
 
 #include <QObject>
 
@@ -47,10 +47,12 @@ public:
     IDialogs* getFriendDialogs(const ToxPk& friendPk) const;
     IDialogs* getGroupDialogs(const GroupId& groupId) const;
 
-    FriendWidget* addFriendToDialog(ContentDialog* dialog, std::shared_ptr<FriendChatroom> chatroom, GenericChatForm* form);
-    GroupWidget* addGroupToDialog(ContentDialog* dialog, std::shared_ptr<GroupChatroom> chatroom, GenericChatForm* form);
+    FriendWidget* addFriendToDialog(ContentDialog* dialog, std::shared_ptr<FriendChatroom> chatroom,
+                                    GenericChatForm* form);
+    GroupWidget* addGroupToDialog(ContentDialog* dialog, std::shared_ptr<GroupChatroom> chatroom,
+                                  GenericChatForm* form);
 
-    void addContentDialog(ContentDialog* dialog);
+    void addContentDialog(ContentDialog& dialog);
 
     static ContentDialogManager* getInstance();
 
@@ -59,7 +61,8 @@ private slots:
     void onDialogActivate();
 
 private:
-    ContentDialog* focusDialog(const ContactId& id, const QHash<const ContactId&, ContentDialog*>& list);
+    ContentDialog* focusDialog(const ContactId& id,
+                               const QHash<const ContactId&, ContentDialog*>& list);
 
     ContentDialog* currentDialog = nullptr;
 

--- a/src/widget/form/chatform.h
+++ b/src/widget/form/chatform.h
@@ -65,6 +65,7 @@ signals:
     void endCallNotification();
     void rejectCall(uint32_t friendId);
     void acceptCall(uint32_t friendId);
+    void updateFriendActivity(Friend& frnd);
 
 public slots:
     void onAvInvite(uint32_t friendId, bool video);
@@ -75,7 +76,6 @@ public slots:
     void clearChatArea();
 
 private slots:
-    void updateFriendActivity();
     void updateFriendActivityForFile(const ToxFile& file);
     void onAttachClicked() override;
     void onScreenshotClicked() override;
@@ -96,6 +96,8 @@ private slots:
     void sendImage(const QPixmap& pixmap);
     void doScreenshot();
     void onCopyStatusMessage();
+
+    void callUpdateFriendActivity();
 
 private:
     void updateMuteMicButton();

--- a/src/widget/form/settings/generalform.cpp
+++ b/src/widget/form/settings/generalform.cpp
@@ -152,8 +152,7 @@ GeneralForm::GeneralForm(SettingsWidget* myParent)
 
 
 #ifndef QTOX_PLATFORM_EXT
-    bodyUI->autoAwayLabel->setEnabled(
-        false); // these don't seem to change the appearance of the widgets,
+    bodyUI->autoAwayLabel->setEnabled(false); // these don't seem to change the appearance of the widgets,
     bodyUI->autoAwaySpinBox->setEnabled(false); // though they are unusable
 #endif
 
@@ -203,7 +202,7 @@ void GeneralForm::on_closeToTray_stateChanged()
 void GeneralForm::on_lightTrayIcon_stateChanged()
 {
     Settings::getInstance().setLightTrayIcon(bodyUI->lightTrayIcon->isChecked());
-    Widget::getInstance()->updateIcons();
+    emit updateIcons();
 }
 
 void GeneralForm::on_minimizeToTray_stateChanged()

--- a/src/widget/form/settings/generalform.h
+++ b/src/widget/form/settings/generalform.h
@@ -38,6 +38,8 @@ public:
     {
         return tr("General");
     }
+signals:
+    void updateIcons();
 
 private slots:
     void on_transComboBox_currentIndexChanged(int index);

--- a/src/widget/form/settings/privacyform.cpp
+++ b/src/widget/form/settings/privacyform.cpp
@@ -59,7 +59,7 @@ void PrivacyForm::on_cbKeepHistory_stateChanged()
 {
     Settings::getInstance().setEnableLogging(bodyUI->cbKeepHistory->isChecked());
     if (!bodyUI->cbKeepHistory->isChecked()) {
-        Widget::getInstance()->clearAllReceipts();
+        emit clearAllReceipts();
         QMessageBox::StandardButton dialogDelHistory;
         dialogDelHistory =
             QMessageBox::question(nullptr, tr("Confirmation"),

--- a/src/widget/form/settings/privacyform.h
+++ b/src/widget/form/settings/privacyform.h
@@ -37,6 +37,9 @@ public:
         return tr("Privacy");
     }
 
+signals:
+    void clearAllReceipts();
+
 private slots:
     void on_cbKeepHistory_stateChanged();
     void on_cbTypingNotification_stateChanged();

--- a/src/widget/form/settingswidget.cpp
+++ b/src/widget/form/settingswidget.cpp
@@ -41,7 +41,7 @@
 
 #include <memory>
 
-SettingsWidget::SettingsWidget(UpdateCheck* updateCheck, IAudioControl& audio, QWidget* parent)
+SettingsWidget::SettingsWidget(UpdateCheck* updateCheck, IAudioControl& audio, Widget* parent)
     : QWidget(parent, Qt::Window)
 {
     CoreAV* coreAV = Core::getInstance()->getAv();
@@ -58,6 +58,8 @@ SettingsWidget::SettingsWidget(UpdateCheck* updateCheck, IAudioControl& audio, Q
     bodyLayout->addWidget(settingsWidgets.get());
 
     std::unique_ptr<GeneralForm> gfrm(new GeneralForm(this));
+    connect(gfrm.get(), &GeneralForm::updateIcons, parent, &Widget::updateIcons);
+
     std::unique_ptr<UserInterfaceForm> uifrm(new UserInterfaceForm(this));
     std::unique_ptr<PrivacyForm> pfrm(new PrivacyForm());
     AVForm* rawAvfrm = new AVForm(audio, coreAV, camera, audioSettings, videoSettings);

--- a/src/widget/form/settingswidget.cpp
+++ b/src/widget/form/settingswidget.cpp
@@ -62,6 +62,8 @@ SettingsWidget::SettingsWidget(UpdateCheck* updateCheck, IAudioControl& audio, W
 
     std::unique_ptr<UserInterfaceForm> uifrm(new UserInterfaceForm(this));
     std::unique_ptr<PrivacyForm> pfrm(new PrivacyForm());
+    connect(pfrm.get(), &PrivacyForm::clearAllReceipts, parent, &Widget::clearAllReceipts);
+
     AVForm* rawAvfrm = new AVForm(audio, coreAV, camera, audioSettings, videoSettings);
     std::unique_ptr<AVForm> avfrm(rawAvfrm);
     std::unique_ptr<AdvancedForm> expfrm(new AdvancedForm());

--- a/src/widget/form/settingswidget.h
+++ b/src/widget/form/settingswidget.h
@@ -37,12 +37,13 @@ class QLabel;
 class QTabWidget;
 class ContentLayout;
 class UpdateCheck;
+class Widget;
 
 class SettingsWidget : public QWidget
 {
     Q_OBJECT
 public:
-    SettingsWidget(UpdateCheck* updateCheck, IAudioControl& audio, QWidget* parent = nullptr);
+    SettingsWidget(UpdateCheck* updateCheck, IAudioControl& audio, Widget* parent = nullptr);
     ~SettingsWidget();
 
     bool isShown() const;

--- a/src/widget/friendlistwidget.cpp
+++ b/src/widget/friendlistwidget.cpp
@@ -294,8 +294,7 @@ void FriendListWidget::addGroupWidget(GroupWidget* widget)
 {
     groupLayout.addSortedWidget(widget);
     Group* g = widget->getGroup();
-    connect(g, &Group::titleChanged,
-            [=](const QString& author, const QString& name) {
+    connect(g, &Group::titleChanged, [=](const QString& author, const QString& name) {
         Q_UNUSED(author);
         renameGroupWidget(widget, name);
     });
@@ -330,7 +329,7 @@ void FriendListWidget::removeFriendWidget(FriendWidget* w)
         CircleWidget* circleWidget = CircleWidget::getFromID(id);
         if (circleWidget != nullptr) {
             circleWidget->removeFriendWidget(w, contact->getStatus());
-            Widget::getInstance()->searchCircle(circleWidget);
+            emit searchCircle(*circleWidget);
         }
     }
 }
@@ -354,10 +353,10 @@ void FriendListWidget::addCircleWidget(FriendWidget* friendWidget)
             circleWidget->setExpanded(true);
 
             if (circleOriginal != nullptr)
-                Widget::getInstance()->searchCircle(circleOriginal);
+                emit searchCircle(*circleOriginal);
         }
 
-        Widget::getInstance()->searchCircle(circleWidget);
+        emit searchCircle(*circleWidget);
 
         if (window()->isActiveWindow())
             circleWidget->editName();
@@ -420,7 +419,7 @@ void FriendListWidget::onFriendWidgetRenamed(FriendWidget* friendWidget)
         if (circleWidget != nullptr) {
             circleWidget->removeFriendWidget(friendWidget, status);
             circleWidget->addFriendWidget(friendWidget, status);
-            Widget::getInstance()->searchCircle(circleWidget);
+            emit searchCircle(*circleWidget);
         } else {
             listLayout->removeFriendWidget(friendWidget, status);
             listLayout->addFriendWidget(friendWidget, status);
@@ -575,7 +574,7 @@ void FriendListWidget::dragEnterEvent(QDragEnterEvent* event)
     if (!event->mimeData()->hasFormat("toxPk")) {
         return;
     }
-    ToxPk toxPk(event->mimeData()->data("toxPk"));;
+    ToxPk toxPk(event->mimeData()->data("toxPk"));
     Friend* frnd = FriendList::findFriend(toxPk);
     if (frnd)
         event->acceptProposedAction();
@@ -673,6 +672,7 @@ CircleWidget* FriendListWidget::createCircleWidget(int id)
     assert(circleLayout != nullptr);
 
     CircleWidget* circleWidget = new CircleWidget(this, id);
+    emit connectCircleWidget(*circleWidget);
     circleLayout->addSortedWidget(circleWidget);
     connect(this, &FriendListWidget::onCompactChanged, circleWidget, &CircleWidget::onCompactChanged);
     connect(circleWidget, &CircleWidget::renameRequested, this, &FriendListWidget::renameCircleWidget);

--- a/src/widget/friendlistwidget.h
+++ b/src/widget/friendlistwidget.h
@@ -65,6 +65,8 @@ public:
 
 signals:
     void onCompactChanged(bool compact);
+    void connectCircleWidget(CircleWidget& circleWidget);
+    void searchCircle(CircleWidget& circleWidget);
 
 public slots:
     void renameGroupWidget(GroupWidget* groupWidget, const QString& newName);

--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -72,7 +72,8 @@ FriendWidget::FriendWidget(std::shared_ptr<FriendChatroom> chatroom, bool compac
     connect(nameLabel, &CroppingLabel::editFinished, frnd, &Friend::setAlias);
     // update on changes of the displayed name
     connect(frnd, &Friend::displayedNameChanged, nameLabel, &CroppingLabel::setText);
-    connect(frnd, &Friend::displayedNameChanged, this, [this](const QString /* &newName */){emit friendWidgetRenamed(this);});
+    connect(frnd, &Friend::displayedNameChanged, this,
+            [this](const QString /* &newName */) { emit friendWidgetRenamed(this); });
     connect(chatroom.get(), &FriendChatroom::activeChanged, this, &FriendWidget::setActive);
     statusMessageLabel->setTextFormat(Qt::PlainText);
 }
@@ -125,9 +126,7 @@ void FriendWidget::onContextMenuCalled(QContextMenuEvent* event)
 
     for (const auto group : chatroom->getGroups()) {
         const auto groupAction = inviteMenu->addAction(tr("Invite to group '%1'").arg(group.name));
-        connect(groupAction, &QAction::triggered, [=]() {
-            chatroom->inviteFriend(group.group);
-        });
+        connect(groupAction, &QAction::triggered, [=]() { chatroom->inviteFriend(group.group); });
     }
 
     const auto circleId = chatroom->getCircleId();
@@ -242,7 +241,7 @@ void FriendWidget::removeFromCircle()
 
     if (circleWidget != nullptr) {
         circleWidget->updateStatus();
-        Widget::getInstance()->searchCircle(circleWidget);
+        emit searchCircle(*circleWidget);
     }
 }
 
@@ -258,7 +257,7 @@ void FriendWidget::moveToCircle(int newCircleId)
     if (newCircleWidget) {
         newCircleWidget->addFriendWidget(this, frnd->getStatus());
         newCircleWidget->setExpanded(true);
-        Widget::getInstance()->searchCircle(newCircleWidget);
+        emit searchCircle(*newCircleWidget);
         s.savePersonal();
     } else {
         s.setFriendCircleID(pk, newCircleId);
@@ -266,7 +265,7 @@ void FriendWidget::moveToCircle(int newCircleId)
 
     if (oldCircleWidget) {
         oldCircleWidget->updateStatus();
-        Widget::getInstance()->searchCircle(oldCircleWidget);
+        emit searchCircle(*oldCircleWidget);
     }
 }
 
@@ -274,8 +273,10 @@ void FriendWidget::changeAutoAccept(bool enable)
 {
     if (enable) {
         const auto oldDir = chatroom->getAutoAcceptDir();
-        const auto newDir = QFileDialog::getExistingDirectory(
-            Q_NULLPTR, tr("Choose an auto accept directory", "popup title"), oldDir);
+        const auto newDir =
+            QFileDialog::getExistingDirectory(Q_NULLPTR,
+                                              tr("Choose an auto accept directory", "popup title"),
+                                              oldDir);
         chatroom->setAutoAcceptDir(newDir);
     } else {
         chatroom->disableAutoAccept();
@@ -305,8 +306,8 @@ void FriendWidget::setActive(bool active)
 {
     GenericChatroomWidget::setActive(active);
     if (isDefaultAvatar) {
-        const auto uri = active ? QStringLiteral(":img/contact_dark.svg")
-                                : QStringLiteral(":img/contact.svg");
+        const auto uri =
+            active ? QStringLiteral(":img/contact_dark.svg") : QStringLiteral(":img/contact.svg");
         avatar->setPixmap(QPixmap{uri});
     }
 }

--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -287,7 +287,7 @@ void FriendWidget::showDetails()
     const auto frnd = chatroom->getFriend();
     const auto iabout = new AboutFriend(frnd, &Settings::getInstance());
     std::unique_ptr<IAboutFriend> about = std::unique_ptr<IAboutFriend>(iabout);
-    const auto aboutUser = new AboutFriendForm(std::move(about), Widget::getInstance());
+    const auto aboutUser = new AboutFriendForm(std::move(about), this);
     connect(aboutUser, &AboutFriendForm::histroyRemoved, this, &FriendWidget::friendHistoryRemoved);
     aboutUser->show();
 }

--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -326,7 +326,7 @@ void FriendWidget::updateStatusLight()
             circleWidget->setExpanded(true);
         }
 
-        Widget::getInstance()->updateFriendActivity(frnd);
+        emit updateFriendActivity(*frnd);
     }
 
     statusPic.setMargin(event ? 1 : 3);

--- a/src/widget/friendwidget.h
+++ b/src/widget/friendwidget.h
@@ -28,6 +28,7 @@
 class FriendChatroom;
 class QPixmap;
 class MaskablePixmapWidget;
+class CircleWidget;
 
 class FriendWidget : public GenericChatroomWidget
 {
@@ -53,6 +54,7 @@ signals:
     void contextMenuCalled(QContextMenuEvent* event);
     void friendHistoryRemoved();
     void friendWidgetRenamed(FriendWidget* friendWidget);
+    void searchCircle(CircleWidget& circleWidget);
 
 public slots:
     void onAvatarSet(const ToxPk& friendPk, const QPixmap& pic);

--- a/src/widget/friendwidget.h
+++ b/src/widget/friendwidget.h
@@ -55,6 +55,7 @@ signals:
     void friendHistoryRemoved();
     void friendWidgetRenamed(FriendWidget* friendWidget);
     void searchCircle(CircleWidget& circleWidget);
+    void updateFriendActivity(Friend& frnd);
 
 public slots:
     void onAvatarSet(const ToxPk& friendPk, const QPixmap& pic);

--- a/src/widget/tool/callconfirmwidget.cpp
+++ b/src/widget/tool/callconfirmwidget.cpp
@@ -22,6 +22,7 @@
 #include "src/widget/style.h"
 #include "src/widget/widget.h"
 #include <QDialogButtonBox>
+#include <QFontMetrics>
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QPaintEvent>
@@ -30,7 +31,6 @@
 #include <QPushButton>
 #include <QRect>
 #include <QVBoxLayout>
-#include <QFontMetrics>
 #include <assert.h>
 
 /**
@@ -76,12 +76,12 @@ CallConfirmWidget::CallConfirmWidget(const QWidget* anchor)
     // Note: At the moment this may not work properly. For languages written
     // from right to left, there is no translation for the phrase "Incoming call...".
     // In this situation, the phrase "Incoming call..." looks as "...oming call..."
-    Qt::TextElideMode elideMode = (QGuiApplication::layoutDirection() == Qt::LeftToRight)
-                                  ? Qt::ElideRight : Qt::ElideLeft;
+    Qt::TextElideMode elideMode =
+        (QGuiApplication::layoutDirection() == Qt::LeftToRight) ? Qt::ElideRight : Qt::ElideLeft;
     int marginSize = 12;
     QFontMetrics fontMetrics(callLabel->font());
-    QString elidedText = fontMetrics.elidedText(callLabel->text(), elideMode,
-                                                rectW - marginSize * 2 - 4);
+    QString elidedText =
+        fontMetrics.elidedText(callLabel->text(), elideMode, rectW - marginSize * 2 - 4);
     callLabel->setText(elidedText);
 
     QDialogButtonBox* buttonBox = new QDialogButtonBox(Qt::Horizontal, this);
@@ -154,14 +154,11 @@ void CallConfirmWidget::paintEvent(QPaintEvent*)
 
 void CallConfirmWidget::showEvent(QShowEvent*)
 {
+    // Kriby: Legacy comment, is this still true?
     // If someone does show() from Widget or lower, the event will reach us
     // because it's our parent, and we could show up in the wrong form.
     // So check here if our friend's form is actually the active one.
-    // if (!Widget::getInstance()->isFriendWidgetCurActiveWidget(&f))
-    {
-        // QWidget::hide();
-        // return;
-    }
+
     reposition();
     update();
 }

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -602,23 +602,6 @@ Widget::~Widget()
 }
 
 /**
- * @param audio Only used for initialization from Nexus, to pass IAudioControl
- * @brief Returns the singleton instance.
- */
-Widget* Widget::getInstance(IAudioControl* audio)
-{
-    if (!instance) {
-        // Passing audio via pointer here is a hack
-        // to allow for default paramters.
-        // once Widget::getInstance is removed it won't be neccessary
-        assert(audio != nullptr);
-        instance = new Widget(*audio);
-    }
-
-    return instance;
-}
-
-/**
  * @brief Switches to the About settings page.
  */
 void Widget::showUpdateDownloadProgress()

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1818,26 +1818,30 @@ void Widget::onUpdateAvailable(QString /*latestVersion*/, QUrl /*link*/)
 ContentDialog* Widget::createContentDialog() const
 {
     ContentDialog* contentDialog = new ContentDialog();
-    ContentDialogManager::getInstance()->addContentDialog(contentDialog);
 
-    connect(contentDialog, &ContentDialog::friendDialogShown, this, &Widget::onFriendDialogShown);
-    connect(contentDialog, &ContentDialog::groupDialogShown, this, &Widget::onGroupDialogShown);
-    connect(core, &Core::usernameSet, contentDialog, &ContentDialog::setUsername);
-    connect(&settings, &Settings::groupchatPositionChanged, contentDialog,
+    registerContentDialog(*contentDialog);
+    return contentDialog;
+}
+
+void Widget::registerContentDialog(ContentDialog& contentDialog) const
+{
+    ContentDialogManager::getInstance()->addContentDialog(contentDialog);
+    connect(&contentDialog, &ContentDialog::friendDialogShown, this, &Widget::onFriendDialogShown);
+    connect(&contentDialog, &ContentDialog::groupDialogShown, this, &Widget::onGroupDialogShown);
+    connect(core, &Core::usernameSet, &contentDialog, &ContentDialog::setUsername);
+    connect(&settings, &Settings::groupchatPositionChanged, &contentDialog,
             &ContentDialog::reorderLayouts);
-    connect(contentDialog, &ContentDialog::addFriendDialog, this, &Widget::addFriendDialog);
-    connect(contentDialog, &ContentDialog::addGroupDialog, this, &Widget::addGroupDialog);
-    connect(contentDialog, &ContentDialog::connectFriendWidget, this, &Widget::connectFriendWidget);
+    connect(&contentDialog, &ContentDialog::addFriendDialog, this, &Widget::addFriendDialog);
+    connect(&contentDialog, &ContentDialog::addGroupDialog, this, &Widget::addGroupDialog);
+    connect(&contentDialog, &ContentDialog::connectFriendWidget, this, &Widget::connectFriendWidget);
 
 #ifdef Q_OS_MAC
     Nexus& n = Nexus::getInstance();
-    connect(contentDialog, &ContentDialog::destroyed, &n, &Nexus::updateWindowsClosed);
-    connect(contentDialog, &ContentDialog::windowStateChanged, &n, &Nexus::onWindowStateChanged);
-    connect(contentDialog->windowHandle(), &QWindow::windowTitleChanged, &n, &Nexus::updateWindows);
+    connect(&contentDialog, &ContentDialog::destroyed, &n, &Nexus::updateWindowsClosed);
+    connect(&contentDialog, &ContentDialog::windowStateChanged, &n, &Nexus::onWindowStateChanged);
+    connect(contentDialog.windowHandle(), &QWindow::windowTitleChanged, &n, &Nexus::updateWindows);
     n.updateWindows();
 #endif
-
-    return contentDialog;
 }
 
 ContentLayout* Widget::createContentDialog(DialogType type) const
@@ -2702,6 +2706,7 @@ void Widget::refreshPeerListsLocal(const QString& username)
 void Widget::connectCircleWidget(CircleWidget& circleWidget)
 {
     connect(&circleWidget, &CircleWidget::searchCircle, this, &Widget::searchCircle);
+    connect(&circleWidget, &CircleWidget::newContentDialog, this, &Widget::registerContentDialog);
 }
 
 void Widget::connectFriendWidget(FriendWidget& friendWidget)

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1157,6 +1157,7 @@ void Widget::addFriend(uint32_t friendId, const ToxPk& friendPk)
         std::make_shared<ChatHistory>(*newfriend, history, *core, Settings::getInstance(),
                                       *friendMessageDispatcher);
     auto friendForm = new ChatForm(newfriend, *chatHistory, *friendMessageDispatcher);
+    connect(friendForm, &ChatForm::updateFriendActivity, this, &Widget::updateFriendActivity);
 
     friendMessageDispatchers[friendPk] = friendMessageDispatcher;
     friendChatLogs[friendPk] = chatHistory;
@@ -1704,14 +1705,14 @@ void Widget::onFileReceiveRequested(const ToxFile& file)
                           true, true);
 }
 
-void Widget::updateFriendActivity(const Friend* frnd)
+void Widget::updateFriendActivity(const Friend& frnd)
 {
-    const ToxPk& pk = frnd->getPublicKey();
+    const ToxPk& pk = frnd.getPublicKey();
     const auto oldTime = settings.getFriendActivity(pk);
     const auto newTime = QDateTime::currentDateTime();
     settings.setFriendActivity(pk, newTime);
-    FriendWidget* widget = friendWidgets[frnd->getPublicKey()];
-    contactListWidget->moveWidget(widget, frnd->getStatus());
+    FriendWidget* widget = friendWidgets[frnd.getPublicKey()];
+    contactListWidget->moveWidget(widget, frnd.getStatus());
     contactListWidget->updateActivityTime(oldTime); // update old category widget
 }
 
@@ -1928,7 +1929,7 @@ void Widget::onGroupInviteReceived(const GroupInvite& inviteInfo)
     const uint32_t friendId = inviteInfo.getFriendId();
     const ToxPk& friendPk = FriendList::id2Key(friendId);
     const Friend* f = FriendList::findFriend(friendPk);
-    updateFriendActivity(f);
+    updateFriendActivity(*f);
 
     const uint8_t confType = inviteInfo.getType();
     if (confType == TOX_CONFERENCE_TYPE_TEXT || confType == TOX_CONFERENCE_TYPE_AV) {
@@ -2706,4 +2707,5 @@ void Widget::connectCircleWidget(CircleWidget& circleWidget)
 void Widget::connectFriendWidget(FriendWidget& friendWidget)
 {
     connect(&friendWidget, &FriendWidget::searchCircle, this, &Widget::searchCircle);
+    connect(&friendWidget, &FriendWidget::updateFriendActivity, this, &Widget::updateFriendActivity);
 }

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -2158,7 +2158,7 @@ void Widget::onEmptyGroupCreated(uint32_t groupnumber, const GroupId& groupId, c
     }
     if (title.isEmpty()) {
         // Only rename group if groups are visible.
-        if (Widget::getInstance()->groupsVisible()) {
+        if (groupsVisible()) {
             groupWidgets[groupId]->editName();
         }
     } else {

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1820,6 +1820,8 @@ ContentDialog* Widget::createContentDialog() const
     connect(core, &Core::usernameSet, contentDialog, &ContentDialog::setUsername);
     connect(&settings, &Settings::groupchatPositionChanged, contentDialog,
             &ContentDialog::reorderLayouts);
+    connect(contentDialog, &ContentDialog::addFriendDialog, this, &Widget::addFriendDialog);
+    connect(contentDialog, &ContentDialog::addGroupDialog, this, &Widget::addGroupDialog);
 
 #ifdef Q_OS_MAC
     Nexus& n = Nexus::getInstance();

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -145,7 +145,6 @@ public:
     void reloadTheme();
     static inline QIcon prepareIcon(QString path, int w = 0, int h = 0);
 
-    void searchCircle(CircleWidget* circleWidget);
     bool groupsVisible() const;
 
     void resetIcon();
@@ -241,6 +240,9 @@ private slots:
     void dispatchFile(ToxFile file);
     void dispatchFileWithBool(ToxFile file, bool);
     void dispatchFileSendFailed(uint32_t friendId, const QString& fileName);
+    void connectCircleWidget(CircleWidget& circleWidget);
+    void connectFriendWidget(FriendWidget& friendWidget);
+    void searchCircle(CircleWidget& circleWidget);
 
 private:
     // QMainWindow overrides

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -174,7 +174,6 @@ public slots:
     void onReceiptReceived(int friendId, ReceiptNum receipt);
     void onFriendRequestReceived(const ToxPk& friendPk, const QString& message);
     void onFileReceiveRequested(const ToxFile& file);
-    void updateFriendActivity(const Friend* frnd);
     void onEmptyGroupCreated(uint32_t groupnumber, const GroupId& groupId, const QString& title);
     void onGroupJoined(int groupNum, const GroupId& groupId);
     void onGroupInviteReceived(const GroupInvite& inviteInfo);
@@ -243,6 +242,7 @@ private slots:
     void connectCircleWidget(CircleWidget& circleWidget);
     void connectFriendWidget(FriendWidget& friendWidget);
     void searchCircle(CircleWidget& circleWidget);
+    void updateFriendActivity(const Friend& frnd);
 
 private:
     // QMainWindow overrides

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -243,6 +243,7 @@ private slots:
     void connectFriendWidget(FriendWidget& friendWidget);
     void searchCircle(CircleWidget& circleWidget);
     void updateFriendActivity(const Friend& frnd);
+    void registerContentDialog(ContentDialog& contentDialog) const;
 
 private:
     // QMainWindow overrides


### PR DESCRIPTION
This PR replaces all cases where Widget::getInstance() is used with alternate solutions using signals and removes Widget::getInstance entirely.

Commits also run clang-format on affected files.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5733)
<!-- Reviewable:end -->
