### PR TITLE
fix(db): prepare and execute queued statements one at a time

### DIFF
--- a/src/persistence/db/rawdatabase.cpp
+++ b/src/persistence/db/rawdatabase.cpp
@@ -744,10 +744,9 @@ void RawDatabase::process()
                 }
                 curParam += nParams;
             } while (compileTail != query.query.data() + query.query.size());
-        }
 
-        // Execute each statement of each query of our transaction
-        for (Query& query : trans.queries) {
+
+            // Execute each statement of each query of our transaction
             for (sqlite3_stmt* stmt : query.statements) {
                 int column_count = sqlite3_column_count(stmt);
                 int result;


### PR DESCRIPTION
* Allows for queued preparations to depend on the execution of previous statements

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5842)
<!-- Reviewable:end -->
