### PR TITLE
fix(chatlog): enable dynamic view range in chatlog with history disabled 

### DIFF
--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -52,8 +52,8 @@ T clamp(T x, T min, T max)
     return x;
 }
 
-ChatLog::ChatLog(const bool canRemove, QWidget* parent)
-    : QGraphicsView(parent), canRemove(canRemove)
+ChatLog::ChatLog(QWidget* parent)
+    : QGraphicsView(parent)
 {
     // Create the scene
     busyScene = new QGraphicsScene(this);
@@ -394,7 +394,7 @@ void ChatLog::insertChatlineAtBottom(const QList<ChatLine::Ptr>& newLines)
     if (newLines.isEmpty())
         return;
 
-    if (canRemove && lines.size() + DEF_NUM_MSG_TO_LOAD >= maxMessages) {
+    if (lines.size() + DEF_NUM_MSG_TO_LOAD >= maxMessages) {
         removeFirsts(DEF_NUM_MSG_TO_LOAD);
     }
 
@@ -444,7 +444,7 @@ void ChatLog::insertChatlinesOnTop(const QList<ChatLine::Ptr>& newLines)
         combLines.push_back(l);
     }
 
-    if (canRemove && lines.size() + DEF_NUM_MSG_TO_LOAD >= maxMessages) {
+    if (lines.size() + DEF_NUM_MSG_TO_LOAD >= maxMessages) {
         removeLasts(DEF_NUM_MSG_TO_LOAD);
     }
 

--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -41,7 +41,7 @@ class ChatLog : public QGraphicsView
 {
     Q_OBJECT
 public:
-    explicit ChatLog(const bool canRemove, QWidget* parent = nullptr);
+    explicit ChatLog(QWidget* parent = nullptr);
     virtual ~ChatLog();
 
     void insertChatlineAtBottom(ChatLine::Ptr l);
@@ -188,7 +188,6 @@ private:
 
     int numRemove{0};
     const int maxMessages{300};
-    bool canRemove;
 };
 
 #endif // CHATLOG_H

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -259,7 +259,7 @@ GenericChatForm::GenericChatForm(const Contact* contact, IChatLog& chatLog,
     headWidget = new ChatFormHeader();
     searchForm = new SearchForm();
     dateInfo = new QLabel(this);
-    chatWidget = new ChatLog(contact->useHistory(), this);
+    chatWidget = new ChatLog(this);
     chatWidget->setBusyNotification(ChatMessage::createBusyNotification());
     searchForm->hide();
     dateInfo->setAlignment(Qt::AlignHCenter);


### PR DESCRIPTION
Message caching is handled by SessionChatLog in memory even when history is
disabled. ChatLog doesn't need to worry about how the messages its rendering
are being stored. Dynamic loading up and down in chatlog is sitll functional.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6027)
<!-- Reviewable:end -->
