### PR TITLE
WIP fix(chatlog): stick scroll to bottom if at bottom, else leave unchanged

### DIFF
--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -396,6 +396,7 @@ void ChatLog::insertChatlineAtBottom(const QList<ChatLine::Ptr>& newLines)
 
     const bool stickToBtm = stickToBottom();
 
+    auto firstVisible = visibleLines.first()->getRow();
     if (canRemove && lines.size() > maxMessages) {
         removeFirsts(DEF_NUM_MSG_TO_LOAD);
     }
@@ -729,6 +730,16 @@ void ChatLog::reloadTheme()
     for (ChatLine::Ptr l : lines) {
         l->reloadTheme();
     }
+}
+
+void ChatLog::removeLinesAroundView()
+{
+    auto firstVisible = visibleLines.first()->getRow();
+    auto lastVisible = visibleLines.last()->getRow();
+    if (canRemove && lines.size() + DEF_NUM_MSG_TO_LOAD >= maxMessages) {
+        removeFirsts(DEF_NUM_MSG_TO_LOAD);
+    }
+
 }
 
 void ChatLog::removeFirsts(const int num)

--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -396,7 +396,7 @@ void ChatLog::insertChatlineAtBottom(const QList<ChatLine::Ptr>& newLines)
 
     const bool stickToBtm = stickToBottom();
 
-    if (canRemove && lines.size() + DEF_NUM_MSG_TO_LOAD >= maxMessages) {
+    if (canRemove && lines.size() > maxMessages) {
         removeFirsts(DEF_NUM_MSG_TO_LOAD);
     }
 
@@ -449,7 +449,7 @@ void ChatLog::insertChatlinesOnTop(const QList<ChatLine::Ptr>& newLines)
         combLines.push_back(l);
     }
 
-    if (canRemove && lines.size() + DEF_NUM_MSG_TO_LOAD >= maxMessages) {
+    if (canRemove && lines.size() > maxMessages) {
         removeLasts(DEF_NUM_MSG_TO_LOAD);
     }
 

--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -394,6 +394,8 @@ void ChatLog::insertChatlineAtBottom(const QList<ChatLine::Ptr>& newLines)
     if (newLines.isEmpty())
         return;
 
+    const bool stickToBtm = stickToBottom();
+
     if (canRemove && lines.size() + DEF_NUM_MSG_TO_LOAD >= maxMessages) {
         removeFirsts(DEF_NUM_MSG_TO_LOAD);
     }
@@ -406,12 +408,14 @@ void ChatLog::insertChatlineAtBottom(const QList<ChatLine::Ptr>& newLines)
     }
 
     layout(lines.last()->getRow(), lines.size(), useableWidth());
+    updateSceneRect();
 
-    if (visibleLines.size() > 1) {
-        startResizeWorker(visibleLines[1]);
-    } else {
-        startResizeWorker();
+    if (stickToBtm) {
+        scrollToBottom();
     }
+
+    checkVisibility();
+    updateTypingNotification();
 }
 
 void ChatLog::insertChatlineOnTop(ChatLine::Ptr l)

--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -187,7 +187,7 @@ private:
     qreal lineSpacing = 5.0f;
 
     int numRemove{0};
-    const int maxMessages{300};
+    const int maxMessages{200};
     bool canRemove;
 };
 

--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -59,6 +59,7 @@ public:
     void fontChanged(const QFont& font);
     void reloadTheme();
     void removeFirsts(const int num);
+    void removeLinesAroundView();
     void removeLasts(const int num);
     void setScroll(const bool scroll);
     int getNumRemove() const;


### PR DESCRIPTION
This reverts behaviour to be similar to the other insertChatlineAtBottom.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5939)
<!-- Reviewable:end -->
