### PR TITLE
refactor(style): use only one of override, virtual, or final

### DIFF
--- a/src/chatlog/chatlinecontent.h
+++ b/src/chatlog/chatlinecontent.h
@@ -39,7 +39,7 @@ public:
     int getRow() const;
 
     virtual void setWidth(qreal width) = 0;
-    virtual int type() const final;
+    int type() const final;
 
     virtual void selectionMouseMove(QPointF scenePos);
     virtual void selectionStarted(QPointF scenePos);

--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -107,16 +107,16 @@ protected:
     void scrollToBottom();
     void startResizeWorker(ChatLine::Ptr anchorLine = nullptr);
 
-    virtual void mouseDoubleClickEvent(QMouseEvent* ev) final override;
-    virtual void mousePressEvent(QMouseEvent* ev) final override;
-    virtual void mouseReleaseEvent(QMouseEvent* ev) final override;
-    virtual void mouseMoveEvent(QMouseEvent* ev) final override;
-    virtual void scrollContentsBy(int dx, int dy) final override;
-    virtual void resizeEvent(QResizeEvent* ev) final override;
-    virtual void showEvent(QShowEvent*) final override;
-    virtual void focusInEvent(QFocusEvent* ev) final override;
-    virtual void focusOutEvent(QFocusEvent* ev) final override;
-    virtual void wheelEvent(QWheelEvent *event) final override;
+    void mouseDoubleClickEvent(QMouseEvent* ev) final;
+    void mousePressEvent(QMouseEvent* ev) final;
+    void mouseReleaseEvent(QMouseEvent* ev) final;
+    void mouseMoveEvent(QMouseEvent* ev) final;
+    void scrollContentsBy(int dx, int dy) final;
+    void resizeEvent(QResizeEvent* ev) final;
+    void showEvent(QShowEvent*) final;
+    void focusInEvent(QFocusEvent* ev) final;
+    void focusOutEvent(QFocusEvent* ev) final;
+    void wheelEvent(QWheelEvent *event) final;
 
     void updateMultiSelectionRect();
     void updateTypingNotification();

--- a/src/chatlog/content/filetransferwidget.h
+++ b/src/chatlog/content/filetransferwidget.h
@@ -62,7 +62,7 @@ protected:
 
     bool drawButtonAreaNeeded() const;
 
-    virtual void paintEvent(QPaintEvent*) final override;
+    void paintEvent(QPaintEvent*) final;
 
 private slots:
     void onLeftButtonClicked();

--- a/src/chatlog/content/image.h
+++ b/src/chatlog/content/image.h
@@ -29,11 +29,11 @@ class Image : public ChatLineContent
 public:
     Image(QSize size, const QString& filename);
 
-    virtual QRectF boundingRect() const override;
-    virtual void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
+    QRectF boundingRect() const override;
+    void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
                        QWidget* widget) override;
-    virtual void setWidth(qreal width) override;
-    virtual qreal getAscent() const override;
+    void setWidth(qreal width) override;
+    qreal getAscent() const override;
 
 private:
     QSize size;

--- a/src/chatlog/content/notificationicon.h
+++ b/src/chatlog/content/notificationicon.h
@@ -33,11 +33,11 @@ class NotificationIcon : public ChatLineContent
 public:
     explicit NotificationIcon(QSize size);
 
-    virtual QRectF boundingRect() const override;
-    virtual void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
+    QRectF boundingRect() const override;
+    void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
                        QWidget* widget) override;
-    virtual void setWidth(qreal width) override;
-    virtual qreal getAscent() const override;
+    void setWidth(qreal width) override;
+    qreal getAscent() const override;
 
 private slots:
     void updateGradient();

--- a/src/chatlog/content/spinner.h
+++ b/src/chatlog/content/spinner.h
@@ -34,12 +34,12 @@ class Spinner : public ChatLineContent
 public:
     Spinner(const QString& img, QSize size, qreal speed);
 
-    virtual QRectF boundingRect() const override;
-    virtual void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
+    QRectF boundingRect() const override;
+    void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
                        QWidget* widget) override;
