### PR TITLE
fix(search): application crash when starting a search

### DIFF
--- a/src/model/sessionchatlog.cpp
+++ b/src/model/sessionchatlog.cpp
@@ -189,6 +189,11 @@ SearchResult SessionChatLog::searchBackward(SearchPos startPos, const QString& p
 
     // If we don't have it we'll start at the end
     if (startIt == items.end()) {
+        if (items.empty()) {
+            SearchResult ret;
+            ret.found = false;
+            return ret;
+        }
         startIt = std::prev(items.end());
         startPos.numMatches = 0;
     }


### PR DESCRIPTION

The application crashes if:
1. no messages in chat (clear)
2. try to do a backward search

I think this is because std::prev requires iterator which can be decremented
Added a check of this requirement and fixed crash

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5738)
<!-- Reviewable:end -->
