### PR TITLE
Fix group call SIGSEGV on window resize

### DIFF
--- a/src/video/groupnetcamview.cpp
+++ b/src/video/groupnetcamview.cpp
@@ -37,7 +37,7 @@
 class LabeledVideo : public QFrame
 {
 public:
-    LabeledVideo(const QPixmap& avatar, QWidget* parent = nullptr, bool expanding = true)
+    LabeledVideo(const QPixmap& avatar, QString fontColorString, QWidget* parent = nullptr, bool expanding = true)
         : QFrame(parent)
     {
         qDebug() << "Created expanding? " << expanding;
@@ -48,7 +48,7 @@ public:
         connect(videoSurface, &VideoSurface::ratioChanged, this, &LabeledVideo::updateSize);
         label = new CroppingLabel(this);
         label->setTextFormat(Qt::PlainText);
-        label->setStyleSheet("color: white");
+        label->setStyleSheet(QString("color: %1").arg(fontColorString));
 
         label->setAlignment(Qt::AlignCenter);
 
@@ -108,7 +108,7 @@ GroupNetCamView::GroupNetCamView(int group, QWidget* parent)
     : GenericNetCamView(parent)
     , group(group)
 {
-    videoLabelSurface = new LabeledVideo(QPixmap(), this, false);
+    videoLabelSurface = new LabeledVideo(QPixmap(), "white", this, false);
     videoSurface = videoLabelSurface->getVideoSurface();
     videoSurface->setMinimumHeight(256);
     videoSurface->setContentsMargins(6, 6, 6, 0);
@@ -139,7 +139,7 @@ GroupNetCamView::GroupNetCamView(int group, QWidget* parent)
     horLayout = new QHBoxLayout(widget);
     horLayout->addStretch(1);
 
-    selfVideoSurface = new LabeledVideo(Nexus::getProfile()->loadAvatar(), this);
+    selfVideoSurface = new LabeledVideo(Nexus::getProfile()->loadAvatar(), "black", this);
     horLayout->addWidget(selfVideoSurface);
 
     horLayout->addStretch(1);
@@ -176,7 +176,7 @@ void GroupNetCamView::clearPeers()
 void GroupNetCamView::addPeer(const ToxPk& peer, const QString& name)
 {
     QPixmap groupAvatar = Nexus::getProfile()->loadAvatar(peer);
-    LabeledVideo* labeledVideo = new LabeledVideo(groupAvatar, this);
+    LabeledVideo* labeledVideo = new LabeledVideo(groupAvatar, "black", this);
     labeledVideo->setText(name);
     horLayout->insertWidget(horLayout->count() - 1, labeledVideo);
     PeerVideo peerVideo;

--- a/src/video/groupnetcamview.cpp
+++ b/src/video/groupnetcamview.cpp
@@ -128,6 +128,11 @@ GroupNetCamView::GroupNetCamView(int group, QWidget* parent)
 
     QScrollArea* scrollArea = new QScrollArea();
     scrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+
+    // Note this is needed to prevent oscillations that result in segfaults
+    scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
+    scrollArea->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum));
+
     scrollArea->setFrameStyle(QFrame::NoFrame);
     QWidget* widget = new QWidget(nullptr);
     scrollArea->setWidgetResizable(true);


### PR DESCRIPTION
Avatars for group members currently in a call are resized depending on
the area they are displayed in. Previously a scrollbar would appear and
disapear based on the size of the contents. This resulted in
oscillations that ended in a SIGSEGV.
    
This fix avoids the oscillations by fixing the scrollbar to always be
shown.

After changing the layout I noticed that label text was incorrect so I fixed that too.

This fix is _far_ from ideal but my main goal here was to avoid the crashes while disrupting UI as little as possible. Given #5918 exists I'm not motivated to put a lot of work in to make sure it looks good at the same time.

New UI looks as follows
![image](https://user-images.githubusercontent.com/1069811/68540877-2e289c80-034d-11ea-8310-af94d31c3120.png)

Note the permanently visible scrollbar in the bottom.

Test steps to produce the SIGSEGV are to basically attempt to resize your window to look like this

![image](https://user-images.githubusercontent.com/1069811/68540883-48627a80-034d-11ea-9a4d-9c878443f9e6.png)

As the avatars start scrolling if you play with the size of the window you can end up in a case where a SIGSEGV occurs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5920)
<!-- Reviewable:end -->
