### PR TITLE
refactor(widget): remove uneeded check of if message is targetted

### DIFF
--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1166,10 +1166,6 @@ void Widget::addFriend(uint32_t friendId, const ToxPk& friendPk)
 
 
     auto notifyReceivedCallback = [this, friendPk](const ToxPk& author, const Message& message) {
-        auto isTargeted = std::any_of(message.metadata.begin(), message.metadata.end(),
-                                      [](MessageMetadata metadata) {
-                                          return metadata.type == MessageMetadataType::selfMention;
-                                      });
         newFriendMessageAlert(friendPk, message.content);
     };
 


### PR DESCRIPTION
It's only relevant for group messages, where the check already exists.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5938)
<!-- Reviewable:end -->
