### PR TITLE
fix(login): show login screen when autologin fails

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,6 +38,7 @@
 #include <QMutex>
 #include <QMutexLocker>
 
+#include <QtWidgets/QMessageBox>
 #include <ctime>
 #include <sodium.h>
 #include <stdio.h>
@@ -343,6 +344,10 @@ int main(int argc, char* argv[])
     Profile* profile = nullptr;
     if (autoLogin && Profile::exists(profileName) && !Profile::isEncrypted(profileName)) {
         profile = Profile::loadProfile(profileName, QString(), settings);
+        if (!profile) {
+            QMessageBox::information(nullptr, QObject::tr("Error"),
+                                     QObject::tr("Failed to load profile automatically."));
+        }
     }
     if (profile) {
         settings.updateProfileData(profile);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -340,8 +340,11 @@ int main(int argc, char* argv[])
     // Autologin
     // TODO (kriby): Shift responsibility of linking views to model objects from nexus
     // Further: generate view instances separately (loginScreen, mainGUI, audio)
+    Profile* profile = nullptr;
     if (autoLogin && Profile::exists(profileName) && !Profile::isEncrypted(profileName)) {
-        Profile* profile = Profile::loadProfile(profileName, QString(), settings);
+        profile = Profile::loadProfile(profileName, QString(), settings);
+    }
+    if (profile) {
         settings.updateProfileData(profile);
         nexus.bootstrapWithProfile(profile);
     } else {


### PR DESCRIPTION
This commit catches a case where loadProfile fails to load a profile, but qtox attempted to start without a profile anyway. Failure to load a profile automatically will now bring up the login screen.

Fixes #5781

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5783)
<!-- Reviewable:end -->
