### PR TITLE
fix: empty username causes mention on ever message

### DIFF
--- a/src/model/message.h
+++ b/src/model/message.h
@@ -75,11 +75,17 @@ public:
         {
             return sanitizedNameMention;
         }
+        QRegularExpression GetPublicKeyMention() const
+        {
+            return pubKeyMention;
+        }
         void onUserNameSet(const QString& username);
+        void setPublicKey(const QString& pk);
 
     private:
         QRegularExpression nameMention;
         QRegularExpression sanitizedNameMention;
+        QRegularExpression pubKeyMention;
     };
 
     MessageProcessor(const SharedParams& sharedParams);

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -691,6 +691,8 @@ void Widget::onCoreChanged(Core& core)
     connect(this, &Widget::statusSet, &core, &Core::setStatus);
     connect(this, &Widget::friendRequested, &core, &Core::requestFriendship);
     connect(this, &Widget::friendRequestAccepted, &core, &Core::acceptFriendRequest);
+
+    sharedMessageProcessorParams.setPublicKey(core.getSelfPublicKey().toString());
 }
 
 void Widget::onConnected()


### PR DESCRIPTION
This fixes #2119 and additionally introduces the possibility to mention
users by their public key.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5779)
<!-- Reviewable:end -->
