### PR TITLE
fix(calls): Fix SIGSEGV on quit while in call

### DIFF
--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -68,18 +68,6 @@
  * deadlock.
  */
 
-/**
- * @brief Maps friend IDs to ToxFriendCall.
- * @note Need to use STL container here, because Qt containers need a copy constructor.
- */
-std::map<uint32_t, CoreAV::ToxFriendCallPtr> CoreAV::calls;
-
-/**
- * @brief Maps group IDs to ToxGroupCalls.
- * @note Need to use STL container here, because Qt containers need a copy constructor.
- */
-std::map<int, CoreAV::ToxGroupCallPtr> CoreAV::groupCalls;
-
 CoreAV::CoreAV(std::unique_ptr<ToxAV, ToxAVDeleter> toxav)
     : audio{nullptr}
     , toxav{std::move(toxav)}
@@ -789,12 +777,12 @@ void CoreAV::stateCallback(ToxAV* toxav, uint32_t friendNum, uint32_t state, voi
 
     if (state & TOXAV_FRIEND_CALL_STATE_ERROR) {
         qWarning() << "Call with friend" << friendNum << "died of unnatural causes!";
-        calls.erase(friendNum);
+        self->calls.erase(friendNum);
         // why not self->
         emit self->avEnd(friendNum, true);
     } else if (state & TOXAV_FRIEND_CALL_STATE_FINISHED) {
         qDebug() << "Call with friend" << friendNum << "finished quietly";
-        calls.erase(friendNum);
+        self->calls.erase(friendNum);
         // why not self->
         emit self->avEnd(friendNum);
     } else {
@@ -875,7 +863,7 @@ void CoreAV::audioFrameCallback(ToxAV*, uint32_t friendNum, const int16_t* pcm, 
                                 uint8_t channels, uint32_t samplingRate, void* vSelf)
 {
     CoreAV* self = static_cast<CoreAV*>(vSelf);
-    auto it = calls.find(friendNum);
+    auto it = self->calls.find(friendNum);
     if (it == self->calls.end()) {
         return;
     }
@@ -891,10 +879,12 @@ void CoreAV::audioFrameCallback(ToxAV*, uint32_t friendNum, const int16_t* pcm, 
 
 void CoreAV::videoFrameCallback(ToxAV*, uint32_t friendNum, uint16_t w, uint16_t h,
                                 const uint8_t* y, const uint8_t* u, const uint8_t* v,
-                                int32_t ystride, int32_t ustride, int32_t vstride, void*)
+                                int32_t ystride, int32_t ustride, int32_t vstride, void* vSelf)
 {
-    auto it = calls.find(friendNum);
-    if (it == calls.end()) {
+    auto self = static_cast<CoreAV*>(vSelf);
+
+    auto it = self->calls.find(friendNum);
+    if (it == self->calls.end()) {
         return;
     }
 

--- a/src/core/coreav.h
+++ b/src/core/coreav.h
@@ -132,9 +132,19 @@ private:
     std::unique_ptr<QThread> coreavThread;
     QTimer* iterateTimer = nullptr;
     using ToxFriendCallPtr = std::unique_ptr<ToxFriendCall>;
-    static std::map<uint32_t, ToxFriendCallPtr> calls;
+    /**
+     * @brief Maps friend IDs to ToxFriendCall.
+     * @note Need to use STL container here, because Qt containers need a copy constructor.
+     */
+    std::map<uint32_t, ToxFriendCallPtr> calls;
+
+
     using ToxGroupCallPtr = std::unique_ptr<ToxGroupCall>;
-    static std::map<int, ToxGroupCallPtr> groupCalls;
+    /**
+     * @brief Maps group IDs to ToxGroupCalls.
+     * @note Need to use STL container here, because Qt containers need a copy constructor.
+     */
+    std::map<int, ToxGroupCallPtr> groupCalls;
     std::atomic_flag threadSwitchLock;
 };
 


### PR DESCRIPTION
On application close we used to access invalid memory associated with
the audio subsystem. This was because on destruction of static variables
we tried to access state associated with an already destructed item.

These variables seem to have no good reason to be static. They should be
tied to a single CoreAV instance and are only accessed through an
existing CoreAV instance.

Tested by joining a group audio call and attempting to close qTox (which previously had a near 100% repro rate on SIGSEGVs). Inspection indicates that this is a valid fix but suggestions for more through testing are welcome :).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5921)
<!-- Reviewable:end -->
