### PR TITLE
fix(login): fix a crash when many dialogs are open

### DIFF
--- a/src/nexus.cpp
+++ b/src/nexus.cpp
@@ -158,6 +158,8 @@ int Nexus::showLogin(const QString& profileName)
     LoginScreen loginScreen{profileName};
     connectLoginScreen(loginScreen);
 
+    QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
+
     // TODO(kriby): Move core out of profile
     // This is awkward because the core is in the profile
     // The connection order ensures profile will be ready for bootstrap for now


### PR DESCRIPTION
This PR fix next (reproducible always):

1. Open chat in new window
2. Logout
3. Login
4. there is segfault

Crash reason: 
after logout ContentDialog is not destructed
after login ContentDialog calls method from destructed Friend

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5815)
<!-- Reviewable:end -->
