### PR TITLE
refactor: remove AppImage update bridge

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,6 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 option(PLATFORM_EXTENSIONS "Enable platform specific extensions, requires extra dependencies" ON)
 option(USE_FILTERAUDIO "Enable the echo canceling backend" ON)
 option(UPDATE_CHECK "Enable automatic update check" ON)
-option(APPIMAGE_UPDATER_BRIDGE "Use AppImageUpdaterBridge to do the update" OFF)
 option(USE_CCACHE "Use ccache when available" ON)
 option(SPELL_CHECK "Enable spell cheching support" ON)
 option(SVGZ_ICON "Compress the SVG icon of qTox" ON)
@@ -54,11 +53,6 @@ set(ENV{PKG_CONFIG_PATH}
 if(APPLE)
   set(ENV{PKG_CONFIG_PATH}
     /usr/local/opt/openal-soft/lib/pkgconfig:$ENV{PKG_CONFIG_PATH})
-endif()
-
-if(${APPIMAGE_UPDATER_BRIDGE})
-  set(ENV{PKG_CONFIG_PATH}
-    /usr/local/lib/pkgconfig:$ENV{PKG_CONFIG_PATH})
 endif()
 
 execute_process(
@@ -648,17 +642,6 @@ endif()
 
 if(${UPDATE_CHECK})
     add_definitions(-DUPDATE_CHECK_ENABLED=1)
-    if(${APPIMAGE_UPDATER_BRIDGE})
-        search_dependency(AIUB  PACKAGE AppImageUpdaterBridge)
-        if(AIUB_FOUND)
-		message(STATUS "using AppImageUpdaterBridge")
-                add_definitions(-DAPPIMAGE_UPDATER_BRIDGE_ENABLED=1)
-	else()
-                message(STATUS "cannot find AppImageUpdaterBridge , ignoring cmake flag")
-        endif()
-    else()
-        message(STATUS "not using AppImageUpdaterBridge")
-    endif()
     set(${PROJECT_NAME}_SOURCES ${${PROJECT_NAME}_SOURCES}
         src/net/updatecheck.cpp
         src/net/updatecheck.h)

--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -47,12 +47,6 @@ readonly APT_FLAGS="-y --no-install-recommends"
 readonly SNORE_GIT="https://github.com/KDE/snorenotify"
 # snorenotify build directory
 readonly SNORE_BUILD_DIR="$BUILD_DIR"/snorenotify
-# "appimage updater bridge" becomes aub
-readonly AUB_SRC_DIR="$BUILD_DIR"/aub
-# aub source
-readonly AUB_GIT="https://github.com/antony-jr/AppImageUpdaterBridge"
-# aub build dir
-readonly AUB_BUILD_DIR="$BUILD_DIR"/aub/build
 
 # update information to be embeded in AppImage
 if [ "cron" == "${TRAVIS_EVENT_TYPE:-}" ]
@@ -110,18 +104,6 @@ LDFLAGS="-lcrypto"
 make
 make install
 
-# build aub into a static library and later use it in
-# qTox
-git clone "$AUB_GIT" "$AUB_SRC_DIR"
-cd "$AUB_SRC_DIR" # we need to checkout first
-git checkout tags/v1.1.2
-mkdir $AUB_BUILD_DIR
-cd $AUB_BUILD_DIR
-cmake .. -DLOGGING_DISABLED=ON
-
-make
-make install
-
 # copy qtox source
 cp -r "$QTOX_SRC_DIR" "$QTOX_BUILD_DIR"
 cd "$QTOX_BUILD_DIR"
@@ -138,7 +120,6 @@ cd _build
 # need to build with -DDESKTOP_NOTIFICATIONS=True for snorenotify
 cmake -DDESKTOP_NOTIFICATIONS=True \
       -DUPDATE_CHECK=True \
-      -DAPPIMAGE_UPDATER_BRIDGE=True \
       ../
 
 make

--- a/src/net/updatecheck.h
+++ b/src/net/updatecheck.h
@@ -20,12 +20,6 @@
 #include <QObject>
 #include <QTimer>
 
-#ifdef APPIMAGE_UPDATER_BRIDGE_ENABLED
-#include <QScopedPointer>
-#include <AppImageUpdaterBridge>
-#include <AppImageUpdaterDialog>
-#endif // APPIMAGE_UPDATER_BRIDGE_ENABLED
-
 #include <memory>
 
 class Settings;
@@ -41,35 +35,15 @@ public:
     void checkForUpdate();
 
 signals:
-#ifndef APPIMAGE_UPDATER_BRIDGE_ENABLED
     void updateAvailable(QString latestVersion, QUrl link);
-#else
-    void updateAvailable();
-#endif
     void upToDate();
     void updateCheckFailed();
 
-#ifndef APPIMAGE_UPDATER_BRIDGE_ENABLED
 private slots:
     void handleResponse(QNetworkReply* reply);
-#endif
-
-#ifdef APPIMAGE_UPDATER_BRIDGE_ENABLED
-public slots:
-    void initUpdate();
-
-private slots:
-    void handleUpdate(bool);
-    void handleUpdateEnd();
-#endif
 
 private:
-#ifndef APPIMAGE_UPDATER_BRIDGE_ENABLED
     QNetworkAccessManager manager;
-#else
-    AppImageUpdaterBridge::AppImageDeltaRevisioner revisioner;
-    QScopedPointer<AppImageUpdaterBridge::AppImageUpdaterDialog> updateDialog;
-#endif // APPIMAGE_UPDATER_BRIDGE_ENABLED
     QTimer updateTimer;
     const Settings& settings;
 };

--- a/src/widget/form/settings/aboutform.cpp
+++ b/src/widget/form/settings/aboutform.cpp
@@ -96,10 +96,6 @@ void AboutForm::replaceVersions()
         connect(updateCheck, &UpdateCheck::updateAvailable, this, &AboutForm::onUpdateAvailable);
         connect(updateCheck, &UpdateCheck::upToDate, this, &AboutForm::onUpToDate);
         connect(updateCheck, &UpdateCheck::updateCheckFailed, this, &AboutForm::onUpdateCheckFailed);
-#ifdef APPIMAGE_UPDATER_BRIDGE_ENABLED
-        connect(bodyUI->updateAvailableButton, &QPushButton::clicked, updateCheck,
-                &UpdateCheck::initUpdate);
-#endif
     } else {
         qWarning() << "AboutForm passed null UpdateCheck!";
     }
