### PR TITLE
fix(chatlog): out of bounds access when loading messages

### DIFF
--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -731,6 +731,8 @@ void ChatLog::removeFirsts(const int num)
         lines.clear();
     }
 
+    clearSelection();
+
     for (int i = 0; i < lines.size(); ++i) {
         lines[i]->setRow(i);
     }
@@ -744,6 +746,8 @@ void ChatLog::removeLasts(const int num)
     } else {
         lines.clear();
     }
+
+    clearSelection();
 }
 
 void ChatLog::setScroll(const bool scroll)


### PR DESCRIPTION
We need to invalidate the selection when adding/removing lines from the
chatlog because the selection stores them as absolute indices.

A nicer solution would be to actually update the selection accordingly,
but this will be a major overhaul of the code.

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5806)
<!-- Reviewable:end -->
