### PR TITLE
chore(style): remove old style casts and cross sign comparisons

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
 set(POSITION_INDEPENDENT_CODE True)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wstrict-overflow")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wstrict-aliasing")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wold-style-cast")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wsign-compare")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
 
 # avoid timestamps in binary for reproducible builds, not added until GCC 4.9

--- a/src/audio/backend/openal.cpp
+++ b/src/audio/backend/openal.cpp
@@ -764,7 +764,6 @@ void OpenAL::cleanupBuffers(uint sourceId)
     std::vector<ALuint> bufids;
     // should never be out of range, just to be sure
     assert(processed >= 0);
-    assert(processed <= SIZE_MAX);
     bufids.resize(processed);
     alSourceUnqueueBuffers(sourceId, processed, bufids.data());
     // delete all buffers

--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -394,7 +394,7 @@ void ChatLog::insertChatlineAtBottom(const QList<ChatLine::Ptr>& newLines)
     if (newLines.isEmpty())
         return;
 
-    if (canRemove && lines.size() + DEF_NUM_MSG_TO_LOAD >= maxMessages) {
+    if (canRemove && lines.size() + static_cast<int>(DEF_NUM_MSG_TO_LOAD) >= maxMessages) {
         removeFirsts(DEF_NUM_MSG_TO_LOAD);
     }
 
@@ -444,7 +444,7 @@ void ChatLog::insertChatlinesOnTop(const QList<ChatLine::Ptr>& newLines)
         combLines.push_back(l);
     }
 
