### PR TITLE
fix(core): avoid logging which bootstrap node is being connected to

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -146,7 +146,7 @@ jobs:
           - /opt/build-windows/x86_64
     - stage: "macOS, AppImage and Flatpak"
       os: osx
-      osx_image: xcode9.2
+      osx_image: xcode9.3
       env: JOB=build-osx
       cache:
         timeout: 300 # seconds

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -597,7 +597,7 @@ See [AppArmor] to enable confinement for increased security.
 
 ## OS X
 
-Supported OS X versions: >=10.8. (NOTE: only 10.12 is tested during CI)
+Supported OS X versions: >=10.8. (NOTE: only 10.13 is tested during CI)
 
 Compiling qTox on OS X for development requires 2 tools:
 [Xcode](https://developer.apple.com/xcode/) and [homebrew](https://brew.sh).

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -58,7 +58,9 @@ git config --global alias.logs 'log --show-signature'
   merge-commit **must** be signed. To simplify the process, and ensure that
   things are done "right", it's preferable to use the [`merge-pr.sh`] script,
   which does that for you automatically.
-- **use** [`merge-pr.sh`] script to merge PRs, e.g. `./merge-pr.sh 1234`.
+- **use** [`merge-pr.sh`] script to merge PRs. First checkout the target
+  branch, usually either `master` or a release dev branch e.g. `v1.17-dev`,
+  make sure it's up to date with qTox/qTox, then e.g. `./merge-pr.sh 1234`.
 
   You don't have to use it, but then you're running into risk of breaking
   travis build of master & other PRs, since it verifies all commit messages,

--- a/merge-pr.sh
+++ b/merge-pr.sh
@@ -52,6 +52,9 @@ source_functions() {
 main() {
     local remote_name="upstream"
     local merge_branch="merge"
+    local base_branch # because assigning on the same line will break error code parsing.. http://www.tldp.org/LDP/abs/html/localvar.html
+    base_branch=$(git symbolic-ref HEAD --short)
+
     source_functions
     exit_if_not_pr $PR
     add_remote

--- a/osx/qTox-Mac-Deployer-ULTIMATE.sh
+++ b/osx/qTox-Mac-Deployer-ULTIMATE.sh
@@ -170,9 +170,23 @@ install() {
     # needed for kf5-sonnet
     brew tap kde-mac/kde
 
-    # verbose so that build output is shown, otherwise qt5 build has no output for >10 mins
-    # and is killed by Travis CI
-    brew install --verbose ffmpeg libexif qrencode qt5 sqlcipher openal-soft #kf5-sonnet
+    # brew install qt5 might take a long time to build Qt. Travis kills us if
+    # we don't output for 10 minutes. Travis also kills us if we output too much,
+    # so verbose isn't an option. So just output some dots...
+    if [[ $TRAVIS = true ]]
+    then
+        echo "outputting dots to keep travis from killing us..."
+        while true; do
+            echo -n "."
+            sleep 10
+        done &
+        DOT_PID=$!
+    fi
+    brew install ffmpeg libexif qrencode qt5 sqlcipher openal-soft #kf5-sonnet
+    if [[ $TRAVIS = true ]]
+    then
+        kill $DOT_PID
+    fi
 
     fcho "Cloning filter_audio ... "
     git clone --branch v0.0.1 --depth=1 https://github.com/irungentoo/filter_audio "$FILTERAUIO_DIR"

--- a/osx/qTox-Mac-Deployer-ULTIMATE.sh
+++ b/osx/qTox-Mac-Deployer-ULTIMATE.sh
@@ -92,6 +92,26 @@ install() {
         read -n1 -rsp $'Press any key to continue or Ctrl+C to exit...\n'
     fi
 
+    # osx 10.13 High Sierra doesn't come with a /usr/local/sbin, yet it is needed by some brew packages
+    NEEDED_DEP_DIR="/usr/local/sbin"
+    if [[ $TRAVIS = true ]]
+    then
+        sudo mkdir -p $NEEDED_DEP_DIR
+        sudo chown -R $(whoami) $NEEDED_DEP_DIR
+    elif [[ ! -d $NEEDED_DEP_DIR ]]
+    then
+        fcho "The direcory $NEEDED_DEP_DIR must exist for some development packages."
+        read -r -p "Would you like to create it now, and set the owner to $(whoami)? [y/N] " response
+        if [[ $response =~ ^([yY][eE][sS]|[yY])$ ]]
+        then
+            sudo mkdir $NEEDED_DEP_DIR
+            sudo chown -R $(whoami) $NEEDED_DEP_DIR
+        else
+            fcho "Cannot proceed without $NEEDED_DEP_DIR. Exiting."
+            exit 0
+        fi
+    fi
+
     #fcho "Installing x-code Command line tools ..."
     #xcode-select --install
 

--- a/tools/lib/PR_bash.source
+++ b/tools/lib/PR_bash.source
@@ -60,24 +60,24 @@ add_remote() {
 after_merge_msg() {
     echo ""
     echo "PR #$PR was merged into «$@$PR» branch."
-    echo "To compare with master:"
+    echo "To compare with $base_branch:"
     echo ""
-    echo "  git diff master..$@$PR"
+    echo "  git diff $base_branch..$@$PR"
     echo ""
     if [[ "$@" == "merge" ]]
     then
-        echo "To push that to master on github:"
+        echo "To push that to $base_branch on github:"
         echo ""
-        echo "  git checkout master && git merge --ff $@$PR && git push upstream master"
+        echo "  git checkout $base_branch && git merge --ff $@$PR && git push upstream $base_branch"
         echo ""
-        echo "After pushing to master, delete branches:"
+        echo "After pushing to $base_branch, delete branches:"
         echo ""
         echo "  git branch -d {$@,}$PR"
         echo ""
     fi
     echo "To discard any changes:"
     echo ""
-    echo "  git checkout master && git branch -D {$@,}$PR"
+    echo "  git checkout $base_branch && git branch -D {$@,}$PR"
     echo ""
 }
 
@@ -88,7 +88,7 @@ after_merge_failure_msg() {
     echo ""
     echo "You may want to remove not merged branches, if they exist:"
     echo ""
-    echo "  git checkout master && git branch -D {$@,}$PR"
+    echo "  git checkout $base_branch && git branch -D {$@,}$PR"
     echo ""
 }
 
@@ -100,16 +100,13 @@ rm_obsolete_branch() {
 get_sources() {
     add_remote
     rm_obsolete_branch
-    git fetch $remote_name && \
-    git checkout master && \
-    git rebase $remote_name/master master && \
     git fetch $remote_name pull/$PR/head:$PR && \
-    git checkout master -b $merge_branch$PR
+    git checkout $base_branch -b $merge_branch$PR
 }
 
 # check whether to sign
 merge() {
     "${@}" --no-ff $PR -m "Merge pull request #$PR
 $OPT_MSG
-$(git shortlog master..$PR)"
+$(git shortlog $base_branch..$PR)"
 }


### PR DESCRIPTION
Errors are parsed and printed, but which specific node is being connected to
isn't very relevant to any errors that would occur, and the nodes list is
already updated to prune offline nodes based on nodes.tox.chat periodically.
This provides some extra privacy about which connections are being made,
even though the bootstrap nodes are already public.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5865)
<!-- Reviewable:end -->
