### PR TITLE
fix(ci): fix travis' window build in debian docker by upgrading libseccomp2

### DIFF
--- a/.travis/build-windows.sh
+++ b/.travis/build-windows.sh
@@ -108,6 +108,11 @@ ls -lbh "$CACHE_DIR"
 # Purely for debugging
 ls -lbh "$PWD"
 
+sudo apt-get update -qq
+# even though we're building in docker, libseccomp2 is used by docker, and needs to be up to date
+# to support functionality used by Qt's configure
+sudo apt-get install libseccomp2 -y --force-yes
+
 # Build
 sudo docker run --rm \
                 -v "$PWD/workspace":/workspace \


### PR DESCRIPTION
- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5876)
<!-- Reviewable:end -->
