### PR TITLE
[WIP] feat: Add username to tray menu

### DIFF
--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -31,6 +31,7 @@
 #include <QShortcut>
 #include <QString>
 #include <QSvgRenderer>
+#include <QWidgetAction>
 #include <QWindow>
 #ifdef Q_OS_MAC
 #include <QMenuBar>
@@ -2249,7 +2250,14 @@ void Widget::onTryCreateTrayIcon()
             icon = std::unique_ptr<QSystemTrayIcon>(new QSystemTrayIcon);
             updateIcons();
             trayMenu = new QMenu(this);
+            QLabel* trayUser = new QLabel(getUsername(), this);
+            QWidgetAction* trayUserAction = new QWidgetAction(trayMenu);
 
+            trayUser->setAlignment(Qt::AlignCenter);
+            trayUserAction->setDefaultWidget(trayUser);
+
+            trayMenu->addAction(trayUserAction);
+            trayMenu->addSeparator();
             // adding activate to the top, avoids accidentally clicking quit
             trayMenu->addAction(actionShow);
             trayMenu->addSeparator();


### PR DESCRIPTION
This is a 'first try' at displaying the user name in the tray menu.

Updating the name only happens when restarting the client, and truncating too long ones is not there yet.

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5943)
<!-- Reviewable:end -->
