### PR TITLE
fix(widget): update local Widget Core pointer when changing core

### DIFF
--- a/src/nexus.cpp
+++ b/src/nexus.cpp
@@ -235,6 +235,7 @@ void Nexus::showMainGUI()
     connect(profile, &Profile::selfAvatarChanged, widget, &Widget::onSelfAvatarLoaded);
 
     connect(profile, &Profile::coreChanged, widget, &Widget::onCoreChanged);
+    connect(profile, &Profile::coreAVChanged, widget, &Widget::onCoreAVChanged);
 
     connect(profile, &Profile::failedToStart, widget, &Widget::onFailedToStartCore,
             Qt::BlockingQueuedConnection);
@@ -389,7 +390,7 @@ void Nexus::updateWindowsArg(QWindow* closedWindow)
         QAction* action = windowActions->addAction(windowList[i]->title());
         action->setCheckable(true);
         action->setChecked(windowList[i] == activeWindow);
-        connect(action, &QAction::triggered, [=] { onOpenWindow(windowList[i]);});
+        connect(action, &QAction::triggered, [=] { onOpenWindow(windowList[i]); });
         windowMenu->addAction(action);
         dockMenu->insertAction(dockLast, action);
     }

--- a/src/persistence/profile.cpp
+++ b/src/persistence/profile.cpp
@@ -420,6 +420,7 @@ void Profile::startCore()
     // kriby: code duplication belongs in initCore, but cannot yet due to Core/Profile coupling
     connect(core.get(), &Core::requestSent, this, &Profile::onRequestSent);
     emit coreChanged(*core);
+    emit coreAVChanged(*core);
 
     core->start();
 
@@ -915,18 +916,13 @@ void Profile::restartCore()
 
         // save to disk just in case
         if (saveToxSave(savedata)) {
-            qDebug() << "Restarting Core";
-            const bool isNewProfile{false};
+            qDebug() << "Restarting Core Tox Instance";
             IAudioControl* audioBak = core->getAv()->getAudio();
             assert(audioBak != nullptr);
-            initCore(savedata, Settings::getInstance(), isNewProfile);
+            disconnect(core->getAv());
+            core->remakeTox(savedata, &Settings::getInstance());
             core->getAv()->setAudio(*audioBak);
-
-            // kriby: code duplication belongs in initCore, but cannot yet due to Core/Profile coupling
-            connect(core.get(), &Core::requestSent, this, &Profile::onRequestSent);
-            emit coreChanged(*core);
-
-            core->start();
+            emit coreAVChanged(*core);
         } else {
             qCritical() << "Failed to save, not restarting core";
         }

--- a/src/persistence/profile.h
+++ b/src/persistence/profile.h
@@ -88,6 +88,7 @@ signals:
     void failedToStart();
     void badProxy();
     void coreChanged(Core& core);
+    void coreAVChanged(Core& core);
 
 public slots:
     void onRequestSent(const ToxPk& friendPk, const QString& message);

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -145,11 +145,6 @@ ChatForm::ChatForm(Friend* chatFriend, IChatLog& chatLog, IMessageDispatcher& me
     connect(core, &Core::friendStatusChanged, this, &ChatForm::onFriendStatusChanged);
     connect(coreFile, &CoreFile::fileNameChanged, this, &ChatForm::onFileNameChanged);
 
-    const CoreAV* av = core->getAv();
-    connect(av, &CoreAV::avInvite, this, &ChatForm::onAvInvite);
-    connect(av, &CoreAV::avStart, this, &ChatForm::onAvStart);
-    connect(av, &CoreAV::avEnd, this, &ChatForm::onAvEnd);
-
     connect(headWidget, &ChatFormHeader::callTriggered, this, &ChatForm::onCallTriggered);
     connect(headWidget, &ChatFormHeader::videoCallTriggered, this, &ChatForm::onVideoCallTriggered);
     connect(headWidget, &ChatFormHeader::micMuteToggle, this, &ChatForm::onMicMuteToggle);

--- a/src/widget/form/settings/advancedform.cpp
+++ b/src/widget/form/settings/advancedform.cpp
@@ -29,8 +29,8 @@
 
 #include "src/core/core.h"
 #include "src/core/coreav.h"
-#include "src/nexus.h"
 #include "src/model/status.h"
+#include "src/nexus.h"
 #include "src/persistence/profile.h"
 #include "src/persistence/settings.h"
 #include "src/widget/gui.h"
@@ -223,7 +223,7 @@ void AdvancedForm::on_reconnectButton_clicked()
         return;
     }
 
