### PR TITLE
fix(history): check history settings when getting initial chatlog idx

### DIFF
--- a/src/model/chathistory.cpp
+++ b/src/model/chathistory.cpp
@@ -34,22 +34,6 @@ bool needsLoadFromHistory(ChatLogIdx idx, const SessionChatLog& sessionChatLog)
 }
 
 /**
- * @brief Gets the initial chat log index for a sessionChatLog with 0 items loaded from history.
- * Needed to keep history indexes in sync with chat log indexes
- * @param[in] history
- * @param[in] f
- * @return Initial chat log index
- */
-ChatLogIdx getInitialChatLogIdx(History* history, Friend& f)
-{
-    if (!history) {
-        return ChatLogIdx(0);
-    }
-
-    return ChatLogIdx(history->getNumMessagesForFriend(f.getPublicKey()));
-}
-
-/**
  * @brief Finds the first item in sessionChatLog that contains a message
  * @param[in] sessionChatLog
  * @return index of first message
@@ -90,9 +74,9 @@ ChatHistory::ChatHistory(Friend& f_, History* history_, const ICoreIdHandler& co
                          const Settings& settings_, IMessageDispatcher& messageDispatcher)
     : f(f_)
     , history(history_)
-    , sessionChatLog(getInitialChatLogIdx(history, f), coreIdHandler)
     , settings(settings_)
     , coreIdHandler(coreIdHandler)
+    , sessionChatLog(getInitialChatLogIdx(), coreIdHandler)
 {
     connect(&messageDispatcher, &IMessageDispatcher::messageComplete, this,
             &ChatHistory::onMessageComplete);
@@ -480,4 +464,19 @@ void ChatHistory::completeMessage(DispatchedMessageId id)
 bool ChatHistory::canUseHistory() const
 {
     return history && settings.getEnableLogging();
+}
+
+/**
+ * @brief Gets the initial chat log index for a sessionChatLog with 0 items loaded from history.
+ * Needed to keep history indexes in sync with chat log indexes
+ * @param[in] history
+ * @param[in] f
+ * @return Initial chat log index
+ */
+ChatLogIdx ChatHistory::getInitialChatLogIdx() const
+{
+    if (canUseHistory()) {
+        return ChatLogIdx(history->getNumMessagesForFriend(f.getPublicKey()));
+    }
+    return ChatLogIdx(0);
 }

--- a/src/model/chathistory.h
+++ b/src/model/chathistory.h
@@ -61,12 +61,13 @@ private:
     void handleDispatchedMessage(DispatchedMessageId dispatchId, RowId historyId);
     void completeMessage(DispatchedMessageId id);
     bool canUseHistory() const;
+    ChatLogIdx getInitialChatLogIdx() const;
 
     Friend& f;
     History* history;
-    mutable SessionChatLog sessionChatLog;
     const Settings& settings;
     const ICoreIdHandler& coreIdHandler;
+    mutable SessionChatLog sessionChatLog;
 
     // If a message completes before it's inserted into history it will end up
     // in this set


### PR DESCRIPTION
Checking if history pointer is valid is not sufficient, the setting must also
be checked. This caused asserts in history when history was disabled in
settings.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6026)
<!-- Reviewable:end -->
