### PR TITLE
chore(cleanup): don't use 0 as nullptr

### DIFF
--- a/src/nexus.cpp
+++ b/src/nexus.cpp
@@ -113,7 +113,7 @@ void Nexus::start()
 
 #ifdef Q_OS_MAC
     // TODO: still needed?
-    globalMenuBar = new QMenuBar(0);
+    globalMenuBar = new QMenuBar();
     dockMenu = new QMenu(globalMenuBar);
 
     viewMenu = globalMenuBar->addMenu(QString());

--- a/src/persistence/db/rawdatabase.cpp
+++ b/src/persistence/db/rawdatabase.cpp
@@ -738,7 +738,9 @@ void RawDatabase::process()
                     const QByteArray& blob = query.blobs[curParam + i];
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
-                    // SQLITE_STATIC uses old-style cast and comes from system headers, so can't be fixed by us
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
+                    // SQLITE_STATIC uses old-style cast and 0 as null pointer butcomes from system headers, so can't
+                    // be fixed by us
                     auto sqliteDataType = SQLITE_STATIC;
 #pragma GCC diagnostic pop
                     if (sqlite3_bind_blob(stmt, i + 1, blob.data(), blob.size(), sqliteDataType)

--- a/src/persistence/db/rawdatabase.h
+++ b/src/persistence/db/rawdatabase.h
@@ -39,7 +39,10 @@
 #define SQLITE_HAS_CODEC
 #define SQLITE_TEMP_STORE 2
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
 #include <sqlite3.h>
+#pragma GCC diagnostic pop
 
 using RowId = NamedType<int64_t, struct RowIdTag, Orderable>;
 Q_DECLARE_METATYPE(RowId);

--- a/src/platform/autorun_win.cpp
+++ b/src/platform/autorun_win.cpp
@@ -57,7 +57,7 @@ inline tstring currentRegistryKeyName()
 
 bool Platform::setAutorun(bool on)
 {
-    HKEY key = 0;
+    HKEY key = nullptr;
     if (RegOpenKeyEx(HKEY_CURRENT_USER, TEXT("Software\\Microsoft\\Windows\\CurrentVersion\\Run"),
                      0, KEY_ALL_ACCESS, &key)
         != ERROR_SUCCESS)
@@ -80,7 +80,7 @@ bool Platform::setAutorun(bool on)
 
 bool Platform::getAutorun()
 {
-    HKEY key = 0;
+    HKEY key = nullptr;
     if (RegOpenKeyEx(HKEY_CURRENT_USER, TEXT("Software\\Microsoft\\Windows\\CurrentVersion\\Run"),
                      0, KEY_ALL_ACCESS, &key)
         != ERROR_SUCCESS)
@@ -93,7 +93,7 @@ bool Platform::getAutorun()
     DWORD type = REG_SZ;
     bool result = false;
 
-    if (RegQueryValueEx(key, keyName.c_str(), 0, &type, const_cast<PBYTE>(reinterpret_cast<const unsigned char*>(path)), &length) == ERROR_SUCCESS
+    if (RegQueryValueEx(key, keyName.c_str(), nullptr, &type, const_cast<PBYTE>(reinterpret_cast<const unsigned char*>(path)), &length) == ERROR_SUCCESS
         && type == REG_SZ)
         result = true;
 

--- a/src/platform/camera/directshow.cpp
+++ b/src/platform/camera/directshow.cpp
@@ -42,10 +42,10 @@
 
 static char* wcharToUtf8(wchar_t* w)
 {
-    int l = WideCharToMultiByte(CP_UTF8, 0, w, -1, 0, 0, 0, 0);
+    int l = WideCharToMultiByte(CP_UTF8, 0, w, -1, nullptr, 0, nullptr, nullptr);
     char* s = new char[l];
     if (s)
-        WideCharToMultiByte(CP_UTF8, 0, w, -1, s, l, 0, 0);
+        WideCharToMultiByte(CP_UTF8, 0, w, -1, s, l, nullptr, nullptr);
     return s;
 }
 
@@ -157,7 +157,7 @@ static IBaseFilter* getDevFilter(QString devName)
         if (devName != devIdString)
             goto fail;
 
-        if (m->BindToObject(0, 0, IID_IBaseFilter, reinterpret_cast<void**>(&devFilter)) != S_OK)
+        if (m->BindToObject(nullptr, nullptr, IID_IBaseFilter, reinterpret_cast<void**>(&devFilter)) != S_OK)
             goto fail;
 
     fail:

--- a/test/model/groupmessagedispatcher_test.cpp
+++ b/test/model/groupmessagedispatcher_test.cpp
@@ -55,7 +55,7 @@ class MockGroupQuery : public ICoreGroupQuery
 public:
     GroupId getGroupPersistentId(uint32_t groupNumber) const override
     {
-        return GroupId(0);
+        return GroupId();
     }
 
     uint32_t getGroupNumberPeers(int groupId) const override
@@ -211,7 +211,7 @@ void TestGroupMessageDispatcher::init()
     groupQuery = std::unique_ptr<MockGroupQuery>(new MockGroupQuery());
     coreIdHandler = std::unique_ptr<MockCoreIdHandler>(new MockCoreIdHandler());
     g = std::unique_ptr<Group>(
-        new Group(0, GroupId(0), "TestGroup", false, "me", *groupQuery, *coreIdHandler));
+        new Group(0, GroupId(), "TestGroup", false, "me", *groupQuery, *coreIdHandler));
     messageSender = std::unique_ptr<MockGroupMessageSender>(new MockGroupMessageSender());
     sharedProcessorParams =
         std::unique_ptr<MessageProcessor::SharedParams>(new MessageProcessor::SharedParams());


### PR DESCRIPTION
Fix #6008

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6015)
<!-- Reviewable:end -->