-    emit Core::getInstance()->statusSet(Status::Status::Offline);
+    Core::getInstance()->setStatus(Status::Status::Offline);
     Nexus::getProfile()->restartCore();
 }
 

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -663,7 +663,7 @@ void Widget::onSelfAvatarLoaded(const QPixmap& pic)
 
 void Widget::onCoreChanged(Core& core)
 {
-
+    this->core = &core;
     connect(&core, &Core::connected, this, &Widget::onConnected);
     connect(&core, &Core::disconnected, this, &Widget::onDisconnected);
     connect(&core, &Core::statusSet, this, &Widget::onStatusSet);

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -664,6 +664,7 @@ void Widget::onSelfAvatarLoaded(const QPixmap& pic)
 void Widget::onCoreChanged(Core& core)
 {
     this->core = &core;
+
     connect(&core, &Core::connected, this, &Widget::onConnected);
     connect(&core, &Core::disconnected, this, &Widget::onDisconnected);
     connect(&core, &Core::statusSet, this, &Widget::onStatusSet);
@@ -693,6 +694,29 @@ void Widget::onCoreChanged(Core& core)
     connect(this, &Widget::friendRequestAccepted, &core, &Core::acceptFriendRequest);
 
     sharedMessageProcessorParams.setPublicKey(core.getSelfPublicKey().toString());
+}
+
+void Widget::onCoreAVChanged(Core& core)
+{
+    const CoreAV* av = core.getAv();
+    connect(av, &CoreAV::avInvite, this, &Widget::onAvInvite);
+    connect(av, &CoreAV::avStart, this, &Widget::onAvStart);
+    connect(av, &CoreAV::avEnd, this, &Widget::onAvEnd);
+}
+
+void Widget::onAvInvite(uint32_t friendId, bool video)
+{
+    chatForms[core->getFriendPublicKey(friendId)]->onAvInvite(friendId, video);
+}
+
+void Widget::onAvStart(uint32_t friendId, bool video)
+{
+    chatForms[core->getFriendPublicKey(friendId)]->onAvStart(friendId, video);
+}
+
+void Widget::onAvEnd(uint32_t friendId, bool error)
+{
+    chatForms[core->getFriendPublicKey(friendId)]->onAvEnd(friendId, error);
 }
 
 void Widget::onConnected()

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1121,6 +1121,9 @@ void Widget::onRejectCall(uint32_t friendId)
 
 void Widget::addFriend(uint32_t friendId, const ToxPk& friendPk)
 {
+    if (FriendList::findFriend(friendPk)) {
+        return;
+    }
     settings.updateFriendAddress(friendPk.toString());
 
     Friend* newfriend = FriendList::addFriend(friendId, friendPk);

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -194,6 +194,7 @@ public slots:
     void refreshPeerListsLocal(const QString& username);
     void onUpdateAvailable();
     void onCoreChanged(Core& core);
+    void onCoreAVChanged(Core& core);
 
 signals:
     void friendRequestAccepted(const ToxPk& friendPk);
@@ -244,6 +245,9 @@ private slots:
     void searchCircle(CircleWidget& circleWidget);
     void updateFriendActivity(const Friend& frnd);
     void registerContentDialog(ContentDialog& contentDialog) const;
+    void onAvInvite(uint32_t friendId, bool video);
+    void onAvStart(uint32_t friendId, bool video);
+    void onAvEnd(uint32_t friendId, bool error);
 
 private:
     // QMainWindow overrides


### PR DESCRIPTION
Widget carried a Core* that wasn't being updated when changing Core, this commit fixes that. Widget::addFriend would add duplicate friends when restarting a Core, so a check was added to prevent adding duplicates of friends.

Fixes #5758

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5766)
<!-- Reviewable:end -->
