### PR TITLE
fix(loginScreen): make loginScreen return values comply with Qt standards

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -391,8 +391,8 @@ int main(int argc, char* argv[])
     } else {
         nexus.setParser(&parser);
         int returnval = nexus.showLogin(profileName);
-        if (returnval != 0) {
-            return returnval;
+        if (returnval == QDialog::Rejected) {
+            return -1;
         }
     }
 

--- a/src/nexus.cpp
+++ b/src/nexus.cpp
@@ -163,6 +163,11 @@ int Nexus::showLogin(const QString& profileName)
     // The connection order ensures profile will be ready for bootstrap for now
     connect(this, &Nexus::currentProfileChanged, this, &Nexus::bootstrapWithProfile);
     int returnval = loginScreen.exec();
+    if (returnval == QDialog::Rejected) {
+        // Kriby: This will terminate the main application loop, necessary until we refactor
+        // away the split startup/return to login behavior.
+        qApp->quit();
+    }
     disconnect(this, &Nexus::currentProfileChanged, this, &Nexus::bootstrapWithProfile);
     return returnval;
 }

--- a/src/widget/loginscreen.cpp
+++ b/src/widget/loginscreen.cpp
@@ -72,15 +72,6 @@ LoginScreen::~LoginScreen()
     delete ui;
 }
 
-void LoginScreen::closeEvent(QCloseEvent* event)
-{
-
-    // If we are in the bootstrap, returning -1 will give us something to exit with in main.cpp
-    this->setResult(-1);
-    // If we are in application exec, we can quit by closing it, instead.
-    qApp->quit();
-}
-
 /**
  * @brief Resets the UI, clears all fields.
  */
@@ -110,10 +101,11 @@ void LoginScreen::reset(const QString& initialProfileName)
 
 void LoginScreen::onProfileLoaded()
 {
-    done(0);
+    done(QDialog::Accepted);
 }
 
-void LoginScreen::onProfileLoadFailed() {
+void LoginScreen::onProfileLoadFailed()
+{
     QMessageBox::critical(this, tr("Couldn't load this profile"), tr("Wrong password."));
     ui->loginPassword->setFocus();
     ui->loginPassword->selectAll();

--- a/src/widget/loginscreen.h
+++ b/src/widget/loginscreen.h
@@ -21,9 +21,9 @@
 #ifndef LOGINSCREEN_H
 #define LOGINSCREEN_H
 
+#include <QDialog>
 #include <QShortcut>
 #include <QToolButton>
-#include <QDialog>
 
 class Profile;
 
@@ -46,9 +46,6 @@ signals:
     void autoLoginChanged(bool state);
     void createNewProfile(QString name, const QString& pass);
     void loadProfile(QString name, const QString& pass);
-
-protected:
-    virtual void closeEvent(QCloseEvent* event) final override;
 
 public slots:
     void onProfileLoaded();


### PR DESCRIPTION
This commit makes LoginScreen return QDialog::Rejected (0) and
QDialog::Accepted (1) instead of C standard return values. This should be more
robust with regards to special cases in Qt implementation.

Fixes #5781 

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5894)
<!-- Reviewable:end -->
