### PR TITLE
refactor(coreav): fix locking and threading between Core and CoreAV

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -628,7 +628,7 @@ ToxCorePtr Core::makeToxCore(const QByteArray& savedata, const ICoreSettings* co
 
     // toxcore is successfully created, create toxav
     // TODO(sudden6): don't create CoreAv here, Core should be usable without CoreAV
-    core->av = CoreAV::makeCoreAV(core->tox.get());
+    core->av = CoreAV::makeCoreAV(core->tox.get(), core->coreLoopLock);
     if (!core->av) {
         qCritical() << "Toxav failed to start";
         if (err) {

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -484,12 +484,14 @@ Core::Core(QThread* coreThread)
 
 Core::~Core()
 {
-    // need to reset av first, because it uses tox
-    av.reset();
-
+    /*
+     * First stop the thread to stop the timer and avoid Core emitting callbacks
+     * into an already destructed CoreAV.
+     */
     coreThread->exit(0);
     coreThread->wait();
 
+    av.reset();
     tox.reset();
 }
 

--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -365,7 +365,7 @@ bool CoreAV::sendCallAudio(uint32_t callId, const int16_t* pcm, size_t samples, 
 
 void CoreAV::sendCallVideo(uint32_t callId, std::shared_ptr<VideoFrame> vframe)
 {
-    QReadLocker locker{&callsLock};
+    QWriteLocker locker{&callsLock};
 
     // We might be running in the FFmpeg thread and holding the CameraSource lock
     // So be careful not to deadlock with anything while toxav locks in toxav_video_send_frame
@@ -420,7 +420,7 @@ void CoreAV::sendCallVideo(uint32_t callId, std::shared_ptr<VideoFrame> vframe)
  */
 void CoreAV::toggleMuteCallInput(const Friend* f)
 {
-    QReadLocker locker{&callsLock};
+    QWriteLocker locker{&callsLock};
 
     auto it = calls.find(f->getId());
     if (f && (it != calls.end())) {
@@ -435,7 +435,7 @@ void CoreAV::toggleMuteCallInput(const Friend* f)
  */
 void CoreAV::toggleMuteCallOutput(const Friend* f)
 {
-    QReadLocker locker{&callsLock};
+    QWriteLocker locker{&callsLock};
 
     auto it = calls.find(f->getId());
     if (f && (it != calls.end())) {
@@ -503,7 +503,7 @@ void CoreAV::groupCallCallback(void* tox, uint32_t group, uint32_t peer, const i
  */
 void CoreAV::invalidateGroupCallPeerSource(int group, ToxPk peerPk)
 {
-    QReadLocker locker{&callsLock};
+    QWriteLocker locker{&callsLock};
 
     auto it = groupCalls.find(group);
     if (it == groupCalls.end()) {
@@ -594,7 +594,7 @@ bool CoreAV::sendGroupCallAudio(int groupId, const int16_t* pcm, size_t samples,
  */
 void CoreAV::muteCallInput(const Group* g, bool mute)
 {
-    QReadLocker locker{&callsLock};
+    QWriteLocker locker{&callsLock};
 
     auto it = groupCalls.find(g->getId());
     if (g && (it != groupCalls.end())) {
@@ -609,7 +609,7 @@ void CoreAV::muteCallInput(const Group* g, bool mute)
  */
 void CoreAV::muteCallOutput(const Group* g, bool mute)
 {
-    QReadLocker locker{&callsLock};
+    QWriteLocker locker{&callsLock};
 
     auto it = groupCalls.find(g->getId());
     if (g && (it != groupCalls.end())) {
@@ -693,7 +693,7 @@ bool CoreAV::isCallOutputMuted(const Friend* f) const
  */
 void CoreAV::sendNoVideo()
 {
-    QReadLocker locker{&callsLock};
+    QWriteLocker locker{&callsLock};
 
     // We don't change the audio bitrate, but we signal that we're not sending video anymore
     qDebug() << "CoreAV: Signaling end of video sending";

--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -731,9 +731,10 @@ void CoreAV::callCallback(ToxAV* toxav, uint32_t friendNum, bool audio, bool vid
         state |= TOXAV_FRIEND_CALL_STATE_SENDING_V | TOXAV_FRIEND_CALL_STATE_ACCEPTING_V;
     it.first->second->setState(static_cast<TOXAV_FRIEND_CALL_STATE>(state));
 
+    // Must explicitely unlock, because a deadlock can happen via ChatForm/Audio
     locker.unlock();
 
-    emit reinterpret_cast<CoreAV*>(self)->avInvite(friendNum, video);
+    emit self->avInvite(friendNum, video);
 }
 
 void CoreAV::stateCallback(ToxAV* toxav, uint32_t friendNum, uint32_t state, void* vSelf)
@@ -741,6 +742,7 @@ void CoreAV::stateCallback(ToxAV* toxav, uint32_t friendNum, uint32_t state, voi
     Q_UNUSED(toxav);
     CoreAV* self = static_cast<CoreAV*>(vSelf);
 
+    // we must unlock this lock before emitting any signals
     QWriteLocker locker{&self->callsLock};
 
     auto it = self->calls.find(friendNum);
@@ -765,14 +767,18 @@ void CoreAV::stateCallback(ToxAV* toxav, uint32_t friendNum, uint32_t state, voi
         // If our state was null, we started the call and were still ringing
         if (!call.getState() && state) {
             call.setActive(true);
+            bool videoEnabled = call.getVideoEnabled();
+            call.setState(static_cast<TOXAV_FRIEND_CALL_STATE>(state));
             locker.unlock();
-            emit self->avStart(friendNum, call.getVideoEnabled());
+            emit self->avStart(friendNum, videoEnabled);
         } else if ((call.getState() & TOXAV_FRIEND_CALL_STATE_SENDING_V)
                    && !(state & TOXAV_FRIEND_CALL_STATE_SENDING_V)) {
             qDebug() << "Friend" << friendNum << "stopped sending video";
             if (call.getVideoSource()) {
                 call.getVideoSource()->stopSource();
             }
+
+            call.setState(static_cast<TOXAV_FRIEND_CALL_STATE>(state));
         } else if (!(call.getState() & TOXAV_FRIEND_CALL_STATE_SENDING_V)
                    && (state & TOXAV_FRIEND_CALL_STATE_SENDING_V)) {
             // Workaround toxav sometimes firing callbacks for "send last frame" -> "stop sending
@@ -783,9 +789,9 @@ void CoreAV::stateCallback(ToxAV* toxav, uint32_t friendNum, uint32_t state, voi
             if (call.getVideoSource()) {
                 call.getVideoSource()->restartSource();
             }
-        }
 
-        call.setState(static_cast<TOXAV_FRIEND_CALL_STATE>(state));
+            call.setState(static_cast<TOXAV_FRIEND_CALL_STATE>(state));
+        }
     }
 }
 

--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -555,7 +555,6 @@ bool CoreAV::sendGroupCallAudio(int groupId, const int16_t* pcm, size_t samples,
                                 uint32_t rate) const
 {
     QMutexLocker locker{&callsLock};
-    assert(QThread::currentThread() == coreavThread.get());
 
     std::map<int, ToxGroupCallPtr>::const_iterator it = groupCalls.find(groupId);
     if (it == groupCalls.end()) {
@@ -679,8 +678,6 @@ bool CoreAV::isCallOutputMuted(const Friend* f) const
 void CoreAV::sendNoVideo()
 {
     QMutexLocker locker{&callsLock};
-    // This callback should come from the Core thread
-    assert(QThread::currentThread() != coreavThread.get());
 
     // We don't change the audio bitrate, but we signal that we're not sending video anymore
     qDebug() << "CoreAV: Signaling end of video sending";
@@ -696,8 +693,6 @@ void CoreAV::callCallback(ToxAV* toxav, uint32_t friendNum, bool audio, bool vid
     CoreAV* self = static_cast<CoreAV*>(vSelf);
 
     QMutexLocker locker{&self->callsLock};
-    // This callback should come from the Core thread
-    assert(QThread::currentThread() != self->coreavThread.get());
 
     // Audio backend must be set before receiving a call
     assert(self->audio != nullptr);
@@ -727,8 +722,6 @@ void CoreAV::stateCallback(ToxAV* toxav, uint32_t friendNum, uint32_t state, voi
 {
     Q_UNUSED(toxav);
     CoreAV* self = static_cast<CoreAV*>(vSelf);
-    // This callback should come from the Core thread
-    assert(QThread::currentThread() != self->coreavThread.get());
 
     QMutexLocker locker{&self->callsLock};
 

--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -181,7 +181,7 @@ void CoreAV::process()
  */
 bool CoreAV::isCallStarted(const Friend* f) const
 {
-    QMutexLocker locker{&callsLock};
+    QReadLocker locker{&callsLock};
     return f && (calls.find(f->getId()) != calls.end());
 }
 
@@ -192,7 +192,7 @@ bool CoreAV::isCallStarted(const Friend* f) const
  */
 bool CoreAV::isCallStarted(const Group* g) const
 {
-    QMutexLocker locker{&callsLock};
+    QReadLocker locker{&callsLock};
     return g && (groupCalls.find(g->getId()) != groupCalls.end());
 }
 
@@ -203,7 +203,7 @@ bool CoreAV::isCallStarted(const Group* g) const
  */
 bool CoreAV::isCallActive(const Friend* f) const
 {
-    QMutexLocker locker{&callsLock};
+    QReadLocker locker{&callsLock};
     auto it = calls.find(f->getId());
     if (it == calls.end()) {
         return false;
@@ -218,7 +218,7 @@ bool CoreAV::isCallActive(const Friend* f) const
  */
 bool CoreAV::isCallActive(const Group* g) const
 {
-    QMutexLocker locker{&callsLock};
+    QReadLocker locker{&callsLock};
     auto it = groupCalls.find(g->getId());
     if (it == groupCalls.end()) {
         return false;
@@ -228,14 +228,14 @@ bool CoreAV::isCallActive(const Group* g) const
 
 bool CoreAV::isCallVideoEnabled(const Friend* f) const
 {
-    QMutexLocker locker{&callsLock};
+    QReadLocker locker{&callsLock};
     auto it = calls.find(f->getId());
     return isCallStarted(f) && it->second->getVideoEnabled();
 }
 
 bool CoreAV::answerCall(uint32_t friendNum, bool video)
 {
-    QMutexLocker locker{&callsLock};
+    QWriteLocker locker{&callsLock};
     QMutexLocker coreLocker{&coreLock};
 
     qDebug() << QString("Answering call %1").arg(friendNum);
@@ -258,7 +258,7 @@ bool CoreAV::answerCall(uint32_t friendNum, bool video)
 
 bool CoreAV::startCall(uint32_t friendNum, bool video)
 {
-    QMutexLocker locker{&callsLock};
+    QWriteLocker locker{&callsLock};
     QMutexLocker coreLocker{&coreLock};
 
     qDebug() << QString("Starting call with %1").arg(friendNum);
@@ -283,7 +283,7 @@ bool CoreAV::startCall(uint32_t friendNum, bool video)
 
 bool CoreAV::cancelCall(uint32_t friendNum)
 {
-    QMutexLocker locker{&callsLock};
+    QWriteLocker locker{&callsLock};
     QMutexLocker coreLocker{&coreLock};
 
     qDebug() << QString("Cancelling call with %1").arg(friendNum);
@@ -293,13 +293,15 @@ bool CoreAV::cancelCall(uint32_t friendNum)
     }
 
     calls.erase(friendNum);
+    locker.unlock();
+
     emit avEnd(friendNum);
     return true;
 }
 
 void CoreAV::timeoutCall(uint32_t friendNum)
 {
-    QMutexLocker locker{&callsLock};
+    QWriteLocker locker{&callsLock};
 
     if (!cancelCall(friendNum)) {
         qWarning() << QString("Failed to timeout call with %1").arg(friendNum);
@@ -320,7 +322,7 @@ void CoreAV::timeoutCall(uint32_t friendNum)
 bool CoreAV::sendCallAudio(uint32_t callId, const int16_t* pcm, size_t samples, uint8_t chans,
                            uint32_t rate) const
 {
-    QMutexLocker locker{&callsLock};
+    QReadLocker locker{&callsLock};
 
     auto it = calls.find(callId);
     if (it == calls.end()) {
@@ -356,7 +358,7 @@ bool CoreAV::sendCallAudio(uint32_t callId, const int16_t* pcm, size_t samples, 
 
 void CoreAV::sendCallVideo(uint32_t callId, std::shared_ptr<VideoFrame> vframe)
 {
-    QMutexLocker locker{&callsLock};
+    QReadLocker locker{&callsLock};
 
     // We might be running in the FFmpeg thread and holding the CameraSource lock
     // So be careful not to deadlock with anything while toxav locks in toxav_video_send_frame
@@ -411,7 +413,7 @@ void CoreAV::sendCallVideo(uint32_t callId, std::shared_ptr<VideoFrame> vframe)
  */
 void CoreAV::toggleMuteCallInput(const Friend* f)
 {
-    QMutexLocker locker{&callsLock};
+    QReadLocker locker{&callsLock};
 
     auto it = calls.find(f->getId());
     if (f && (it != calls.end())) {
@@ -426,7 +428,7 @@ void CoreAV::toggleMuteCallInput(const Friend* f)
  */
 void CoreAV::toggleMuteCallOutput(const Friend* f)
 {
-    QMutexLocker locker{&callsLock};
+    QReadLocker locker{&callsLock};
 
     auto it = calls.find(f->getId());
     if (f && (it != calls.end())) {
@@ -454,7 +456,7 @@ void CoreAV::groupCallCallback(void* tox, uint32_t group, uint32_t peer, const i
     Core* c = static_cast<Core*>(core);
     CoreAV* cav = c->getAv();
 
-    QMutexLocker locker{&cav->callsLock};
+    QReadLocker locker{&cav->callsLock};
     assert(QThread::currentThread() == cav->coreavThread.get());
 
     const ToxPk peerPk = c->getGroupPeerPk(group, peer);
@@ -487,7 +489,7 @@ void CoreAV::groupCallCallback(void* tox, uint32_t group, uint32_t peer, const i
  */
 void CoreAV::invalidateGroupCallPeerSource(int group, ToxPk peerPk)
 {
-    QMutexLocker locker{&callsLock};
+    QReadLocker locker{&callsLock};
 
     auto it = groupCalls.find(group);
     if (it == groupCalls.end()) {
@@ -503,7 +505,7 @@ void CoreAV::invalidateGroupCallPeerSource(int group, ToxPk peerPk)
  */
 VideoSource* CoreAV::getVideoSourceFromCall(int friendNum) const
 {
-    QMutexLocker locker{&callsLock};
+    QReadLocker locker{&callsLock};
 
     auto it = calls.find(friendNum);
     if (it == calls.end()) {
@@ -521,7 +523,7 @@ VideoSource* CoreAV::getVideoSourceFromCall(int friendNum) const
  */
 void CoreAV::joinGroupCall(int groupId)
 {
-    QMutexLocker locker{&callsLock};
+    QWriteLocker locker{&callsLock};
 
     qDebug() << QString("Joining group call %1").arg(groupId);
 
@@ -544,7 +546,7 @@ void CoreAV::joinGroupCall(int groupId)
  */
 void CoreAV::leaveGroupCall(int groupId)
 {
-    QMutexLocker locker{&callsLock};
+    QWriteLocker locker{&callsLock};
 
     qDebug() << QString("Leaving group call %1").arg(groupId);
 
@@ -554,7 +556,7 @@ void CoreAV::leaveGroupCall(int groupId)
 bool CoreAV::sendGroupCallAudio(int groupId, const int16_t* pcm, size_t samples, uint8_t chans,
                                 uint32_t rate) const
 {
-    QMutexLocker locker{&callsLock};
+    QReadLocker locker{&callsLock};
 
     std::map<int, ToxGroupCallPtr>::const_iterator it = groupCalls.find(groupId);
     if (it == groupCalls.end()) {
@@ -578,7 +580,7 @@ bool CoreAV::sendGroupCallAudio(int groupId, const int16_t* pcm, size_t samples,
  */
 void CoreAV::muteCallInput(const Group* g, bool mute)
 {
-    QMutexLocker locker{&callsLock};
+    QReadLocker locker{&callsLock};
 
     auto it = groupCalls.find(g->getId());
     if (g && (it != groupCalls.end())) {
@@ -593,7 +595,7 @@ void CoreAV::muteCallInput(const Group* g, bool mute)
  */
 void CoreAV::muteCallOutput(const Group* g, bool mute)
 {
-    QMutexLocker locker{&callsLock};
+    QReadLocker locker{&callsLock};
 
     auto it = groupCalls.find(g->getId());
     if (g && (it != groupCalls.end())) {
@@ -608,7 +610,7 @@ void CoreAV::muteCallOutput(const Group* g, bool mute)
  */
 bool CoreAV::isGroupCallInputMuted(const Group* g) const
 {
-    QMutexLocker locker{&callsLock};
+    QReadLocker locker{&callsLock};
 
     if (!g) {
         return false;
@@ -626,7 +628,7 @@ bool CoreAV::isGroupCallInputMuted(const Group* g) const
  */
 bool CoreAV::isGroupCallOutputMuted(const Group* g) const
 {
-    QMutexLocker locker{&callsLock};
+    QReadLocker locker{&callsLock};
 
     if (!g) {
         return false;
@@ -644,7 +646,7 @@ bool CoreAV::isGroupCallOutputMuted(const Group* g) const
  */
 bool CoreAV::isCallInputMuted(const Friend* f) const
 {
-    QMutexLocker locker{&callsLock};
+    QReadLocker locker{&callsLock};
 
     if (!f) {
         return false;
@@ -661,7 +663,7 @@ bool CoreAV::isCallInputMuted(const Friend* f) const
  */
 bool CoreAV::isCallOutputMuted(const Friend* f) const
 {
-    QMutexLocker locker{&callsLock};
+    QReadLocker locker{&callsLock};
 
     if (!f) {
         return false;
@@ -677,7 +679,7 @@ bool CoreAV::isCallOutputMuted(const Friend* f) const
  */
 void CoreAV::sendNoVideo()
 {
-    QMutexLocker locker{&callsLock};
+    QReadLocker locker{&callsLock};
 
     // We don't change the audio bitrate, but we signal that we're not sending video anymore
     qDebug() << "CoreAV: Signaling end of video sending";
@@ -692,7 +694,7 @@ void CoreAV::callCallback(ToxAV* toxav, uint32_t friendNum, bool audio, bool vid
 {
     CoreAV* self = static_cast<CoreAV*>(vSelf);
 
-    QMutexLocker locker{&self->callsLock};
+    QWriteLocker locker{&self->callsLock};
 
     // Audio backend must be set before receiving a call
     assert(self->audio != nullptr);
@@ -715,6 +717,8 @@ void CoreAV::callCallback(ToxAV* toxav, uint32_t friendNum, bool audio, bool vid
         state |= TOXAV_FRIEND_CALL_STATE_SENDING_V | TOXAV_FRIEND_CALL_STATE_ACCEPTING_V;
     it.first->second->setState(static_cast<TOXAV_FRIEND_CALL_STATE>(state));
 
+    locker.unlock();
+
     emit reinterpret_cast<CoreAV*>(self)->avInvite(friendNum, video);
 }
 
@@ -723,7 +727,7 @@ void CoreAV::stateCallback(ToxAV* toxav, uint32_t friendNum, uint32_t state, voi
     Q_UNUSED(toxav);
     CoreAV* self = static_cast<CoreAV*>(vSelf);
 
-    QMutexLocker locker{&self->callsLock};
+    QWriteLocker locker{&self->callsLock};
 
     auto it = self->calls.find(friendNum);
     if (it == self->calls.end()) {
@@ -736,15 +740,18 @@ void CoreAV::stateCallback(ToxAV* toxav, uint32_t friendNum, uint32_t state, voi
     if (state & TOXAV_FRIEND_CALL_STATE_ERROR) {
         qWarning() << "Call with friend" << friendNum << "died of unnatural causes!";
         self->calls.erase(friendNum);
+        locker.unlock();
         emit self->avEnd(friendNum, true);
     } else if (state & TOXAV_FRIEND_CALL_STATE_FINISHED) {
         qDebug() << "Call with friend" << friendNum << "finished quietly";
         self->calls.erase(friendNum);
+        locker.unlock();
         emit self->avEnd(friendNum);
     } else {
         // If our state was null, we started the call and were still ringing
         if (!call.getState() && state) {
             call.setActive(true);
+            locker.unlock();
             emit self->avStart(friendNum, call.getVideoEnabled());
         } else if ((call.getState() & TOXAV_FRIEND_CALL_STATE_SENDING_V)
                    && !(state & TOXAV_FRIEND_CALL_STATE_SENDING_V)) {
@@ -806,7 +813,7 @@ void CoreAV::audioFrameCallback(ToxAV*, uint32_t friendNum, const int16_t* pcm, 
     CoreAV* self = static_cast<CoreAV*>(vSelf);
     // This callback should come from the CoreAV thread
     assert(QThread::currentThread() == self->coreavThread.get());
-    QMutexLocker locker{&self->callsLock};
+    QReadLocker locker{&self->callsLock};
 
     auto it = self->calls.find(friendNum);
     if (it == self->calls.end()) {
@@ -829,7 +836,7 @@ void CoreAV::videoFrameCallback(ToxAV*, uint32_t friendNum, uint16_t w, uint16_t
     auto self = static_cast<CoreAV*>(vSelf);
     // This callback should come from the CoreAV thread
     assert(QThread::currentThread() == self->coreavThread.get());
-    QMutexLocker locker{&self->callsLock};
+    QReadLocker locker{&self->callsLock};
 
     auto it = self->calls.find(friendNum);
     if (it == self->calls.end()) {

--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -168,6 +168,7 @@ void CoreAV::start()
 
 void CoreAV::process()
 {
+    assert(QThread::currentThread() == coreavThread.get());
     toxav_iterate(toxav.get());
     iterateTimer->start(toxav_iteration_interval(toxav.get()));
 }
@@ -235,6 +236,9 @@ bool CoreAV::answerCall(uint32_t friendNum, bool video)
 {
     QMutexLocker locker{&callsLock};
 
+    // This callback should come from the Core thread
+    assert(QThread::currentThread() != coreavThread.get());
+
     qDebug() << QString("Answering call %1").arg(friendNum);
     auto it = calls.find(friendNum);
     assert(it != calls.end());
@@ -256,6 +260,9 @@ bool CoreAV::answerCall(uint32_t friendNum, bool video)
 bool CoreAV::startCall(uint32_t friendNum, bool video)
 {
     QMutexLocker locker{&callsLock};
+
+    // This callback should come from the Core thread
+    assert(QThread::currentThread() != coreavThread.get());
 
     qDebug() << QString("Starting call with %1").arg(friendNum);
     auto it = calls.find(friendNum);
@@ -281,6 +288,9 @@ bool CoreAV::startCall(uint32_t friendNum, bool video)
 bool CoreAV::cancelCall(uint32_t friendNum)
 {
     QMutexLocker locker{&callsLock};
+
+    // This callback should come from the Core thread
+    assert(QThread::currentThread() != coreavThread.get());
 
     qDebug() << QString("Cancelling call with %1").arg(friendNum);
     if (!toxav_call_control(toxav.get(), friendNum, TOXAV_CALL_CONTROL_CANCEL, nullptr)) {
@@ -450,6 +460,7 @@ void CoreAV::groupCallCallback(void* tox, uint32_t group, uint32_t peer, const i
     CoreAV* cav = c->getAv();
 
     QMutexLocker locker{&cav->callsLock};
+    assert(QThread::currentThread() == cav->coreavThread.get());
 
     const ToxPk peerPk = c->getGroupPeerPk(group, peer);
     const Settings& s = Settings::getInstance();
@@ -549,6 +560,7 @@ bool CoreAV::sendGroupCallAudio(int groupId, const int16_t* pcm, size_t samples,
                                 uint32_t rate) const
 {
     QMutexLocker locker{&callsLock};
+    assert(QThread::currentThread() == coreavThread.get());
 
     std::map<int, ToxGroupCallPtr>::const_iterator it = groupCalls.find(groupId);
     if (it == groupCalls.end()) {
@@ -672,6 +684,8 @@ bool CoreAV::isCallOutputMuted(const Friend* f) const
 void CoreAV::sendNoVideo()
 {
     QMutexLocker locker{&callsLock};
+    // This callback should come from the Core thread
+    assert(QThread::currentThread() != coreavThread.get());
 
     // We don't change the audio bitrate, but we signal that we're not sending video anymore
     qDebug() << "CoreAV: Signaling end of video sending";
@@ -687,6 +701,8 @@ void CoreAV::callCallback(ToxAV* toxav, uint32_t friendNum, bool audio, bool vid
     CoreAV* self = static_cast<CoreAV*>(vSelf);
 
     QMutexLocker locker{&self->callsLock};
+    // This callback should come from the Core thread
+    assert(QThread::currentThread() != self->coreavThread.get());
 
     // Audio backend must be set before receiving a call
     assert(self->audio != nullptr);
@@ -716,6 +732,8 @@ void CoreAV::stateCallback(ToxAV* toxav, uint32_t friendNum, uint32_t state, voi
 {
     Q_UNUSED(toxav);
     CoreAV* self = static_cast<CoreAV*>(vSelf);
+    // This callback should come from the Core thread
+    assert(QThread::currentThread() != self->coreavThread.get());
 
     QMutexLocker locker{&self->callsLock};
 
@@ -799,6 +817,8 @@ void CoreAV::audioFrameCallback(ToxAV*, uint32_t friendNum, const int16_t* pcm, 
                                 uint8_t channels, uint32_t samplingRate, void* vSelf)
 {
     CoreAV* self = static_cast<CoreAV*>(vSelf);
+    // This callback should come from the CoreAV thread
+    assert(QThread::currentThread() == self->coreavThread.get());
     QMutexLocker locker{&self->callsLock};
 
     auto it = self->calls.find(friendNum);
@@ -820,6 +840,8 @@ void CoreAV::videoFrameCallback(ToxAV*, uint32_t friendNum, uint16_t w, uint16_t
                                 int32_t ystride, int32_t ustride, int32_t vstride, void* vSelf)
 {
     auto self = static_cast<CoreAV*>(vSelf);
+    // This callback should come from the CoreAV thread
+    assert(QThread::currentThread() == self->coreavThread.get());
     QMutexLocker locker{&self->callsLock};
 
     auto it = self->calls.find(friendNum);

--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -86,8 +86,7 @@ CoreAV::CoreAV(std::unique_ptr<ToxAV, ToxAVDeleter> toxav)
 
     connect(iterateTimer, &QTimer::timeout, this, &CoreAV::process);
     connect(coreavThread.get(), &QThread::finished, iterateTimer, &QTimer::stop);
-
-    coreavThread->start();
+    connect(coreavThread.get(), &QThread::started, this, &CoreAV::process);
 }
 
 void CoreAV::connectCallbacks(ToxAV& toxav)
@@ -164,10 +163,7 @@ CoreAV::~CoreAV()
  */
 void CoreAV::start()
 {
-    // Timers can only be touched from their own thread
-    if (QThread::currentThread() != coreavThread.get())
-        return (void)QMetaObject::invokeMethod(this, "start", Qt::BlockingQueuedConnection);
-    iterateTimer->start();
+    coreavThread->start();
 }
 
 void CoreAV::process()

--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -73,7 +73,6 @@ CoreAV::CoreAV(std::unique_ptr<ToxAV, ToxAVDeleter> toxav)
     , toxav{std::move(toxav)}
     , coreavThread{new QThread{this}}
     , iterateTimer{new QTimer{this}}
-    , threadSwitchLock{false}
 {
     assert(coreavThread);
     assert(iterateTimer);
@@ -184,6 +183,7 @@ void CoreAV::process()
  */
 bool CoreAV::isCallStarted(const Friend* f) const
 {
+    QMutexLocker locker{&callsLock};
     return f && (calls.find(f->getId()) != calls.end());
 }
 
@@ -194,6 +194,7 @@ bool CoreAV::isCallStarted(const Friend* f) const
  */
 bool CoreAV::isCallStarted(const Group* g) const
 {
+    QMutexLocker locker{&callsLock};
     return g && (groupCalls.find(g->getId()) != groupCalls.end());
 }
 
@@ -204,6 +205,7 @@ bool CoreAV::isCallStarted(const Group* g) const
  */
 bool CoreAV::isCallActive(const Friend* f) const
 {
+    QMutexLocker locker{&callsLock};
     auto it = calls.find(f->getId());
     if (it == calls.end()) {
         return false;
@@ -218,6 +220,7 @@ bool CoreAV::isCallActive(const Friend* f) const
  */
 bool CoreAV::isCallActive(const Group* g) const
 {
+    QMutexLocker locker{&callsLock};
     auto it = groupCalls.find(g->getId());
     if (it == groupCalls.end()) {
         return false;
@@ -227,26 +230,14 @@ bool CoreAV::isCallActive(const Group* g) const
 
 bool CoreAV::isCallVideoEnabled(const Friend* f) const
 {
+    QMutexLocker locker{&callsLock};
     auto it = calls.find(f->getId());
     return isCallStarted(f) && it->second->getVideoEnabled();
 }
 
 bool CoreAV::answerCall(uint32_t friendNum, bool video)
 {
-    if (QThread::currentThread() != coreavThread.get()) {
-        if (threadSwitchLock.test_and_set(std::memory_order_acquire)) {
-            qDebug() << "CoreAV::answerCall: Backed off of thread-switch lock";
-            return false;
-        }
-
-        bool ret;
-        QMetaObject::invokeMethod(this, "answerCall", Qt::BlockingQueuedConnection,
-                                  Q_RETURN_ARG(bool, ret), Q_ARG(uint32_t, friendNum),
-                                  Q_ARG(bool, video));
-
-        threadSwitchLock.clear(std::memory_order_release);
-        return ret;
-    }
+    QMutexLocker locker{&callsLock};
 
     qDebug() << QString("Answering call %1").arg(friendNum);
     auto it = calls.find(friendNum);
@@ -268,20 +259,7 @@ bool CoreAV::answerCall(uint32_t friendNum, bool video)
 
 bool CoreAV::startCall(uint32_t friendNum, bool video)
 {
-    if (QThread::currentThread() != coreavThread.get()) {
-        if (threadSwitchLock.test_and_set(std::memory_order_acquire)) {
-            qDebug() << "CoreAV::startCall: Backed off of thread-switch lock";
-            return false;
-        }
-
-        bool ret;
-        QMetaObject::invokeMethod(this, "startCall", Qt::BlockingQueuedConnection,
-                                  Q_RETURN_ARG(bool, ret), Q_ARG(uint32_t, friendNum),
-                                  Q_ARG(bool, video));
-
-        threadSwitchLock.clear(std::memory_order_release);
-        return ret;
-    }
+    QMutexLocker locker{&callsLock};
 
     qDebug() << QString("Starting call with %1").arg(friendNum);
     auto it = calls.find(friendNum);
@@ -306,19 +284,7 @@ bool CoreAV::startCall(uint32_t friendNum, bool video)
 
 bool CoreAV::cancelCall(uint32_t friendNum)
 {
-    if (QThread::currentThread() != coreavThread.get()) {
-        if (threadSwitchLock.test_and_set(std::memory_order_acquire)) {
-            qDebug() << "CoreAV::cancelCall: Backed off of thread-switch lock";
-            return false;
-        }
-
-        bool ret;
-        QMetaObject::invokeMethod(this, "cancelCall", Qt::BlockingQueuedConnection,
-                                  Q_RETURN_ARG(bool, ret), Q_ARG(uint32_t, friendNum));
-
-        threadSwitchLock.clear(std::memory_order_release);
-        return ret;
-    }
+    QMutexLocker locker{&callsLock};
 
     qDebug() << QString("Cancelling call with %1").arg(friendNum);
     if (!toxav_call_control(toxav.get(), friendNum, TOXAV_CALL_CONTROL_CANCEL, nullptr)) {
@@ -333,13 +299,7 @@ bool CoreAV::cancelCall(uint32_t friendNum)
 
 void CoreAV::timeoutCall(uint32_t friendNum)
 {
-    // Non-blocking switch to the CoreAV thread, we really don't want to be coming
-    // blocking-queued from the UI thread while we emit blocking-queued to it
-    if (QThread::currentThread() != coreavThread.get()) {
-        QMetaObject::invokeMethod(this, "timeoutCall", Qt::QueuedConnection,
-                                  Q_ARG(uint32_t, friendNum));
-        return;
-    }
+    QMutexLocker locker{&callsLock};
 
     if (!cancelCall(friendNum)) {
         qWarning() << QString("Failed to timeout call with %1").arg(friendNum);
@@ -360,6 +320,8 @@ void CoreAV::timeoutCall(uint32_t friendNum)
 bool CoreAV::sendCallAudio(uint32_t callId, const int16_t* pcm, size_t samples, uint8_t chans,
                            uint32_t rate) const
 {
+    QMutexLocker locker{&callsLock};
+
     auto it = calls.find(callId);
     if (it == calls.end()) {
         return false;
@@ -394,6 +356,8 @@ bool CoreAV::sendCallAudio(uint32_t callId, const int16_t* pcm, size_t samples, 
 
 void CoreAV::sendCallVideo(uint32_t callId, std::shared_ptr<VideoFrame> vframe)
 {
+    QMutexLocker locker{&callsLock};
+
     // We might be running in the FFmpeg thread and holding the CameraSource lock
     // So be careful not to deadlock with anything while toxav locks in toxav_video_send_frame
     auto it = calls.find(callId);
@@ -446,6 +410,8 @@ void CoreAV::sendCallVideo(uint32_t callId, std::shared_ptr<VideoFrame> vframe)
  */
 void CoreAV::toggleMuteCallInput(const Friend* f)
 {
+    QMutexLocker locker{&callsLock};
+
     auto it = calls.find(f->getId());
     if (f && (it != calls.end())) {
         ToxCall& call = *it->second;
@@ -459,6 +425,8 @@ void CoreAV::toggleMuteCallInput(const Friend* f)
  */
 void CoreAV::toggleMuteCallOutput(const Friend* f)
 {
+    QMutexLocker locker{&callsLock};
+
     auto it = calls.find(f->getId());
     if (f && (it != calls.end())) {
         ToxCall& call = *it->second;
@@ -482,8 +450,11 @@ void CoreAV::groupCallCallback(void* tox, uint32_t group, uint32_t peer, const i
                                unsigned samples, uint8_t channels, uint32_t sample_rate, void* core)
 {
     Q_UNUSED(tox);
-
     Core* c = static_cast<Core*>(core);
+    CoreAV* cav = c->getAv();
+
+    QMutexLocker locker{&cav->callsLock};
+
     const ToxPk peerPk = c->getGroupPeerPk(group, peer);
     const Settings& s = Settings::getInstance();
     // don't play the audio if it comes from a muted peer
@@ -492,8 +463,6 @@ void CoreAV::groupCallCallback(void* tox, uint32_t group, uint32_t peer, const i
     }
 
     emit c->groupPeerAudioPlaying(group, peerPk);
-
-    CoreAV* cav = c->getAv();
 
     auto it = cav->groupCalls.find(group);
     if (it == cav->groupCalls.end()) {
@@ -516,6 +485,8 @@ void CoreAV::groupCallCallback(void* tox, uint32_t group, uint32_t peer, const i
  */
 void CoreAV::invalidateGroupCallPeerSource(int group, ToxPk peerPk)
 {
+    QMutexLocker locker{&callsLock};
+
     auto it = groupCalls.find(group);
     if (it == groupCalls.end()) {
         return;
@@ -530,6 +501,8 @@ void CoreAV::invalidateGroupCallPeerSource(int group, ToxPk peerPk)
  */
 VideoSource* CoreAV::getVideoSourceFromCall(int friendNum) const
 {
+    QMutexLocker locker{&callsLock};
+
     auto it = calls.find(friendNum);
     if (it == calls.end()) {
         qWarning() << "CoreAV::getVideoSourceFromCall: No such call, possibly cancelled";
@@ -546,6 +519,8 @@ VideoSource* CoreAV::getVideoSourceFromCall(int friendNum) const
  */
 void CoreAV::joinGroupCall(int groupId)
 {
+    QMutexLocker locker{&callsLock};
+
     qDebug() << QString("Joining group call %1").arg(groupId);
 
     // Audio backend must be set before starting a call
@@ -567,6 +542,8 @@ void CoreAV::joinGroupCall(int groupId)
  */
 void CoreAV::leaveGroupCall(int groupId)
 {
+    QMutexLocker locker{&callsLock};
+
     qDebug() << QString("Leaving group call %1").arg(groupId);
 
     groupCalls.erase(groupId);
@@ -575,6 +552,8 @@ void CoreAV::leaveGroupCall(int groupId)
 bool CoreAV::sendGroupCallAudio(int groupId, const int16_t* pcm, size_t samples, uint8_t chans,
                                 uint32_t rate) const
 {
+    QMutexLocker locker{&callsLock};
+
     std::map<int, ToxGroupCallPtr>::const_iterator it = groupCalls.find(groupId);
     if (it == groupCalls.end()) {
         return false;
@@ -597,6 +576,8 @@ bool CoreAV::sendGroupCallAudio(int groupId, const int16_t* pcm, size_t samples,
  */
 void CoreAV::muteCallInput(const Group* g, bool mute)
 {
+    QMutexLocker locker{&callsLock};
+
     auto it = groupCalls.find(g->getId());
     if (g && (it != groupCalls.end())) {
         it->second->setMuteMic(mute);
@@ -610,6 +591,8 @@ void CoreAV::muteCallInput(const Group* g, bool mute)
  */
 void CoreAV::muteCallOutput(const Group* g, bool mute)
 {
+    QMutexLocker locker{&callsLock};
+
     auto it = groupCalls.find(g->getId());
     if (g && (it != groupCalls.end())) {
         it->second->setMuteVol(mute);
@@ -623,6 +606,8 @@ void CoreAV::muteCallOutput(const Group* g, bool mute)
  */
 bool CoreAV::isGroupCallInputMuted(const Group* g) const
 {
+    QMutexLocker locker{&callsLock};
+
     if (!g) {
         return false;
     }
@@ -639,6 +624,8 @@ bool CoreAV::isGroupCallInputMuted(const Group* g) const
  */
 bool CoreAV::isGroupCallOutputMuted(const Group* g) const
 {
+    QMutexLocker locker{&callsLock};
+
     if (!g) {
         return false;
     }
@@ -655,6 +642,8 @@ bool CoreAV::isGroupCallOutputMuted(const Group* g) const
  */
 bool CoreAV::isCallInputMuted(const Friend* f) const
 {
+    QMutexLocker locker{&callsLock};
+
     if (!f) {
         return false;
     }
@@ -670,6 +659,8 @@ bool CoreAV::isCallInputMuted(const Friend* f) const
  */
 bool CoreAV::isCallOutputMuted(const Friend* f) const
 {
+    QMutexLocker locker{&callsLock};
+
     if (!f) {
         return false;
     }
@@ -684,6 +675,8 @@ bool CoreAV::isCallOutputMuted(const Friend* f) const
  */
 void CoreAV::sendNoVideo()
 {
+    QMutexLocker locker{&callsLock};
+
     // We don't change the audio bitrate, but we signal that we're not sending video anymore
     qDebug() << "CoreAV: Signaling end of video sending";
     for (auto& kv : calls) {
@@ -697,22 +690,7 @@ void CoreAV::callCallback(ToxAV* toxav, uint32_t friendNum, bool audio, bool vid
 {
     CoreAV* self = static_cast<CoreAV*>(vSelf);
 
-    // Run this slow callback asynchronously on the AV thread to avoid deadlocks with what our
-    // caller (toxcore) holds
-    // Also run the code to switch to the CoreAV thread in yet another thread, in case CoreAV
-    // has threadSwitchLock and wants a toxcore lock that our call stack is holding...
-    if (QThread::currentThread() != self->coreavThread.get()) {
-        QtConcurrent::run([=]() {
-            // We assume the original caller doesn't come from the CoreAV thread here
-            while (self->threadSwitchLock.test_and_set(std::memory_order_acquire))
-                QThread::yieldCurrentThread(); // Shouldn't spin for long, we have priority
-
-            QMetaObject::invokeMethod(self, "callCallback", Qt::QueuedConnection,
-                                      Q_ARG(ToxAV*, toxav), Q_ARG(uint32_t, friendNum),
-                                      Q_ARG(bool, audio), Q_ARG(bool, video), Q_ARG(void*, vSelf));
-        });
-        return;
-    }
+    QMutexLocker locker{&self->callsLock};
 
     // Audio backend must be set before receiving a call
     assert(self->audio != nullptr);
@@ -721,10 +699,6 @@ void CoreAV::callCallback(ToxAV* toxav, uint32_t friendNum, bool audio, bool vid
 
     auto it = self->calls.emplace(friendNum, std::move(call));
     if (it.second == false) {
-        /// Hanging up from a callback is supposed to be UB,
-        /// but since currently the toxav callbacks are fired from the toxcore thread,
-        /// we'll always reach this point through a non-blocking queud connection, so not in the
-        /// callback.
         qWarning() << QString("Rejecting call invite from %1, we're already in that call!").arg(friendNum);
         toxav_call_control(toxav, friendNum, TOXAV_CALL_CONTROL_CANCEL, nullptr);
         return;
@@ -738,37 +712,20 @@ void CoreAV::callCallback(ToxAV* toxav, uint32_t friendNum, bool audio, bool vid
     if (video)
         state |= TOXAV_FRIEND_CALL_STATE_SENDING_V | TOXAV_FRIEND_CALL_STATE_ACCEPTING_V;
     it.first->second->setState(static_cast<TOXAV_FRIEND_CALL_STATE>(state));
-    // note: changed to self->
 
     emit reinterpret_cast<CoreAV*>(self)->avInvite(friendNum, video);
-    self->threadSwitchLock.clear(std::memory_order_release);
 }
 
 void CoreAV::stateCallback(ToxAV* toxav, uint32_t friendNum, uint32_t state, void* vSelf)
 {
+    Q_UNUSED(toxav);
     CoreAV* self = static_cast<CoreAV*>(vSelf);
 
-    // Run this slow callback asynchronously on the AV thread to avoid deadlocks with what our
-    // caller (toxcore) holds
-    // Also run the code to switch to the CoreAV thread in yet another thread, in case CoreAV
-    // has threadSwitchLock and wants a toxcore lock that our call stack is holding...
-    if (QThread::currentThread() != self->coreavThread.get()) {
-        QtConcurrent::run([=]() {
-            // We assume the original caller doesn't come from the CoreAV thread here
-            while (self->threadSwitchLock.test_and_set(std::memory_order_acquire))
-                QThread::yieldCurrentThread(); // Shouldn't spin for long, we have priority
-
-            QMetaObject::invokeMethod(self, "stateCallback", Qt::QueuedConnection,
-                                      Q_ARG(ToxAV*, toxav), Q_ARG(uint32_t, friendNum),
-                                      Q_ARG(uint32_t, state), Q_ARG(void*, vSelf));
-        });
-        return;
-    }
+    QMutexLocker locker{&self->callsLock};
 
     auto it = self->calls.find(friendNum);
     if (it == self->calls.end()) {
         qWarning() << QString("stateCallback called, but call %1 is already dead").arg(friendNum);
-        self->threadSwitchLock.clear(std::memory_order_release);
         return;
     }
 
@@ -777,12 +734,10 @@ void CoreAV::stateCallback(ToxAV* toxav, uint32_t friendNum, uint32_t state, voi
     if (state & TOXAV_FRIEND_CALL_STATE_ERROR) {
         qWarning() << "Call with friend" << friendNum << "died of unnatural causes!";
         self->calls.erase(friendNum);
-        // why not self->
         emit self->avEnd(friendNum, true);
     } else if (state & TOXAV_FRIEND_CALL_STATE_FINISHED) {
         qDebug() << "Call with friend" << friendNum << "finished quietly";
         self->calls.erase(friendNum);
-        // why not self->
         emit self->avEnd(friendNum);
     } else {
         // If our state was null, we started the call and were still ringing
@@ -810,50 +765,36 @@ void CoreAV::stateCallback(ToxAV* toxav, uint32_t friendNum, uint32_t state, voi
 
         call.setState(static_cast<TOXAV_FRIEND_CALL_STATE>(state));
     }
-    self->threadSwitchLock.clear(std::memory_order_release);
 }
 
+// This is only a dummy implementation for now
 void CoreAV::bitrateCallback(ToxAV* toxav, uint32_t friendNum, uint32_t arate, uint32_t vrate,
                              void* vSelf)
 {
     CoreAV* self = static_cast<CoreAV*>(vSelf);
-
-    // Run this slow path callback asynchronously on the AV thread to avoid deadlocks
-    if (QThread::currentThread() != self->coreavThread.get()) {
-        return (void)QMetaObject::invokeMethod(self, "bitrateCallback", Qt::QueuedConnection,
-                                               Q_ARG(ToxAV*, toxav), Q_ARG(uint32_t, friendNum),
-                                               Q_ARG(uint32_t, arate), Q_ARG(uint32_t, vrate),
-                                               Q_ARG(void*, vSelf));
-    }
+    Q_UNUSED(self);
+    Q_UNUSED(toxav);
 
     qDebug() << "Recommended bitrate with" << friendNum << " is now " << arate << "/" << vrate
              << ", ignoring it";
 }
 
+// This is only a dummy implementation for now
 void CoreAV::audioBitrateCallback(ToxAV* toxav, uint32_t friendNum, uint32_t rate, void* vSelf)
 {
     CoreAV* self = static_cast<CoreAV*>(vSelf);
-
-    // Run this slow path callback asynchronously on the AV thread to avoid deadlocks
-    if (QThread::currentThread() != self->coreavThread.get()) {
-        return (void)QMetaObject::invokeMethod(self, "audioBitrateCallback", Qt::QueuedConnection,
-                                               Q_ARG(ToxAV*, toxav), Q_ARG(uint32_t, friendNum),
-                                               Q_ARG(uint32_t, rate), Q_ARG(void*, vSelf));
-    }
+    Q_UNUSED(self);
+    Q_UNUSED(toxav);
 
     qDebug() << "Recommended audio bitrate with" << friendNum << " is now " << rate << ", ignoring it";
 }
 
+// This is only a dummy implementation for now
 void CoreAV::videoBitrateCallback(ToxAV* toxav, uint32_t friendNum, uint32_t rate, void* vSelf)
 {
     CoreAV* self = static_cast<CoreAV*>(vSelf);
-
-    // Run this slow path callback asynchronously on the AV thread to avoid deadlocks
-    if (QThread::currentThread() != self->coreavThread.get()) {
-        return (void)QMetaObject::invokeMethod(self, "videoBitrateCallback", Qt::QueuedConnection,
-                                               Q_ARG(ToxAV*, toxav), Q_ARG(uint32_t, friendNum),
-                                               Q_ARG(uint32_t, rate), Q_ARG(void*, vSelf));
-    }
+    Q_UNUSED(self);
+    Q_UNUSED(toxav);
 
     qDebug() << "Recommended video bitrate with" << friendNum << " is now " << rate << ", ignoring it";
 }
@@ -862,6 +803,8 @@ void CoreAV::audioFrameCallback(ToxAV*, uint32_t friendNum, const int16_t* pcm, 
                                 uint8_t channels, uint32_t samplingRate, void* vSelf)
 {
     CoreAV* self = static_cast<CoreAV*>(vSelf);
+    QMutexLocker locker{&self->callsLock};
+
     auto it = self->calls.find(friendNum);
     if (it == self->calls.end()) {
         return;
@@ -881,6 +824,7 @@ void CoreAV::videoFrameCallback(ToxAV*, uint32_t friendNum, uint16_t w, uint16_t
                                 int32_t ystride, int32_t ustride, int32_t vstride, void* vSelf)
 {
     auto self = static_cast<CoreAV*>(vSelf);
+    QMutexLocker locker{&self->callsLock};
 
     auto it = self->calls.find(friendNum);
     if (it == self->calls.end()) {

--- a/src/core/coreav.h
+++ b/src/core/coreav.h
@@ -23,6 +23,7 @@
 
 #include "src/core/toxcall.h"
 #include <QObject>
+#include <QMutex>
 #include <atomic>
 #include <memory>
 #include <tox/toxav.h>
@@ -145,7 +146,9 @@ private:
      * @note Need to use STL container here, because Qt containers need a copy constructor.
      */
     std::map<int, ToxGroupCallPtr> groupCalls;
-    std::atomic_flag threadSwitchLock;
+
+    // protect 'calls' and 'groupCalls' from being modified by ToxAV and Tox threads
+    mutable QMutex callsLock{QMutex::Recursive};
 };
 
 #endif // COREAV_H

--- a/src/core/coreav.h
+++ b/src/core/coreav.h
@@ -113,7 +113,7 @@ private:
         }
     };
 
-    explicit CoreAV(std::unique_ptr<ToxAV, ToxAVDeleter> tox, QMutex &toxCoreLock);
+    CoreAV(std::unique_ptr<ToxAV, ToxAVDeleter> tox, QMutex &toxCoreLock);
     void connectCallbacks(ToxAV& toxav);
 
     void process();
@@ -148,7 +148,7 @@ private:
      */
     std::map<int, ToxGroupCallPtr> groupCalls;
 
-    // protect 'calls' and 'groupCalls' from being modified by ToxAV and Tox threads
+    // protect 'calls' and 'groupCalls'
     mutable QReadWriteLock callsLock{QReadWriteLock::Recursive};
 
     /**

--- a/src/core/coreav.h
+++ b/src/core/coreav.h
@@ -24,6 +24,7 @@
 #include "src/core/toxcall.h"
 #include <QObject>
 #include <QMutex>
+#include <QReadWriteLock>
 #include <atomic>
 #include <memory>
 #include <tox/toxav.h>
@@ -148,7 +149,7 @@ private:
     std::map<int, ToxGroupCallPtr> groupCalls;
 
     // protect 'calls' and 'groupCalls' from being modified by ToxAV and Tox threads
-    mutable QMutex callsLock{QMutex::Recursive};
+    mutable QReadWriteLock callsLock{QReadWriteLock::Recursive};
 
     /**
      * @brief needed to synchronize with the Core thread, some toxav_* functions

--- a/src/core/toxcall.cpp
+++ b/src/core/toxcall.cpp
@@ -190,29 +190,6 @@ void ToxFriendCall::onAudioSinkInvalidated()
     sink = std::move(newSink);
 }
 
-void ToxFriendCall::startTimeout(uint32_t callId)
-{
-    if (!timeoutTimer) {
-        timeoutTimer = std::unique_ptr<QTimer>{new QTimer{}};
-        // We might move, so we need copies of members. CoreAV won't move while we're alive
-        CoreAV* avCopy = av;
-        QObject::connect(timeoutTimer.get(), &QTimer::timeout,
-                         [avCopy, callId]() { avCopy->timeoutCall(callId); });
-    }
-
-    if (!timeoutTimer->isActive())
-        timeoutTimer->start(CALL_TIMEOUT);
-}
-
-void ToxFriendCall::stopTimeout()
-{
-    if (!timeoutTimer)
-        return;
-
-    timeoutTimer->stop();
-    timeoutTimer.reset();
-}
-
 TOXAV_FRIEND_CALL_STATE ToxFriendCall::getState() const
 {
     return state;

--- a/src/core/toxcall.h
+++ b/src/core/toxcall.h
@@ -95,16 +95,10 @@ public:
     ToxFriendCall& operator=(ToxFriendCall&& other) = delete;
     ~ToxFriendCall();
 
-    void startTimeout(uint32_t callId);
-    void stopTimeout();
-
     TOXAV_FRIEND_CALL_STATE getState() const;
     void setState(const TOXAV_FRIEND_CALL_STATE& value);
 
     void playAudioBuffer(const int16_t* data, int samples, unsigned channels, int sampleRate) const;
-
-protected:
-    std::unique_ptr<QTimer> timeoutTimer;
 
 private:
     QMetaObject::Connection audioSinkInvalid;
@@ -113,7 +107,6 @@ private:
 
 private:
     TOXAV_FRIEND_CALL_STATE state{TOXAV_FRIEND_CALL_STATE_NONE};
-    static constexpr int CALL_TIMEOUT = 45000;
     std::unique_ptr<IAudioSink> sink = nullptr;
     uint32_t friendId;
 };


### PR DESCRIPTION
Use a standard mutex instead of trying to build proper locking
ourselfes.

This should make it easier to fix all the concurrency issues in Core and CoreAV. We also need to rework the calls to c-toxcore with regards to toxav threading.

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5926)
<!-- Reviewable:end -->
