### PR TITLE
feat/appimage delta updater

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 option(PLATFORM_EXTENSIONS "Enable platform specific extensions, requires extra dependencies" ON)
 option(USE_FILTERAUDIO "Enable the echo canceling backend" ON)
 option(UPDATE_CHECK "Enable automatic update check" ON)
+option(APPIMAGE_UPDATER_BRIDGE "Use AppImageUpdaterBridge to do the update" OFF)
 option(USE_CCACHE "Use ccache when available" ON)
 option(SPELL_CHECK "Enable spell cheching support" ON)
 option(SVGZ_ICON "Compress the SVG icon of qTox" ON)
@@ -690,6 +691,13 @@ endif()
 
 if(${UPDATE_CHECK})
     add_definitions(-DUPDATE_CHECK_ENABLED=1)
+    if(APPIMAGE_UPDATER_BRIDGE_SRC_DIR AND APPIMAGE_UPDATER_BRIDGE_BUILD_DIR)
+        message(STATUS "using AppImageUpdaterBridge")
+        add_definitions(-DAPPIMAGE_UPDATER_BRIDGE_ENABLED=1)
+        include_directories(${APPIMAGE_UPDATER_BRIDGE_SRC_DIR})
+    else()
+        message(STATUS "NOT using AppImageUpdaterBridge")
+    endif()
     set(${PROJECT_NAME}_SOURCES ${${PROJECT_NAME}_SOURCES}
         src/net/updatecheck.cpp
         src/net/updatecheck.h)
@@ -729,10 +737,18 @@ add_library(${PROJECT_NAME}_static
   ${${PROJECT_NAME}_SOURCES}
   ${${PROJECT_NAME}_QM_FILES}
   ${${PROJECT_NAME}_RESOURCES})
-target_link_libraries(${PROJECT_NAME}_static
-  ${CMAKE_REQUIRED_LIBRARIES}
-  ${ALL_LIBRARIES})
 
+if(APPIMAGE_UPDATER_BRIDGE_BUILD_DIR AND APPIMAGE_UPDATER_BRIDGE_SRC_DIR AND UPDATE_CHECK)
+    target_link_libraries(${PROJECT_NAME}_static
+    ${CMAKE_REQUIRED_LIBRARIES}
+    ${ALL_LIBRARIES}
+    ${APPIMAGE_UPDATER_BRIDGE_BUILD_DIR}/libAppImageUpdaterBridge.a)
+else()
+    target_link_libraries(${PROJECT_NAME}_static
+    ${CMAKE_REQUIRED_LIBRARIES}
+    ${ALL_LIBRARIES})
+endif()
+  
 add_executable(${PROJECT_NAME}
   WIN32
   MACOSX_BUNDLE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,11 @@ if(APPLE)
     /usr/local/opt/openal-soft/lib/pkgconfig:$ENV{PKG_CONFIG_PATH})
 endif()
 