-    virtual void setWidth(qreal width) override;
-    virtual void visibilityChanged(bool visible) override;
-    virtual qreal getAscent() const override;
+    void setWidth(qreal width) override;
+    void visibilityChanged(bool visible) override;
+    qreal getAscent() const override;
 
 private slots:
     void timeout();

--- a/src/chatlog/content/text.h
+++ b/src/chatlog/content/text.h
@@ -49,30 +49,30 @@ public:
     void selectText(const QRegularExpression& exp, const std::pair<int, int>& point);
     void deselectText();
 
-    virtual void setWidth(qreal width) final;
+    void setWidth(qreal width) final;
 
-    virtual void selectionMouseMove(QPointF scenePos) final;
-    virtual void selectionStarted(QPointF scenePos) final;
-    virtual void selectionCleared() final;
-    virtual void selectionDoubleClick(QPointF scenePos) final;
-    virtual void selectionTripleClick(QPointF scenePos) final;
-    virtual void selectionFocusChanged(bool focusIn) final;
-    virtual bool isOverSelection(QPointF scenePos) const final;
-    virtual QString getSelectedText() const final;
-    virtual void fontChanged(const QFont& font) final;
+    void selectionMouseMove(QPointF scenePos) final;
+    void selectionStarted(QPointF scenePos) final;
+    void selectionCleared() final;
+    void selectionDoubleClick(QPointF scenePos) final;
+    void selectionTripleClick(QPointF scenePos) final;
+    void selectionFocusChanged(bool focusIn) final;
+    bool isOverSelection(QPointF scenePos) const final;
+    QString getSelectedText() const final;
+    void fontChanged(const QFont& font) final;
 
-    virtual QRectF boundingRect() const final;
-    virtual void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget) final;
+    QRectF boundingRect() const final;
+    void paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget) final;
 
-    virtual void visibilityChanged(bool keepInMemory) final;
-    virtual void reloadTheme() final override;
+    void visibilityChanged(bool keepInMemory) final;
+    void reloadTheme() final;
 
-    virtual qreal getAscent() const final;
-    virtual void mousePressEvent(QGraphicsSceneMouseEvent* event) final override;
-    virtual void mouseReleaseEvent(QGraphicsSceneMouseEvent* event) final override;
-    void hoverMoveEvent(QGraphicsSceneHoverEvent* event) final override;    
+    qreal getAscent() const final;
+    void mousePressEvent(QGraphicsSceneMouseEvent* event) final;
+    void mouseReleaseEvent(QGraphicsSceneMouseEvent* event) final;
+    void hoverMoveEvent(QGraphicsSceneHoverEvent* event) final;
 
-    virtual QString getText() const final;
+    QString getText() const final;
     QString getLinkAt(QPointF scenePos) const;
 
 protected:

--- a/src/model/friend.h
+++ b/src/model/friend.h
@@ -55,7 +55,7 @@ public:
     Status::Status getStatus() const;
     bool isOnline() const;
 
-    bool useHistory() const override final;
+    bool useHistory() const final;
 
 signals:
     void nameChanged(const ToxPk& friendId, const QString& name);

--- a/src/model/group.h
+++ b/src/model/group.h
@@ -61,7 +61,7 @@ public:
     void setSelfName(const QString& name);
     QString getSelfName() const;
 
-    bool useHistory() const override final;
+    bool useHistory() const final;
 
 signals:
     void titleChangedByUser(const QString& title);

--- a/src/video/camerasource.h
+++ b/src/video/camerasource.h
@@ -43,8 +43,8 @@ public:
     bool isNone() const;
 
     // VideoSource interface
-    virtual void subscribe() override;
-    virtual void unsubscribe() override;
+    void subscribe() override;
+    void unsubscribe() override;
 
 public slots:
     void setupDevice(const QString& deviceName, const VideoMode& mode);

--- a/src/video/corevideosource.h
+++ b/src/video/corevideosource.h
@@ -31,8 +31,8 @@ class CoreVideoSource : public VideoSource
     Q_OBJECT
 public:
     // VideoSource interface
