### PR TITLE
Improve CI Release Publisher python selection

### DIFF
--- a/.travis/cirp/install.sh
+++ b/.travis/cirp/install.sh
@@ -28,7 +28,7 @@ else
   python3 --version || true
   pyenv versions || true
 
-  pyenv global 3.7
+  pyenv global $(pyenv versions | grep -o ' 3\.[5-99]\.[1-99]' | tail -n1)
 fi
 
 pip install --upgrade pip

--- a/.travis/cirp/install.sh
+++ b/.travis/cirp/install.sh
@@ -53,9 +53,9 @@ if ! pip list --format=columns | grep '^ci-release-publisher '
 then
   cd .
   cd "$(mktemp -d)"
-  VERSION="0.2.0a3"
+  VERSION="0.2.0"
   FILENAME="ci_release_publisher-$VERSION-py3-none-any.whl"
-  HASH="399d0c645ea115d72c646c87e3b4094af04018c5bcb6a95abed4c09cdeec8bd3"
+  HASH="da7f139e90c57fb64ed2eb83c883ad6434d7c0598c843f7be7b572377bed4bc4"
   pip download ci_release_publisher==$VERSION
   check_sha256 "$HASH" "$FILENAME"
   pip install --no-index --find-links "$PWD" "$FILENAME"


### PR DESCRIPTION
For some reason it's very hard to select the right python3 version on Travis, and if that wasn't enough they also keep changing - older versions removed and new added. This should make it a bit more future proof against Travis-CI changes. @anthonybilinski has already faced this issue before in https://github.com/qTox/qTox/commit/a44cce65beb60c5f280b651e0c084fa9c2bdb0dc

Also bumped CIRP to 0.2.0. There are very minimal changes between 0.2.0a3 and 0.2.0, so it should work the same.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5987)
<!-- Reviewable:end -->
