### PR TITLE
chore(docs): build toxcore with bootstrap daemon disabled

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -499,7 +499,7 @@ Provided that you have all required dependencies installed, you can simply run:
 git clone https://github.com/toktok/c-toxcore.git toxcore
 cd toxcore
 git checkout v0.2.10
-cmake .
+cmake . -DBOOTSTRAP_DAEMON=OFF
 make -j$(nproc)
 sudo make install
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -114,11 +114,11 @@ install_toxcore() {
         # compile and install
         if [[ $SYSTEM_WIDE = "false" ]]
         then
-            cmake . -DCMAKE_INSTALL_PREFIX=${BASE_DIR}
+            cmake . -DCMAKE_INSTALL_PREFIX=${BASE_DIR} -DBOOTSTRAP_DAEMON=OFF
             make -j $(nproc)
             make install
         else
-            cmake .
+            cmake . -DBOOTSTRAP_DAEMON=OFF
             make -j $(nproc)
             sudo make install
             sudo ldconfig

--- a/flatpak/io.github.qtox.qTox.json
+++ b/flatpak/io.github.qtox.qTox.json
@@ -145,6 +145,7 @@
         {
             "name": "c-toxcore",
             "buildsystem": "cmake-ninja",
+            "config-opts": ["-DBOOTSTRAP_DAEMON=OFF"],
             "sources": [
                 {
                     "type": "git",


### PR DESCRIPTION
toxcore requires libconfig to build the bootstrap daemon. our current
dependencies don't list libconfig, and we have no use for the bootstrap daemon,
so don't build it for qTox.

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5892)
<!-- Reviewable:end -->
