### PR TITLE
chore(docs): update install.md to reflect updated OSes

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,9 +20,7 @@
     - [Fedora](#fedora-other-deps)
     - [openSUSE](#opensuse-other-deps)
     - [Slackware](#slackware-other-deps)
-    - [Ubuntu >=15.04](#ubuntu-other-deps)
-    - [Ubuntu >=16.04](#ubuntu-other-1604-deps)
-  - [sqlcipher](#sqlcipher)
+    - [Ubuntu](#ubuntu-other-deps)
   - [Compile toxcore](#compile-toxcore)
   - [Compile qTox](#compile-qtox)
   - [Security hardening with AppArmor](#security-hardening-with-apparmor)
@@ -290,8 +288,6 @@ sudo pacman -S --needed base-devel qt5 openal libxss qrencode ffmpeg opus libvpx
 
 #### Debian
 
-**Note that only Debian >=9 stable (stretch) is supported.**
-
 ```bash
 sudo apt-get install \
     automake \
@@ -363,8 +359,6 @@ sudo dnf install \
     sqlcipher-devel
 ```
 
-**Go to [sqlcipher](#sqlcipher) section to compile it if necessary.**
-
 <a name="opensuse-other-deps" />
 
 #### openSUSE
@@ -404,44 +398,7 @@ http://slackbuilds.org/repository/14.2/network/qTox/
 
 <a name="ubuntu-other-deps" />
 
-#### Ubuntu >=15.04
-
-```bash
-sudo apt-get install \
-    automake \
-    autotools-dev \
-    build-essential cmake \
-    check \
-    checkinstall \
-    libavcodec-ffmpeg-dev \
-    libavdevice-ffmpeg-dev \
-    libavfilter-ffmpeg-dev \
-    libavutil-ffmpeg-dev \
-    libexif-dev \
-    libgdk-pixbuf2.0-dev \
-    libglib2.0-dev \
-    libgtk2.0-dev \
-    libkdeui5 \
-    libopenal-dev \
-    libopus-dev \
-    libqrencode-dev \
-    libqt5opengl5-dev \
-    libqt5svg5-dev \
-    libsodium-dev \
-    libsqlcipher-dev \
-    libswresample-ffmpeg-dev \
-    libswscale-ffmpeg-dev \
-    libtool \
-    libvpx-dev \
-    libxss-dev \
-    qrencode \
-    qt5-default \
-    qttools5-dev-tools
-```
-
-<a name="ubuntu-other-1604-deps" />
-
-#### Ubuntu >=16.04:
+#### Ubuntu:
 
 ```bash
 sudo apt-get install \
@@ -471,22 +428,6 @@ sudo apt-get install \
     qt5-default \
     qttools5-dev-tools \
     qttools5-dev
-```
-
-### sqlcipher
-
-If you are not using an old version of Fedora, skip this section, and go
-directly to compiling
-[**toxcore**](#compile-toxcore).
-
-```bash
-git clone https://github.com/sqlcipher/sqlcipher
-cd sqlcipher
-./configure --enable-tempstore=yes CFLAGS="-DSQLITE_HAS_CODEC" \
-    LDFLAGS="-lcrypto"
-make
-sudo make install
-cd ..
 ```
 
 ### Compile toxcore
@@ -843,7 +784,6 @@ Switches:
 [pkg-config]: https://www.freedesktop.org/wiki/Software/pkg-config/
 [qrencode]: https://fukuchi.org/works/qrencode/
 [Qt]: https://www.qt.io/
-[sqlcipher]: https://www.zetetic.net/sqlcipher/
 [toxcore]: https://github.com/TokTok/c-toxcore/
 [filteraudio]: https://github.com/irungentoo/filter_audio
 [sonnet]: https://github.com/KDE/sonnet


### PR DESCRIPTION
* remove Ubuntu 15.04 deps from INSTALL.md, since it's EOL
* fedora 29 (the oldest currently supported version) has no issue with
  sqlcipher
* remove warning about debian version older than 9, since 9 is the current
  oldest support debian version

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5893)
<!-- Reviewable:end -->
