### PR TITLE
fix(offlinemsg): Fix offline message dispatching on history load

### DIFF
--- a/src/model/sessionchatlog.cpp
+++ b/src/model/sessionchatlog.cpp
@@ -284,8 +284,8 @@ std::vector<IChatLog::DateChatLogIdxPair> SessionChatLog::getDateIdxs(const QDat
     return ret;
 }
 
-void SessionChatLog::insertMessageAtIdx(ChatLogIdx idx, ToxPk sender, QString senderName,
-                                        ChatLogMessage message)
+void SessionChatLog::insertCompleteMessageAtIdx(ChatLogIdx idx, ToxPk sender, QString senderName,
+                                                ChatLogMessage message)
 {
     auto item = ChatLogItem(sender, message);
 
@@ -293,7 +293,25 @@ void SessionChatLog::insertMessageAtIdx(ChatLogIdx idx, ToxPk sender, QString se
         item.setDisplayName(senderName);
     }
 
+    assert(message.isComplete == true);
+
     items.emplace(idx, std::move(item));
+}
+
+void SessionChatLog::insertIncompleteMessageAtIdx(ChatLogIdx idx, ToxPk sender, QString senderName,
+                                                  ChatLogMessage message,
+                                                  DispatchedMessageId dispatchId)
+{
+    auto item = ChatLogItem(sender, message);
+
+    if (!senderName.isEmpty()) {
+        item.setDisplayName(senderName);
+    }
+
+    assert(message.isComplete == false);
+
+    items.emplace(idx, std::move(item));
+    outgoingMessages.insert(dispatchId, idx);
 }
 
 void SessionChatLog::insertFileAtIdx(ChatLogIdx idx, ToxPk sender, QString senderName, ChatLogFile file)

--- a/src/model/sessionchatlog.h
+++ b/src/model/sessionchatlog.h
@@ -46,7 +46,10 @@ public:
     ChatLogIdx getNextIdx() const override;
     std::vector<DateChatLogIdxPair> getDateIdxs(const QDate& startDate, size_t maxDates) const override;
 
-    void insertMessageAtIdx(ChatLogIdx idx, ToxPk sender, QString senderName, ChatLogMessage message);
+    void insertCompleteMessageAtIdx(ChatLogIdx idx, ToxPk sender, QString senderName,
+                                    ChatLogMessage message);
+    void insertIncompleteMessageAtIdx(ChatLogIdx idx, ToxPk sender, QString senderName,
+                                      ChatLogMessage message, DispatchedMessageId dispatchId);
     void insertFileAtIdx(ChatLogIdx idx, ToxPk sender, QString senderName, ChatLogFile file);
 
 public slots:

--- a/src/persistence/history.cpp
+++ b/src/persistence/history.cpp
@@ -627,10 +627,8 @@ QList<History::HistMessage> History::getUnsentMessagesForFriend(const ToxPk& fri
         auto friend_key = row[3].toString();
         auto display_name = QString::fromUtf8(row[4].toByteArray().replace('\0', ""));
         auto sender_key = row[5].toString();
-        if (row[6].isNull()) {
-            ret += {id,           isOfflineMessage, timestamp,        friend_key,
-                    display_name, sender_key,       row[6].toString()};
-        }
+        ret += {id,           isOfflineMessage, timestamp,        friend_key,
+                display_name, sender_key,       row[6].toString()};
     };
 
     db->execNow({queryText, rowCallback});


### PR DESCRIPTION
Fixes #5734 

I apologize, this path had several bugs. I remember testing this case but I either touched the code more since then or just remembered incorrectly.

Fixes are
* Fix callback hookup order in ChatHistory
* Add correct call to SessionChatLog to insert an unfinished message
* Fix incorrect logic in parsing History database response

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5735)
<!-- Reviewable:end -->
