### PR TITLE
Cherry pick v1.17 dev

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -1242,6 +1242,7 @@ QStringList Core::getGroupPeerNames(int groupId) const
         TOX_ERR_CONFERENCE_PEER_QUERY error;
         size_t length = tox_conference_peer_get_name_size(tox.get(), groupId, i, &error);
         if (!parsePeerQueryError(error)) {
+            names.append(QString());
             continue;
         }
 
@@ -1250,8 +1251,12 @@ QStringList Core::getGroupPeerNames(int groupId) const
         bool ok = tox_conference_peer_get_name(tox.get(), groupId, i, namePtr, &error);
         if (ok && parsePeerQueryError(error)) {
             names.append(ToxString(name).getQString());
+        } else {
+            names.append(QString());
         }
     }
+
+    assert(names.size() == nPeers);
 
     return names;
 }

--- a/src/video/groupnetcamview.cpp
+++ b/src/video/groupnetcamview.cpp
@@ -37,7 +37,7 @@
 class LabeledVideo : public QFrame
 {
 public:
-    LabeledVideo(const QPixmap& avatar, QWidget* parent = nullptr, bool expanding = true)
+    LabeledVideo(const QPixmap& avatar, QString fontColorString, QWidget* parent = nullptr, bool expanding = true)
         : QFrame(parent)
     {
         qDebug() << "Created expanding? " << expanding;
@@ -48,7 +48,7 @@ public:
         connect(videoSurface, &VideoSurface::ratioChanged, this, &LabeledVideo::updateSize);
         label = new CroppingLabel(this);
         label->setTextFormat(Qt::PlainText);
-        label->setStyleSheet("color: white");
+        label->setStyleSheet(QString("color: %1").arg(fontColorString));
 
         label->setAlignment(Qt::AlignCenter);
 
@@ -108,7 +108,7 @@ GroupNetCamView::GroupNetCamView(int group, QWidget* parent)
     : GenericNetCamView(parent)
     , group(group)
 {
-    videoLabelSurface = new LabeledVideo(QPixmap(), this, false);
+    videoLabelSurface = new LabeledVideo(QPixmap(), "white", this, false);
     videoSurface = videoLabelSurface->getVideoSurface();
     videoSurface->setMinimumHeight(256);
     videoSurface->setContentsMargins(6, 6, 6, 0);
@@ -139,7 +139,7 @@ GroupNetCamView::GroupNetCamView(int group, QWidget* parent)
     horLayout = new QHBoxLayout(widget);
     horLayout->addStretch(1);
 
-    selfVideoSurface = new LabeledVideo(Nexus::getProfile()->loadAvatar(), this);
+    selfVideoSurface = new LabeledVideo(Nexus::getProfile()->loadAvatar(), "black", this);
     horLayout->addWidget(selfVideoSurface);
 
     horLayout->addStretch(1);
@@ -176,7 +176,7 @@ void GroupNetCamView::clearPeers()
 void GroupNetCamView::addPeer(const ToxPk& peer, const QString& name)
 {
     QPixmap groupAvatar = Nexus::getProfile()->loadAvatar(peer);
-    LabeledVideo* labeledVideo = new LabeledVideo(groupAvatar, this);
+    LabeledVideo* labeledVideo = new LabeledVideo(groupAvatar, "black", this);
     labeledVideo->setText(name);
     horLayout->insertWidget(horLayout->count() - 1, labeledVideo);
     PeerVideo peerVideo;

--- a/src/video/groupnetcamview.cpp
+++ b/src/video/groupnetcamview.cpp
@@ -128,6 +128,11 @@ GroupNetCamView::GroupNetCamView(int group, QWidget* parent)
 
     QScrollArea* scrollArea = new QScrollArea();
     scrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+
+    // Note this is needed to prevent oscillations that result in segfaults
+    scrollArea->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
+    scrollArea->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum));
+
     scrollArea->setFrameStyle(QFrame::NoFrame);
     QWidget* widget = new QWidget(nullptr);
     scrollArea->setWidgetResizable(true);


### PR DESCRIPTION
Our v1.17-dev branch had two divergent heads, this moves one on top of the other and then advances the v1.17-dev branch to the tip of both.

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5928)
<!-- Reviewable:end -->
