### PR TITLE
fix(calls): create dummy source for invalidated callback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,6 +262,8 @@ set(${PROJECT_NAME}_SOURCES
   src/audio/backend/alsink.h
   src/audio/backend/alsource.cpp
   src/audio/backend/alsource.h
+  src/audio/backend/dummysource.cpp
+  src/audio/backend/dummysource.h
   src/audio/backend/openal.cpp
   src/audio/backend/openal.h
   src/audio/iaudiosettings.h

--- a/src/audio/backend/alsource.h
+++ b/src/audio/backend/alsource.h
@@ -36,9 +36,9 @@ public:
     AlSource& operator=(AlSource&& other) = delete;
     ~AlSource();
 
-    operator bool() const;
+    operator bool() const override;
 
-    void kill();
+    void kill() override;
 
 private:
     OpenAL& audio;

--- a/src/audio/backend/dummysource.h
+++ b/src/audio/backend/dummysource.h
@@ -17,33 +17,32 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef IAUDIOSOURCE_H
-#define IAUDIOSOURCE_H
+#ifndef DUMMYSOURCE_H
+#define DUMMYSOURCE_H
 
+#include "src/audio/iaudiosource.h"
+#include <QMutex>
 #include <QObject>
+#include <atomic>
 
-/**
- * @fn void Audio::frameAvailable(const int16_t *pcm, size_t sample_count, uint8_t channels,
- * uint32_t sampling_rate);
- *
- * When there are input subscribers, we regularly emit captured audio frames with this signal
- * Always connect with a blocking queued connection lambda, else the behaviour is undefined
- */
-
-class IAudioSource : public QObject
+class OpenAL;
+class DummySource : public IAudioSource
 {
     Q_OBJECT
 public:
-    virtual ~IAudioSource() = default;
+    DummySource(OpenAL& al);
+    DummySource(DummySource& src) = delete;
+    DummySource& operator=(const DummySource&) = delete;
+    DummySource(DummySource&& other) = delete;
+    DummySource& operator=(DummySource&& other) = delete;
+    ~DummySource();
 
-    virtual operator bool() const = 0;
-    virtual void kill() = 0;
+    operator bool() const override;
+    void kill() override;
 
-signals:
-    void frameAvailable(const int16_t* pcm, size_t sample_count, uint8_t channels,
-                        uint32_t sampling_rate);
-    void volumeAvailable(float value);
-    void invalidated();
+private:
+    OpenAL& audio;
+    std::atomic<bool> killed{false};
 };
 
-#endif // IAUDIOSOURCE_H
+#endif // DUMMYSOURCE_H

--- a/src/audio/backend/openal.h
+++ b/src/audio/backend/openal.h
@@ -149,7 +149,7 @@ protected:
     // Qt containers need copy operators, so use stdlib containers
     std::unordered_set<AlSink*> sinks;
     std::unordered_set<AlSink*> soundSinks;
-    std::unordered_set<AlSource*> sources;
+    std::unordered_set<IAudioSource*> sources;
 
     int channels = 0;
     qreal gain = 0;

--- a/src/audio/backend/openal.h
+++ b/src/audio/backend/openal.h
@@ -53,45 +53,45 @@ public:
     OpenAL();
     virtual ~OpenAL();
 
-    qreal maxOutputVolume() const
+    qreal maxOutputVolume() const override
     {
         return 1;
     }
-    qreal minOutputVolume() const
+    qreal minOutputVolume() const override
     {
         return 0;
     }
-    qreal outputVolume() const;
-    void setOutputVolume(qreal volume);
+    qreal outputVolume() const override;
+    void setOutputVolume(qreal volume) override;
 
-    qreal minInputGain() const;
-    void setMinInputGain(qreal dB);
+    qreal minInputGain() const override;
+    void setMinInputGain(qreal dB) override;
 
-    qreal maxInputGain() const;
-    void setMaxInputGain(qreal dB);
+    qreal maxInputGain() const override;
+    void setMaxInputGain(qreal dB) override;
 
-    qreal inputGain() const;
-    void setInputGain(qreal dB);
+    qreal inputGain() const override;
+    void setInputGain(qreal dB) override;
 
-    qreal minInputThreshold() const;
-    qreal maxInputThreshold() const;
+    qreal minInputThreshold() const override;
+    qreal maxInputThreshold() const override;
 
-    qreal getInputThreshold() const;
-    void setInputThreshold(qreal normalizedThreshold);
+    qreal getInputThreshold() const override;
+    void setInputThreshold(qreal normalizedThreshold) override;
 
-    void reinitInput(const QString& inDevDesc);
-    bool reinitOutput(const QString& outDevDesc);
+    void reinitInput(const QString& inDevDesc) override;
+    bool reinitOutput(const QString& outDevDesc) override;
 
-    bool isOutputReady() const;
+    bool isOutputReady() const override;
 
-    QStringList outDeviceNames();
-    QStringList inDeviceNames();
+    QStringList outDeviceNames() override;
+    QStringList inDeviceNames() override;
 
-    std::unique_ptr<IAudioSink> makeSink();
+    std::unique_ptr<IAudioSink> makeSink() override;
     void destroySink(AlSink& sink);
 
-    std::unique_ptr<IAudioSource> makeSource();
-    void destroySource(AlSource& source);
+    std::unique_ptr<IAudioSource> makeSource() override;
+    void destroySource(IAudioSource& source);
 
     void startLoop(uint sourceId);
     void stopLoop(uint sourceId);

--- a/src/core/toxcall.cpp
+++ b/src/core/toxcall.cpp
@@ -261,7 +261,7 @@ void ToxGroupCall::onAudioSourceInvalidated()
     auto newSrc = audio.makeSource();
     // TODO(sudden6): move this to audio source
     audioInConn =
-        QObject::connect(audioSource.get(), &IAudioSource::frameAvailable,
+        QObject::connect(newSrc.get(), &IAudioSource::frameAvailable,
                          [this](const int16_t* pcm, size_t samples, uint8_t chans, uint32_t rate) {
                              this->av->sendGroupCallAudio(this->groupId, pcm, samples, chans, rate);
                          });


### PR DESCRIPTION
Fixes mute friend and group calls when mic is switched to disabled then back to a valid source. Now ToxCall can register to the DummySource, and re-register when the source is changed, like when two normal sources are used.

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5759)
<!-- Reviewable:end -->
