### PR TITLE
fix(ui): fix auto-accept directory setup display

### DIFF
--- a/src/widget/about/aboutfriendform.cpp
+++ b/src/widget/about/aboutfriendform.cpp
@@ -92,7 +92,7 @@ void AboutFriendForm::onAutoAcceptDirClicked()
 
 void AboutFriendForm::onAutoAcceptDirChanged(const QString& path)
 {
-    const bool enabled = path.isNull();
+    const bool enabled = !path.isNull();
     ui->autoacceptfile->setChecked(enabled);
     ui->selectSaveDir->setEnabled(enabled);
     ui->selectSaveDir->setText(enabled ? path : tr("Auto accept for this contact is disabled"));


### PR DESCRIPTION
When a path is passed in to `onAutoAcceptDirChanged`, the `enabled` boolean is mistakenly set to false.

Immediately before selecting a path:
![1](https://user-images.githubusercontent.com/1592123/69925594-08d80b80-147f-11ea-8df7-d1e1f13332dc.png)

Immediately after:
![2](https://user-images.githubusercontent.com/1592123/69925593-083f7500-147f-11ea-8f68-53e72414eee3.png)



Fixes #5917

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5941)
<!-- Reviewable:end -->
