### PR TITLE
fix(core): don't log critical on every group join

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -1160,6 +1160,11 @@ QString Core::getGroupPeerName(int groupId, int peerId) const
 {
     QMutexLocker ml{&coreLoopLock};
 
+    // from tox.h: "If peer_number == UINT32_MAX, then author is unknown (e.g. initial joining the conference)."
+    if (peerId != std::numeric_limits<uint32_t>::max()) {
+        return {};
+    }
+
     Tox_Err_Conference_Peer_Query error;
     size_t length = tox_conference_peer_get_name_size(tox.get(), groupId, peerId, &error);
     if (!parsePeerQueryError(error)) {


### PR DESCRIPTION
It's expected behaviour that the peer is unknown when first joining a group.

Fix #5118

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5833)
<!-- Reviewable:end -->