-    virtual void subscribe() override;
-    virtual void unsubscribe() override;
+    void subscribe() override;
+    void unsubscribe() override;
 
 private:
     CoreVideoSource();

--- a/src/video/groupnetcamview.cpp
+++ b/src/video/groupnetcamview.cpp
@@ -83,7 +83,7 @@ public:
     }
 
 protected:
-    void resizeEvent(QResizeEvent* event) final override
+    void resizeEvent(QResizeEvent* event) final
     {
         updateSize();
         QWidget::resizeEvent(event);

--- a/src/video/netcamview.h
+++ b/src/video/netcamview.h
@@ -46,7 +46,7 @@ public:
     void toggleVideoPreview();
 
 protected:
-    void showEvent(QShowEvent* event) final override;
+    void showEvent(QShowEvent* event) final;
 
 private slots:
     void updateRatio();

--- a/src/video/videosurface.h
+++ b/src/video/videosurface.h
@@ -49,9 +49,9 @@ protected:
     void subscribe();
     void unsubscribe();
 
-    virtual void paintEvent(QPaintEvent* event) final override;
-    virtual void resizeEvent(QResizeEvent* event) final override;
-    virtual void showEvent(QShowEvent* event) final override;
+    void paintEvent(QPaintEvent* event) final;
+    void resizeEvent(QResizeEvent* event) final;
+    void showEvent(QShowEvent* event) final;
 
 private slots:
     void onNewFrameAvailable(const std::shared_ptr<VideoFrame>& newFrame);

--- a/src/widget/categorywidget.h
+++ b/src/widget/categorywidget.h
@@ -55,8 +55,8 @@ public slots:
     void moveFriendWidgets(FriendListWidget* friendList);
 
 protected:
-    virtual void leaveEvent(QEvent* event) final override;
-    virtual void mouseReleaseEvent(QMouseEvent* event) final override;
+    void leaveEvent(QEvent* event) final;
+    void mouseReleaseEvent(QMouseEvent* event) final;
 
     void editName();
     void setContainerAttribute(Qt::WidgetAttribute attribute, bool enabled);

--- a/src/widget/circlewidget.h
+++ b/src/widget/circlewidget.h
@@ -40,15 +40,15 @@ signals:
     void newContentDialog(ContentDialog& contentDialog);
 
 protected:
-    void contextMenuEvent(QContextMenuEvent* event) final override;
-    void dragEnterEvent(QDragEnterEvent* event) final override;
-    void dragLeaveEvent(QDragLeaveEvent* event) final override;
-    void dropEvent(QDropEvent* event) final override;
+    void contextMenuEvent(QContextMenuEvent* event) final;
+    void dragEnterEvent(QDragEnterEvent* event) final;
+    void dragLeaveEvent(QDragLeaveEvent* event) final;
+    void dropEvent(QDropEvent* event) final;
 
 private:
-    void onSetName() final override;
-    void onExpand() final override;
-    void onAddFriendWidget(FriendWidget* w) final override;
+    void onSetName() final;
+    void onExpand() final;
+    void onAddFriendWidget(FriendWidget* w) final;
     void updateID(int index);
 
     static QHash<int, CircleWidget*> circleList;

--- a/src/widget/contentdialog.h
+++ b/src/widget/contentdialog.h
@@ -92,9 +92,9 @@ public slots:
     void setUsername(const QString& newName);
 
 protected:
-    bool event(QEvent* event) final override;
-    void dragEnterEvent(QDragEnterEvent* event) final override;
-    void dropEvent(QDropEvent* event) final override;
+    bool event(QEvent* event) final;
+    void dragEnterEvent(QDragEnterEvent* event) final;
+    void dropEvent(QDropEvent* event) final;
     void changeEvent(QEvent* event) override;
     void resizeEvent(QResizeEvent* event) override;
     void moveEvent(QMoveEvent* event) override;

--- a/src/widget/emoticonswidget.h
+++ b/src/widget/emoticonswidget.h
@@ -44,10 +44,10 @@ private slots:
     void PageButtonsUpdate();
 
 protected:
-    void mouseReleaseEvent(QMouseEvent* ev) final override;
-    void mousePressEvent(QMouseEvent* ev) final override;
-    void wheelEvent(QWheelEvent* event) final override;
-    void keyPressEvent(QKeyEvent* e) final override;
+    void mouseReleaseEvent(QMouseEvent* ev) final;
+    void mousePressEvent(QMouseEvent* ev) final;
+    void wheelEvent(QWheelEvent* event) final;
+    void keyPressEvent(QKeyEvent* e) final;
 
 private:
     QStackedWidget stack;

--- a/src/widget/form/chatform.h
+++ b/src/widget/form/chatform.h
@@ -52,8 +52,8 @@ public:
 
     void setFriendTyping(bool isTyping);
 
-    virtual void show(ContentLayout* contentLayout) final override;
-    virtual void reloadTheme() final override;
+    void show(ContentLayout* contentLayout) final;
+    void reloadTheme() final;
 
     static const QString ACTION_PREFIX;
 
@@ -109,12 +109,12 @@ private:
     void updateCallButtons();
 
 protected:
-    GenericNetCamView* createNetcam() final override;
-    void insertChatMessage(ChatMessage::Ptr msg) final override;
-    void dragEnterEvent(QDragEnterEvent* ev) final override;
-    void dropEvent(QDropEvent* ev) final override;
-    void hideEvent(QHideEvent* event) final override;
-    void showEvent(QShowEvent* event) final override;
+    GenericNetCamView* createNetcam() final;
+    void insertChatMessage(ChatMessage::Ptr msg) final;
+    void dragEnterEvent(QDragEnterEvent* ev) final;
+    void dropEvent(QDropEvent* ev) final;
+    void hideEvent(QHideEvent* event) final;
+    void showEvent(QShowEvent* event) final;
 
 private:
     Friend* f;

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -75,9 +75,6 @@ public:
     ~GenericChatForm() override;
 
     void setName(const QString& newName);
-    virtual void show() final
-    {
-    }
     virtual void show(ContentLayout* contentLayout);
     virtual void reloadTheme();
 
@@ -150,11 +147,11 @@ protected:
     virtual GenericNetCamView* createNetcam() = 0;
     virtual void insertChatMessage(ChatMessage::Ptr msg);
     void adjustFileMenuPosition();
-    virtual void hideEvent(QHideEvent* event) override;
-    virtual void showEvent(QShowEvent*) override;
-    virtual bool event(QEvent*) final override;
-    virtual void resizeEvent(QResizeEvent* event) final override;
-    virtual bool eventFilter(QObject* object, QEvent* event) final override;
+    void hideEvent(QHideEvent* event) override;
+    void showEvent(QShowEvent*) override;
+    bool event(QEvent*) final;
+    void resizeEvent(QResizeEvent* event) final;
+    bool eventFilter(QObject* object, QEvent* event) final;
     void disableSearchText();
     void enableSearchText();
     bool searchInText(const QString& phrase, const ParameterSearch& parameter, SearchDirection direction);

--- a/src/widget/form/groupchatform.h
+++ b/src/widget/form/groupchatform.h
@@ -57,12 +57,12 @@ private slots:
     void onLabelContextMenuRequested(const QPoint& localPos);
 
 protected:
-    virtual GenericNetCamView* createNetcam() final override;
-    virtual void keyPressEvent(QKeyEvent* ev) final override;
-    virtual void keyReleaseEvent(QKeyEvent* ev) final override;
+    GenericNetCamView* createNetcam() final;
+    void keyPressEvent(QKeyEvent* ev) final;
+    void keyReleaseEvent(QKeyEvent* ev) final;
     // drag & drop
-    virtual void dragEnterEvent(QDragEnterEvent* ev) final override;
-    virtual void dropEvent(QDropEvent* ev) final override;
+    void dragEnterEvent(QDragEnterEvent* ev) final;
+    void dropEvent(QDropEvent* ev) final;
 
 private:
     void retranslateUi();

--- a/src/widget/form/groupinviteform.h
+++ b/src/widget/form/groupinviteform.h
@@ -55,7 +55,7 @@ signals:
     void groupInvitesSeen();
 
 protected:
-    void showEvent(QShowEvent* event) final override;
+    void showEvent(QShowEvent* event) final;
 
 private:
     void retranslateUi();

--- a/src/widget/form/profileform.h
+++ b/src/widget/form/profileform.h
@@ -43,7 +43,7 @@ signals:
     void clicked();
 
 protected:
-    virtual void mouseReleaseEvent(QMouseEvent*) final override
+    void mouseReleaseEvent(QMouseEvent*) final
     {
         emit clicked();
     }
@@ -55,9 +55,6 @@ class ProfileForm : public QWidget
 public:
     ProfileForm(IProfileInfo* profileInfo, QWidget* parent = nullptr);
     ~ProfileForm();
-    virtual void show() final
-    {
-    }
     void show(ContentLayout* contentLayout);
     bool isShown() const;
 

--- a/src/widget/form/settings/aboutform.h
+++ b/src/widget/form/settings/aboutform.h
@@ -39,7 +39,7 @@ class AboutForm : public GenericForm
 public:
     AboutForm(UpdateCheck* updateCheck);
     ~AboutForm();
-    virtual QString getFormName() final override
+    QString getFormName() final
     {
         return tr("About");
     }

--- a/src/widget/form/settings/advancedform.h
+++ b/src/widget/form/settings/advancedform.h
@@ -34,7 +34,7 @@ class AdvancedForm : public GenericForm
 public:
     AdvancedForm();
     ~AdvancedForm();
-    virtual QString getFormName() final override
+    QString getFormName() final
     {
         return tr("Advanced");
     }

--- a/src/widget/form/settings/avform.h
+++ b/src/widget/form/settings/avform.h
@@ -45,7 +45,7 @@ public:
     AVForm(IAudioControl& audio, CoreAV* coreAV, CameraSource& camera,
            IAudioSettings* audioSettings, IVideoSettings* videoSettings);
     ~AVForm() override;
-    QString getFormName() final override
+    QString getFormName() final
     {
         return tr("Audio/Video");
     }
@@ -90,8 +90,8 @@ protected:
     void updateVideoModes(int curIndex);
 
 private:
-    void hideEvent(QHideEvent* event) final override;
-    void showEvent(QShowEvent* event) final override;
+    void hideEvent(QHideEvent* event) final;
+    void showEvent(QShowEvent* event) final;
     void open(const QString& devName, const VideoMode& mode);
     int getStepsFromValue(qreal val, qreal valMin, qreal valMax);
     qreal getValueFromSteps(int steps, qreal valMin, qreal valMax);

--- a/src/widget/form/settings/generalform.h
+++ b/src/widget/form/settings/generalform.h
@@ -34,7 +34,7 @@ class GeneralForm : public GenericForm
 public:
     explicit GeneralForm(SettingsWidget* parent);
     ~GeneralForm();
-    virtual QString getFormName() final override
+    QString getFormName() final
     {
         return tr("General");
     }

--- a/src/widget/form/settings/genericsettings.h
+++ b/src/widget/form/settings/genericsettings.h
@@ -35,7 +35,7 @@ public:
     QPixmap getFormIcon();
 
 protected:
-    bool eventFilter(QObject* o, QEvent* e) final override;
+    bool eventFilter(QObject* o, QEvent* e) final;
     void eventsInit();
 
 protected:

--- a/src/widget/form/settings/privacyform.h
+++ b/src/widget/form/settings/privacyform.h
@@ -32,7 +32,7 @@ class PrivacyForm : public GenericForm
 public:
     PrivacyForm();
     ~PrivacyForm();
-    virtual QString getFormName() final override
+    QString getFormName() final
     {
         return tr("Privacy");
     }
@@ -47,7 +47,7 @@ private slots:
     void on_randomNosapamButton_clicked();
     void on_nospamLineEdit_textChanged();
     void on_blackListTextEdit_textChanged();
-    virtual void showEvent(QShowEvent*) final override;
+    void showEvent(QShowEvent*) final;
 
 private:
     void retranslateUi();

--- a/src/widget/form/settings/userinterfaceform.h
+++ b/src/widget/form/settings/userinterfaceform.h
@@ -35,7 +35,7 @@ class UserInterfaceForm : public GenericForm
 public:
     explicit UserInterfaceForm(SettingsWidget* myParent);
     ~UserInterfaceForm();
-    virtual QString getFormName() final override
+    QString getFormName() final
     {
         return tr("User interface");
     }

--- a/src/widget/form/settings/verticalonlyscroller.h
+++ b/src/widget/form/settings/verticalonlyscroller.h
@@ -32,8 +32,8 @@ public:
     explicit VerticalOnlyScroller(QWidget* parent = nullptr);
 
 protected:
-    virtual void resizeEvent(QResizeEvent* event) final override;
-    virtual void showEvent(QShowEvent* event) final override;
+    void resizeEvent(QResizeEvent* event) final;
+    void showEvent(QShowEvent* event) final;
 };
 
 #endif // VERTICALONLYSCROLLER_H

