### PR TITLE
fix(profile): load settings before starting Core

### DIFF
--- a/src/persistence/profile.h
+++ b/src/persistence/profile.h
@@ -41,7 +41,7 @@ class Profile : public QObject
     Q_OBJECT
 
 public:
-    static Profile* loadProfile(const QString& name, const QString& password, const Settings& settings);
+    static Profile* loadProfile(const QString& name, const QString& password, Settings& settings);
     static Profile* createProfile(const QString& name, const QString& password,
                                   const Settings& settings);
     ~Profile();


### PR DESCRIPTION
This is a quick fix to load settings before Core is started. Ideally
this would not need to be inside the Profile, but at the moment the
decryption key is not available before starting Core.

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5797)
<!-- Reviewable:end -->
