### PR TITLE
Add AppArmor 2.13.3 profile

### DIFF
--- a/security/apparmor/2.13.3/install.sh
+++ b/security/apparmor/2.13.3/install.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+#   Copyright © 2019 by The qTox Project Contributors
+#
+#   This file is part of qTox, a Qt-based graphical interface for Tox.
+#   qTox is libre software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   qTox is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with qTox.  If not, see <http://www.gnu.org/licenses/>
+
+
+set -e -u pipefail
+
+readonly SCRIPT_DIR=$(dirname $(readlink -f $0))
+
+if [[ $(id -u) != 0 ]]
+then
+    >&2 echo "Please run as root."
+    exit 1
+fi
+
+if [[ -z $(which apparmor_parser) ]]
+then
+   >&2 echo "AppArmor not found."
+   exit 1
+fi
+
+#NOTE: we do not need to create /etc/apparmor.d/tunables/usr.bin.qtox.d/ or
+#/etc/apparmor.d/local/usr.bin.qtox because AppArmor >2.13 support #include if
+#exists
+
+echo "Copying AppArmor files..."
+cp -v "${SCRIPT_DIR}/tunables/usr.bin.qtox" "/etc/apparmor.d/tunables/"
+cp -v "${SCRIPT_DIR}/usr.bin.qtox" "/etc/apparmor.d/"
+
+echo "Restarting AppArmor..."
+systemctl restart apparmor
+
+echo "Done."
+

--- a/security/apparmor/2.13.3/tunables/usr.bin.qtox
+++ b/security/apparmor/2.13.3/tunables/usr.bin.qtox
@@ -1,0 +1,28 @@
+#   Copyright © 2019 by The qTox Project Contributors
+#
+#   This file is part of qTox, a Qt-based graphical interface for Tox.
+#   qTox is libre software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   qTox is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with qTox.  If not, see <http://www.gnu.org/licenses/>
+
+@{qtox_prefix} = /usr /usr/local
+
+# Allow to read & write into mounted media, etc.
+# for convenient sending & receiving of files.
+@{qtox_additional_rw_dirs} = /mnt /media
+
+# Create /etc/apparmor.d/tunables/usr.bin.qtox.d/local file to append values as
+# needed, such as:
+# @{qtox_prefix} += @{HOME}/opt/qtox
+# @{qtox_additional_rw_dirs} = /data/nfs_storage
+#include if exists <tunables/usr.bin.qtox.d/>
+

