### PR TITLE
Remove invalid usages of raw chatlog indexes

### DIFF
--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -35,7 +35,7 @@ class QTimer;
 class ChatLineContent;
 struct ToxFile;
 
-static const auto DEF_NUM_MSG_TO_LOAD = 100;
+static const size_t DEF_NUM_MSG_TO_LOAD = 100;
 
 class ChatLog : public QGraphicsView
 {

--- a/src/model/chathistory.cpp
+++ b/src/model/chathistory.cpp
@@ -226,15 +226,6 @@ std::vector<IChatLog::DateChatLogIdxPair> ChatHistory::getDateIdxs(const QDate& 
     }
 }
 
-std::size_t ChatHistory::size() const
-{
-    if (canUseHistory()) {
-        return history->getNumMessagesForFriend(f.getPublicKey());
-    }
-
-    return sessionChatLog.size();
-}
-
 void ChatHistory::onFileUpdated(const ToxPk& sender, const ToxFile& file)
 {
     if (canUseHistory()) {

--- a/src/model/chathistory.h
+++ b/src/model/chathistory.h
@@ -42,7 +42,6 @@ public:
     ChatLogIdx getFirstIdx() const override;
     ChatLogIdx getNextIdx() const override;
     std::vector<DateChatLogIdxPair> getDateIdxs(const QDate& startDate, size_t maxDates) const override;
-    std::size_t size() const override;
 
 public slots:
     void onFileUpdated(const ToxPk& sender, const ToxFile& file);

--- a/src/model/ichatlog.h
+++ b/src/model/ichatlog.h
@@ -138,8 +138,6 @@ public:
     virtual std::vector<DateChatLogIdxPair> getDateIdxs(const QDate& startDate,
                                                         size_t maxDates) const = 0;
 
-    virtual std::size_t size() const = 0;
-
 signals:
     void itemUpdated(ChatLogIdx idx);
 };

--- a/src/model/sessionchatlog.cpp
+++ b/src/model/sessionchatlog.cpp
@@ -289,11 +289,6 @@ std::vector<IChatLog::DateChatLogIdxPair> SessionChatLog::getDateIdxs(const QDat
     return ret;
 }
 
-std::size_t SessionChatLog::size() const
-{
-    return items.size();
-}
-
 void SessionChatLog::insertMessageAtIdx(ChatLogIdx idx, ToxPk sender, QString senderName,
                                         ChatLogMessage message)
 {

--- a/src/model/sessionchatlog.h
+++ b/src/model/sessionchatlog.h
@@ -45,7 +45,6 @@ public:
     ChatLogIdx getFirstIdx() const override;
     ChatLogIdx getNextIdx() const override;
     std::vector<DateChatLogIdxPair> getDateIdxs(const QDate& startDate, size_t maxDates) const override;
-    std::size_t size() const override;
 
     void insertMessageAtIdx(ChatLogIdx idx, ToxPk sender, QString senderName, ChatLogMessage message);
     void insertFileAtIdx(ChatLogIdx idx, ToxPk sender, QString senderName, ChatLogFile file);


### PR DESCRIPTION
ChatLogIdx is a strong type where the underlying data is only supposed to be used in very rare  circumstances. The ChatLog providing the indexes provides no guarantees about what the first ChatLogIdx or last ChatLogIdx will be. This commit removes unnecessary casts to underlying data and fixes assumptions made about the underlying data

PRd to master since I believe is not a critical fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5847)
<!-- Reviewable:end -->