+if(${APPIMAGE_UPDATER_BRIDGE})
+  set(ENV{PKG_CONFIG_PATH}
+    /usr/local/lib/pkgconfig:$ENV{PKG_CONFIG_PATH})
+endif()
+
 execute_process(
   COMMAND brew --prefix qt5
   OUTPUT_VARIABLE QT_PREFIX_PATH
@@ -691,12 +696,16 @@ endif()
 
 if(${UPDATE_CHECK})
     add_definitions(-DUPDATE_CHECK_ENABLED=1)
-    if(APPIMAGE_UPDATER_BRIDGE_SRC_DIR AND APPIMAGE_UPDATER_BRIDGE_BUILD_DIR)
-        message(STATUS "using AppImageUpdaterBridge")
-        add_definitions(-DAPPIMAGE_UPDATER_BRIDGE_ENABLED=1)
-        include_directories(${APPIMAGE_UPDATER_BRIDGE_SRC_DIR})
+    if(${APPIMAGE_UPDATER_BRIDGE})
+        search_dependency(AIUB  PACKAGE AppImageUpdaterBridge)
+        if(AIUB_FOUND)
+		message(STATUS "using AppImageUpdaterBridge")
+                add_definitions(-DAPPIMAGE_UPDATER_BRIDGE_ENABLED=1)
+	else()
+                message(STATUS "cannot find AppImageUpdaterBridge , ignoring cmake flag")
+        endif()
     else()
-        message(STATUS "NOT using AppImageUpdaterBridge")
+        message(STATUS "not using AppImageUpdaterBridge")
     endif()
     set(${PROJECT_NAME}_SOURCES ${${PROJECT_NAME}_SOURCES}
         src/net/updatecheck.cpp
@@ -737,18 +746,10 @@ add_library(${PROJECT_NAME}_static
   ${${PROJECT_NAME}_SOURCES}
   ${${PROJECT_NAME}_QM_FILES}
   ${${PROJECT_NAME}_RESOURCES})
+target_link_libraries(${PROJECT_NAME}_static
+  ${CMAKE_REQUIRED_LIBRARIES}
+  ${ALL_LIBRARIES})
 
-if(APPIMAGE_UPDATER_BRIDGE_BUILD_DIR AND APPIMAGE_UPDATER_BRIDGE_SRC_DIR AND UPDATE_CHECK)
-    target_link_libraries(${PROJECT_NAME}_static
-    ${CMAKE_REQUIRED_LIBRARIES}
-    ${ALL_LIBRARIES}
-    ${APPIMAGE_UPDATER_BRIDGE_BUILD_DIR}/libAppImageUpdaterBridge.a)
-else()
-    target_link_libraries(${PROJECT_NAME}_static
-    ${CMAKE_REQUIRED_LIBRARIES}
-    ${ALL_LIBRARIES})
-endif()
-  
 add_executable(${PROJECT_NAME}
   WIN32
   MACOSX_BUNDLE

--- a/appimage/build-appimage.sh
+++ b/appimage/build-appimage.sh
@@ -31,7 +31,7 @@ readonly DEBUG="$1"
 
 # Set this to True to upload the PR version of the 
 # AppImage to transfer.sh for testing.
-readonly UPLOAD_PR_APPIMAGE="True"
+readonly UPLOAD_PR_APPIMAGE="False"
 
 # Fail out on error
 set -exo pipefail

--- a/appimage/build-appimage.sh
+++ b/appimage/build-appimage.sh
@@ -2,7 +2,7 @@
 
 # MIT License
 #
-# Copyright © 2018 by The qTox Project Contributors
+# Copyright © 2019 by The qTox Project Contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -137,7 +137,8 @@ cd _build
 # need to build with -DDESKTOP_NOTIFICATIONS=True for snorenotify
 cmake -DDESKTOP_NOTIFICATIONS=True \
       -DUPDATE_CHECK=True \
-      -DAPPIMAGE_UPDATER_BRIDGE=True
+      -DAPPIMAGE_UPDATER_BRIDGE=True \
+      ../
 
 make
 

--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -191,6 +191,12 @@ eval "$LDQT_BIN $QTOX_DESKTOP_FILE -bundle-non-qt-libs -extra-plugins=libsnore-q
 mv "$QTOX_APP_DIR"/usr/* "$QTOX_APP_DIR/"
 rm -rf "$QTOX_APP_DIR/usr"
 
+# copy OpenSSL libs to AppImage
+# Warning: This is hard coded to debain:stretch.
+cp /usr/lib/x86_64-linux-gnu/libssl.so* "$QTOX_APP_DIR/local/lib/"
+cp /usr/lib/x86_64-linux-gnu/libcrypt.so* "$QTOX_APP_DIR/local/lib/"
+cp /usr/lib/x86_64-linux-gnu/libcrypto.so* "$QTOX_APP_DIR/local/lib"
+
 # this is important , aitool automatically uses the same filename in .zsync meta file.
 # if this name does not match with the one we upload , the update always fails.
 if [ -n "$TRAVIS_TAG" ]

--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -2,7 +2,7 @@
 
 # MIT License
 #
-# Copyright © 2018 by The qTox Project Contributors
+# Copyright © 2019 by The qTox Project Contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -117,8 +117,9 @@ git checkout tags/v1.1.2
 mkdir $AUB_BUILD_DIR
 cd $AUB_BUILD_DIR
 cmake .. -DLOGGING_DISABLED=ON
-make
 
+make
+make install
 
 # copy qtox source
 cp -r "$QTOX_SRC_DIR" "$QTOX_BUILD_DIR"
@@ -136,8 +137,7 @@ cd _build
 # need to build with -DDESKTOP_NOTIFICATIONS=True for snorenotify
 cmake -DDESKTOP_NOTIFICATIONS=True \
       -DUPDATE_CHECK=True \
-      -DAPPIMAGE_UPDATER_BRIDGE_SRC_DIR="$AUB_SRC_DIR" \
-      -DAPPIMAGE_UPDATER_BRIDGE_BUILD_DIR="$AUB_BUILD_DIR" ../
+      -DAPPIMAGE_UPDATER_BRIDGE=True
 
 make
 

--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -196,6 +196,8 @@ rm -rf "$QTOX_APP_DIR/usr"
 cp /usr/lib/x86_64-linux-gnu/libssl.so* "$QTOX_APP_DIR/local/lib/"
 cp /usr/lib/x86_64-linux-gnu/libcrypt.so* "$QTOX_APP_DIR/local/lib/"
 cp /usr/lib/x86_64-linux-gnu/libcrypto.so* "$QTOX_APP_DIR/local/lib"
+# Also bundle libjack.so* without which the AppImage does not work in Fedora Workstation
+cp /usr/lib/x86_64-linux-gnu/libjack.so* "$QTOX_APP_DIR/local/lib"
 
 # this is important , aitool automatically uses the same filename in .zsync meta file.
 # if this name does not match with the one we upload , the update always fails.

--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -22,7 +22,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-
 # Fail out on error
 set -exuo pipefail
 
@@ -110,11 +109,11 @@ LDFLAGS="-lcrypto"
 make
 make install
 
-# build aub into a static library and later use it in 
+# build aub into a static library and later use it in
 # qTox
 git clone "$AUB_GIT" "$AUB_SRC_DIR"
 cd "$AUB_SRC_DIR" # we need to checkout first
-git checkout tags/v1.1.1
+git checkout tags/v1.1.2
 mkdir $AUB_BUILD_DIR
 cd $AUB_BUILD_DIR
 cmake .. -DLOGGING_DISABLED=ON

--- a/src/net/updatecheck.cpp
+++ b/src/net/updatecheck.cpp
@@ -19,7 +19,14 @@
 #include "src/net/updatecheck.h"
 #include "src/persistence/settings.h"
 
+#ifndef APPIMAGE_UPDATER_BRIDGE_ENABLED
 #include <QNetworkAccessManager>
+#else
+#include <QApplication>
+#include <QScreen>
+#include <AppImageUpdaterBridge>
+#include <AppImageUpdaterDialog>
+#endif
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QRegularExpression>
@@ -29,16 +36,34 @@
 #include <QDebug>
 #include <cassert>
 
+#ifndef APPIMAGE_UPDATER_BRIDGE_ENABLED
 namespace {
-    const QString versionUrl{QStringLiteral("https://api.github.com/repos/qTox/qTox/releases/latest")};
+const QString versionUrl{QStringLiteral("https://api.github.com/repos/qTox/qTox/releases/latest")};
 } // namespace
+#else
+using AppImageUpdaterBridge::AppImageDeltaRevisioner;
+using AppImageUpdaterBridge::AppImageUpdaterDialog;
+#endif
 
 UpdateCheck::UpdateCheck(const Settings& settings)
     : settings(settings)
 {
     updateTimer.start(1000 * 60 * 60 * 24 /* 1 day */);
     connect(&updateTimer, &QTimer::timeout, this, &UpdateCheck::checkForUpdate);
+#ifndef APPIMAGE_UPDATER_BRIDGE_ENABLED
     connect(&manager, &QNetworkAccessManager::finished, this, &UpdateCheck::handleResponse);
+#else
+    connect(&revisioner, &AppImageDeltaRevisioner::updateAvailable, this, &UpdateCheck::handleUpdate);
+    connect(&revisioner, &AppImageDeltaRevisioner::error, this, &UpdateCheck::updateCheckFailed,
+            Qt::DirectConnection);
+
+    updateDialog.reset(new AppImageUpdaterDialog(QPixmap(":/img/icons/qtox.svg")));
+    connect(updateDialog.data(), &AppImageUpdaterDialog::quit, QApplication::instance(),
+            &QApplication::quit, Qt::QueuedConnection);
+    connect(updateDialog.data(), &AppImageUpdaterDialog::canceled, this, &UpdateCheck::handleUpdateEnd);
+    connect(updateDialog.data(), &AppImageUpdaterDialog::finished, this, &UpdateCheck::handleUpdateEnd);
+    connect(updateDialog.data(), &AppImageUpdaterDialog::error, this, &UpdateCheck::handleUpdateEnd);
+#endif
 }
 
 void UpdateCheck::checkForUpdate()
@@ -47,11 +72,30 @@ void UpdateCheck::checkForUpdate()
         // still run the timer to check periodically incase setting changes
         return;
     }
