### PR TITLE
fix(chatlog): update multi line selection on chatlog change

### DIFF
--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -58,6 +58,8 @@ public:
     void selectAll();
     void fontChanged(const QFont& font);
     void reloadTheme();
+    void moveSelectionRectUpIfMulti(int offset);
+    void moveSelectionRectDownIfMulti(int offset);
     void removeFirsts(const int num);
     void removeLasts(const int num);
     void setScroll(const bool scroll);


### PR DESCRIPTION
Fixes crash due to out of bound access. Fixes selection box jumping on history load.

Fix #5769

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5811)
<!-- Reviewable:end -->
