### PR TITLE
chore: add OARS tags to appimage.xml

### DIFF
--- a/res/io.github.qtox.qTox.appdata.xml
+++ b/res/io.github.qtox.qTox.appdata.xml
@@ -63,6 +63,10 @@
  <url type="homepage">https://qtox.github.io</url>
  <update_contact>barrdetwix@gmail.com</update_contact>
  <project_group>qTox</project_group>
+   <content_rating type="oars-1.0">
+    <content_attribute id="social-chat">intense</content_attribute>
+    <content_attribute id="social-audio">intense</content_attribute>
+  </content_rating>
  <releases>
 ​  <release version="1.16.3" date="2018-07-21"/>
  </releases>


### PR DESCRIPTION
These tags help app stores and application launchers to put qTox in the
correct categories.

Fixes #5152

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5896)
<!-- Reviewable:end -->
