### PR TITLE
fix(chatlog): Prepare geometry changes on chatline proxy

### DIFF
--- a/src/chatlog/chatlinecontentproxy.cpp
+++ b/src/chatlog/chatlinecontentproxy.cpp
@@ -78,6 +78,7 @@ QWidget* ChatLineContentProxy::getWidget() const
 
 void ChatLineContentProxy::setWidth(qreal width)
 {
+    prepareGeometryChange();
     proxy->widget()->setFixedWidth(qMax(static_cast<int>(width * widthPercent), widthMin));
 }
 


### PR DESCRIPTION
Closes #5818. If output of boundingRect() changes for a QGraphicsItem
prepareGeomeotryChange() must be called.

Verified that my 100% repro rate case no longer crashed. I was triggering the issue by doing a search for a string that appeared far back in history and spamming enter

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5827)
<!-- Reviewable:end -->
