### PR TITLE
feat(groups): Allow being in group call if only member

### DIFF
--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -535,17 +535,17 @@ VideoSource* CoreAV::getVideoSourceFromCall(int friendNum) const
  * @note Call from the GUI thread.
  * @param groupId Id of group to join
  */
-void CoreAV::joinGroupCall(int groupId)
+void CoreAV::joinGroupCall(const Group& group)
 {
     QWriteLocker locker{&callsLock};
 
-    qDebug() << QString("Joining group call %1").arg(groupId);
+    qDebug() << QString("Joining group call %1").arg(group.getId());
 
     // Audio backend must be set before starting a call
     assert(audio != nullptr);
-    ToxGroupCallPtr groupcall = ToxGroupCallPtr(new ToxGroupCall{groupId, *this, *audio});
+    ToxGroupCallPtr groupcall = ToxGroupCallPtr(new ToxGroupCall{group, *this, *audio});
     assert(groupcall != nullptr);
-    auto ret = groupCalls.emplace(groupId, std::move(groupcall));
+    auto ret = groupCalls.emplace(group.getId(), std::move(groupcall));
     if (ret.second == false) {
         qWarning() << "This group call already exists, not joining!";
         return;

--- a/src/core/coreav.h
+++ b/src/core/coreav.h
@@ -68,7 +68,7 @@ public:
     VideoSource* getVideoSourceFromCall(int callNumber) const;
     void sendNoVideo();
 
-    void joinGroupCall(int groupNum);
+    void joinGroupCall(const Group& group);
     void leaveGroupCall(int groupNum);
     void muteCallInput(const Group* g, bool mute);
     void muteCallOutput(const Group* g, bool mute);

--- a/src/core/toxcall.cpp
+++ b/src/core/toxcall.cpp
@@ -23,6 +23,7 @@
 #include "src/persistence/settings.h"
 #include "src/video/camerasource.h"
 #include "src/video/corevideosource.h"
+#include "src/model/group.h"
 #include <QTimer>
 #include <QtConcurrent/QtConcurrent>
 
@@ -205,15 +206,18 @@ void ToxFriendCall::playAudioBuffer(const int16_t* data, int samples, unsigned c
     }
 }
 
-ToxGroupCall::ToxGroupCall(int GroupNum, CoreAV& av, IAudioControl& audio)
+ToxGroupCall::ToxGroupCall(const Group& group, CoreAV& av, IAudioControl& audio)
     : ToxCall(false, av, audio)
-    , groupId{GroupNum}
+    , group{group}
 {
     // register audio
     audioInConn =
         QObject::connect(audioSource.get(), &IAudioSource::frameAvailable,
                          [this](const int16_t* pcm, size_t samples, uint8_t chans, uint32_t rate) {
-                             this->av->sendGroupCallAudio(this->groupId, pcm, samples, chans, rate);
+                             if (this->group.getPeersCount() <= 1)
+                                return;
+
+                             this->av->sendGroupCallAudio(this->group.getId(), pcm, samples, chans, rate);
                          });
 
     if (!audioInConn) {
@@ -237,7 +241,10 @@ void ToxGroupCall::onAudioSourceInvalidated()
     audioInConn =
         QObject::connect(audioSource.get(), &IAudioSource::frameAvailable,
                          [this](const int16_t* pcm, size_t samples, uint8_t chans, uint32_t rate) {
-                             this->av->sendGroupCallAudio(this->groupId, pcm, samples, chans, rate);
+                             if (this->group.getPeersCount() <= 1)
+                                return;
+
+                             this->av->sendGroupCallAudio(this->group.getId(), pcm, samples, chans, rate);
                          });
 
     audioSource = std::move(newSrc);

--- a/src/core/toxcall.h
+++ b/src/core/toxcall.h
@@ -37,6 +37,7 @@ class QTimer;
 class AudioFilterer;
 class CoreVideoSource;
 class CoreAV;
+class Group;
 
 class ToxCall : public QObject
 {
@@ -117,7 +118,7 @@ class ToxGroupCall : public ToxCall
 {
 public:
     ToxGroupCall() = delete;
-    ToxGroupCall(int GroupNum, CoreAV& av, IAudioControl& audio);
+    ToxGroupCall(const Group& group, CoreAV& av, IAudioControl& audio);
     ToxGroupCall(ToxGroupCall&& other) = delete;
     ~ToxGroupCall();
 
@@ -134,7 +135,7 @@ private:
 
     std::map<ToxPk, std::unique_ptr<IAudioSink>> peers;
     std::map<ToxPk, QMetaObject::Connection> sinkInvalid;
-    int groupId;
+    const Group& group;
 
     void onAudioSourceInvalidated();
     void onAudioSinkInvalidated(ToxPk peerId);

--- a/src/widget/form/groupchatform.cpp
+++ b/src/widget/form/groupchatform.cpp
@@ -325,18 +325,14 @@ void GroupChatForm::onVolMuteToggle()
 void GroupChatForm::onCallClicked()
 {
     CoreAV* av = Core::getInstance()->getAv();
+
     if (!inCall) {
-        av->joinGroupCall(group->getId());
-        audioInputFlag = true;
-        audioOutputFlag = true;
-        inCall = true;
+        joinGroupCall();
     } else {
         leaveGroupCall();
     }
 
-    const int peersCount = group->getPeersCount();
-    const bool online = peersCount > 1;
-    headWidget->updateCallButtons(online, inCall);
+    headWidget->updateCallButtons(true, inCall);
 
     const bool inMute = av->isGroupCallInputMuted(group);
     headWidget->updateMuteMicButton(inCall, inMute);
@@ -373,11 +369,7 @@ void GroupChatForm::keyReleaseEvent(QKeyEvent* ev)
 void GroupChatForm::updateUserCount(int numPeers)
 {
     nusersLabel->setText(tr("%n user(s) in chat", "Number of users in chat", numPeers));
-    const bool online = numPeers > 1;
-    headWidget->updateCallButtons(online, inCall);
-    if (inCall && (!online || !group->isAvGroupchat())) {
-        leaveGroupCall();
-    }
+    headWidget->updateCallButtons(true, inCall);
 }
 
 void GroupChatForm::retranslateUi()
@@ -440,6 +432,15 @@ void GroupChatForm::onLabelContextMenuRequested(const QPoint& localPos)
 
         s.setBlackList(blackList);
     }
+}
+
+void GroupChatForm::joinGroupCall()
+{
+    CoreAV* av = Core::getInstance()->getAv();
+    av->joinGroupCall(*group);
+    audioInputFlag = true;
+    audioOutputFlag = true;
+    inCall = true;
 }
 
 void GroupChatForm::leaveGroupCall()

--- a/src/widget/form/groupchatform.h
+++ b/src/widget/form/groupchatform.h
@@ -67,6 +67,7 @@ private:
     void retranslateUi();
     void updateUserCount(int numPeers);
     void updateUserNames();
+    void joinGroupCall();
     void leaveGroupCall();
 
 private:


### PR DESCRIPTION
In other applications chatrooms allow you to idle in a call and have
people hop in and out as desired. If a user is the only one presently
online in a group but knows someone will be joining shortly they should
be able to join the call ahead of time.

Tested in a group call with another qtox instance.
* Muting before anyone else was online worked as expected
* Deafening before anyone else was online worked as expected
* Joining and leaving calls before anyone was online worked as expected

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5982)
<!-- Reviewable:end -->
