### PR TITLE
chore: update wording of CI job restart instructions

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -84,8 +84,9 @@ git config --global alias.logs 'log --show-signature'
 # Continous Integration
 
 qTox nightly builds can be found in [qTox-nightly-release]. Should one build
-fail, it is important to restart the whole Travis CI pipeline and not just
-a single job or the tool managing the nightly builds can get confused.
+fail, it is important to restart the whole Travis CI build and not just a
+single job. The tool managing the nightly builds deletes all build artifacts
+on any job failure, so all need to be rebuilt.
 
 # Issues
 


### PR DESCRIPTION
The tool isn't confused in this case, just cleaning up.

Following https://github.com/qTox/qTox/pull/5992#issuecomment-594215059.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/5994)
<!-- Reviewable:end -->
