### PR TITLE
refactor(MacOSX): switch to Qt 5.13 compliant methods for OSX

### DIFF
--- a/src/chatlog/content/filetransferwidget.cpp
+++ b/src/chatlog/content/filetransferwidget.cpp
@@ -195,13 +195,14 @@ void FileTransferWidget::paintEvent(QPaintEvent*)
     // Draw the widget background:
     painter.setClipRect(QRect(0, 0, width(), height()));
     painter.setBrush(QBrush(backgroundColor));
-    painter.drawRoundRect(geometry(), r * ratio, r);
+    painter.drawRoundedRect(geometry(), r * ratio, r, Qt::RelativeSize);
 
     if (drawButtonAreaNeeded()) {
         // Draw the button background:
         QPainterPath buttonBackground;
-        buttonBackground.addRoundRect(width() - 2 * buttonFieldWidth - lineWidth * 2, 0,
-                                      buttonFieldWidth, buttonFieldWidth + lineWidth, 50, 50);
+        buttonBackground.addRoundedRect(width() - 2 * buttonFieldWidth - lineWidth * 2, 0,
+                                      buttonFieldWidth, buttonFieldWidth + lineWidth, 50, 50,
+                                      Qt::RelativeSize);
         buttonBackground.addRect(width() - 2 * buttonFieldWidth - lineWidth * 2, 0,
                                  buttonFieldWidth * 2, buttonFieldWidth / 2);
         buttonBackground.addRect(width() - 1.5 * buttonFieldWidth - lineWidth * 2, 0,
@@ -212,9 +213,9 @@ void FileTransferWidget::paintEvent(QPaintEvent*)
 
         // Draw the left button:
         QPainterPath leftButton;
-        leftButton.addRoundRect(QRect(width() - 2 * buttonFieldWidth - lineWidth, 0,
+        leftButton.addRoundedRect(QRect(width() - 2 * buttonFieldWidth - lineWidth, 0,
                                       buttonFieldWidth, buttonFieldWidth),
-                                50, 50);
+                                50, 50, Qt::RelativeSize);
         leftButton.addRect(QRect(width() - 2 * buttonFieldWidth - lineWidth, 0,
                                  buttonFieldWidth / 2, buttonFieldWidth / 2));
         leftButton.addRect(QRect(width() - 1.5 * buttonFieldWidth - lineWidth, 0,
@@ -226,7 +227,7 @@ void FileTransferWidget::paintEvent(QPaintEvent*)
         // Draw the right button:
         painter.setBrush(QBrush(buttonColor));
         painter.setClipRect(QRect(width() - buttonFieldWidth, 0, buttonFieldWidth, buttonFieldWidth));
-        painter.drawRoundRect(geometry(), r * ratio, r);
+        painter.drawRoundedRect(geometry(), r * ratio, r, Qt::RelativeSize);
     }
 }
 
@@ -539,7 +540,7 @@ void FileTransferWidget::showPreview(const QString& filename)
         ui->previewButton->show();
         // Show mouseover preview, but make sure it's not larger than 50% of the screen
         // width/height
-        const QRect desktopSize = QApplication::desktop()->screenGeometry();
+        const QRect desktopSize = QApplication::desktop()->geometry();
         const int maxPreviewWidth{desktopSize.width() / 2};
         const int maxPreviewHeight{desktopSize.height() / 2};
         const QImage previewImage = [&image, maxPreviewWidth, maxPreviewHeight]() {

--- a/src/nexus.cpp
+++ b/src/nexus.cpp
@@ -138,9 +138,6 @@ void Nexus::start()
     quitAction->setMenuRole(QAction::QuitRole);
     connect(quitAction, &QAction::triggered, qApp, &QApplication::quit);
 
-    windowMapper = new QSignalMapper(this);
-    connect(windowMapper, SIGNAL(mapped(QObject*)), this, SLOT(onOpenWindow(QObject*)));
-
     retranslateUi();
 #endif
     showMainGUI();
@@ -392,8 +389,7 @@ void Nexus::updateWindowsArg(QWindow* closedWindow)
         QAction* action = windowActions->addAction(windowList[i]->title());
         action->setCheckable(true);
         action->setChecked(windowList[i] == activeWindow);
-        connect(action, SIGNAL(triggered()), windowMapper, SLOT(map()));
-        windowMapper->setMapping(action, windowList[i]);
+        connect(action, &QAction::triggered, [=] { onOpenWindow(windowList[i]);});
         windowMenu->addAction(action);
         dockMenu->insertAction(dockLast, action);
     }

--- a/src/nexus.h
+++ b/src/nexus.h
@@ -77,7 +77,6 @@ public slots:
 private:
     void updateWindowsArg(QWindow* closedWindow);
 
-    QSignalMapper* windowMapper;
     QActionGroup* windowActions = nullptr;
 #endif
 signals:

--- a/src/persistence/offlinemsgengine.cpp
+++ b/src/persistence/offlinemsgengine.cpp
@@ -101,7 +101,7 @@ void OfflineMsgEngine::deliverOfflineMsgs()
 
     QVector<OfflineMessage> messages = sentMessages.values().toVector() + unsentMessages;
     // order messages by authorship time to resend in same order as they were written
-    qSort(messages.begin(), messages.end(), [](const OfflineMessage& lhs, const OfflineMessage& rhs) {
+    std::sort(messages.begin(), messages.end(), [](const OfflineMessage& lhs, const OfflineMessage& rhs) {
         return lhs.authorshipTime < rhs.authorshipTime;
     });
     removeAllMessages();

--- a/src/video/genericnetcamview.cpp
+++ b/src/video/genericnetcamview.cpp
@@ -20,6 +20,7 @@
 #include "genericnetcamview.h"
 
 #include <QApplication>
+#include <QScreen>
 #include <QBoxLayout>
 #include <QDesktopWidget>
 #include <QKeyEvent>
@@ -136,8 +137,11 @@ void GenericNetCamView::enterFullScreen()
     showFullScreen();
     enterFullScreenButton->hide();
     toggleMessagesButton->hide();
-
-    const auto screenSize = QApplication::desktop()->screenGeometry(this);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+    const auto screenSize = QGuiApplication::screenAt(this->pos())->geometry();
+#else
+    const QRect screenSize = QApplication::desktop()->screenGeometry(this);
+#endif
     buttonPanel->setGeometry((screenSize.width() / 2) - buttonPanel->width() / 2,
             screenSize.height() - BTN_PANEL_HEIGHT - 25, BTN_PANEL_WIDTH, BTN_PANEL_HEIGHT);
     buttonPanel->show();

--- a/src/widget/contentdialog.cpp
+++ b/src/widget/contentdialog.cpp
@@ -69,7 +69,11 @@ ContentDialog::ContentDialog(QWidget* parent)
                friendLayout->getLayoutOffline()};
 
     if (s.getGroupchatPosition()) {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 13, 0))
+        layouts.swapItemsAt(0, 1);
+#else
         layouts.swap(0, 1);
+#endif
     }
 
     QWidget* friendWidget = new QWidget();
@@ -399,7 +403,12 @@ void ContentDialog::reorderLayouts(bool newGroupOnTop)
 {
     bool oldGroupOnTop = layouts.first() == groupLayout.getLayout();
     if (newGroupOnTop != oldGroupOnTop) {
+        // Kriby: Maintain backwards compatibility
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 13, 0))
+        layouts.swapItemsAt(0, 1);
+#else
         layouts.swap(0, 1);
+#endif
     }
 }
 

