### PR TITLE
fix(chatform): fix a crash when there are no messages to load

### DIFF
--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -1099,6 +1099,10 @@ void GenericChatForm::loadHistoryLower()
 
 void GenericChatForm::loadHistoryUpper()
 {
+    if (messages.empty()) {
+        return;
+    }
+
     auto msg = messages.crbegin()->second;
     loadHistoryFrom(QDateTime());
     chatWidget->scrollToLine(msg);


### PR DESCRIPTION
- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

@TriKriSta This prevents a crash that sometimes happens when scrolling in an empty group. Can you review this and verify I'm not just masking the root cause?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5762)
<!-- Reviewable:end -->