--- a/security/apparmor/2.13.3/usr.bin.qtox
+++ b/security/apparmor/2.13.3/usr.bin.qtox
@@ -1,0 +1,351 @@
+#   Copyright © 2019 by The qTox Project Contributors
+#
+#   This file is part of qTox, a Qt-based graphical interface for Tox.
+#   qTox is libre software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   qTox is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with qTox.  If not, see <http://www.gnu.org/licenses/>
+
+#include <tunables/global>
+#include <tunables/usr.bin.qtox>
+
+# using variables in profile name is not yet recommended due to issues with
+# AppArmor tools
+# TODO: use this alternative in the future when available
+#profile qtox @{qtox_prefix}/bin/qtox {
+profile qtox /usr{,/local}/bin/qtox {
+  #include <abstractions/audio>
+  #include <abstractions/base>
+  #include <abstractions/dbus-accessibility>
+  #include <abstractions/dbus-session-strict>
+  #include <abstractions/dri-enumerate>
+  #include <abstractions/gnome>
+  #include <abstractions/ibus>
+  #include <abstractions/kde-globals-write>
+  #include <abstractions/kde-icon-cache-write>
+  #include <abstractions/kde>
+  #include <abstractions/mesa>
+  #include <abstractions/nameservice>
+  #include <abstractions/openssl>
+  #include <abstractions/qt5-compose-cache-write>
+  #include <abstractions/qt5-settings-write>
+  #include <abstractions/recent-documents-write>
+  #include <abstractions/video>
+
+  # Site-specific additions and overrides. See local/README for details.
+  #include if exists <local/usr.bin.qtox>
+
+  # Main executable
+
+  @{qtox_prefix}/bin/qtox mr,
+
+  # Other executables
+
+  #TODO: use xdg-open abstraction when it's available
+  /usr/bin/xdg-open PUx,
+  #TODO: use named profile or abstraction when it's available
+  /usr/lib/@{multiarch}/libexec/kf5/kioslave PUx,
+
+  # Additional libraries
+
+  # Allow /usr/local/lib/libtoxcore.so...
+  @{qtox_prefix}/lib/*.so* mr,
+
+  # Networking
+
+  network inet udp,
+  network inet6 udp,
+  network inet tcp,
+  network inet6 tcp,
+
+  # DBus
+
+  dbus send
+    bus=session
+    path=/org/a11y/bus
+    interface=org.freedesktop.DBus.Properties
+    member=Get
+    peer=(label=unconfined),
+
+  dbus receive
+    bus=session
+    path=/
+    interface=org.freedesktop.DBus.Introspectable
+    member=Introspect
+    peer=(label=unconfined),
+
+  dbus send
+    bus=session
+    path=/StatusNotifierWatcher
+    interface=org.freedesktop.DBus.Introspectable
+    member=Introspect
+    peer=(label=unconfined),
+
+  dbus (send,receive)
+    bus=session
+    path=/StatusNotifierWatcher
+    interface=org.freedesktop.DBus.Properties
+    member=Get
+    peer=(label=unconfined),
+
+  dbus receive
+    bus=session
+    path=/StatusNotifierItem
+    interface=org.freedesktop.DBus.Properties
+    member=GetAll
+    peer=(label=unconfined),
+
+  dbus send
+    bus=system
+    path=/org/freedesktop/NetworkManager
+    interface=org.freedesktop.DBus.Properties
+    member=GetAll
+    peer=(label=unconfined),
+
+  dbus send
+    bus=system
+    path=/org/freedesktop/NetworkManager
+    interface=org.freedesktop.NetworkManager
+    member=GetDevices
+    peer=(label=unconfined),
+
+  dbus receive
+    bus=system
+    path=/org/freedesktop/NetworkManager
+    interface=org.freedesktop.NetworkManager
+    member=PropertiesChanged
+    peer=(label=unconfined),
+
+  dbus send
+    bus=system
+    path=/org/freedesktop/NetworkManager/Settings
+    interface=org.freedesktop.NetworkManager.Settings
+    member=ListConnections
+    peer=(label=unconfined),
+
+  dbus send
+    bus=system
+    path=/org/freedesktop/NetworkManager/Settings/[0-9]*
+    interface=org.freedesktop.NetworkManager.Settings.Connection
+    member=GetSettings
+    peer=(label=unconfined),
+
+  dbus send
+    bus=system
+    path=/org/freedesktop/NetworkManager/ActiveConnection/[0-9]*
+    interface=org.freedesktop.DBus.Properties
+    member=GetAll
+    peer=(label=unconfined),
+
+  dbus receive
+    bus=system
+    path=/org/freedesktop/NetworkManager/ActiveConnection/[0-9]*
+    interface=org.freedesktop.NetworkManager.Connection.Active
+    member=PropertiesChanged
+    peer=(label=unconfined),
+
+  dbus send
+    bus=system
+    path=/org/freedesktop/NetworkManager/Devices/[0-9]*
+    interface=org.freedesktop.DBus.Properties
+    member=GetAll
+    peer=(label=unconfined),
+
+  dbus send
+    bus=session
+    path=/StatusNotifierWatcher
+    interface=org.kde.StatusNotifierWatcher
+    member=RegisterStatusNotifierItem
+    peer=(label=unconfined),
+
+  dbus receive
+    bus=session
+    path=/StatusNotifierItem
+    interface=org.kde.StatusNotifierItem
+    member=Activate
+    peer=(label=unconfined),
+
+  dbus (send,receive)
+    bus=session
+    path=/MenuBar
+    interface=com.canonical.dbusmenu
+    member=GetLayout
+    peer=(label=unconfined),
+
+  dbus (send,receive)
+    bus=session
+    path=/MenuBar
+    interface=com.canonical.dbusmenu
+    member={AboutToShow,Event}
+    peer=(label=unconfined),
+
+  dbus send
+    bus=session
+    path=/StatusNotifierItem
+    interface=org.kde.StatusNotifierItem
+    member={NewIcon,NewToolTip}
+    peer=(label=unconfined),
+
+  dbus send
+    bus=system
+    path=/org/freedesktop/UPower
+    interface=org.freedesktop.DBus.Introspectable
+    member=Introspect
+    peer=(label=unconfined),
+
+  dbus send
+    bus=system
+    path=/org/freedesktop/UDisks2/{block_devices,block_devices/*,drives,drives/*}
+    interface=org.freedesktop.DBus.Introspectable
+    member=Introspect
+    peer=(label=unconfined),
+
+  dbus send
+    bus=system
+    path=/org/freedesktop/UDisks2/{block_devices,drives}/*
+    interface=org.freedesktop.DBus.Properties
+    member={Get,GetAll}
+    peer=(label=unconfined),
+
+  dbus send
+    bus=session
+    path=/org/freedesktop/DBus
+    interface=org.freedesktop.DBus
+    member=GetConnectionUnixUser
+    peer=(label=unconfined),
+
+  dbus send
+    bus=session
+    path=/
+    interface=org.kde.KDirNotify
+    member={enteredDirectory,leftDirectory}
+    peer=(label=unconfined),
+
+  dbus receive
+    bus=session
+    path=/
+    interface=org.kde.KDirNotify
+    member=FilesAdded
+    peer=(label=unconfined),
+
+  dbus send
+    bus=session
+    path=/KLauncher
+    interface=org.kde.KSlaveLauncher
+    member=requestSlave
+    peer=(label=unconfined),
+
+  # Denied files
+
+  # libpcre2 on openSUSE tries to mmap() shared memory on directory.
+  # see: https://lists.ubuntu.com/archives/apparmor/2019-January/011925.html
+  # AppArmor does not allow to distinguish "real" file vs shared memory one,
+  # so we deny this path to protect from loading exploits from /tmp.
+  deny /tmp/#[0-9][0-9][0-9][0-9][0-9] m,
+
+  # libfontconfig bug? Should not write to root-owned dirs.
+  deny /usr/share/fonts/** w,
+  deny /var/cache/fontconfig/ w,
+
+  # System files
+
+  /usr/share/hunspell/* r,
+  @{qtox_additional_rw_dirs}/ r,
+  @{qtox_additional_rw_dirs}/** rw,
+
+  # Sensitive directory access!!!
+  # Allow navigating directories with file dialog, to access directory you
+  # can write (read) file to, for most convenience (though against maximum
+  # security). Note: this allows reading only directory contents (list),
+  # not the files itself.
+  /{,**/} r,
+
+  /dev/ r,
+  /dev/dri/ r,
+  /dev/video[0-9]* rw, # webcam
+  /etc/fstab r, # file dialog
+  /etc/xdg/menus/ r, # file dialog
+  /proc/sys/kernel/core_pattern r, # for  KCrash::initialize()
+  /proc/sys/kernel/random/boot_id r, # for QSysInfo::bootUniqueId(), mvoe to qt5 abstraction?
+  /run/udev/data/*:* r, # libKF5KIOFileWidgets.so -> libudev.so (KDE file dialog)
+  /sys/bus/ r, # file dialog
+  /sys/bus/usb/devices/ r, # file dialog
+  /sys/class/ r, # file dialog
+  /sys/devices/**/uevent r, # file dialog
+  /sys/devices/system/node/ r,  # for ld-linux-x86-64.so -> libnuma1.so
+  /sys/devices/system/node/node[0-9]*/meminfo r, # for ld-linux-x86-64.so -> libnuma1.so
+  /usr/share/emoticons/{,**} r,
+  /usr/share/hwdata/pnp.ids r, # For OpenSUSE only?
+  /usr/share/icu/[0-9]*.[0-9]*/icudt[0-9]*.dat r, # For OpenSUSE only?
+  /usr/share/kservices5/{,**} r, # file dialog
+  /usr/share/mime/ r, # file dialog
+  /usr/share/plasma/look-and-feel/*/contents/defaults r, # TODO: move to kde abstraction?
+  /usr/share/sounds/ r, # file dialog (alert)
+  /{,var/}run/udev/data/* r, # file dialog
+
+  # User files
+
+  # Sensitive file access!!!
+  # Allow reading & writing into $HOME, EXCEPT for dot files and directories,
+  # for most convenience (though against maximum security).
+  owner @{HOME}/ r,
+  owner @{HOME}/[^.]* rw,
+  owner @{HOME}/[^.]*/{,**} rw,
+  # QSaveFile security measures? While saving log file
+  owner @{HOME}/[^.]* l -> @{HOME}/#[0-9]*[0-9],
+  owner @{HOME}/[^.]*/** l -> @{HOME}/#[0-9]*[0-9],
+
+  owner /{,var/}run/user/@{uid}/#[0-9]*[0-9] rw, # file dialog
+  owner /{,var/}run/user/@{uid}/qTox*.slave-socket rwl -> /{,var/}run/user/@{uid}/#[0-9]*[0-9], # file dialog
+  owner @{HOME}/.cache/Tox/ w,
+  owner @{HOME}/.cache/Tox/qTox/{,**} rw,
+  owner @{HOME}/.cache/fontconfig/** rwk,
+  owner @{HOME}/.cache/qTox/{,**} rw,
+  owner @{HOME}/.cache/thumbnails/** rw, # receiving image file produces thumbnail?
+  owner @{HOME}/.config/menus/ r, # file dialog
+  owner @{HOME}/.config/menus/applications-merged/ r, # file dialog
+  owner @{HOME}/.config/qToxrc rw,
+  owner @{HOME}/.config/qToxrc.?????? rwl -> @{HOME}/.config/#[0-9]*[0-9], # QSaveFile?
+  owner @{HOME}/.config/qToxrc.lock rwk,
+  owner @{HOME}/.config/tox/** l -> @{HOME}/.config/tox/**, # QSaveFile?
+  owner @{HOME}/.config/tox/{,**} rwk,
+  owner @{HOME}/.fonts/.uuid* rw,
+  owner @{HOME}/.fonts/.uuid.* l -> @{HOME}/.fonts/.uuid.*,
+  owner @{HOME}/.fonts/.uuid.*/ rw,
+  owner @{HOME}/.local/share/Tox/{,**} rw,
+  owner @{HOME}/.local/share/qTox/{,**} rw,
+  owner @{HOME}/.local/share/user-places.xbel r, # file dialog
+  owner @{PROC}/@{pid}/cmdline r,
+
+  # Backport from more recent qt5-compose-cache-write abstraction
+  # commit 1250402471d9d83134b0faa90239a733a37f23f0
+  owner @{HOME}/.cache/qt_compose_cache_{little,big}_endian_* rwl -> @{HOME}/.cache/#[0-9]*[0-9],
+  owner @{HOME}/.cache/#[0-9]*[0-9] rw, # QSaveFile (anonymous shared memory)
+
+  # Backport kde abstraction
+  # commit aae838faca57905d2dbc27db7bffd595c09d26f0
+  # commit dc3b73daf9f648336a6f9ab90103acc962c0bf40
+  /etc/xdg/kdeglobals r,
+  /usr/share/knotifications5/*.notifyrc r, # KNotification::sendEvent()
+  /usr/share/kubuntu-default-settings/kf5-settings/* r,
+  owner @{HOME}/.cache/ksycoca5_??_* r, # KDE System Configuration Cache
+  owner @{HOME}/.config/baloofilerc r, # indexing options (excludes, etc), used by KFileWidget
+  owner @{HOME}/.config/dolphinrc r, # settings used by KFileWidget
+  owner @{HOME}/.config/kde.org/libphonon.conf r, # for KNotifications::sendEvent()
+  owner @{HOME}/.config/kdeglobals r, # global settings, used by Breeze style, etc.
+  owner @{HOME}/.config/klanguageoverridesrc r, # per-application languages, for KDEPrivate::initializeLanguages() from libKF5XmlGui.so
+  owner @{HOME}/.config/trashrc r, # Used by KFileWidget
+
+  # Backport dri-common abstraction
+  # commit 2d8d2f06d5697d9692330686bb5ddb0095621144
+  /usr/share/drirc.d/{,*.conf} r,
+
+}

--- a/security/apparmor/2.13.3/usr.bin.qtox
+++ b/security/apparmor/2.13.3/usr.bin.qtox
@@ -269,7 +269,6 @@ profile qtox /usr{,/local}/bin/qtox {
   /{,**/} r,
 
   /dev/ r,
