### PR TITLE
fix: add missing type for Qt slot

### DIFF
--- a/src/nexus.cpp
+++ b/src/nexus.cpp
@@ -94,6 +94,7 @@ void Nexus::start()
     qRegisterMetaType<const int16_t*>("const int16_t*");
     qRegisterMetaType<int32_t>("int32_t");
     qRegisterMetaType<int64_t>("int64_t");
+    qRegisterMetaType<size_t>("size_t");
     qRegisterMetaType<QPixmap>("QPixmap");
     qRegisterMetaType<Profile*>("Profile*");
     qRegisterMetaType<ToxAV*>("ToxAV*");


### PR DESCRIPTION
In 6b468e41fab5f158a26a9166cc15e190ea845d5f a slot with the type `size_t` is used, but it is not registered with Qt so the connection fails. The result is not working audio calls.

@anthonybilinski ping

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6016)
<!-- Reviewable:end -->
