### PR TITLE
fix(widget): don't try to play audio if it's disable

### DIFF
--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1008,6 +1008,11 @@ void Widget::setStatusMessage(const QString& statusMessage)
  */
 void Widget::playNotificationSound(IAudioSink::Sound sound, bool loop)
 {
+    if (!settings.getAudioOutDevEnabled()) {
+        // don't try to play sounds if audio is disabled
+        return;
+    }
+
     if (audioNotification == nullptr) {
         audioNotification = std::unique_ptr<IAudioSink>(audio.makeSink());
         if (audioNotification == nullptr) {


### PR DESCRIPTION
- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

fixes the following log spam:

```
[20:56:31.403 UTC] audio/backend/openal.cpp:265 : Warning: Failed to subscribe to audio output device.
[20:56:31.403 UTC] widget/widget.cpp:1014 : Debug: Failed to allocate AudioSink
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5798)
<!-- Reviewable:end -->