--- a/src/widget/friendwidget.h
+++ b/src/widget/friendwidget.h
@@ -36,14 +36,14 @@ class FriendWidget : public GenericChatroomWidget
 public:
     FriendWidget(std::shared_ptr<FriendChatroom> chatform, bool compact);
 
-    void contextMenuEvent(QContextMenuEvent* event) override final;
-    void setAsActiveChatroom() override final;
-    void setAsInactiveChatroom() override final;
-    void updateStatusLight() override final;
-    void resetEventFlags() override final;
-    QString getStatusString() const override final;
-    const Friend* getFriend() const override final;
-    const Contact* getContact() const override final;
+    void contextMenuEvent(QContextMenuEvent* event) final;
+    void setAsActiveChatroom() final;
+    void setAsInactiveChatroom() final;
+    void updateStatusLight() final;
+    void resetEventFlags() final;
+    QString getStatusString() const final;
+    const Friend* getFriend() const final;
+    const Contact* getContact() const final;
 
     void search(const QString& searchString, bool hide = false);
 
@@ -64,8 +64,8 @@ public slots:
     void setActive(bool active);
 
 protected:
-    virtual void mousePressEvent(QMouseEvent* ev) override;
-    virtual void mouseMoveEvent(QMouseEvent* ev) override;
+    void mousePressEvent(QMouseEvent* ev) override;
+    void mouseMoveEvent(QMouseEvent* ev) override;
     void setFriendAlias();
 
 private slots:

