### PR TITLE
chore(cleanup): don't explicitly initialize std::unique_ptr to nullptr

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -475,7 +475,6 @@ bool parseErr(Tox_Err_Conference_Delete error, int line)
 
 Core::Core(QThread* coreThread)
     : tox(nullptr)
-    , av(nullptr)
     , toxTimer{new QTimer{this}}
     , coreThread(coreThread)
 {

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -251,7 +251,7 @@ private:
     // recursive, since we might call our own functions
     mutable QMutex coreLoopLock{QMutex::Recursive};
 
-    std::unique_ptr<QThread> coreThread = nullptr;
+    std::unique_ptr<QThread> coreThread;
 };
 
 #endif // CORE_HPP

--- a/src/core/toxcall.h
+++ b/src/core/toxcall.h
@@ -84,7 +84,7 @@ protected:
     QMetaObject::Connection videoInConn;
     bool videoEnabled{false};
     bool nullVideoBitrate{false};
-    std::unique_ptr<IAudioSource> audioSource = nullptr;
+    std::unique_ptr<IAudioSource> audioSource;
 };
 
 class ToxFriendCall : public ToxCall
@@ -109,7 +109,7 @@ private slots:
 private:
     QMetaObject::Connection audioSinkInvalid;
     TOXAV_FRIEND_CALL_STATE state{TOXAV_FRIEND_CALL_STATE_NONE};
-    std::unique_ptr<IAudioSink> sink = nullptr;
+    std::unique_ptr<IAudioSink> sink;
     uint32_t friendId;
 };
 

--- a/src/persistence/profile.cpp
+++ b/src/persistence/profile.cpp
@@ -73,7 +73,7 @@ enum class CreateToxDataError
 std::unique_ptr<ToxEncrypt> loadToxData(const QString& password, const QString& filePath,
                                         QByteArray& data, LoadToxDataError& error)
 {
-    std::unique_ptr<ToxEncrypt> tmpKey = nullptr;
+    std::unique_ptr<ToxEncrypt> tmpKey;
     qint64 fileSize = 0;
 
     QFile saveFile(filePath);
@@ -133,7 +133,7 @@ fail:
 std::unique_ptr<ToxEncrypt> createToxData(const QString& name, const QString& password,
                                           const QString& filePath, CreateToxDataError& error)
 {
-    std::unique_ptr<ToxEncrypt> newKey{nullptr};
+    std::unique_ptr<ToxEncrypt> newKey;
     if (!password.isEmpty()) {
         newKey = ToxEncrypt::makeToxEncrypt(password);
         if (!newKey) {

--- a/src/persistence/profile.h
+++ b/src/persistence/profile.h
@@ -109,9 +109,9 @@ private:
     void initCore(const QByteArray& toxsave, const ICoreSettings& s, bool isNewProfile);
 
 private:
-    std::unique_ptr<Core> core = nullptr;
+    std::unique_ptr<Core> core;
     QString name;
-    std::unique_ptr<ToxEncrypt> passkey = nullptr;
+    std::unique_ptr<ToxEncrypt> passkey;
     std::shared_ptr<RawDatabase> database;
     std::shared_ptr<History> history;
     bool isRemoved;

--- a/src/widget/form/settings/avform.h
+++ b/src/widget/form/settings/avform.h
@@ -104,8 +104,8 @@ private:
     IVideoSettings* videoSettings;
 
     bool subscribedToAudioIn;
-    std::unique_ptr<IAudioSink> audioSink = nullptr;
-    std::unique_ptr<IAudioSource> audioSrc = nullptr;
+    std::unique_ptr<IAudioSink> audioSink;
+    std::unique_ptr<IAudioSource> audioSrc;
     VideoSurface* camVideoSurface;
     CameraSource& camera;
     QVector<QPair<QString, QString>> videoDeviceList;

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -139,7 +139,6 @@ Widget* Widget::instance{nullptr};
 
 Widget::Widget(IAudioControl& audio, QWidget* parent)
     : QMainWindow(parent)
-    , icon{nullptr}
     , trayMenu{nullptr}
     , ui(new Ui::MainWindow)
     , activeChatroomWidget{nullptr}

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -328,7 +328,7 @@ private:
     int icon_size;
 
     IAudioControl& audio;
-    std::unique_ptr<IAudioSink> audioNotification = nullptr;
+    std::unique_ptr<IAudioSink> audioNotification;
     Settings& settings;
 
     QMap<ToxPk, FriendWidget*> friendWidgets;


### PR DESCRIPTION
Fix #6009

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6014)
<!-- Reviewable:end -->
