### PR TITLE
fix: remove unused variables

### DIFF
--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -619,7 +619,6 @@ void GenericChatForm::setColorizedNames(bool enable)
 void GenericChatForm::addSystemInfoMessage(const QString& message, ChatMessage::SystemMessageType type,
                                            const QDateTime& datetime)
 {
-    previousId = ToxPk();
     insertChatMessage(ChatMessage::createChatInfoMessage(message, type, datetime));
 }
 
@@ -628,7 +627,6 @@ void GenericChatForm::addSystemDateMessage(const QDate& date)
     const Settings& s = Settings::getInstance();
     QString dateText = date.toString(s.getDateFormat());
 
-    previousId = ToxPk();
     insertChatMessage(ChatMessage::createChatInfoMessage(dateText, ChatMessage::INFO, QDateTime()));
 }
 
@@ -784,7 +782,6 @@ void GenericChatForm::clearChatArea(bool confirm, bool inform)
     }
 
     chatWidget->clear();
-    previousId = ToxPk();
 
     if (inform)
         addSystemInfoMessage(tr("Cleared"), ChatMessage::INFO, QDateTime::currentDateTime());
@@ -1123,7 +1120,7 @@ void GenericChatForm::renderMessages(ChatLogIdx begin, ChatLogIdx end,
         if (onCompletion) {
             auto connection = std::make_shared<QMetaObject::Connection>();
             *connection = connect(chatWidget, &ChatLog::workerTimeoutFinished,
-                                  [onCompletion, connection, this] {
+                                  [onCompletion, connection] {
                                       onCompletion();
                                       disconnect(*connection);
                                   });

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -165,8 +165,6 @@ protected:
     QAction* exportChatAction;
     QAction* goCurrentDateAction;
 
-    ToxPk previousId;
-
     QMenu menu;
 
     QPushButton* emoteButton;


### PR DESCRIPTION
Found some unused variables, should be trivial.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5990)
<!-- Reviewable:end -->