-    if (canRemove && lines.size() + DEF_NUM_MSG_TO_LOAD >= maxMessages) {
+    if (canRemove && lines.size() + static_cast<int>(DEF_NUM_MSG_TO_LOAD) >= maxMessages) {
         removeLasts(DEF_NUM_MSG_TO_LOAD);
     }
 

--- a/src/chatlog/chatmessage.cpp
+++ b/src/chatlog/chatmessage.cpp
@@ -93,7 +93,7 @@ ChatMessage::Ptr ChatMessage::createChatMessage(const QString& sender, const QSt
     QColor color = Style::getColor(Style::MainText);
     if (colorizeName) {
         QByteArray hash = QCryptographicHash::hash((sender.toUtf8()), QCryptographicHash::Sha256);
-        quint8 *data = (quint8*)hash.data();
+        const auto* data = hash.data();
 
         color.setHsv(data[0], 255, 196);
 

--- a/src/chatlog/content/filetransferwidget.cpp
+++ b/src/chatlog/content/filetransferwidget.cpp
@@ -237,7 +237,7 @@ QString FileTransferWidget::getHumanReadableSize(qint64 size)
     int exp = 0;
 
     if (size > 0) {
-        exp = std::min((int)(log(size) / log(1024)), (int)(sizeof(suffix) / sizeof(suffix[0]) - 1));
+        exp = std::min(static_cast<int>(log(size) / log(1024)), static_cast<int>(sizeof(suffix) / sizeof(suffix[0]) - 1));
     }
 
     return QString().setNum(size / pow(1024, exp), 'f', exp > 1 ? 2 : 0).append(suffix[exp]);

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -948,7 +948,11 @@ void Core::onGroupTitleChange(Tox*, uint32_t groupId, uint32_t peerId, const uin
                               size_t length, void* vCore)
 {
     Core* core = static_cast<Core*>(vCore);
-    QString author = core->getGroupPeerName(groupId, peerId);
+    QString author;
+    // from tox.h: "If peer_number == UINT32_MAX, then author is unknown (e.g. initial joining the conference)."
+    if (peerId != std::numeric_limits<uint32_t>::max()) {
+        author = core->getGroupPeerName(groupId, peerId);
+    }
     emit core->saveRequest();
     emit core->groupTitleChanged(groupId, author, ToxString(cTitle, length).getQString());
 }
@@ -1032,7 +1036,7 @@ bool Core::sendMessageWithType(uint32_t friendId, const QString& message, Tox_Me
                                ReceiptNum& receipt)
 {
     int size = message.toUtf8().size();
-    auto maxSize = tox_max_message_length();
+    auto maxSize = static_cast<int>(tox_max_message_length());
     if (size > maxSize) {
         qCritical() << "Core::sendMessageWithType called with message of size:" << size
                     << "when max is:" << maxSize << ". Ignoring.";
@@ -1077,7 +1081,7 @@ void Core::sendGroupMessageWithType(int groupId, const QString& message, Tox_Mes
     QMutexLocker ml{&coreLoopLock};
 
     int size = message.toUtf8().size();
-    auto maxSize = tox_max_message_length();
+    auto maxSize = static_cast<int>(tox_max_message_length());
     if (size > maxSize) {
         qCritical() << "Core::sendMessageWithType called with message of size:" << size
                     << "when max is:" << maxSize << ". Ignoring.";
@@ -1318,7 +1322,7 @@ QByteArray Core::getToxSaveData()
     uint32_t fileSize = tox_get_savedata_size(tox.get());
     QByteArray data;
     data.resize(fileSize);
-    tox_get_savedata(tox.get(), (uint8_t*)data.data());
+    tox_get_savedata(tox.get(), reinterpret_cast<uint8_t*>(data.data()));
     return data;
 }
 
@@ -1455,11 +1459,6 @@ QString Core::getGroupPeerName(int groupId, int peerId) const
 {
     QMutexLocker ml{&coreLoopLock};
 
-    // from tox.h: "If peer_number == UINT32_MAX, then author is unknown (e.g. initial joining the conference)."
-    if (peerId == std::numeric_limits<uint32_t>::max()) {
-        return {};
-    }
-
     Tox_Err_Conference_Peer_Query error;
     size_t length = tox_conference_peer_get_name_size(tox.get(), groupId, peerId, &error);
     if (!PARSE_ERR(error) || !length) {
@@ -1508,7 +1507,7 @@ QStringList Core::getGroupPeerNames(int groupId) const
     }
 
     QStringList names;
-    for (uint32_t i = 0; i < nPeers; ++i) {
+    for (int i = 0; i < static_cast<int>(nPeers); ++i) {
         Tox_Err_Conference_Peer_Query error;
         size_t length = tox_conference_peer_get_name_size(tox.get(), groupId, i, &error);
 
@@ -1526,7 +1525,7 @@ QStringList Core::getGroupPeerNames(int groupId) const
         }
     }
 
-    assert(names.size() == nPeers);
+    assert(names.size() == static_cast<int>(nPeers));
 
     return names;
 }
@@ -1711,7 +1710,7 @@ QStringList Core::splitMessage(const QString& message)
      *
      * (uint32_t tox_max_message_length(void); declared in tox.h, unable to see explicit definition)
      */
-    const auto maxLen = tox_max_message_length() - 50;
+    const auto maxLen = static_cast<int>(tox_max_message_length()) - 50;
 
     while (ba_message.size() > maxLen) {
         int splitPos = ba_message.lastIndexOf('\n', maxLen - 1);

--- a/src/ipc.cpp
+++ b/src/ipc.cpp
@@ -103,11 +103,11 @@ IPC::~IPC()
 time_t IPC::postEvent(const QString& name, const QByteArray& data, uint32_t dest)
 {
     QByteArray binName = name.toUtf8();
-    if (binName.length() > (int32_t)sizeof(IPCEvent::name)) {
+    if (binName.length() > static_cast<int32_t>(sizeof(IPCEvent::name))) {
         return 0;
     }
 
-    if (data.length() > (int32_t)sizeof(IPCEvent::data)) {
+    if (data.length() > static_cast<int32_t>(sizeof(IPCEvent::data))) {
         return 0;
     }
 

--- a/src/model/chathistory.cpp
+++ b/src/model/chathistory.cpp
@@ -352,7 +352,7 @@ void ChatHistory::loadHistoryIntoSessionChatLog(ChatLogIdx start) const
     assert(getFirstIdx() == ChatLogIdx(0));
     auto messages = history->getMessagesForFriend(f.getPublicKey(), start.get(), end.get());
 
-    assert(messages.size() == end.get() - start.get());
+    assert(messages.size() == static_cast<int>(end.get() - start.get()));
     ChatLogIdx nextIdx = start;
 
     for (const auto& message : messages) {

--- a/src/model/sessionchatlog.cpp
+++ b/src/model/sessionchatlog.cpp
@@ -158,12 +158,12 @@ SearchResult SessionChatLog::searchForward(SearchPos startPos, const QString& ph
 
         auto numMatches = 0;
         QRegularExpressionMatch lastMatch;
-        while (match.isValid() && numMatches <= currentPos.numMatches && match.hasNext()) {
+        while (match.isValid() && numMatches <= static_cast<int>(currentPos.numMatches) && match.hasNext()) {
             lastMatch = match.next();
             numMatches++;
         }
 
-        if (numMatches > currentPos.numMatches) {
+        if (numMatches > static_cast<int>(currentPos.numMatches)) {
             SearchResult res;
             res.found = true;
             res.pos.logIdx = key;
@@ -223,13 +223,13 @@ SearchResult SessionChatLog::searchBackward(SearchPos startPos, const QString& p
         while (match.isValid() && match.hasNext()) {
             auto currentMatch = match.next();
             totalMatches++;
-            if (currentPos.numMatches == 0 || currentPos.numMatches > numMatchesBeforePos) {
+            if (currentPos.numMatches == 0 || static_cast<int>(currentPos.numMatches) > numMatchesBeforePos) {
                 lastMatch = currentMatch;
                 numMatchesBeforePos++;
             }
         }
 
-        if ((numMatchesBeforePos < currentPos.numMatches || currentPos.numMatches == 0)
+        if ((numMatchesBeforePos < static_cast<int>(currentPos.numMatches) || currentPos.numMatches == 0)
             && numMatchesBeforePos > 0) {
             SearchResult res;
             res.found = true;
@@ -285,7 +285,7 @@ std::vector<IChatLog::DateChatLogIdxPair> SessionChatLog::getDateIdxs(const QDat
         ret.push_back(std::move(pair));
 
         dateIt = dateIt.addDays(1);
-        if (startDate.daysTo(dateIt) > maxDates && maxDates != 0) {
+        if (startDate.daysTo(dateIt) > static_cast<long>(maxDates) && maxDates != 0) {
             break;
         }
     }

--- a/src/persistence/db/rawdatabase.cpp
+++ b/src/persistence/db/rawdatabase.cpp
@@ -736,7 +736,12 @@ void RawDatabase::process()
                 }
                 for (int i = 0; i < nParams; ++i) {
                     const QByteArray& blob = query.blobs[curParam + i];
-                    if (sqlite3_bind_blob(stmt, i + 1, blob.data(), blob.size(), SQLITE_STATIC)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+                    // SQLITE_STATIC uses old-style cast and comes from system headers, so can't be fixed by us
+                    auto sqliteDataType = SQLITE_STATIC;
+#pragma GCC diagnostic pop
+                    if (sqlite3_bind_blob(stmt, i + 1, blob.data(), blob.size(), sqliteDataType)
                         != SQLITE_OK) {
                         qWarning() << "Failed to bind param" << curParam + i << "to query"
                                    << anonymizeQuery(query.query);

--- a/src/persistence/profile.cpp
+++ b/src/persistence/profile.cpp
@@ -523,8 +523,8 @@ QString Profile::avatarPath(const ToxPk& owner, bool forceUnencrypted)
                       && hashSize <= crypto_generichash_KEYBYTES_MAX,
                   "Key size not supported by libsodium");
     QByteArray hash(hashSize, 0);
-    crypto_generichash((uint8_t*)hash.data(), hashSize, (uint8_t*)idData.data(), idData.size(),
-                       (uint8_t*)pubkeyData.data(), pubkeyData.size());
+    crypto_generichash(reinterpret_cast<uint8_t*>(hash.data()), hashSize, reinterpret_cast<uint8_t*>(idData.data()), idData.size(),
+                       reinterpret_cast<uint8_t*>(pubkeyData.data()), pubkeyData.size());
     return Settings::getInstance().getSettingsDirPath() + "avatars/" + hash.toHex().toUpper() + ".png";
 }
 
@@ -728,7 +728,7 @@ QByteArray Profile::getAvatarHash(const ToxPk& owner)
 {
     QByteArray pic = loadAvatarData(owner);
     QByteArray avatarHash(TOX_HASH_LENGTH, 0);
-    tox_hash((uint8_t*)avatarHash.data(), (uint8_t*)pic.data(), pic.size());
+    tox_hash(reinterpret_cast<uint8_t*>(avatarHash.data()), reinterpret_cast<uint8_t*>(pic.data()), pic.size());
     return avatarHash;
 }
 
@@ -812,7 +812,7 @@ bool Profile::isEncrypted(QString name)
         return false;
     }
 
-    saveFile.read((char*)data, TOX_PASS_ENCRYPTION_EXTRA_LENGTH);
+    saveFile.read(reinterpret_cast<char*>(data), TOX_PASS_ENCRYPTION_EXTRA_LENGTH);
     saveFile.close();
 
     return tox_is_data_encrypted(data);

--- a/src/platform/autorun_win.cpp
+++ b/src/platform/autorun_win.cpp
@@ -68,7 +68,7 @@ bool Platform::setAutorun(bool on)
 
     if (on) {
         tstring path = currentCommandLine();
-        result = RegSetValueEx(key, keyName.c_str(), 0, REG_SZ, (PBYTE)path.c_str(),
+        result = RegSetValueEx(key, keyName.c_str(), 0, REG_SZ, const_cast<PBYTE>(reinterpret_cast<const unsigned char*>(path.c_str())),
                                path.length() * sizeof(TCHAR))
                  == ERROR_SUCCESS;
     } else
@@ -93,7 +93,7 @@ bool Platform::getAutorun()
     DWORD type = REG_SZ;
     bool result = false;
 
-    if (RegQueryValueEx(key, keyName.c_str(), 0, &type, (PBYTE)path, &length) == ERROR_SUCCESS
+    if (RegQueryValueEx(key, keyName.c_str(), 0, &type, const_cast<PBYTE>(reinterpret_cast<const unsigned char*>(path)), &length) == ERROR_SUCCESS
         && type == REG_SZ)
         result = true;
 

--- a/src/platform/camera/avfoundation.mm
+++ b/src/platform/camera/avfoundation.mm
@@ -63,7 +63,7 @@ QVector<VideoMode> avfoundation::getDeviceModes(QString devName)
         for (AVCaptureDeviceFormat* format in [device formats]) {
             CMFormatDescriptionRef formatDescription;
             CMVideoDimensions dimensions;
-            formatDescription = (CMFormatDescriptionRef)[format performSelector:@selector(formatDescription)];
+            formatDescription = static_cast<CMFormatDescriptionRef>([format performSelector:@selector(formatDescription)]);
             dimensions = CMVideoFormatDescriptionGetDimensions(formatDescription);
 
             for (AVFrameRateRange* range in format.videoSupportedFrameRateRanges) {

--- a/src/platform/camera/directshow.cpp
+++ b/src/platform/camera/directshow.cpp
@@ -56,12 +56,12 @@ QVector<QPair<QString, QString>> DirectShow::getDeviceList()
 
     ICreateDevEnum* devenum = nullptr;
     if (CoCreateInstance(CLSID_SystemDeviceEnum, nullptr, CLSCTX_INPROC_SERVER, IID_ICreateDevEnum,
-                         (void**)&devenum)
+                         reinterpret_cast<void**>(&devenum))
         != S_OK)
         return devices;
 
     IEnumMoniker* classenum = nullptr;
-    if (devenum->CreateClassEnumerator(CLSID_VideoInputDeviceCategory, (IEnumMoniker**)&classenum, 0)
+    if (devenum->CreateClassEnumerator(CLSID_VideoInputDeviceCategory, reinterpret_cast<IEnumMoniker**>(&classenum), 0)
         != S_OK)
         return devices;
 
@@ -89,7 +89,7 @@ QVector<QPair<QString, QString>> DirectShow::getDeviceList()
                 devIdString[i] = '_';
 
         // Get a human friendly name/description
-        if (m->BindToStorage(nullptr, nullptr, IID_IPropertyBag, (void**)&bag) != S_OK)
+        if (m->BindToStorage(nullptr, nullptr, IID_IPropertyBag, reinterpret_cast<void**>(&bag)) != S_OK)
             goto fail;
 
         var.vt = VT_BSTR;
@@ -125,12 +125,12 @@ static IBaseFilter* getDevFilter(QString devName)
 
     ICreateDevEnum* devenum = nullptr;
     if (CoCreateInstance(CLSID_SystemDeviceEnum, nullptr, CLSCTX_INPROC_SERVER, IID_ICreateDevEnum,
-                         (void**)&devenum)
+                         reinterpret_cast<void**>(&devenum))
         != S_OK)
         return devFilter;
 
     IEnumMoniker* classenum = nullptr;
-    if (devenum->CreateClassEnumerator(CLSID_VideoInputDeviceCategory, (IEnumMoniker**)&classenum, 0)
+    if (devenum->CreateClassEnumerator(CLSID_VideoInputDeviceCategory, reinterpret_cast<IEnumMoniker**>(&classenum), 0)
         != S_OK)
         return devFilter;
 
@@ -157,7 +157,7 @@ static IBaseFilter* getDevFilter(QString devName)
         if (devName != devIdString)
             goto fail;
 
-        if (m->BindToObject(0, 0, IID_IBaseFilter, (void**)&devFilter) != S_OK)
+        if (m->BindToObject(0, 0, IID_IBaseFilter, reinterpret_cast<void**>(&devFilter)) != S_OK)
             goto fail;
 
     fail:
@@ -200,7 +200,7 @@ QVector<VideoMode> DirectShow::getDeviceModes(QString devName)
         info.pFilter->Release();
         if (info.dir != PINDIR_OUTPUT)
             goto next;
-        if (pin->QueryInterface(IID_IKsPropertySet, (void**)&p) != S_OK)
+        if (pin->QueryInterface(IID_IKsPropertySet, reinterpret_cast<void**>(&p)) != S_OK)
             goto next;
         if (p->Get(AMPROPSETID_Pin, AMPROPERTY_PIN_CATEGORY, nullptr, 0, &category, sizeof(GUID), &r2)
             != S_OK)
@@ -214,7 +214,7 @@ QVector<VideoMode> DirectShow::getDeviceModes(QString devName)
             IAMStreamConfig* config = nullptr;
             VIDEO_STREAM_CONFIG_CAPS* vcaps = nullptr;
             int size, n;
-            if (pin->QueryInterface(IID_IAMStreamConfig, (void**)&config) != S_OK)
+            if (pin->QueryInterface(IID_IAMStreamConfig, reinterpret_cast<void**>(&config)) != S_OK)
                 goto next;
             if (config->GetNumberOfCapabilities(&n, &size) != S_OK)
                 goto pinend;
@@ -225,7 +225,7 @@ QVector<VideoMode> DirectShow::getDeviceModes(QString devName)
             for (int i = 0; i < n; ++i) {
                 AM_MEDIA_TYPE* type = nullptr;
                 VideoMode mode;
-                if (config->GetStreamCaps(i, &type, (BYTE*)vcaps) != S_OK)
+                if (config->GetStreamCaps(i, &type, reinterpret_cast<BYTE*>(vcaps)) != S_OK)
                     goto nextformat;
 
                 if (!IsEqualGUID(type->formattype, FORMAT_VideoInfo)

--- a/src/platform/camera/v4l2.cpp
+++ b/src/platform/camera/v4l2.cpp
@@ -206,7 +206,7 @@ QVector<QPair<QString, QString>> v4l2::getDeviceList()
         ioctl(fd, VIDIOC_QUERYCAP, &caps);
         close(fd);
 
-        devices += {file, (const char*)caps.card};
+        devices += {file, reinterpret_cast<const char*>(caps.card)};
     }
     return devices;
 }

--- a/src/platform/timer_osx.cpp
+++ b/src/platform/timer_osx.cpp
@@ -44,7 +44,7 @@ uint32_t Platform::getIdleTime()
     }
 
     property = IORegistryEntryCreateCFProperty(service, CFSTR("HIDIdleTime"), kCFAllocatorDefault, 0);
-    CFNumberGetValue((CFNumberRef)property, kCFNumberSInt64Type, &idleTime_ns);
+    CFNumberGetValue(static_cast<CFNumberRef>(property), kCFNumberSInt64Type, &idleTime_ns);
     CFRelease(property);
 
     return idleTime_ns / 1000000;

--- a/src/platform/timer_x11.cpp
+++ b/src/platform/timer_x11.cpp
@@ -39,7 +39,10 @@ uint32_t Platform::getIdleTime()
     if (hasExtension) {
         XScreenSaverInfo* info = XScreenSaverAllocInfo();
         if (info) {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
             XScreenSaverQueryInfo(display, DefaultRootWindow(display), info);
+#pragma GCC diagnostic pop
             idleTime = info->idle;
             XFree(info);
         } else

--- a/src/video/cameradevice.cpp
+++ b/src/video/cameradevice.cpp
@@ -22,8 +22,11 @@
 #include <QDesktopWidget>
 #include <QScreen>
 extern "C" {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
 #include <libavdevice/avdevice.h>
 #include <libavformat/avformat.h>
+#pragma GCC disagnostic pop
 }
 #include "cameradevice.h"
 #include "src/persistence/settings.h"
@@ -294,7 +297,7 @@ QVector<QPair<QString, QString>> CameraDevice::getRawDeviceListGeneric()
             return devices;
         }
         if (s->iformat->priv_class) {
-            *(const AVClass**)s->priv_data = s->iformat->priv_class;
+            *static_cast<const AVClass**>(s->priv_data) = s->iformat->priv_class;
             av_opt_set_defaults(s->priv_data);
         }
     } else {

--- a/src/video/camerasource.cpp
+++ b/src/video/camerasource.cpp
@@ -18,10 +18,13 @@
 */
 
 extern "C" {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
 #include <libavcodec/avcodec.h>
 #include <libavdevice/avdevice.h>
 #include <libavformat/avformat.h>
 #include <libswscale/swscale.h>
+#pragma GCC diagnostic pop
 }
 #include "cameradevice.h"
 #include "camerasource.h"

--- a/src/video/corevideosource.cpp
+++ b/src/video/corevideosource.cpp
@@ -18,8 +18,11 @@
 */
 
 extern "C" {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
 #include <libavcodec/avcodec.h>
 #include <libavutil/imgutils.h>
+#pragma GCC disagnostic pop
 }
 
 #include "corevideosource.h"

--- a/src/video/videoframe.h
+++ b/src/video/videoframe.h
@@ -27,7 +27,10 @@
 #include <QSize>
 
 extern "C" {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
 #include <libavcodec/avcodec.h>
+#pragma GCC diagnostic pop
 }
 
 #include <atomic>

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -728,7 +728,7 @@ bool GenericChatForm::loadHistoryFrom(const QDateTime &time)
 
 void GenericChatForm::removeFirstsMessages(const int num)
 {
-    if (messages.size() > num) {
+    if (static_cast<int>(messages.size()) > num) {
         messages.erase(messages.begin(), std::next(messages.begin(), num));
     } else {
         messages.clear();
@@ -737,7 +737,7 @@ void GenericChatForm::removeFirstsMessages(const int num)
 
 void GenericChatForm::removeLastsMessages(const int num)
 {
-    if (messages.size() > num) {
+    if (static_cast<int>(messages.size()) > num) {
         messages.erase(std::next(messages.end(), -num), messages.end());
     } else {
         messages.clear();

--- a/src/widget/form/settings/privacyform.cpp
+++ b/src/widget/form/settings/privacyform.cpp
@@ -102,9 +102,9 @@ void PrivacyForm::on_randomNosapamButton_clicked()
 {
     QTime time = QTime::currentTime();
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
-    QRandomGenerator((uint)time.msec());
+    QRandomGenerator(static_cast<uint>(time.msec()));
 #else
-    qsrand((uint)time.msec());
+    qsrand(static_cast<uint>(time.msec()));
 #endif
 
     uint32_t newNospam{0};

--- a/test/core/toxstring_test.cpp
+++ b/test/core/toxstring_test.cpp
@@ -41,13 +41,13 @@ private:
     static const QString testStr;
     static const QByteArray testByte;
     static const uint8_t* testUINT8;
-    static const size_t lengthUINT8;
+    static const int lengthUINT8;
 
     //"" - empty test text
     static const QString emptyStr;
     static const QByteArray emptyByte;
     static const uint8_t* emptyUINT8;
-    static const size_t emptyLength;
+    static const int emptyLength;
 };
 
 
@@ -56,13 +56,13 @@ private:
 const QString TestToxString::testStr = QStringLiteral("My Test String");
 const QByteArray TestToxString::testByte = QByteArrayLiteral("My Test String");
 const uint8_t* TestToxString::testUINT8 = reinterpret_cast<const uint8_t*>("My Test String");
-const size_t TestToxString::lengthUINT8 = 14;
+const int TestToxString::lengthUINT8 = 14;
 
 //"" - empty test text
 const QString TestToxString::emptyStr = QStringLiteral("");
 const QByteArray TestToxString::emptyByte = QByteArrayLiteral("");
 const uint8_t* TestToxString::emptyUINT8 = reinterpret_cast<const uint8_t*>("");
-const size_t TestToxString::emptyLength = 0;
+const int TestToxString::emptyLength = 0;
 
 /**
  * @brief Use QString as input data, check output: QString, QByteArray, size_t and uint8_t


### PR DESCRIPTION
Enable warnings for both.

Fix #6010
Fix #6012

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

@iphydf this included a lot more reinterpret_casts than https://github.com/qTox/qTox/issues/6012 thought would be necessary. Do you think this should be done differently for all the pointer casts?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6013)
<!-- Reviewable:end -->