--- a/src/widget/genericchatroomwidget.h
+++ b/src/widget/genericchatroomwidget.h
@@ -52,7 +52,7 @@ public slots:
         return nullptr;
     }
 
-    virtual bool eventFilter(QObject*, QEvent*) final override;
+    bool eventFilter(QObject*, QEvent*) final;
 
     bool isActive();
 

--- a/src/widget/groupwidget.h
+++ b/src/widget/groupwidget.h
@@ -33,13 +33,13 @@ class GroupWidget final : public GenericChatroomWidget
 public:
     GroupWidget(std::shared_ptr<GroupChatroom> chatroom, bool compact);
     ~GroupWidget();
-    void setAsInactiveChatroom() final override;
-    void setAsActiveChatroom() final override;
-    void updateStatusLight() final override;
-    void resetEventFlags() final override;
-    QString getStatusString() const final override;
-    Group* getGroup() const final override;
-    const Contact* getContact() const final override;
+   void setAsInactiveChatroom() final;
+    void setAsActiveChatroom() final;
+    void updateStatusLight() final;
+    void resetEventFlags() final;
+    QString getStatusString() const final;
+    Group* getGroup() const final;
+    const Contact* getContact() const final;
     void setName(const QString& name);
     void editName();
 
@@ -48,9 +48,9 @@ signals:
     void removeGroup(const GroupId& groupId);
 
 protected:
