### PR TITLE
chore(build): update appimage updater library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,11 +56,6 @@ if(APPLE)
     /usr/local/opt/openal-soft/lib/pkgconfig:$ENV{PKG_CONFIG_PATH})
 endif()
 
-if(${APPIMAGE_UPDATER_BRIDGE})
-  set(ENV{PKG_CONFIG_PATH}
-    /usr/local/lib/pkgconfig:$ENV{PKG_CONFIG_PATH})
-endif()
-
 execute_process(
   COMMAND brew --prefix qt5
   OUTPUT_VARIABLE QT_PREFIX_PATH
@@ -647,11 +642,12 @@ endif()
 if(${UPDATE_CHECK})
     add_definitions(-DUPDATE_CHECK_ENABLED=1)
     if(${APPIMAGE_UPDATER_BRIDGE})
-        search_dependency(AIUB  PACKAGE AppImageUpdaterBridge)
-        if(AIUB_FOUND)
-		message(STATUS "using AppImageUpdaterBridge")
+        find_package(AppImageUpdaterBridge)
+        if(AppImageUpdaterBridge_FOUND)
+                message(STATUS "using AppImageUpdaterBridge")
                 add_definitions(-DAPPIMAGE_UPDATER_BRIDGE_ENABLED=1)
-	else()
+                add_dependency(AppImageUpdaterBridge)
+        else()
                 message(STATUS "cannot find AppImageUpdaterBridge , ignoring cmake flag")
         endif()
     else()

--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -114,7 +114,7 @@ make install
 # qTox
 git clone "$AUB_GIT" "$AUB_SRC_DIR"
 cd "$AUB_SRC_DIR" # we need to checkout first
-git checkout tags/v1.1.2
+git checkout tags/v1.1.5
 mkdir $AUB_BUILD_DIR
 cd $AUB_BUILD_DIR
 cmake .. -DLOGGING_DISABLED=ON


### PR DESCRIPTION
- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

This PR updates the library used to do the delta update in qTox AppImages and also removes hard coded paths in ```CMakeLists.txt``` as suggested in an earlier PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5905)
<!-- Reviewable:end -->