+#ifndef APPIMAGE_UPDATER_BRIDGE_ENABLED
     manager.setProxy(settings.getProxy());
     QNetworkRequest request{versionUrl};
     manager.get(request);
+#else
+    revisioner.clear();
+    revisioner.setProxy(settings.getProxy());
+    revisioner.checkForUpdate();
+#endif
 }
 
+#ifdef APPIMAGE_UPDATER_BRIDGE_ENABLED
+void UpdateCheck::initUpdate()
+{
+    disconnect(&revisioner, &AppImageDeltaRevisioner::updateAvailable, this,
+               &UpdateCheck::handleUpdate);
+    disconnect(&revisioner, &AppImageDeltaRevisioner::error, this, &UpdateCheck::updateCheckFailed);
+    updateDialog->move(QGuiApplication::primaryScreen()->geometry().center()
+                       - updateDialog->rect().center());
+    updateDialog->init(&revisioner);
+}
+#endif
+
+#ifndef APPIMAGE_UPDATER_BRIDGE_ENABLED
 void UpdateCheck::handleResponse(QNetworkReply *reply)
 {
     assert(reply != nullptr);
@@ -92,3 +136,23 @@ void UpdateCheck::handleResponse(QNetworkReply *reply)
     }
     reply->deleteLater();
 }