-    void contextMenuEvent(QContextMenuEvent* event) final override;
-    void mousePressEvent(QMouseEvent* event) final override;
-    void mouseMoveEvent(QMouseEvent* event) final override;
+    void contextMenuEvent(QContextMenuEvent* event) final;
+    void mousePressEvent(QMouseEvent* event) final;
+    void mouseMoveEvent(QMouseEvent* event) final;
     void dragEnterEvent(QDragEnterEvent* ev) override;
     void dragLeaveEvent(QDragLeaveEvent* ev) override;
     void dropEvent(QDropEvent* ev) override;

--- a/src/widget/loginscreen.h
+++ b/src/widget/loginscreen.h
@@ -38,7 +38,7 @@ class LoginScreen : public QDialog
 public:
     LoginScreen(const QString& initialProfileName = QString(), QWidget* parent = nullptr);
     ~LoginScreen();
-    bool event(QEvent* event) final override;
+    bool event(QEvent* event) final;
 
 signals:
 
@@ -48,7 +48,7 @@ signals:
     void loadProfile(QString name, const QString& pass);
 
 protected:
-    virtual void closeEvent(QCloseEvent* event) final override;
+    void closeEvent(QCloseEvent* event) final;
 
 public slots:
     void onProfileLoaded();

--- a/src/widget/maskablepixmapwidget.h
+++ b/src/widget/maskablepixmapwidget.h
@@ -38,7 +38,7 @@ signals:
     void clicked();
 
 protected:
