### PR TITLE
chore: log schema version when we error due to future db

### DIFF
--- a/src/persistence/history.cpp
+++ b/src/persistence/history.cpp
@@ -196,7 +196,8 @@ void dbSchemaUpgrade(std::shared_ptr<RawDatabase>& db)
     }
 
     if (databaseSchemaVersion > SCHEMA_VERSION) {
-        qWarning() << "Database version is newer than we currently support. Please upgrade qTox";
+        qWarning().nospace() << "Database version (" << databaseSchemaVersion <<
+            ") is newer than we currently support (" << SCHEMA_VERSION << "). Please upgrade qTox";
         // We don't know what future versions have done, we have to disable db access until we re-upgrade
         db.reset();
         return;


### PR DESCRIPTION
- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5911)
<!-- Reviewable:end -->
