### PR TITLE
[WIP] fix build with Qt 5.14

### DIFF
--- a/src/core/toxlogger.cpp
+++ b/src/core/toxlogger.cpp
@@ -32,7 +32,7 @@ namespace {
 QByteArray cleanPath(const char *file)
 {
     // for privacy, make the path relative to the c-toxcore source directory
-    const QRegularExpression pathCleaner(QLatin1Literal{"[\\s|\\S]*c-toxcore."});
+    const QRegularExpression pathCleaner(QLatin1String{"[\\s|\\S]*c-toxcore."});
     QByteArray cleanedPath = QString{file}.remove(pathCleaner).toUtf8();
     cleanedPath.append('\0');
     return cleanedPath;

--- a/src/net/bootstrapnodeupdater.cpp
+++ b/src/net/bootstrapnodeupdater.cpp
@@ -30,22 +30,22 @@
 
 namespace {
 const QUrl NodeListAddress{"https://nodes.tox.chat/json"};
-const QLatin1Literal jsonNodeArrayName{"nodes"};
-const QLatin1Literal emptyAddress{"-"};
+const QLatin1String jsonNodeArrayName{"nodes"};
+const QLatin1String emptyAddress{"-"};
 const QRegularExpression ToxPkRegEx(QString("(^|\\s)[A-Fa-f0-9]{%1}($|\\s)").arg(64));
-const QLatin1Literal builtinNodesFile{":/conf/nodes.json"};
+const QLatin1String builtinNodesFile{":/conf/nodes.json"};
 } // namespace
 
 namespace NodeFields {
-const QLatin1Literal status_udp{"status_udp"};
-const QLatin1Literal status_tcp{"status_tcp"};
-const QLatin1Literal ipv4{"ipv4"};
-const QLatin1Literal ipv6{"ipv6"};
-const QLatin1Literal public_key{"public_key"};
-const QLatin1Literal port{"port"};
-const QLatin1Literal maintainer{"maintainer"};
+const QLatin1String status_udp{"status_udp"};
+const QLatin1String status_tcp{"status_tcp"};
+const QLatin1String ipv4{"ipv4"};
+const QLatin1String ipv6{"ipv6"};
+const QLatin1String public_key{"public_key"};
+const QLatin1String port{"port"};
+const QLatin1String maintainer{"maintainer"};
 // TODO(sudden6): make use of this field once we differentiate between TCP nodes, and bootstrap nodes
-const QLatin1Literal tcp_ports{"tcp_ports"};
+const QLatin1String tcp_ports{"tcp_ports"};
 const QStringList neededFields{status_udp, status_tcp, ipv4, ipv6, public_key, port, maintainer};
 } // namespace NodeFields
 

--- a/src/persistence/paths.cpp
+++ b/src/persistence/paths.cpp
@@ -29,20 +29,20 @@
 #include <QStringList>
 
 namespace {
-const QLatin1Literal globalSettingsFile{"qtox.ini"};
-const QLatin1Literal profileFolder{"profiles"};
-const QLatin1Literal themeFolder{"themes"};
-const QLatin1Literal avatarsFolder{"avatars"};
-const QLatin1Literal transfersFolder{"transfers"};
-const QLatin1Literal screenshotsFolder{"screenshots"};
+const QLatin1String globalSettingsFile{"qtox.ini"};
+const QLatin1String profileFolder{"profiles"};
+const QLatin1String themeFolder{"themes"};
+const QLatin1String avatarsFolder{"avatars"};
+const QLatin1String transfersFolder{"transfers"};
+const QLatin1String screenshotsFolder{"screenshots"};
 
 // NOTE(sudden6): currently unused, but reflects the TCS at 2018-11
 #ifdef Q_OS_WIN
-const QLatin1Literal TCSToxFileFolder{"%APPDATA%/tox/"};
+const QLatin1String TCSToxFileFolder{"%APPDATA%/tox/"};
 #elif defined(Q_OS_OSX)
-const QLatin1Literal TCSToxFileFolder{"~/Library/Application Support/Tox"};
+const QLatin1String TCSToxFileFolder{"~/Library/Application Support/Tox"};
 #else
-const QLatin1Literal TCSToxFileFolder{"~/.config/tox/"};
+const QLatin1String TCSToxFileFolder{"~/.config/tox/"};
 #endif
 } // namespace
 

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -88,18 +88,18 @@ QString secondsToDHMS(quint32 duration)
 
     // I assume no one will ever have call longer than a month
     if (days) {
-        return cD + res.sprintf("%dd%02dh %02dm %02ds", days, hours, minutes, seconds);
+        return cD + res.asprintf("%dd%02dh %02dm %02ds", days, hours, minutes, seconds);
     }
 
     if (hours) {
-        return cD + res.sprintf("%02dh %02dm %02ds", hours, minutes, seconds);
+        return cD + res.asprintf("%02dh %02dm %02ds", hours, minutes, seconds);
     }
 
     if (minutes) {
-        return cD + res.sprintf("%02dm %02ds", minutes, seconds);
+        return cD + res.asprintf("%02dm %02ds", minutes, seconds);
     }
 
-    return cD + res.sprintf("%02ds", seconds);
+    return cD + res.asprintf("%02ds", seconds);
 }
 } // namespace
 