-    void mousePressEvent(QMouseEvent*) final override;
+    void mousePressEvent(QMouseEvent*) final;
 
 private:
     void updatePixmap();

--- a/src/widget/notificationedgewidget.h
+++ b/src/widget/notificationedgewidget.h
@@ -41,7 +41,7 @@ signals:
     void clicked();
 
 protected:
-    void mouseReleaseEvent(QMouseEvent* event) final override;
+    void mouseReleaseEvent(QMouseEvent* event) final;
 
 private:
     QLabel* textLabel;

--- a/src/widget/notificationscrollarea.h
+++ b/src/widget/notificationscrollarea.h
@@ -37,7 +37,7 @@ public slots:
     void updateTracking(GenericChatroomWidget* widget);
 
 protected:
-    void resizeEvent(QResizeEvent* event) final override;
+    void resizeEvent(QResizeEvent* event) final;
 
 private slots:
     void findNextWidget();

--- a/src/widget/searchform.h
+++ b/src/widget/searchform.h
@@ -48,7 +48,7 @@ public:
     void reloadTheme();
 
 protected:
-    virtual void showEvent(QShowEvent* event) final override;
+    void showEvent(QShowEvent* event) final;
 
 private:
     // TODO: Merge with 'createButton' from chatformheader.cpp
@@ -101,7 +101,7 @@ public:
     LineEdit(QWidget* parent = nullptr);
 
 protected:
-    virtual void keyPressEvent(QKeyEvent* event) final override;
+    void keyPressEvent(QKeyEvent* event) final;
 
 signals:
     void clickEnter();

--- a/src/widget/tool/adjustingscrollarea.h
+++ b/src/widget/tool/adjustingscrollarea.h
@@ -30,8 +30,8 @@ public:
     virtual ~AdjustingScrollArea() = default;
 
 protected:
-    virtual void resizeEvent(QResizeEvent* ev) override;
-    virtual QSize sizeHint() const final override;
+    void resizeEvent(QResizeEvent* ev) override;
+    QSize sizeHint() const final;
 };
 
 #endif // ADJUSTINGSCROLLAREA_H

--- a/src/widget/tool/chattextedit.h
+++ b/src/widget/tool/chattextedit.h
@@ -38,7 +38,7 @@ signals:
     void pasteImage(const QPixmap& pixmap);
 
 protected:
-    virtual void keyPressEvent(QKeyEvent* event) final override;
+    void keyPressEvent(QKeyEvent* event) final;
 
 private:
     void retranslateUi();

--- a/src/widget/tool/croppinglabel.h
+++ b/src/widget/tool/croppinglabel.h
@@ -52,10 +52,10 @@ protected:
     void setElidedText();
     void hideTextEdit();
     void showTextEdit();
