### PR TITLE
remove extra comma in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ the encrypted peer-to-peer Tox protocol.
 
 Windows | Linux | OS X | FreeBSD
 --------|-------|------|--------
-**[64 bit release]**| **[Arch]**, , **[Debian]**, **[Fedora]**, **[Gentoo]**, **[openSUSE]**, **[Ubuntu]** | **[Latest release]**  | **[Package & Port]**
+**[64 bit release]**| **[Arch]**, **[Debian]**, **[Fedora]**, **[Gentoo]**, **[openSUSE]**, **[Ubuntu]** | **[Latest release]**  | **[Package & Port]**
 [32 bit release]|**[AppImage]**, [Flatpak] | [Building instructions] |
 [64 bit][64nightly], [32 bit][32nightly] nightly | [From Source] | |
 


### PR DESCRIPTION
- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

This is a very minor change mostly not needed. This PR just removes the extra comma in the tabulation under the Linux column.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5756)
<!-- Reviewable:end -->
