### PR TITLE
fix(group): don't display netcam view for group voice calls

### DIFF
--- a/src/widget/form/groupchatform.cpp
+++ b/src/widget/form/groupchatform.cpp
@@ -342,7 +342,6 @@ void GroupChatForm::onCallClicked()
         audioInputFlag = true;
         audioOutputFlag = true;
         inCall = true;
-        showNetcam();
     } else {
         leaveGroupCall();
     }
@@ -477,5 +476,4 @@ void GroupChatForm::leaveGroupCall()
     audioInputFlag = false;
     audioOutputFlag = false;
     inCall = false;
-    hideNetcam();
 }


### PR DESCRIPTION
This is a minimal fix to reduce risk for the release. A more complete
re-architecture will be made.

The netcam covers much of the chat in groups, and has nothing to show since
group video calls aren't possible. Who is speaking in call is already shown by
the bold names at the top of the group, taking much less space.

Fix #5918

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5973)
<!-- Reviewable:end -->