--- a/src/widget/form/groupchatform.cpp
+++ b/src/widget/form/groupchatform.cpp
@@ -218,7 +218,7 @@ void GroupChatForm::updateUserNames()
     // add the labels in alphabetical order into the layout
     auto nickLabelList = peerLabels.values();
 
-    qSort(nickLabelList.begin(), nickLabelList.end(), [](const QLabel* a, const QLabel* b)
+    std::sort(nickLabelList.begin(), nickLabelList.end(), [](const QLabel* a, const QLabel* b)
     {
         return a->text().toLower() < b->text().toLower();
     });

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -105,9 +105,11 @@ AVForm::AVForm(IAudioControl& audio, CoreAV* coreAV, CameraSource& camera,
     eventsInit();
 
     QDesktopWidget* desktop = QApplication::desktop();
-    connect(desktop, &QDesktopWidget::resized, this, &AVForm::rescanDevices);
     connect(desktop, &QDesktopWidget::screenCountChanged, this, &AVForm::rescanDevices);
 
+    for (QScreen* qScreen : QGuiApplication::screens()) {
+        connect(qScreen, &QScreen::geometryChanged, this, &AVForm::rescanDevices);
+    }
     Translator::registerHandler(std::bind(&AVForm::retranslateUi, this), this);
 }
 

--- a/src/widget/form/settings/avform.h
+++ b/src/widget/form/settings/avform.h
@@ -95,6 +95,7 @@ private:
     void open(const QString& devName, const VideoMode& mode);
     int getStepsFromValue(qreal val, qreal valMin, qreal valMax);
     qreal getValueFromSteps(int steps, qreal valMin, qreal valMax);
+    void trackNewScreenGeometry(QScreen* qScreen);
 
 private:
     IAudioControl& audio;

--- a/src/widget/systemtrayicon.cpp
+++ b/src/widget/systemtrayicon.cpp
@@ -115,9 +115,13 @@ GdkPixbuf* SystemTrayIcon::convertQIconToPixbuf(const QIcon& icon)
     QImage image = icon.pixmap(64, 64).toImage();
     if (image.format() != QImage::Format_RGBA8888_Premultiplied)
         image = image.convertToFormat(QImage::Format_RGBA8888_Premultiplied);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+    guchar* image_bytes = new guchar[image.sizeInBytes()];
+    memcpy(image_bytes, image.bits(), image.sizeInBytes());
+#else
     guchar* image_bytes = new guchar[image.byteCount()];
     memcpy(image_bytes, image.bits(), image.byteCount());
-
+#endif
     return gdk_pixbuf_new_from_data(image_bytes, GDK_COLORSPACE_RGB, image.hasAlphaChannel(), 8,
                                     image.width(), image.height(), image.bytesPerLine(),
                                     callbackFreeImage, nullptr);
@@ -214,8 +218,8 @@ void SystemTrayIcon::setContextMenu(QMenu* menu)
             else if (a->icon().isNull())
                 item = gtk_menu_item_new_with_label(aText.c_str());
             else {
-                const std::string iconPath = extractIconToFile(a->icon(),
-                                             "iconmenu" + a->icon().name()).toStdString();
+                const std::string iconPath =
+                    extractIconToFile(a->icon(), "iconmenu" + a->icon().name()).toStdString();
                 GtkWidget* image = gtk_image_new_from_file(iconPath.c_str());
                 item = gtk_image_menu_item_new_with_label(aText.c_str());
                 gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(item), image);

--- a/src/widget/tool/callconfirmwidget.cpp
+++ b/src/widget/tool/callconfirmwidget.cpp
@@ -148,7 +148,7 @@ void CallConfirmWidget::paintEvent(QPaintEvent*)
     painter.setBrush(brush);
     painter.setPen(Qt::NoPen);
 
-    painter.drawRoundRect(mainRect, roundedFactor * rectRatio, roundedFactor);
+    painter.drawRoundedRect(mainRect, roundedFactor * rectRatio, roundedFactor, Qt::RelativeSize);
     painter.drawPolygon(spikePoly);
 }
 

