### PR TITLE
perf(history): enable sql index on chat_id in history table

### DIFF
--- a/test/persistence/dbschema_test.cpp
+++ b/test/persistence/dbschema_test.cpp
@@ -37,6 +37,7 @@ private slots:
     void test0to1();
     void test1to2();
     void test2to3();
+    void test3to4();
     void cleanupTestCase();
 private:
     bool initSucess{false};
@@ -50,8 +51,11 @@ const QString testFileList[] = {
     "testIsNewDbFalse.db",
     "test0to1.db",
     "test1to2.db",
-    "test2to3.db"
+    "test2to3.db",
+    "test3to4.db"
 };
+
+// db schemas can be select with "SELECT name, sql FROM sqlite_master;" on the database.
 
 const QMap<QString, QString> schema0 {
     {"aliases", "CREATE TABLE aliases (id INTEGER PRIMARY KEY, owner INTEGER, display_name BLOB NOT NULL, UNIQUE(owner, display_name))"},
@@ -81,6 +85,17 @@ const QMap<QString, QString> schema2 {
 
 // move stuck 0-length action messages to the existing "broken_messages" table. Not a real schema upgrade.
 const auto schema3 = schema2;
+
+// create index in history table on chat_id to improve query speed. Not a real schema upgrade.
+const QMap<QString, QString> schema4 {
+    {"aliases", "CREATE TABLE aliases (id INTEGER PRIMARY KEY, owner INTEGER, display_name BLOB NOT NULL, UNIQUE(owner, display_name))"},
+    {"faux_offline_pending", "CREATE TABLE faux_offline_pending (id INTEGER PRIMARY KEY)"},
+    {"file_transfers", "CREATE TABLE file_transfers (id INTEGER PRIMARY KEY, chat_id INTEGER NOT NULL, file_restart_id BLOB NOT NULL, file_name BLOB NOT NULL, file_path BLOB NOT NULL, file_hash BLOB NOT NULL, file_size INTEGER NOT NULL, direction INTEGER NOT NULL, file_state INTEGER NOT NULL)"},
+    {"history", "CREATE TABLE history (id INTEGER PRIMARY KEY, timestamp INTEGER NOT NULL, chat_id INTEGER NOT NULL, sender_alias INTEGER NOT NULL, message BLOB NOT NULL, file_id INTEGER)"},
+    {"peers", "CREATE TABLE peers (id INTEGER PRIMARY KEY, public_key TEXT NOT NULL UNIQUE)"},
+    {"broken_messages", "CREATE TABLE broken_messages (id INTEGER PRIMARY KEY)"},
+    {"chat_id_idx", "CREATE INDEX chat_id_idx on history (chat_id)"}
+};
 
 void TestDbSchema::initTestCase()
 {
@@ -132,7 +147,7 @@ void TestDbSchema::testCreation()
     QVector<RawDatabase::Query> queries;
     auto db = std::shared_ptr<RawDatabase>{new RawDatabase{"testCreation.db", {}, {}}};
     QVERIFY(createCurrentSchema(*db));
-    verifyDb(db, schema3);
+    verifyDb(db, schema4);
 }
 
 void TestDbSchema::testIsNewDb()
@@ -312,6 +327,14 @@ void TestDbSchema::test2to3()
     QVERIFY(totalHisoryCount == 4);
 
     verifyDb(db, schema3);
+}
+
+void TestDbSchema::test3to4()
+{
+    auto db = std::shared_ptr<RawDatabase>{new RawDatabase{"test3to4.db", {}, {}}};
+    createSchemaAtVersion(db, schema3);
+    QVERIFY(dbSchema3to4(*db));
+    verifyDb(db, schema4);
 }
 
 QTEST_GUILESS_MAIN(TestDbSchema)


### PR DESCRIPTION
This makes every query with a "WHERE history.chat_id" clause quicker,
improving history load time by 50% on my profile.

This PR is based on top of https://github.com/qTox/qTox/pull/5872.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5873)
<!-- Reviewable:end -->
