### PR TITLE
fix(chatform): fix stuck spinner on messages not at end of chatform

### DIFF
--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -1089,11 +1089,6 @@ void GenericChatForm::renderMessages(ChatLogIdx begin, ChatLogIdx end,
     QList<ChatLine::Ptr> beforeLines;
     QList<ChatLine::Ptr> afterLines;
 
-    if (!messages.empty() && !(messages.rbegin()->first == begin || messages.begin()->first == end
-                              || messages.rbegin()->first.get() + 1 == begin.get())) {
-        return;
-    }
-
     for (auto i = begin; i < end; ++i) {
         auto chatMessage = getChatMessageForIdx(i, messages);
         renderItem(chatLog.at(i), needsToHideName(i), colorizeNames, chatMessage);


### PR DESCRIPTION
Fix #5763

remove restriction to not update messages not in last slot in chatform,
allowing completed messages to be timestamped at any position. Fixes
stuck spinner in cases where a second message was sent quickly, or an
incoming message was received before the last send message was completed.

@sphaerophoria does this seem reasonable? Is there a good reason for that check to exist?

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5771)
<!-- Reviewable:end -->
