### PR TITLE
fix(group): use valid pointer, allowing source invalidation

### DIFF
--- a/src/core/toxcall.cpp
+++ b/src/core/toxcall.cpp
@@ -295,12 +295,11 @@ void ToxGroupCall::removePeer(ToxPk peerId)
 void ToxGroupCall::addPeer(ToxPk peerId)
 {
     std::unique_ptr<IAudioSink> newSink = audio.makeSink();
-    peers.emplace(peerId, std::move(newSink));
-
     QMetaObject::Connection con =
         QObject::connect(newSink.get(), &IAudioSink::invalidated,
                          [this, peerId]() { this->onAudioSinkInvalidated(peerId); });
 
+    peers.emplace(peerId, std::move(newSink));
     sinkInvalid.insert({peerId, con});
 }
 


### PR DESCRIPTION
Fix #5681

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5757)
<!-- Reviewable:end -->