-  /dev/dri/ r,
   /dev/video[0-9]* rw, # webcam
   /etc/fstab r, # file dialog
   /etc/xdg/menus/ r, # file dialog
@@ -324,28 +323,5 @@ profile qtox /usr{,/local}/bin/qtox {
   owner @{HOME}/.local/share/qTox/{,**} rw,
   owner @{HOME}/.local/share/user-places.xbel r, # file dialog
   owner @{PROC}/@{pid}/cmdline r,
-
-  # Backport from more recent qt5-compose-cache-write abstraction
-  # commit 1250402471d9d83134b0faa90239a733a37f23f0
-  owner @{HOME}/.cache/qt_compose_cache_{little,big}_endian_* rwl -> @{HOME}/.cache/#[0-9]*[0-9],
-  owner @{HOME}/.cache/#[0-9]*[0-9] rw, # QSaveFile (anonymous shared memory)
-
-  # Backport kde abstraction
-  # commit aae838faca57905d2dbc27db7bffd595c09d26f0
-  # commit dc3b73daf9f648336a6f9ab90103acc962c0bf40
-  /etc/xdg/kdeglobals r,
-  /usr/share/knotifications5/*.notifyrc r, # KNotification::sendEvent()
-  /usr/share/kubuntu-default-settings/kf5-settings/* r,
-  owner @{HOME}/.cache/ksycoca5_??_* r, # KDE System Configuration Cache
-  owner @{HOME}/.config/baloofilerc r, # indexing options (excludes, etc), used by KFileWidget
-  owner @{HOME}/.config/dolphinrc r, # settings used by KFileWidget
-  owner @{HOME}/.config/kde.org/libphonon.conf r, # for KNotifications::sendEvent()
-  owner @{HOME}/.config/kdeglobals r, # global settings, used by Breeze style, etc.
-  owner @{HOME}/.config/klanguageoverridesrc r, # per-application languages, for KDEPrivate::initializeLanguages() from libKF5XmlGui.so
-  owner @{HOME}/.config/trashrc r, # Used by KFileWidget
-
-  # Backport dri-common abstraction
-  # commit 2d8d2f06d5697d9692330686bb5ddb0095621144
-  /usr/share/drirc.d/{,*.conf} r,
 
 }

--- a/security/apparmor/README.md
+++ b/security/apparmor/README.md
@@ -29,10 +29,13 @@ Select AppArmor profile from appropriate `security/apparmor/X` subdirectory
 depending on what AppArmor version is available for your Linux distribution
 release:
 
-- 2.13.2
-  - Debian 10 (buster) (or newer)
-  - Ubuntu 19.04 (Disco Dingo) (or newer)
+- 2.13.3
+  - Debian 11 (bullseye) (or newer)
+  - Ubuntu 19.10 (or newer)
   - openSUSE Tumbleweed
+- 2.13.2
+  - Debian 10 (buster)
+  - Ubuntu 19.04 (Disco Dingo)
 - 2.12.1
   - Debian 9 (stretch) or older
   - Ubuntu 18.10 or older


### PR DESCRIPTION
- [x ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

Ubuntu 19.10 (and current Debian and openSUSE rolling releases) has AppArmor 2.13.3 with updated abstractions. This allows us to create cleaned-up profile, removing rules that are already available in the latest AppArmor release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5855)
<!-- Reviewable:end -->