-    virtual void resizeEvent(QResizeEvent* ev) final override;
-    virtual QSize sizeHint() const final override;
-    virtual QSize minimumSizeHint() const final override;
-    virtual void mouseReleaseEvent(QMouseEvent* e) final override;
+    void resizeEvent(QResizeEvent* ev) final;
+    QSize sizeHint() const final;
+    QSize minimumSizeHint() const final;
+    void mouseReleaseEvent(QMouseEvent* e) final;
 
 private slots:
     void editingFinished();

--- a/src/widget/tool/screengrabberchooserrectitem.h
+++ b/src/widget/tool/screengrabberchooserrectitem.h
@@ -29,7 +29,7 @@ public:
     explicit ScreenGrabberChooserRectItem(QGraphicsScene* scene);
     ~ScreenGrabberChooserRectItem();
 
-    virtual QRectF boundingRect() const final override;
+    QRectF boundingRect() const final;
     void beginResize(QPointF mousePos);
 
     QRect chosenRect() const;
@@ -43,7 +43,7 @@ signals:
     void regionChosen(QRect rect);
 
 protected:
-    virtual bool sceneEventFilter(QGraphicsItem* watched, QEvent* event) final override;
+    bool sceneEventFilter(QGraphicsItem* watched, QEvent* event) final;
 
 private:
     enum State

--- a/src/widget/tool/screengrabberoverlayitem.h
+++ b/src/widget/tool/screengrabberoverlayitem.h
@@ -34,9 +34,9 @@ public:
     void setChosenRect(QRect rect);
 
 protected:
-    virtual void mousePressEvent(QGraphicsSceneMouseEvent* event) final override;
-    virtual void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
-                       QWidget* widget) final override;
+    void mousePressEvent(QGraphicsSceneMouseEvent* event) final;
+    void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
+                       QWidget* widget) final;
 
 private:
     ScreenshotGrabber* screnshootGrabber;

--- a/src/widget/tool/toolboxgraphicsitem.h
+++ b/src/widget/tool/toolboxgraphicsitem.h
@@ -32,12 +32,12 @@ public:
     ToolBoxGraphicsItem();
     ~ToolBoxGraphicsItem();
 
-    virtual void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
-                       QWidget* widget) final override;
+    void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
+                       QWidget* widget) final;
 
 protected:
-    virtual void hoverEnterEvent(QGraphicsSceneHoverEvent* event) final override;
-    virtual void hoverLeaveEvent(QGraphicsSceneHoverEvent* event) final override;
+    void hoverEnterEvent(QGraphicsSceneHoverEvent* event) final;
+    void hoverLeaveEvent(QGraphicsSceneHoverEvent* event) final;
 
 private:
     void startAnimation(QAbstractAnimation::Direction direction);

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -247,12 +247,12 @@ private slots:
 
 private:
     // QMainWindow overrides
-    bool eventFilter(QObject* obj, QEvent* event) final override;
-    bool event(QEvent* e) final override;
-    void closeEvent(QCloseEvent* event) final override;
-    void changeEvent(QEvent* event) final override;
-    void resizeEvent(QResizeEvent* event) final override;
-    void moveEvent(QMoveEvent* event) final override;
+    bool eventFilter(QObject* obj, QEvent* event) final;
+    bool event(QEvent* e) final;
+    void closeEvent(QCloseEvent* event) final;
+    void changeEvent(QEvent* event) final;
+    void resizeEvent(QResizeEvent* event) final;
+    void moveEvent(QMoveEvent* event) final;
 
     bool newMessageAlert(QWidget* currentWindow, bool isActive, bool sound = true, bool notify = true);
     void setActiveToolMenuButton(ActiveToolMenuButton newActiveButton);


### PR DESCRIPTION
refactor(style): use only one of override, virtual, or final
    
following https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md#Rh-override
    
virtual means exactly and only "this is a new virtual function."
override means exactly and only "this is a non-final overrider."
final means exactly and only "this is a final overrider."
    
Nothing was changed from e.g. override to final, just reduced duplication of
these labels.


- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5883)
<!-- Reviewable:end -->
