### PR TITLE
fix(chatform): Fix invalid access of empty container

### DIFF
--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -632,9 +632,12 @@ void GenericChatForm::loadHistory(const QDateTime &time, const LoadHistoryDialog
 
     if (type == LoadHistoryDialog::from) {
         loadHistoryFrom(time);
-        auto msg = messages.cbegin()->second;
-        chatWidget->setScroll(true);
-        chatWidget->scrollToLine(msg);
+        if (!messages.empty())
+        {
+            auto msg = messages.cbegin()->second;
+            chatWidget->setScroll(true);
+            chatWidget->scrollToLine(msg);
+        }
     } else {
         loadHistoryTo(time);
     }


### PR DESCRIPTION
This partially fixes #5832 in that we no long segfault. There is a
deeper underlying problem that the history still relies on undefined
behavior of GROUP BY causing us to get an empty container in some cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5848)
<!-- Reviewable:end -->
