### PR TITLE
[WIP] feat(proxy): provide commandline tools for proxy settings

### DIFF
--- a/doc/user_manual_en.md
+++ b/doc/user_manual_en.md
@@ -10,6 +10,7 @@
 * [Quotes](#quotes)
 * [Multi Window Mode](#multi-window-mode)
 * [Keyboard Shortcuts](#keyboard-shortcuts)
+* [Commandline Options](#commandline-options)
 * [Emoji Packs](#emoji-packs)
 
 
@@ -428,6 +429,25 @@ The following shortcuts are currently supported:
 
 In audio group chat microphone mute state will be changed while `Ctrl` + 
 `p` pressed and reverted on release.
+
+## Commandline Options
+
+| Option                             | Action                                             |
+|------------------------------------|----------------------------------------------------|
+| `-p` `<profile>`                   | Use specified unencrypted profile                  |
+| `-l`                               | Start with loginscreen                             |
+| `-I` `<on/off>`                    | Sets IPv6 toggle [Default: ON]                     |
+| `-U` `<on/off>`                    | Sets UDP toggle [Default: ON]                      |
+| `-L` `<on/off>`                    | Sets LAN toggle [Default: ON]                      |
+| `-P` `<protocol>:<address>:<port>` | Applies [proxy options](#commandline-proxy-options) [Default: NONE]|
+
+### Commandline Proxy Options
+Protocol: NONE, HTTP or SOCKS5 <br>
+Address: Proxy address <br>
+Port: Proxy port number (0-65535) <br>
+Example input: <br>
+`qtox -P SOCKS5:192.168.0.1:2121` <br>
+`qtox -P none`
 
 ## Emoji Packs
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -58,96 +58,6 @@ static QList<QByteArray>* logBuffer =
 QMutex* logBufferMutex = new QMutex();
 #endif
 
-/**
- * Verifies that commandline proxy settings are at least reasonable. Does not verify provided IP
- * or hostname addresses are valid. Code duplication with Settings::applyCommandLineOptions, which
- * also verifies arguments, should be removed in a future refactor.
- * @param parser QCommandLineParser instance
- */
-bool verifyProxySettings(QCommandLineParser& parser)
-{
-    QString IPv6Setting = parser.value("I");
-    QString LANSetting = parser.value("L");
-    QString UDPSetting = parser.value("U");
-    QString proxySettingString = parser.value("proxy");
-    QStringList proxySettings = proxySettingString.split(":");
-    // Check for incompatible settings
-    bool activeProxyType = false;
-
-    if (parser.isSet("P")) {
-        activeProxyType = proxySettings[0].compare(QString("SOCKS5"), Qt::CaseInsensitive) == 0
-                          || proxySettings[0].compare(QString("HTTP"), Qt::CaseInsensitive) == 0;
-    }
-
-
-    if (activeProxyType && (UDPSetting.compare(QString("on"), Qt::CaseInsensitive) == 0)) {
-        qCritical() << "Cannot set UDP on with proxy.";
-        return false;
-    }
-
-    if (activeProxyType && (LANSetting.compare(QString("on"), Qt::CaseInsensitive) == 0)) {
-        qCritical() << "Cannot set LAN discovery on with proxy.";
-        return false;
-    }
-
-    if ((LANSetting.compare(QString("on"), Qt::CaseInsensitive) == 0)
-        && (UDPSetting.compare(QString("off"), Qt::CaseInsensitive) == 0)) {
-        qCritical() << "Incompatible UDP/LAN settings.";
-        return false;
-    }
-
-    if (parser.isSet("I")) {
-        if (!(IPv6Setting.compare(QString("on"), Qt::CaseInsensitive) == 0
-              || IPv6Setting.compare(QString("off"), Qt::CaseInsensitive) == 0)) {
-            qCritical() << "Unable to parse IPv6 setting.";
-            return false;
-        }
-    }
-
-    if (parser.isSet("U")) {
-        if (!(UDPSetting.compare(QString("on"), Qt::CaseInsensitive) == 0
-              || UDPSetting.compare(QString("off"), Qt::CaseInsensitive) == 0)) {
-            qCritical() << "Unable to parse UDP setting.";
-            return false;
-        }
-    }
-
-    if (parser.isSet("L")) {
-        if (!(LANSetting.compare(QString("on"), Qt::CaseInsensitive) == 0
-              || LANSetting.compare(QString("off"), Qt::CaseInsensitive) == 0)) {
-            qCritical() << "Unable to parse LAN setting.";
-            return false;
-        }
-    }
-
-    if (parser.isSet("P")) {
-        if (proxySettings[0].compare(QString("NONE"), Qt::CaseInsensitive) == 0) {
-            return true;
-            // slightly lazy check here, accepting 'NONE[:.*]' is fine since no other
-            // arguments will be investigated when proxy settings are applied.
-        }
-        // Since the first argument isn't 'none', verify format of remaining arguments
-        if (proxySettings.size() != 3) {
-            qCritical() << "Invalid number of proxy arguments.";
-            return false;
-        }
-
-        if (!(proxySettings[0].compare(QString("SOCKS5"), Qt::CaseInsensitive) == 0
-              || proxySettings[0].compare(QString("HTTP"), Qt::CaseInsensitive) == 0)) {
-            qCritical() << "Unable to parse proxy type.";
-            return false;
-        }
-
-        // Kriby: Sanity checking IPv4+IPv6/hostnames sure is a lot of work!
-
-        int portNumber = proxySettings[2].toInt();
-        if (!(portNumber > 0 && portNumber < 65536)) {
-            qCritical() << "Invalid port number range.";
-        }
-    }
-    return true;
-}
-
 void cleanup()
 {
     // force save early even though destruction saves, because Windows OS will
@@ -307,18 +217,21 @@ int main(int argc, char* argv[])
                            QObject::tr("Starts new instance and opens the login screen.")));
     parser.addOption(QCommandLineOption(QStringList() << "I"
                                                       << "IPv6",
-                                        QObject::tr("Sets IPv6 <on>/<off>"), QObject::tr("on/off")));
+                                        QObject::tr("Sets IPv6 <on>/<off>. Default is ON."),
+                                        QObject::tr("on/off")));
     parser.addOption(QCommandLineOption(QStringList() << "U"
                                                       << "UDP",
-                                        QObject::tr("Sets UDP <on>/<off>"), QObject::tr("on/off")));
+                                        QObject::tr("Sets UDP <on>/<off>. Default is ON."),
+                                        QObject::tr("on/off")));
     parser.addOption(
         QCommandLineOption(QStringList() << "L"
                                          << "LAN",
-                           QObject::tr("Sets LAN discovery <on>/<off>. UDP off overrides."),
+                           QObject::tr(
+                               "Sets LAN discovery <on>/<off>. UDP off overrides. Default is ON."),
                            QObject::tr("on/off")));
     parser.addOption(QCommandLineOption(QStringList() << "P"
                                                       << "proxy",
-                                        QObject::tr("Sets proxy settings."),
+                                        QObject::tr("Sets proxy settings. Default is NONE."),
                                         QObject::tr("(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)")));
     parser.process(*a);
 
@@ -436,7 +349,7 @@ int main(int argc, char* argv[])
         }
     }
 
