### PR TITLE
fix(ci): quote shell comparison to avoid errors when unset

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -271,12 +271,12 @@ deploy:
 
 after_success:
   - >
-    test $TRAVIS_PULL_REQUEST == "false"
-    && test $TRAVIS_BRANCH == "master"
-    && test $JOB == "build-docs"
+    test "$TRAVIS_PULL_REQUEST" == "false"
+    && test "$TRAVIS_BRANCH" == "master"
+    && test "$JOB" == "build-docs"
     && bash ./.travis/deploy-docs.sh
   - >
-    test $TRAVIS_PULL_REQUEST == "false"
-    && test $TRAVIS_BRANCH == "master"
-    && test $JOB == "build-gitstats"
+    test "$TRAVIS_PULL_REQUEST" == "false"
+    && test "$TRAVIS_BRANCH" == "master"
+    && test "$JOB" == "build-gitstats"
     && bash ./.travis/deploy-gitstats.sh


### PR DESCRIPTION
Avoids log of "/home/travis/.travis/functions: line 109: test: ==: unary
operator expected" in travisci build output

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5983)
<!-- Reviewable:end -->
