### PR TITLE
fix(chatlog): fix stick to bottom behavior

### DIFF
--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -105,7 +105,7 @@ protected:
     void updateSceneRect();
     void checkVisibility(bool causedWheelEvent = false);
     void scrollToBottom();
-    void startResizeWorker(ChatLine::Ptr anchorLine = nullptr);
+    void startResizeWorker(bool stick, ChatLine::Ptr anchorLine = nullptr);
 
     virtual void mouseDoubleClickEvent(QMouseEvent* ev) final override;
     virtual void mousePressEvent(QMouseEvent* ev) final override;


### PR DESCRIPTION
This commit fixes the behavior when a message is received while the
chatlog is scrolled to the bottom. With this change, the chatlog will
stick to the bottom when it is scrolled all the way down. If it is
somewhere in the middle (e.g. for search) the chatlog will not change
its position.

Please not that this does not attempt to fix any other problems with our chatlog. The fix might also not be perfect, but it should allow us to release qTox v1.17.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5989)
<!-- Reviewable:end -->
