### PR TITLE
fix(history): Prevent invalid history access

### DIFF
--- a/src/persistence/history.h
+++ b/src/persistence/history.h
@@ -201,6 +201,7 @@ private slots:
     void onFileInserted(RowId dbId, QString fileId);
 
 private:
+    bool historyAccessBlocked();
     static RawDatabase::Query generateFileFinished(RowId fileId, bool success,
                                                    const QString& filePath, const QByteArray& fileHash);
     std::shared_ptr<RawDatabase> db;

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -983,6 +983,10 @@ void GenericChatForm::searchInBegin(const QString& phrase, const ParameterSearch
         return;
     }
 
+    if (messages.size() == 0) {
+        return;
+    }
+
     if (chatLog.getNextIdx().get() == messages.rbegin()->first.get() + 1) {
         disableSearchText();
     } else {


### PR DESCRIPTION
* When the DB schema was too new we were accessing history anyways. This
has potential to just completely corrupt the DB
* When history was disabled there was a chance we would attempt to write
to history anyways. Added more checks in this area

Tested by bumping my DB version up to two, committing that to history, then dropping it back down to 1

Stop gap solution for #5683. I'd like to leave that open until we implement a gui popup but getting this in early prevents a lot of invalid history accesses that could cause corruption

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5828)
<!-- Reviewable:end -->
