### PR TITLE
chore(TraviCI): temporarily disable MacOS builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -144,24 +144,6 @@ jobs:
         directories:
           - /opt/build-windows/x86_64
     - stage: "macOS, AppImage and Flatpak"
-      os: osx
-      osx_image: xcode9.2
-      env: JOB=build-osx
-      cache:
-        timeout: 300 # seconds
-        ccache: true
-        directories:
-          - $HOME/Library/Caches/Homebrew
-      before_cache:
-        - brew cleanup
-      script:
-        - "./.travis/$JOB.sh"
-        - export ARTIFACTS_DIR="$(mktemp -d)"
-        - cp -a ./{qTox.dmg,qTox.dmg.sha256} "$ARTIFACTS_DIR"
-        - .travis/cirp/cleanup1.sh
-        - .travis/cirp/store.sh "$ARTIFACTS_DIR"
-        - .travis/cirp/cleanup2.sh
-    - stage: "macOS, AppImage and Flatpak"
       os: linux
       env: JOB=APPIMAGE
       script:


### PR DESCRIPTION
- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5748)
<!-- Reviewable:end -->
