### PR TITLE
fix(ui): quit qTox on Ctrl+Q when "Close to tray" is enabled

### DIFF
--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -334,7 +334,8 @@ void Widget::init()
     // initial request with the sanitized name so there is no work for us to do
 
     // keyboard shortcuts
-    new QShortcut(Qt::CTRL + Qt::Key_Q, this, SLOT(close()));
+    auto* const quitShortcut = new QShortcut(Qt::CTRL + Qt::Key_Q, this);
+    connect(quitShortcut, &QShortcut::activated, qApp, &QApplication::quit);
     new QShortcut(Qt::CTRL + Qt::SHIFT + Qt::Key_Tab, this, SLOT(previousContact()));
     new QShortcut(Qt::CTRL + Qt::Key_Tab, this, SLOT(nextContact()));
     new QShortcut(Qt::CTRL + Qt::Key_PageUp, this, SLOT(previousContact()));


### PR DESCRIPTION
Fixes #5925.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5931)
<!-- Reviewable:end -->