@@ -169,7 +165,6 @@ void AboutForm::replaceVersions()
     bodyUI->authorInfo->setText(authorInfo);
 }
 
-#ifndef APPIMAGE_UPDATER_BRIDGE_ENABLED
 void AboutForm::onUpdateAvailable(QString latestVersion, QUrl link)
 {
     QObject::disconnect(linkConnection);
@@ -177,12 +172,6 @@ void AboutForm::onUpdateAvailable(QString latestVersion, QUrl link)
                              [link]() { QDesktopServices::openUrl(link); });
     bodyUI->updateStack->setCurrentIndex(static_cast<int>(updateIndex::available));
 }
-#else
-void AboutForm::onUpdateAvailable()
-{
-    bodyUI->updateStack->setCurrentIndex(static_cast<int>(updateIndex::available));
-}
-#endif
 
 void AboutForm::onUpToDate()
 {

--- a/src/widget/form/settings/aboutform.h
+++ b/src/widget/form/settings/aboutform.h
@@ -45,11 +45,7 @@ public:
     }
 
 public slots:
-#ifndef APPIMAGE_UPDATER_BRIDGE_ENABLED
     void onUpdateAvailable(QString latestVersion, QUrl link);
-#else
-    void onUpdateAvailable();
-#endif
     void onUpToDate();
     void onUpdateCheckFailed();
 
@@ -62,9 +58,7 @@ private:
     Ui::AboutSettings* bodyUI;
     QTimer* progressTimer;
     UpdateCheck* updateCheck;
-#ifndef APPIMAGE_UPDATER_BRIDGE_ENABLED
     QMetaObject::Connection linkConnection;
-#endif
 };
 
 #endif // ABOUTFORM_H


### PR DESCRIPTION
When re-evaluating our dependencies we decided that the update bridge
has a high potential for security issues because it's not widely used.
Additionally similar functionality is already present in qTox in the form of update notifications.

This should basically revert #5747, with the exception of still adding the update information into the AppImage so that external tools can use it.

@antony-jr FYI, @anthonybilinski and me re-evaluated the use of AppImageUpdate bridge and came to the conclusion that it's better to remove it.

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5908)
<!-- Reviewable:end -->
