### PR TITLE
Fix Build With Qt 5.14 Part Deux

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -75,10 +75,18 @@ void cleanup()
     qDebug() << "Cleanup success";
 
 #ifdef LOG_TO_FILE
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    FILE* f = logFileFile.loadRelaxed();
+#else
     FILE* f = logFileFile.load();
+#endif
     if (f != nullptr) {
         fclose(f);
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+        logFileFile.storeRelaxed(nullptr); // atomically disable logging to file
+#else
         logFileFile.store(nullptr); // atomically disable logging to file
+#endif
     }
 #endif
 }
@@ -128,7 +136,11 @@ void logMessageHandler(QtMsgType type, const QMessageLogContext& ctxt, const QSt
     fwrite(LogMsgBytes.constData(), 1, LogMsgBytes.size(), stderr);
 
 #ifdef LOG_TO_FILE
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    FILE* logFilePtr = logFileFile.loadRelaxed(); // atomically load the file pointer
+#else
     FILE* logFilePtr = logFileFile.load(); // atomically load the file pointer
+#endif
     if (!logFilePtr) {
         logBufferMutex->lock();
         if (logBuffer)
@@ -282,7 +294,11 @@ int main(int argc, char* argv[])
     if (!mainLogFilePtr)
         qCritical() << "Couldn't open logfile" << logfile;
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    logFileFile.storeRelaxed(mainLogFilePtr); // atomically set the logFile
+#else
     logFileFile.store(mainLogFilePtr); // atomically set the logFile
+#endif
 #endif
 
     // Windows platform plugins DLL hell fix

--- a/test/model/messageprocessor_test.cpp
+++ b/test/model/messageprocessor_test.cpp
@@ -54,8 +54,8 @@ private slots:
 void TestMessageProcessor::testSelfMention()
 {
     MessageProcessor::SharedParams sharedParams;
-    const QLatin1Literal testUserName{"MyUserName"};
-    const QLatin1Literal testToxPk{
+    const QLatin1String testUserName{"MyUserName"};
+    const QLatin1String testToxPk{
         "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"};
     sharedParams.onUserNameSet(testUserName);
     sharedParams.setPublicKey(testToxPk);


### PR DESCRIPTION
- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

Note that I did not try building with Qt 5.13 or lower with these changes, which will not have the new QAtomicInteger functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5850)
<!-- Reviewable:end -->
