### PR TITLE
fix(chatform): Prevent date line oscillations maxing CPU

### DIFF
--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -782,6 +782,10 @@ void ChatLog::checkVisibility(bool causedWheelEvent)
     auto upperBound = std::lower_bound(lowerBound, lines.cend(), getVisibleRect().bottom(),
                                        ChatLine::lessThanBSRectTop);
 
+    const ChatLine::Ptr lastLineBeforeVisible = lowerBound == lines.cbegin()
+        ? ChatLine::Ptr()
+        : *std::prev(lowerBound);
+
     // set visibilty
     QList<ChatLine::Ptr> newVisibleLines;
     for (auto itr = lowerBound; itr != upperBound; ++itr) {
@@ -807,7 +811,7 @@ void ChatLog::checkVisibility(bool causedWheelEvent)
     //  visibleLines.last()->getRow() << " total " << visibleLines.size();
 
     if (!visibleLines.isEmpty()) {
-        emit firstVisibleLineChanged(visibleLines.at(0));
+        emit firstVisibleLineChanged(lastLineBeforeVisible, visibleLines.at(0));
     }
 
     if (causedWheelEvent) {

--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -78,7 +78,7 @@ public:
 signals:
     void selectionChanged();
     void workerTimeoutFinished();
-    void firstVisibleLineChanged(const ChatLine::Ptr&);
+    void firstVisibleLineChanged(const ChatLine::Ptr& prevLine, const ChatLine::Ptr& firstLine);
     void loadHistoryLower();
     void loadHistoryUpper();
 

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -647,7 +647,7 @@ QDateTime GenericChatForm::getTime(const ChatLine::Ptr &chatLine) const
         if (timestamp) {
             return timestamp->getTime();
         } else {
-            return QDateTime::currentDateTime();
+            return QDateTime();
         }
     }
 
@@ -1195,9 +1195,14 @@ void GenericChatForm::loadHistoryUpper()
     }
 }
 
-void GenericChatForm::updateShowDateInfo(const ChatLine::Ptr& line)
+void GenericChatForm::updateShowDateInfo(const ChatLine::Ptr& prevLine, const ChatLine::Ptr& topLine)
 {
-    const auto date = getTime(line);
+    // If the dateInfo is visible we need to pretend the top line is the one
+    // covered by the date to prevent oscillations
+    const auto effectiveTopLine = (dateInfo->isVisible() && prevLine)
+        ? prevLine : topLine;
+
+    const auto date = getTime(effectiveTopLine);
 
     if (date.isValid() && date.date() != QDate::currentDate()) {
         const auto dateText = QStringLiteral("<b>%1<\b>").arg(date.toString(Settings::getInstance().getDateFormat()));

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -117,7 +117,7 @@ protected slots:
     void onExportChat();
     void searchFormShow();
     void onSearchTriggered();
-    void updateShowDateInfo(const ChatLine::Ptr& line);
+    void updateShowDateInfo(const ChatLine::Ptr& prevLine, const ChatLine::Ptr& topLine);
 
     void searchInBegin(const QString& phrase, const ParameterSearch& parameter);
     void onSearchUp(const QString& phrase, const ParameterSearch& parameter);


### PR DESCRIPTION
The previous implementation of hiding the date line would cause 100% cpu
usage. When the date line was shown it would hide the top line, causing
the date line to be hidden again due to a state change in which dates
was visible.

This is a minimal patch to work around the issue by pretending the line
covered by the date line is the first visible line when the dateline is
shown

Fixes #5620

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5875)
<!-- Reviewable:end -->
