### PR TITLE
fix(groups): Fix invalid group list on group member join

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -1502,7 +1502,9 @@ QStringList Core::getGroupPeerNames(int groupId) const
     for (uint32_t i = 0; i < nPeers; ++i) {
         Tox_Err_Conference_Peer_Query error;
         size_t length = tox_conference_peer_get_name_size(tox.get(), groupId, i, &error);
+
         if (!PARSE_ERR(error) || !length) {
+            names.append(QString());
             continue;
         }
 
@@ -1510,8 +1512,12 @@ QStringList Core::getGroupPeerNames(int groupId) const
         tox_conference_peer_get_name(tox.get(), groupId, i, nameBuf.data(), &error);
         if (PARSE_ERR(error)) {
             names.append(ToxString(nameBuf.data(), length).getQString());
+        } else {
+            names.append(QString());
         }
     }
+
+    assert(names.size() == nPeers);
 
     return names;
 }


### PR DESCRIPTION
The call to Core::getGroupPeerNames is expected to return a list where
the index in the list is the group member id. In any error case we were
previously breaking this constraint. It turns out that every time
someone joins a group we call this function before they have a valid
name resulting in their id not being added to the list.

This fix ensures that the list coming out of Core::getGroupPeerNames
always has a full list.

Fixes #5838

I tested a group adding 2 members, one in my friends list and one outside. Behavior should be as follows
![image](https://user-images.githubusercontent.com/1069811/68535754-5e941a80-02fc-11ea-9446-732f60e65f49.png)

When the user is in my friends list I get one message that they've joined the group, otherwise I still get one message with their toxid and another that I got the new name. This was the expected behavior according to group.cpp


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5919)
<!-- Reviewable:end -->