+#else
+void UpdateCheck::handleUpdate(bool aval)
+{
+    if (aval) {
+        qInfo() << "Update available";
+        emit updateAvailable();
+        return;
+    }
+    qInfo() << "qTox is up to date";
+    emit upToDate();
+}
+
+void UpdateCheck::handleUpdateEnd()
+{
+    connect(&revisioner, &AppImageDeltaRevisioner::error, this, &UpdateCheck::updateCheckFailed,
+            (Qt::ConnectionType)(Qt::DirectConnection | Qt::UniqueConnection));
+    connect(&revisioner, &AppImageDeltaRevisioner::updateAvailable, this,
+            &UpdateCheck::handleUpdate, Qt::UniqueConnection);
+}
+#endif // APPIMAGE_UPDATER_BRIDGE_ENABLED

--- a/src/net/updatecheck.cpp
+++ b/src/net/updatecheck.cpp
@@ -27,13 +27,13 @@
 #include <AppImageUpdaterBridge>
 #include <AppImageUpdaterDialog>
 #endif
+#include <QDebug>
 #include <QJsonDocument>
 #include <QJsonObject>
-#include <QRegularExpression>
 #include <QNetworkReply>
 #include <QObject>
+#include <QRegularExpression>
 #include <QTimer>
-#include <QDebug>
 #include <cassert>
 
 #ifndef APPIMAGE_UPDATER_BRIDGE_ENABLED
@@ -96,7 +96,7 @@ void UpdateCheck::initUpdate()
 #endif
 
 #ifndef APPIMAGE_UPDATER_BRIDGE_ENABLED