-    if (!verifyProxySettings(parser)) {
+    if (!Settings::verifyProxySettings(parser)) {
         return -1;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -58,6 +58,96 @@ static QList<QByteArray>* logBuffer =
 QMutex* logBufferMutex = new QMutex();
 #endif
 
+/**
+ * Verifies that commandline proxy settings are at least reasonable. Does not verify provided IP
+ * or hostname addresses are valid. Code duplication with Settings::applyCommandLineOptions, which
+ * also verifies arguments, should be removed in a future refactor.
+ * @param parser QCommandLineParser instance
+ */
+bool verifyProxySettings(QCommandLineParser& parser)
+{
+    QString IPv6Setting = parser.value("I");
+    QString LANSetting = parser.value("L");
+    QString UDPSetting = parser.value("U");
+    QString proxySettingString = parser.value("proxy");
+    QStringList proxySettings = proxySettingString.split(":");
+    // Check for incompatible settings
+    bool activeProxyType = false;
+
+    if (parser.isSet("P")) {
+        activeProxyType = proxySettings[0].compare(QString("SOCKS5"), Qt::CaseInsensitive) == 0
+                          || proxySettings[0].compare(QString("HTTP"), Qt::CaseInsensitive) == 0;
+    }
+
+
+    if (activeProxyType && (UDPSetting.compare(QString("on"), Qt::CaseInsensitive) == 0)) {
+        qCritical() << "Cannot set UDP on with proxy.";
+        return false;
+    }
+
+    if (activeProxyType && (LANSetting.compare(QString("on"), Qt::CaseInsensitive) == 0)) {
+        qCritical() << "Cannot set LAN discovery on with proxy.";
+        return false;
+    }
+
+    if ((LANSetting.compare(QString("on"), Qt::CaseInsensitive) == 0)
+        && (UDPSetting.compare(QString("off"), Qt::CaseInsensitive) == 0)) {
+        qCritical() << "Incompatible UDP/LAN settings.";
+        return false;
+    }
+
+    if (parser.isSet("I")) {
+        if (!(IPv6Setting.compare(QString("on"), Qt::CaseInsensitive) == 0
+              || IPv6Setting.compare(QString("off"), Qt::CaseInsensitive) == 0)) {
+            qCritical() << "Unable to parse IPv6 setting.";
+            return false;
+        }
+    }
+
+    if (parser.isSet("U")) {
+        if (!(UDPSetting.compare(QString("on"), Qt::CaseInsensitive) == 0
+              || UDPSetting.compare(QString("off"), Qt::CaseInsensitive) == 0)) {
+            qCritical() << "Unable to parse UDP setting.";
+            return false;
+        }
+    }
+
+    if (parser.isSet("L")) {
+        if (!(LANSetting.compare(QString("on"), Qt::CaseInsensitive) == 0
+              || LANSetting.compare(QString("off"), Qt::CaseInsensitive) == 0)) {
+            qCritical() << "Unable to parse LAN setting.";
+            return false;
+        }
+    }
+
+    if (parser.isSet("P")) {
+        if (proxySettings[0].compare(QString("NONE"), Qt::CaseInsensitive) == 0) {
+            return true;
+            // slightly lazy check here, accepting 'NONE[:.*]' is fine since no other
+            // arguments will be investigated when proxy settings are applied.
+        }
+        // Since the first argument isn't 'none', verify format of remaining arguments
+        if (proxySettings.size() != 3) {
+            qCritical() << "Invalid number of proxy arguments.";
+            return false;
+        }
+
+        if (!(proxySettings[0].compare(QString("SOCKS5"), Qt::CaseInsensitive) == 0
+              || proxySettings[0].compare(QString("HTTP"), Qt::CaseInsensitive) == 0)) {
+            qCritical() << "Unable to parse proxy type.";
+            return false;
+        }
+
+        // Kriby: Sanity checking IPv4+IPv6/hostnames sure is a lot of work!
+
+        int portNumber = proxySettings[2].toInt();
+        if (!(portNumber > 0 && portNumber < 65536)) {
+            qCritical() << "Invalid port number range.";
+        }
+    }
+    return true;
+}
+
 void cleanup()
 {
     // force save early even though destruction saves, because Windows OS will
@@ -215,6 +305,21 @@ int main(int argc, char* argv[])
         QCommandLineOption(QStringList() << "l"
                                          << "login",
                            QObject::tr("Starts new instance and opens the login screen.")));
+    parser.addOption(QCommandLineOption(QStringList() << "I"
+                                                      << "IPv6",
+                                        QObject::tr("Sets IPv6 <on>/<off>"), QObject::tr("on/off")));
+    parser.addOption(QCommandLineOption(QStringList() << "U"
+                                                      << "UDP",
+                                        QObject::tr("Sets UDP <on>/<off>"), QObject::tr("on/off")));
+    parser.addOption(
+        QCommandLineOption(QStringList() << "L"
+                                         << "LAN",
+                           QObject::tr("Sets LAN discovery <on>/<off>. UDP off overrides."),
+                           QObject::tr("on/off")));
+    parser.addOption(QCommandLineOption(QStringList() << "P"
+                                                      << "proxy",
+                                        QObject::tr("Sets proxy settings."),
+                                        QObject::tr("(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)")));
     parser.process(*a);
 
     uint32_t profileId = settings.getCurrentProfileId();
@@ -331,6 +436,10 @@ int main(int argc, char* argv[])
         }
     }
 
