### PR TITLE
Fix the latest nightly release not updating sometimes

### DIFF
--- a/.travis/cirp/install.sh
+++ b/.travis/cirp/install.sh
@@ -53,9 +53,9 @@ if ! pip list --format=columns | grep '^ci-release-publisher '
 then
   cd .
   cd "$(mktemp -d)"
-  VERSION="0.1.0"
+  VERSION="0.2.0a3"
   FILENAME="ci_release_publisher-$VERSION-py3-none-any.whl"
-  HASH="384bd9e2b0dd344381c01948e567bb26151636d6fd9b70fc58ef94aeb6be9466"
+  HASH="399d0c645ea115d72c646c87e3b4094af04018c5bcb6a95abed4c09cdeec8bd3"
   pip download ci_release_publisher==$VERSION
   check_sha256 "$HASH" "$FILENAME"
   pip install --no-index --find-links "$PWD" "$FILENAME"

--- a/.travis/cirp/publish.sh
+++ b/.travis/cirp/publish.sh
@@ -24,6 +24,7 @@ ARTIFACTS_DIR="$1"
 
 ci-release-publisher publish --latest-release \
                              --latest-release-prerelease \
+                             --latest-release-check-event-type cron \
                              --numbered-release \
                              --numbered-release-keep-count 3 \
                              --numbered-release-prerelease \


### PR DESCRIPTION
We have discussed this with @sudden6 a month or so ago, when we noticed that [the Latest Release](https://github.com/qTox/qTox-nightly-releases/releases/tag/ci-master-latest) wasn't updating when there was a new build created on Travis-CI while the cron build was running. Basically the scenario of https://github.com/nurupo/ci-release-publisher/issues/1. It has since been fixed and v0.2.0a3 should be good to use, based on my testing of publishing qTox nighties off my fork qTox repo into my other repo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5750)
<!-- Reviewable:end -->
