### PR TITLE
fix: hide current date at the top of the chat

### DIFF
--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -1199,7 +1199,7 @@ void GenericChatForm::updateShowDateInfo(const ChatLine::Ptr& line)
 {
     const auto date = getTime(line);
 
-    if (date.isValid() && date != QDateTime::currentDateTime()) {
+    if (date.isValid() && date.date() != QDate::currentDate()) {
         const auto dateText = QStringLiteral("<b>%1<\b>").arg(date.toString(Settings::getInstance().getDateFormat()));
         dateInfo->setText(dateText);
         dateInfo->setVisible(true);


### PR DESCRIPTION
- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5819)
<!-- Reviewable:end -->
