### PR TITLE
feat: add Fcitx and Uim support to AppImage

### DIFF
--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -75,7 +75,8 @@ git patchelf tclsh libssl-dev cmake extra-cmake-modules build-essential \
 check checkinstall libavdevice-dev libexif-dev libgdk-pixbuf2.0-dev \
 libgtk2.0-dev libopenal-dev libopus-dev libqrencode-dev libqt5opengl5-dev \
 libqt5svg5-dev libsodium-dev libtool libvpx-dev libxss-dev \
-qt5-default qttools5-dev qttools5-dev-tools qtdeclarative5-dev
+qt5-default qttools5-dev qttools5-dev-tools qtdeclarative5-dev \
+fcitx-frontend-qt5 uim-qt5
 
 # get version
 cd "$QTOX_SRC_DIR"


### PR DESCRIPTION
Qt needs some libraries to be present in order to support IBus, Fcitx and Uim IMEs. Specifically:

```
plugins/platforminputcontexts/libibusplatforminputcontextplugin.so
plugins/platforminputcontexts/libfcitxplatforminputcontextplugin.so
plugins/platforminputcontexts/libuimplatforminputcontextplugin.so
```

[libQt5Gui in Debian already comes with the IBus plugin](https://packages.debian.org/stretch/amd64/libqt5gui5/filelist), so IBus input should have worked all this time, but not Fcitx and Uim, for those you need to manually install [fcitx-frontend-qt5](https://packages.debian.org/buster/fcitx-frontend-qt5) and [uim-qt5](https://packages.debian.org/stretch/uim-qt5) (renamed to [uim-qt5-immodule](https://packages.debian.org/buster/uim-qt5-immodule) in Buster) packages. To include the plugin libraries into qTox AppImage we have to simply install those packages, linuxdeployqt or whatever includes them since these are Qt plugins.

I have verified that in the latest nightly AppImage Fcitx popup doesn't appear, but with these changes it does. I have not tested IBus and Uim, but I assume IBus has always worked and Uim should work after this is merged.

Fixes #5320

---

Note that there is a separate issue related to IMEs: [QTextEdit's placeholder text is visible as you enter the first thing in IME](https://bugreports.qt.io/browse/QTBUG-55758). It was fixed in Qt ==5.6.3 and >=5.8.0. The Qt we use in AppImage is 5.7.1 so it doesn't have that fix. It would get fixed whenever we update the AppImage script to Debian Buster, as it includes Qt 5.11.3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5825)
<!-- Reviewable:end -->
