### PR TITLE
fix(core): message when peer changes group name

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -1183,7 +1183,7 @@ QString Core::getGroupPeerName(int groupId, int peerId) const
     QMutexLocker ml{&coreLoopLock};
 
     // from tox.h: "If peer_number == UINT32_MAX, then author is unknown (e.g. initial joining the conference)."
-    if (peerId != std::numeric_limits<uint32_t>::max()) {
+    if (peerId == std::numeric_limits<uint32_t>::max()) {
         return {};
     }
 


### PR DESCRIPTION
boolean inversion in getGroupPeerName caused it to always return empty string

Fix #6001

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6002)
<!-- Reviewable:end -->
