### PR TITLE
chore: update INSTALL.md for openSUSE

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -352,7 +352,11 @@ sudo zypper install \
     patterns-openSUSE-devel_basis \
     qrencode-devel \
     sqlcipher-devel \
-    sonnet-devel
+    sonnet-devel \
+    qt5-linguist-devel \
+    libQt5Test-devel \
+    ffmpeg-4-libavcodec-devel \
+    ffmpeg-4-libavdevice-devel
 ```
 
 <a name="slackware-other-deps" />


### PR DESCRIPTION
- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

Found these packages missing during a fresh install on openSUSE Leap 15.1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5914)
<!-- Reviewable:end -->