-void UpdateCheck::handleResponse(QNetworkReply *reply)
+void UpdateCheck::handleResponse(QNetworkReply* reply)
 {
     assert(reply != nullptr);
     if (reply == nullptr) {
@@ -129,8 +129,7 @@ void UpdateCheck::handleResponse(QNetworkReply *reply)
         qInfo() << "Update available to version" << latestVersion;
         QUrl link{mainMap["html_url"].toString()};
         emit updateAvailable(latestVersion, link);
-    }
-    else {
+    } else {
         qInfo() << "qTox is up to date";
         emit upToDate();
     }

--- a/src/net/updatecheck.h
+++ b/src/net/updatecheck.h
@@ -57,6 +57,10 @@ private slots:
 #ifdef APPIMAGE_UPDATER_BRIDGE_ENABLED
 public slots:
     void initUpdate();
+
+private slots:
+    void handleUpdate(bool);
+    void handleUpdateEnd();
 #endif
 
 private:

--- a/src/net/updatecheck.h
+++ b/src/net/updatecheck.h
@@ -20,6 +20,12 @@
 #include <QNetworkAccessManager>
 #include <QTimer>
 
+#ifdef APPIMAGE_UPDATER_BRIDGE_ENABLED
+#include <QScopedPointer>
+#include <AppImageUpdaterBridge>
+#include <AppImageUpdaterDialog>
+#endif // APPIMAGE_UPDATER_BRIDGE_ENABLED
+
 #include <memory>
 
 class Settings;
@@ -35,15 +41,29 @@ public:
     void checkForUpdate();
 
 signals:
+#ifndef APPIMAGE_UPDATER_BRIDGE_ENABLED
     void updateAvailable(QString latestVersion, QUrl link);
+#else
+    void updateAvailable();
+#endif
     void upToDate();
     void updateCheckFailed();
 
+#ifndef APPIMAGE_UPDATER_BRIDGE_ENABLED
 private slots:
-    void handleResponse(QNetworkReply *reply);
+    void handleResponse(QNetworkReply* reply);
+
+public slots:
+    void initUpdate();
+#else
 
 private:
+#ifndef APPIMAGE_UPDATER_BRIDGE_ENABLED
     QNetworkAccessManager manager;
+#else
+    AppImageUpdaterBridge::AppImageDeltaRevisioner revisioner;
+    QScopedPointer<AppImageUpdaterBridge::AppImageUpdaterDialog> updateDialog;
+#endif // APPIMAGE_UPDATER_BRIDGE_ENABLED
     QTimer updateTimer;
     const Settings& settings;
 };

--- a/src/net/updatecheck.h
+++ b/src/net/updatecheck.h
@@ -16,8 +16,8 @@
     You should have received a copy of the GNU General Public License
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <QObject>
 #include <QNetworkAccessManager>
+#include <QObject>
 #include <QTimer>
 
 #ifdef APPIMAGE_UPDATER_BRIDGE_ENABLED

--- a/src/net/updatecheck.h
+++ b/src/net/updatecheck.h
@@ -52,10 +52,12 @@ signals:
 #ifndef APPIMAGE_UPDATER_BRIDGE_ENABLED
 private slots:
     void handleResponse(QNetworkReply* reply);
+#endif
 
+#ifdef APPIMAGE_UPDATER_BRIDGE_ENABLED
 public slots:
     void initUpdate();
-#else
+#endif
 
 private:
 #ifndef APPIMAGE_UPDATER_BRIDGE_ENABLED

--- a/src/widget/form/settings/aboutform.cpp
+++ b/src/widget/form/settings/aboutform.cpp
@@ -96,6 +96,10 @@ void AboutForm::replaceVersions()
         connect(updateCheck, &UpdateCheck::updateAvailable, this, &AboutForm::onUpdateAvailable);
         connect(updateCheck, &UpdateCheck::upToDate, this, &AboutForm::onUpToDate);
         connect(updateCheck, &UpdateCheck::updateCheckFailed, this, &AboutForm::onUpdateCheckFailed);
+#ifdef APPIMAGE_UPDATER_BRIDGE_ENABLED
+        connect(bodyUI->updateAvailableButton, &QPushButton::clicked, updateCheck,
+                &UpdateCheck::initUpdate);
+#endif
     } else {
         qWarning() << "AboutForm passed null UpdateCheck!";
     }
@@ -165,6 +169,7 @@ void AboutForm::replaceVersions()
     bodyUI->authorInfo->setText(authorInfo);
 }
 