+    if (!verifyProxySettings(parser)) {
+        return -1;
+    }
+
     // TODO(sudden6): remove once we get rid of Nexus
     Nexus& nexus = Nexus::getInstance();
     // TODO(kriby): Consider moving application initializing variables into a globalSettings object
@@ -343,16 +452,16 @@ int main(int argc, char* argv[])
     // Further: generate view instances separately (loginScreen, mainGUI, audio)
     Profile* profile = nullptr;
     if (autoLogin && Profile::exists(profileName) && !Profile::isEncrypted(profileName)) {
-        profile = Profile::loadProfile(profileName, QString(), settings);
+        profile = Profile::loadProfile(profileName, QString(), settings, &parser);
         if (!profile) {
             QMessageBox::information(nullptr, QObject::tr("Error"),
                                      QObject::tr("Failed to load profile automatically."));
         }
     }
     if (profile) {
-        settings.updateProfileData(profile);
         nexus.bootstrapWithProfile(profile);
     } else {
+        nexus.setParser(&parser);
         int returnval = nexus.showLogin(profileName);
         if (returnval != 0) {
             return returnval;

--- a/src/nexus.h
+++ b/src/nexus.h
@@ -30,6 +30,7 @@ class Profile;
 class Settings;
 class LoginScreen;
 class Core;
+class QCommandLineParser;
 
 #ifdef Q_OS_MAC
 class QMenuBar;
@@ -47,6 +48,7 @@ public:
     void start();
     void showMainGUI();
     void setSettings(Settings* settings);
+    void setParser(QCommandLineParser* parser);
     static Nexus& getInstance();
     static void destroyInstance();
     static Core* getCore();
@@ -89,7 +91,7 @@ public slots:
     void onCreateNewProfile(const QString& name, const QString& pass);
     void onLoadProfile(const QString& name, const QString& pass);
     int showLogin(const QString& profileName = QString());
-    void bootstrapWithProfile(Profile *p);
+    void bootstrapWithProfile(Profile* p);
 
 private:
     explicit Nexus(QObject* parent = nullptr);
@@ -102,6 +104,7 @@ private:
     Settings* settings;
     Widget* widget;
     std::unique_ptr<IAudioControl> audioControl;
+    QCommandLineParser* parser = nullptr;
 };
 
 #endif // NEXUS_H

--- a/src/persistence/profile.h
+++ b/src/persistence/profile.h
@@ -35,15 +35,17 @@
 #include <memory>
 
 class Settings;
+class QCommandLineParser;
 
 class Profile : public QObject
 {
     Q_OBJECT
 
 public:
-    static Profile* loadProfile(const QString& name, const QString& password, Settings& settings);
-    static Profile* createProfile(const QString& name, const QString& password,
-                                  const Settings& settings);
+    static Profile* loadProfile(const QString& name, const QString& password, Settings& settings,
+                                const QCommandLineParser* parser);
+    static Profile* createProfile(const QString& name, const QString& password, Settings& settings,
+                                  const QCommandLineParser* parser);
     ~Profile();
 
     Core* getCore();

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -45,6 +45,7 @@
 #include <QStandardPaths>
 #include <QStyleFactory>
 #include <QThread>
+#include <QtCore/QCommandLineParser>
 
 /**
  * @var QHash<QString, QByteArray> Settings::widgetSettings
@@ -279,7 +280,7 @@ bool Settings::isToxPortable()
     return result;
 }
 
-void Settings::updateProfileData(Profile* profile)
+void Settings::updateProfileData(Profile* profile, const QCommandLineParser* parser)
 {
     QMutexLocker locker{&bigLock};
 
@@ -290,6 +291,141 @@ void Settings::updateProfileData(Profile* profile)
     setCurrentProfile(profile->getName());
     saveGlobal();
     loadPersonal(profile->getName(), profile->getPasskey());
+    if (parser) {
+        applyCommandLineOptions(parser);
+    }
+}
+/**
+ * Applies command line options on top of loaded settings. Fails without changes if attempting to
+ * apply contradicting settings.
+ * @param parser
+ * @return Success indicator (success = true)
+ */
+bool Settings::applyCommandLineOptions(const QCommandLineParser* parser)
+{
+    QString IPv6Setting = parser->value("I");
+    QString LANSetting = parser->value("L");
+    QString UDPSetting = parser->value("U");
+    QString proxySettingString = parser->value("proxy");
+    QStringList proxySettings = proxySettingString.split(":");
+    // Check for incompatible settings
+    bool activeProxyType = false;
+
+    if (parser->isSet("P")) {
+        activeProxyType = proxySettings[0].compare(QString("SOCKS5"), Qt::CaseInsensitive) == 0
+                          || proxySettings[0].compare(QString("HTTP"), Qt::CaseInsensitive) == 0;
+    }
+
+
+    if (activeProxyType && (UDPSetting.compare(QString("on"), Qt::CaseInsensitive) == 0)) {
+        qCritical() << "Cannot set UDP on with proxy.";
+        return false;
+    }
+
+    if (activeProxyType && (LANSetting.compare(QString("on"), Qt::CaseInsensitive) == 0)) {
+        qCritical() << "Cannot set LAN discovery on with proxy.";
+        return false;
+    }
+
+    if ((LANSetting.compare(QString("on"), Qt::CaseInsensitive) == 0)
+        && (UDPSetting.compare(QString("off"), Qt::CaseInsensitive) == 0)) {
+        qCritical() << "Incompatible UDP/LAN settings.";
+        return false;
+    }
+
+    if (parser->isSet("I")) {
+        if (IPv6Setting.compare(QString("on"), Qt::CaseInsensitive) == 0) {
+            enableIPv6 = true;
+            qDebug() << "Setting IPv6 ON.";
+        } else if (IPv6Setting.compare(QString("off"), Qt::CaseInsensitive) == 0) {
+            enableIPv6 = false;
+            qDebug() << "Setting IPv6 OFF.";
+        } else {
+            qCritical() << "Unable to parse IPv6 setting.";
+            return false;
+        }
+    }
+
+    if (parser->isSet("U")) {
+        if (UDPSetting.compare(QString("on"), Qt::CaseInsensitive) == 0) {
+            forceTCP = false;
+            qDebug() << "Setting UDP ON.";
+            if (proxyType != ICoreSettings::ProxyType::ptNone) {
+                qDebug() << "Cannot use UDP with proxy; disabling proxy settings.";
+                proxyType = ICoreSettings::ProxyType::ptNone;
+            }
+        } else if (UDPSetting.compare(QString("off"), Qt::CaseInsensitive) == 0) {
+            forceTCP = true;
+            qDebug() << "Setting UDP OFF.";
+        } else {
+            qCritical() << "Unable to parse UDP setting.";
+            return false;
+        }
+    }
+
+    if (parser->isSet("L")) {
+        if (LANSetting.compare(QString("on"), Qt::CaseInsensitive) == 0) {
+            qDebug() << "Setting LAN Discovery ON.";
+            enableLanDiscovery = true;
+            if (forceTCP) {
+                qDebug() << "Cannot use LAN discovery without UDP; enabling UDP.";
+                proxyType = ICoreSettings::ProxyType::ptNone;
+            }
+            if (proxyType != ICoreSettings::ProxyType::ptNone) {
+                qDebug() << "Cannot use LAN discovery with proxy; disabling proxy settings.";
+                proxyType = ICoreSettings::ProxyType::ptNone;
+            }
+        } else if (LANSetting.compare(QString("off"), Qt::CaseInsensitive) == 0) {
+            enableLanDiscovery = false;
+            qDebug() << "Setting LAN Discovery OFF.";
+        } else {
+            qCritical() << "Unable to parse LAN setting.";
+            return false;
+        }
+    }
+
+    if (parser->isSet("P")) {
+        if (proxySettings[0].compare(QString("NONE"), Qt::CaseInsensitive) == 0) {
+            proxyType = ICoreSettings::ProxyType::ptNone;
+            proxyAddr = "";
+            proxyPort = 0;
+            qDebug() << "Setting proxy type to NONE.";
+            return true;
+        }
+        // Since the first argument isn't 'none', verify format of remaining arguments
+        if (proxySettings.size() != 3) {
+            qCritical() << "Invalid number of proxy arguments.";
+            return false;
+        }
+
+        if (proxySettings[0].compare(QString("SOCKS5"), Qt::CaseInsensitive) == 0) {
+            proxyType = ICoreSettings::ProxyType::ptSOCKS5;
+            forceTCP = true;
+            enableLanDiscovery = false;
+            qDebug() << "Setting proxy type to SOCKS5.";
+        } else if (proxySettings[0].compare(QString("HTTP"), Qt::CaseInsensitive) == 0) {
+            proxyType = ICoreSettings::ProxyType::ptHTTP;
+            forceTCP = true;
+            enableLanDiscovery = false;
+            qDebug() << "Setting proxy type to HTTP.";
+        } else {
+            qCritical() << "Unable to parse proxy type.";
+            return false;
+        }
+
+        // Kriby: Sanity checking IPv4+IPv6/hostnames sure is a lot of work!
+        proxyAddr = proxySettings[1];
+        qDebug() << QString("Setting proxy address to %1.").arg(proxySettings[1]);
+
+        int portNumber = proxySettings[2].toInt();
+        if (portNumber > 0 && portNumber < 65536) {
+            proxyPort = portNumber;
+            qDebug() << QString("Setting port number to %1.").arg(portNumber);
+        } else {
+            qCritical() << "Invalid port number range.";
+        }
+    }
+    return true;
 }
 
 void Settings::loadPersonal(QString profileName, const ToxEncrypt* passKey)

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -292,137 +292,188 @@ void Settings::updateProfileData(Profile* profile, const QCommandLineParser* par
     saveGlobal();
     loadPersonal(profile->getName(), profile->getPasskey());
     if (parser) {
-        applyCommandLineOptions(parser);
+        applyCommandLineOptions(*parser);
     }
 }
+
 /**
- * Applies command line options on top of loaded settings. Fails without changes if attempting to
- * apply contradicting settings.
- * @param parser
- * @return Success indicator (success = true)
+ * Verifies that commandline proxy settings are at least reasonable. Does not verify provided IP
+ * or hostname addresses are valid. Code duplication with Settings::applyCommandLineOptions, which
+ * also verifies arguments, should be removed in a future refactor.
+ * @param parser QCommandLineParser instance
  */
-bool Settings::applyCommandLineOptions(const QCommandLineParser* parser)
+bool Settings::verifyProxySettings(const QCommandLineParser& parser)
 {
-    QString IPv6Setting = parser->value("I");
-    QString LANSetting = parser->value("L");
-    QString UDPSetting = parser->value("U");
-    QString proxySettingString = parser->value("proxy");
-    QStringList proxySettings = proxySettingString.split(":");
+    QString IPv6SettingString = parser.value("I").toLower();
+    QString LANSettingString = parser.value("L").toLower();
+    QString UDPSettingString = parser.value("U").toLower();
+    QString proxySettingString = parser.value("proxy").toLower();
+    QStringList proxySettingStrings = proxySettingString.split(":");
+
+    const QString SOCKS5 = QStringLiteral("socks5");
+    const QString HTTP = QStringLiteral("http");
+    const QString NONE = QStringLiteral("none");
+    const QString ON = QStringLiteral("on");
+    const QString OFF = QStringLiteral("off");
+
     // Check for incompatible settings
     bool activeProxyType = false;
 
-    if (parser->isSet("P")) {
-        activeProxyType = proxySettings[0].compare(QString("SOCKS5"), Qt::CaseInsensitive) == 0
-                          || proxySettings[0].compare(QString("HTTP"), Qt::CaseInsensitive) == 0;
+    if (parser.isSet("P")) {
+        activeProxyType = proxySettingStrings[0] == SOCKS5 || proxySettingStrings[0] == HTTP;
     }
 
-
-    if (activeProxyType && (UDPSetting.compare(QString("on"), Qt::CaseInsensitive) == 0)) {
-        qCritical() << "Cannot set UDP on with proxy.";
-        return false;
-    }
-
-    if (activeProxyType && (LANSetting.compare(QString("on"), Qt::CaseInsensitive) == 0)) {
-        qCritical() << "Cannot set LAN discovery on with proxy.";
-        return false;
-    }
-
-    if ((LANSetting.compare(QString("on"), Qt::CaseInsensitive) == 0)
-        && (UDPSetting.compare(QString("off"), Qt::CaseInsensitive) == 0)) {
-        qCritical() << "Incompatible UDP/LAN settings.";
-        return false;
-    }
-
-    if (parser->isSet("I")) {
-        if (IPv6Setting.compare(QString("on"), Qt::CaseInsensitive) == 0) {
-            enableIPv6 = true;
-            qDebug() << "Setting IPv6 ON.";
-        } else if (IPv6Setting.compare(QString("off"), Qt::CaseInsensitive) == 0) {
-            enableIPv6 = false;
-            qDebug() << "Setting IPv6 OFF.";
-        } else {
+    if (parser.isSet("I")) {
+        if (!(IPv6SettingString == ON || IPv6SettingString == OFF)) {
             qCritical() << "Unable to parse IPv6 setting.";
             return false;
         }
     }
 
-    if (parser->isSet("U")) {
-        if (UDPSetting.compare(QString("on"), Qt::CaseInsensitive) == 0) {
-            forceTCP = false;
-            qDebug() << "Setting UDP ON.";
-            if (proxyType != ICoreSettings::ProxyType::ptNone) {
-                qDebug() << "Cannot use UDP with proxy; disabling proxy settings.";
-                proxyType = ICoreSettings::ProxyType::ptNone;
-            }
-        } else if (UDPSetting.compare(QString("off"), Qt::CaseInsensitive) == 0) {
-            forceTCP = true;
-            qDebug() << "Setting UDP OFF.";
-        } else {
+    if (parser.isSet("U")) {
+        if (!(UDPSettingString == ON || UDPSettingString == OFF)) {
             qCritical() << "Unable to parse UDP setting.";
             return false;
         }
     }
 
-    if (parser->isSet("L")) {
-        if (LANSetting.compare(QString("on"), Qt::CaseInsensitive) == 0) {
-            qDebug() << "Setting LAN Discovery ON.";
-            enableLanDiscovery = true;
-            if (forceTCP) {
-                qDebug() << "Cannot use LAN discovery without UDP; enabling UDP.";
-                proxyType = ICoreSettings::ProxyType::ptNone;
-            }
-            if (proxyType != ICoreSettings::ProxyType::ptNone) {
-                qDebug() << "Cannot use LAN discovery with proxy; disabling proxy settings.";
-                proxyType = ICoreSettings::ProxyType::ptNone;
-            }
-        } else if (LANSetting.compare(QString("off"), Qt::CaseInsensitive) == 0) {
-            enableLanDiscovery = false;
-            qDebug() << "Setting LAN Discovery OFF.";
-        } else {
+    if (parser.isSet("L")) {
+        if (!(LANSettingString == ON || LANSettingString == OFF)) {
             qCritical() << "Unable to parse LAN setting.";
             return false;
         }
     }
+    if (activeProxyType && UDPSettingString == ON) {
+        qCritical() << "Cannot set UDP on with proxy.";
+        return false;
+    }
 
-    if (parser->isSet("P")) {
-        if (proxySettings[0].compare(QString("NONE"), Qt::CaseInsensitive) == 0) {
-            proxyType = ICoreSettings::ProxyType::ptNone;
-            proxyAddr = "";
-            proxyPort = 0;
-            qDebug() << "Setting proxy type to NONE.";
+    if (activeProxyType && LANSettingString == ON) {
+        qCritical() << "Cannot set LAN discovery on with proxy.";
+        return false;
+    }
+
+    if (LANSettingString == ON && UDPSettingString == OFF) {
+        qCritical() << "Incompatible UDP/LAN settings.";
+        return false;
+    }
+
+    if (parser.isSet("P")) {
+        if (proxySettingStrings[0] == NONE) {
+            // slightly lazy check here, accepting 'NONE[:.*]' is fine since no other
+            // arguments will be investigated when proxy settings are applied.
             return true;
         }
         // Since the first argument isn't 'none', verify format of remaining arguments
-        if (proxySettings.size() != 3) {
+        if (proxySettingStrings.size() != 3) {
             qCritical() << "Invalid number of proxy arguments.";
             return false;
         }
 
-        if (proxySettings[0].compare(QString("SOCKS5"), Qt::CaseInsensitive) == 0) {
-            proxyType = ICoreSettings::ProxyType::ptSOCKS5;
-            forceTCP = true;
-            enableLanDiscovery = false;
-            qDebug() << "Setting proxy type to SOCKS5.";
-        } else if (proxySettings[0].compare(QString("HTTP"), Qt::CaseInsensitive) == 0) {
-            proxyType = ICoreSettings::ProxyType::ptHTTP;
-            forceTCP = true;
-            enableLanDiscovery = false;
-            qDebug() << "Setting proxy type to HTTP.";
-        } else {
+        if (!(proxySettingStrings[0] == SOCKS5 || proxySettingStrings[0] == HTTP)) {
             qCritical() << "Unable to parse proxy type.";
             return false;
         }
 
-        // Kriby: Sanity checking IPv4+IPv6/hostnames sure is a lot of work!
-        proxyAddr = proxySettings[1];
-        qDebug() << QString("Setting proxy address to %1.").arg(proxySettings[1]);
+        // TODO(Kriby): Sanity check IPv4/IPv6 addresses/hostnames?
 
-        int portNumber = proxySettings[2].toInt();
-        if (portNumber > 0 && portNumber < 65536) {
-            proxyPort = portNumber;
-            qDebug() << QString("Setting port number to %1.").arg(portNumber);
-        } else {
+        int portNumber = proxySettingStrings[2].toInt();
+        if (!(portNumber > 0 && portNumber < 65536)) {
             qCritical() << "Invalid port number range.";
+        }
+    }
+    return true;
+}
+
+/**
+ * Applies command line options on top of loaded settings. Fails without changes if attempting to
+ * apply contradicting settings.
+ * @param parser QCommandLineParser instance
+ * @return Success indicator (success = true)
+ */
+bool Settings::applyCommandLineOptions(const QCommandLineParser& parser)
+{
+    if (!verifyProxySettings(parser)) {
+        return false;
+    };
+
+    QString IPv6Setting = parser.value("I").toUpper();
+    QString LANSetting = parser.value("L").toUpper();
+    QString UDPSetting = parser.value("U").toUpper();
+    QString proxySettingString = parser.value("proxy").toUpper();
+    QStringList proxySettings = proxySettingString.split(":");
+
+    const QString SOCKS5 = QStringLiteral("SOCKS5");
+    const QString HTTP = QStringLiteral("HTTP");
+    const QString NONE = QStringLiteral("NONE");
+    const QString ON = QStringLiteral("ON");
+    const QString OFF = QStringLiteral("OFF");
+
+
+    if (parser.isSet("I")) {
+        enableIPv6 = IPv6Setting == ON;
+        qDebug() << QString("Setting IPv6 %1.").arg(IPv6Setting);
+    }
+
+    if (parser.isSet("P")) {
+        qDebug() << QString("Setting proxy type to %1.").arg(proxySettings[0]);
+
+        quint16 portNumber = 0;
+        QString address = "";
+
+        if (proxySettings[0] == NONE) {
+            proxyType = ICoreSettings::ProxyType::ptNone;
+        } else {
+            if (proxySettings[0] == SOCKS5) {
+                proxyType = ICoreSettings::ProxyType::ptSOCKS5;
+            } else if (proxySettings[0] == HTTP) {
+                proxyType = ICoreSettings::ProxyType::ptHTTP;
+            } else {
+                qCritical() << "Failed to set valid proxy type";
+                assert(false); // verifyProxySettings should've made this impossible
+            }
+
+            forceTCP = true;
+            enableLanDiscovery = false;
+
+            address = proxySettings[1];
+            portNumber = static_cast<quint16>(proxySettings[2].toInt());
+        }
+
+
+        proxyAddr = address;
+        qDebug() << QString("Setting proxy address to %1.").arg(address);
+        proxyPort = portNumber;
+        qDebug() << QString("Setting port number to %1.").arg(portNumber);
+    }
+
+    if (parser.isSet("U")) {
+        bool shouldForceTCP = UDPSetting == OFF;
+        if (!shouldForceTCP && proxyType != ICoreSettings::ProxyType::ptNone) {
+            qDebug() << "Cannot use UDP with proxy; disable proxy explicitly with '-P none'.";
+        } else {
+            forceTCP = shouldForceTCP;
+            qDebug() << QString("Setting UDP %1.").arg(UDPSetting);
+        }
+
+        // LANSetting == ON is caught by verifyProxySettings, the OFF check removes needless debug
+        if (shouldForceTCP && !(LANSetting == OFF) && enableLanDiscovery) {
+            qDebug() << "Cannot perform LAN discovery without UDP; disabling LAN discovery.";
+            enableLanDiscovery = false;
+        }
+    }
+
+    if (parser.isSet("L")) {
+        bool shouldEnableLAN = LANSetting == ON;
+
+        if (shouldEnableLAN && proxyType != ICoreSettings::ProxyType::ptNone) {
+            qDebug()
+                << "Cannot use LAN discovery with proxy; disable proxy explicitly with '-P none'.";
+        } else if (shouldEnableLAN && forceTCP) {
+            qDebug() << "Cannot use LAN discovery without UDP; enable UDP explicitly with '-U on'.";
+        } else {
+            enableLanDiscovery = shouldEnableLAN;
+            qDebug() << QString("Setting LAN Discovery %1.").arg(LANSetting);
         }
     }
     return true;

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -239,7 +239,8 @@ signals:
     void blackListChanged(QStringList& blist);
 
 public:
-    bool applyCommandLineOptions(const QCommandLineParser* parser);
+    bool applyCommandLineOptions(const QCommandLineParser& parser);
+    static bool verifyProxySettings(const QCommandLineParser& parser);
 
     bool getMakeToxPortable() const;
     void setMakeToxPortable(bool newValue);

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -39,6 +39,7 @@
 #include <QPixmap>
 
 class Profile;
+class QCommandLineParser;
 
 namespace Db {
 enum class syncType;
@@ -170,7 +171,7 @@ public slots:
     void saveGlobal();
     void sync();
     void setAutoLogin(bool state);
-    void updateProfileData(Profile* profile);
+    void updateProfileData(Profile* profile, const QCommandLineParser* parser);
 
 signals:
     // General
@@ -238,6 +239,8 @@ signals:
     void blackListChanged(QStringList& blist);
 
 public:
+    bool applyCommandLineOptions(const QCommandLineParser* parser);
+
     bool getMakeToxPortable() const;
     void setMakeToxPortable(bool newValue);
 


### PR DESCRIPTION
Adds the ability to set proxy settings through command line before qTox attempts to connect. Attempts some very basic sanity checks on the provided settings, and aborts execution before connecting if any issues with the provided settings are found.

If proxy settings are set but qTox is started with a command line option that is incompatible with proxy usage, the commit will currently disable the proxy and continue running. This is fine under the assumption that the user understands which connection settings are incompatible. It may be desirable to more aggressively ensure the user knows what will disable proxy settings however.

The PR is not polished and tested properly yet, but there is enough here to understand the general approach and provide feedback.

If properly implemented, should close #2070

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5789)
<!-- Reviewable:end -->