--- a/src/widget/tool/croppinglabel.cpp
+++ b/src/widget/tool/croppinglabel.cpp
@@ -36,8 +36,7 @@ CroppingLabel::CroppingLabel(QWidget* parent)
     public:
         explicit LineEdit(QWidget* parent = nullptr)
             : QLineEdit(parent)
-        {
-        }
+        {}
 
     protected:
         void keyPressEvent(QKeyEvent* event) override
@@ -106,7 +105,11 @@ QSize CroppingLabel::sizeHint() const
 
 QSize CroppingLabel::minimumSizeHint() const
 {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+    return QSize(fontMetrics().horizontalAdvance("..."), QLabel::minimumSizeHint().height());
+#else
     return QSize(fontMetrics().width("..."), QLabel::minimumSizeHint().height());
+#endif
 }
 
 void CroppingLabel::mouseReleaseEvent(QMouseEvent* e)
@@ -171,7 +174,11 @@ void CroppingLabel::minimizeMaximumWidth()
 {
     // This function chooses the smallest possible maximum width.
     // Text width + padding. Without padding, we'll have elipses.
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
+    setMaximumWidth(fontMetrics().horizontalAdvance(origText) + fontMetrics().horizontalAdvance("..."));
+#else
     setMaximumWidth(fontMetrics().width(origText) + fontMetrics().width("..."));
+#endif
 }
 
 void CroppingLabel::editingFinished()

--- a/src/widget/tool/screenshotgrabber.cpp
+++ b/src/widget/tool/screenshotgrabber.cpp
@@ -203,7 +203,11 @@ void ScreenshotGrabber::chooseHelperTooltipText(QRect rect)
 void ScreenshotGrabber::adjustTooltipPosition()
 {
     QRect recGL = QGuiApplication::primaryScreen()->virtualGeometry();
-    QRect rec = qApp->desktop()->screenGeometry(QCursor::pos());
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 10, 0))
+    const auto rec = QGuiApplication::screenAt(QCursor::pos())->geometry();
+#else
+    const auto rec = qApp->desktop()->screenGeometry(QCursor::pos());
+#endif
     const QRectF ttRect = this->helperToolbox->childrenBoundingRect();
     int x = qAbs(recGL.x()) + rec.x() + ((rec.width() - ttRect.width()) / 2);
     int y = qAbs(recGL.y()) + rec.y();

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -2271,7 +2271,7 @@ void Widget::onTryCreateTrayIcon()
             }
 
 #ifdef Q_OS_MAC
-            qt_mac_set_dock_menu(Nexus::getInstance().dockMenu);
+            Nexus::getInstance().dockMenu->setAsDockMenu();
 #endif
         } else if (!isVisible()) {
             show();

--- a/test/model/groupmessagedispatcher_test.cpp
+++ b/test/model/groupmessagedispatcher_test.cpp
@@ -26,6 +26,7 @@
 #include <QObject>
 #include <QtTest/QtTest>
 
+#include <set>
 #include <deque>
 
 


### PR DESCRIPTION
This commit aims to bring Mac OSX specific code into Qt 5.13 compliance.

This PR will be WIP until ready to utilize TravisCI as I am unable to test Mac OSX functionality directly (Apple licenses forbid running OSX VM on non-Apple hardware.)

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5745)
<!-- Reviewable:end -->