--- a/src/widget/style.cpp
+++ b/src/widget/style.cpp
@@ -64,9 +64,9 @@
  */
 
 namespace {
-    const QLatin1Literal ThemeSubFolder{"themes/"};
-    const QLatin1Literal BuiltinThemeDefaultPath{":themes/default/"};
-    const QLatin1Literal BuiltinThemeDarkPath{":themes/dark/"};
+    const QLatin1String ThemeSubFolder{"themes/"};
+    const QLatin1String BuiltinThemeDefaultPath{":themes/default/"};
+    const QLatin1String BuiltinThemeDarkPath{":themes/dark/"};
 }
 
 // helper functions
@@ -273,15 +273,15 @@ const QString Style::resolve(const QString& filename, const QFont& baseFont)
     }
 
     for (const QString& key : dictColor.keys()) {
-        qss.replace(QRegularExpression(key % QLatin1Literal{"\\b"}), dictColor[key]);
+        qss.replace(QRegularExpression(key % QLatin1String{"\\b"}), dictColor[key]);
     }
 
     for (const QString& key : dictFont.keys()) {
-        qss.replace(QRegularExpression(key % QLatin1Literal{"\\b"}), dictFont[key]);
+        qss.replace(QRegularExpression(key % QLatin1String{"\\b"}), dictFont[key]);
     }
 
     for (const QString& key : dictTheme.keys()) {
-        qss.replace(QRegularExpression(key % QLatin1Literal{"\\b"}), dictTheme[key]);
+        qss.replace(QRegularExpression(key % QLatin1String{"\\b"}), dictTheme[key]);
     }
 
     // @getImagePath() function

--- a/test/persistence/paths_test.cpp
+++ b/test/persistence/paths_test.cpp
@@ -40,12 +40,12 @@ private:
 };
 
 namespace {
-const QLatin1Literal globalSettingsFile{"qtox.ini"};
-const QLatin1Literal profileFolder{"profiles"};
-const QLatin1Literal themeFolder{"themes"};
-const QLatin1Literal avatarsFolder{"avatars"};
-const QLatin1Literal transfersFolder{"transfers"};
-const QLatin1Literal screenshotsFolder{"screenshots"};
+const QLatin1String globalSettingsFile{"qtox.ini"};
+const QLatin1String profileFolder{"profiles"};
+const QLatin1String themeFolder{"themes"};
+const QLatin1String avatarsFolder{"avatars"};
+const QLatin1String transfersFolder{"transfers"};
+const QLatin1String screenshotsFolder{"screenshots"};
 const QString sep{QDir::separator()};
 }
 


### PR DESCRIPTION
- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

These are basically just lazy sed changes to fix the build.  I'm not sure how far back this would be compatible, as a lot of the 'QLatin1String' things seem to be from Qt 5.10, but I'm also not sure yet if any of those new things are actually being used.

To be safe, I thought about enclosing things within a version check, but since there are a bunch of these, and in rather big blocks, it would at least look kind of... weird... or something.  :]

The 'asprintf' should maybe be safe back as far as Qt 5.5, but these parts should probably use 'QTextStream' or 'arg()' instead (according to Qt documentation ( https://doc.qt.io/qt-5/qstring.html#asprintf )).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5795)
<!-- Reviewable:end -->
