### PR TITLE
fix: remove reconnect button

### DIFF
--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -190,16 +190,6 @@ void CoreAV::process()
 }
 
 /**
- * @brief Check, if any calls are currently active.
- * @return true if any calls are currently active, false otherwise
- * @note A call about to start is not yet active.
- */
-bool CoreAV::anyActiveCalls() const
-{
-    return !calls.empty();
-}
-
-/**
  * @brief Checks the call status for a Tox friend.
  * @param f the friend to check
  * @return true, if call is started for the friend, false otherwise

--- a/src/core/coreav.h
+++ b/src/core/coreav.h
@@ -52,7 +52,6 @@ public:
 
     ~CoreAV();
 
-    bool anyActiveCalls() const;
     bool isCallStarted(const Friend* f) const;
     bool isCallStarted(const Group* f) const;
     bool isCallActive(const Friend* f) const;

--- a/src/persistence/profile.cpp
+++ b/src/persistence/profile.cpp
@@ -787,40 +787,6 @@ const ToxEncrypt* Profile::getPasskey() const
 }
 
 /**
- * @brief Delete core and restart a new one
- */
-void Profile::restartCore()
-{
-    GUI::setEnabled(false); // Core::reset re-enables it
-
-    if (core && !isRemoved) {
-        // TODO(sudden6): there's a potential race condition between unlocking the core loop
-        // and killing the core
-        const QByteArray& savedata = core->getToxSaveData();
-
-        // save to disk just in case
-        if (saveToxSave(savedata)) {
-            qDebug() << "Restarting Core";
-            const bool isNewProfile{false};
-            IAudioControl* audioBak = core->getAv()->getAudio();
-            assert(audioBak != nullptr);
-            initCore(savedata, Settings::getInstance(), isNewProfile);
-            core->getAv()->setAudio(*audioBak);
-
-            // kriby: code duplication belongs in initCore, but cannot yet due to Core/Profile coupling
-            connect(core.get(), &Core::requestSent, this, &Profile::onRequestSent);
-            emit coreChanged(*core);
-
-            core->start();
-        } else {
-            qCritical() << "Failed to save, not restarting core";
-        }
-    }
-
-    GUI::setEnabled(true);
-}
-
-/**
  * @brief Changes the encryption password and re-saves everything with it
  * @param newPassword Password for encryption, if empty profile will be decrypted.
  * @param oldPassword Supply previous password if already encrypted or empty QString if not yet

--- a/src/persistence/profile.h
+++ b/src/persistence/profile.h
@@ -47,7 +47,6 @@ public:
     QString getName() const;
 
     void startCore();
-    void restartCore();
     bool isEncrypted() const;
     QString setPassword(const QString& newPassword);
     const ToxEncrypt* getPasskey() const;

--- a/src/widget/form/settings/advancedform.cpp
+++ b/src/widget/form/settings/advancedform.cpp
@@ -27,9 +27,6 @@
 #include <QMessageBox>
 #include <QProcess>
 
-#include "src/core/core.h"
-#include "src/core/coreav.h"
-#include "src/nexus.h"
 #include "src/model/status.h"
 #include "src/persistence/profile.h"
 #include "src/persistence/settings.h"
@@ -73,9 +70,11 @@ AdvancedForm::AdvancedForm()
     QString warningBody = tr("Unless you %1 know what you are doing, "
                              "please do %2 change anything here. Changes "
                              "made here may lead to problems with qTox, and even "
-                             "to loss of your data, e.g. history.")
+                             "to loss of your data, e.g. history."
+                             "%3")
                               .arg(QString("<b>%1</b>").arg(tr("really")))
-                              .arg(QString("<b>%1</b>").arg(tr("not")));
+                              .arg(QString("<b>%1</b>").arg(tr("not")))
+                              .arg(QString("<p>%1</p>").arg(tr("Changes here are applied only after restarting qTox.")));
 
     QString warning = QString("<div style=\"color:#ff0000;\">"
                               "<p><b>%1</b></p><p>%2</p></div>")
@@ -213,18 +212,6 @@ void AdvancedForm::on_proxyType_currentIndexChanged(int index)
     bodyUI->cbEnableUDP->setChecked(!proxyEnabled);
 
     Settings::getInstance().setProxyType(proxytype);
-}
-
-void AdvancedForm::on_reconnectButton_clicked()
-{
-    if (Core::getInstance()->getAv()->anyActiveCalls()) {
-        QMessageBox::warning(this, tr("Call active", "popup title"),
-                             tr("You can't disconnect while a call is active!", "popup text"));
-        return;
-    }
-
-    emit Core::getInstance()->statusSet(Status::Status::Offline);
-    Nexus::getProfile()->restartCore();
 }
 
 /**

--- a/src/widget/form/settings/advancedform.h
+++ b/src/widget/form/settings/advancedform.h
@@ -53,7 +53,6 @@ private slots:
     void on_proxyAddr_editingFinished();
     void on_proxyPort_valueChanged(int port);
     void on_proxyType_currentIndexChanged(int index);
-    void on_reconnectButton_clicked();
 
 private:
     void retranslateUi();

--- a/src/widget/form/settings/advancedsettings.ui
+++ b/src/widget/form/settings/advancedsettings.ui
@@ -121,19 +121,19 @@
               </property>
              </widget>
             </item>
-            <item> 
-              <layout class="QVBoxLayout" name="verticalLayout_6">
-               <property name="leftMargin">
-                <number>40</number>
-               </property>
-               <item>
-                <widget class="QCheckBox" name="cbEnableLanDiscovery"> 
-                 <property name="text"> 
-                  <string>Enable LAN discovery</string> 
-                 </property> 
-                </widget> 
-               </item>
-              </layout>
+            <item>
+             <layout class="QVBoxLayout" name="verticalLayout_6">
+              <property name="leftMargin">
+               <number>40</number>
+              </property>
+              <item>
+               <widget class="QCheckBox" name="cbEnableLanDiscovery">
+                <property name="text">
+                 <string>Enable LAN discovery</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
             </item>
            </layout>
           </item>
@@ -201,15 +201,7 @@
            </layout>
           </item>
           <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_4">
-            <item>
-             <widget class="QPushButton" name="reconnectButton">
-              <property name="text">
-               <string comment="reconnect button">Reconnect</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
+           <layout class="QHBoxLayout" name="horizontalLayout_4"/>
           </item>
          </layout>
         </widget>
@@ -258,7 +250,6 @@
   <tabstop>proxyType</tabstop>
   <tabstop>proxyAddr</tabstop>
   <tabstop>proxyPort</tabstop>
-  <tabstop>reconnectButton</tabstop>
   <tabstop>resetButton</tabstop>
  </tabstops>
  <resources/>


### PR DESCRIPTION
The button didn't work that well and caused all kinds of issues inside
the code, so I replaced it by a notice that changes to the Advanced
settings only apply after a restart of qTox.

In the process I also removed all code that was exclusively used for
that feature.

We may add it back later when qTox's internal architecture makes it less
cumbersome.

fixes #5758,  #4509

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5778)
<!-- Reviewable:end -->
