### PR TITLE
fix(build): appease appstream-glib validate

### DIFF
--- a/res/io.github.qtox.qTox.appdata.xml
+++ b/res/io.github.qtox.qTox.appdata.xml
@@ -53,11 +53,11 @@
  <screenshots>
   <screenshot type="default">
    <image>https://i.imgur.com/olb89CN.png</image>
-   <caption>A sample conversation taking place on qTox.</caption>
+   <caption>A sample conversation taking place on qTox</caption>
   </screenshot>
   <screenshot>
    <image>https://i.imgur.com/tmX8z9s.png</image>
-   <caption>A sample groupchat discussion taking place on qTox.</caption>
+   <caption>A sample groupchat discussion taking place on qTox</caption>
   </screenshot>
  </screenshots>
  <url type="homepage">https://qtox.github.io</url>


### PR DESCRIPTION
Flathub builds fail if appdata file does not pass appstream-glib validate.

```
io.github.qtox.qTox.appdata.xml: FAILED:
? style-invalid         : <caption> cannot end in '.' [A sample conversation taking place on qTox.]
? style-invalid         : <caption> cannot end in '.' [A sample groupchat discussion taking place on qTox.]
Validation of files failed
```

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5958)
<!-- Reviewable:end -->