+#ifndef APPIMAGE_UPDATER_BRIDGE_ENABLED
 void AboutForm::onUpdateAvailable(QString latestVersion, QUrl link)
 {
     QObject::disconnect(linkConnection);
@@ -173,6 +178,12 @@ void AboutForm::onUpdateAvailable(QString latestVersion, QUrl link)
     });
     bodyUI->updateStack->setCurrentIndex(static_cast<int>(updateIndex::available));
 }
+#else
+void AboutForm::onUpdateAvailable()
+{
+    bodyUI->updateStack->setCurrentIndex(static_cast<int>(updateIndex::available));
+}
+#endif
 
 void AboutForm::onUpToDate()
 {

--- a/src/widget/form/settings/aboutform.cpp
+++ b/src/widget/form/settings/aboutform.cpp
@@ -20,17 +20,17 @@
 #include "aboutform.h"
 #include "ui_aboutsettings.h"
 
-#include "src/widget/tool/recursivesignalblocker.h"
 #include "src/net/updatecheck.h"
-#include "src/widget/style.h"
-#include "src/widget/translator.h"
 #include "src/persistence/profile.h"
 #include "src/persistence/settings.h"
+#include "src/widget/style.h"
+#include "src/widget/tool/recursivesignalblocker.h"
+#include "src/widget/translator.h"
 
 #include <tox/tox.h>
 
 #include <QDebug>
-#include <QDesktopServices> 
+#include <QDesktopServices>
 #include <QPushButton>
 #include <QTimer>
 
@@ -173,9 +173,8 @@ void AboutForm::replaceVersions()
 void AboutForm::onUpdateAvailable(QString latestVersion, QUrl link)
 {
     QObject::disconnect(linkConnection);
-    linkConnection = connect(bodyUI->updateAvailableButton, &QPushButton::clicked, [link](){
-        QDesktopServices::openUrl(link);
-    });
+    linkConnection = connect(bodyUI->updateAvailableButton, &QPushButton::clicked,
+                             [link]() { QDesktopServices::openUrl(link); });
     bodyUI->updateStack->setCurrentIndex(static_cast<int>(updateIndex::available));
 }
 #else

--- a/src/widget/form/settings/aboutform.h
+++ b/src/widget/form/settings/aboutform.h
@@ -45,7 +45,11 @@ public:
     }
 
 public slots:
+#ifndef APPIMAGE_UPDATER_BRIDGE_ENABLED
     void onUpdateAvailable(QString latestVersion, QUrl link);
+#else
+    void onUpdateAvailable();
+#endif
     void onUpToDate();
     void onUpdateCheckFailed();
 
@@ -58,7 +62,9 @@ private:
     Ui::AboutSettings* bodyUI;
     QTimer* progressTimer;
     UpdateCheck* updateCheck;
+#ifndef APPIMAGE_UPDATER_BRIDGE_ENABLED
     QMetaObject::Connection linkConnection;
+#endif
 };
 
 #endif // ABOUTFORM_H

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1791,7 +1791,7 @@ void Widget::toggleFullscreen()
     }
 }
 
-void Widget::onUpdateAvailable(QString /*latestVersion*/, QUrl /*link*/)
+void Widget::onUpdateAvailable()
 {
     ui->settingsButton->setProperty("update-available", true);
     ui->settingsButton->style()->unpolish(ui->settingsButton);

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -192,7 +192,7 @@ public slots:
     void onGroupDialogShown(Group* g);
     void toggleFullscreen();
     void refreshPeerListsLocal(const QString& username);
-    void onUpdateAvailable(QString latestVersion, QUrl link);
+    void onUpdateAvailable();
     void onCoreChanged(Core& core);
 
 signals:


### PR DESCRIPTION
- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

> This PR implements the delta updater as mentioned in #5643 for qTox AppImages. The delta updater is only used for AppImage builds and does not break the source code for other platforms. This delta updater is integrated along with UpdateCheck class and uses the existing UI for notifying the update available button. Without the CMake build options , the delta updater library is never touched.

This PR is a re-post of https://github.com/qTox/qTox/pull/5690, This PR was opened because Travis-CI was not tracking the old PR and this also to fixes merge conflicts that was present in the old PR. This is a fresh PR which does the same thing as https://github.com/qTox/qTox/pull/5690

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5747)
<!-- Reviewable:end -->
