### PR TITLE
fix(chatform): crash after opening chat in new window

### DIFF
--- a/src/widget/contentdialog.cpp
+++ b/src/widget/contentdialog.cpp
@@ -151,7 +151,7 @@ FriendWidget* ContentDialog::addFriend(std::shared_ptr<FriendChatroom> chatroom,
 {
     const auto compact = Settings::getInstance().getCompactLayout();
     auto frnd = chatroom->getFriend();
-    auto friendPk = frnd->getPublicKey();
+    const auto& friendPk = frnd->getPublicKey();
     auto friendWidget = new FriendWidget(chatroom, compact);
     emit connectFriendWidget(*friendWidget);
     contactWidgets[friendPk] = friendWidget;
@@ -172,7 +172,7 @@ FriendWidget* ContentDialog::addFriend(std::shared_ptr<FriendChatroom> chatroom,
 GroupWidget* ContentDialog::addGroup(std::shared_ptr<GroupChatroom> chatroom, GenericChatForm* form)
 {
     const auto g = chatroom->getGroup();
-    const auto groupId = g->getPersistentId();
+    const auto& groupId = g->getPersistentId();
     const auto compact = Settings::getInstance().getCompactLayout();
     auto groupWidget = new GroupWidget(chatroom, compact);
     contactWidgets[groupId] = groupWidget;

--- a/src/widget/contentdialogmanager.cpp
+++ b/src/widget/contentdialogmanager.cpp
@@ -63,7 +63,7 @@ FriendWidget* ContentDialogManager::addFriendToDialog(ContentDialog* dialog,
                                                       GenericChatForm* form)
 {
     auto friendWidget = dialog->addFriend(chatroom, form);
-    const auto friendPk = friendWidget->getFriend()->getPublicKey();
+    const auto& friendPk = friendWidget->getFriend()->getPublicKey();
 
     ContentDialog* lastDialog = getFriendDialog(friendPk);
     if (lastDialog) {


### PR DESCRIPTION
When you open a chat in a new window, the application crashes after a while 
OS: Ubuntu 16.04 x64
Qt: 5.5, 5.8

Steps to reproduce:

1. Immediately after start qTox open chat in new window
2. Wait a few seconds

Apparently using a reference to a local object resulted in segfault
This PR fixes it

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5746)
<!-- Reviewable:end -->
