### PR TITLE
fix(interface): use virtual destructors for all interfaces

### DIFF
--- a/src/audio/iaudiocontrol.h
+++ b/src/audio/iaudiocontrol.h
@@ -105,6 +105,7 @@ class IAudioControl : public QObject
     Q_OBJECT
 
 public:
+    virtual ~IAudioControl() = default;
     virtual qreal outputVolume() const = 0;
     virtual void setOutputVolume(qreal volume) = 0;
     virtual qreal maxOutputVolume() const = 0;

--- a/src/audio/iaudiosettings.h
+++ b/src/audio/iaudiosettings.h
@@ -26,6 +26,8 @@
 
 class IAudioSettings {
 public:
+    virtual ~IAudioSettings() = default;
+
     virtual QString getInDev() const = 0;
     virtual void setInDev(const QString& deviceSpecifier) = 0;
 

--- a/src/audio/iaudiosink.h
+++ b/src/audio/iaudiosink.h
@@ -97,7 +97,7 @@ public:
         return {};
     }
 
-    virtual ~IAudioSink() {}
+    virtual ~IAudioSink() = default;
     virtual void playAudioBuffer(const int16_t* data, int samples, unsigned channels,
                                  int sampleRate) const = 0;
     virtual void playMono16Sound(const Sound& sound) = 0;

--- a/src/audio/iaudiosource.h
+++ b/src/audio/iaudiosource.h
@@ -34,7 +34,7 @@ class IAudioSource : public QObject
 {
     Q_OBJECT
 public:
-    virtual ~IAudioSource() {}
+    virtual ~IAudioSource() = default;
 
     virtual operator bool() const = 0;
 

--- a/src/core/icoresettings.h
+++ b/src/core/icoresettings.h
@@ -35,6 +35,7 @@ public:
         ptSOCKS5 = 1,
         ptHTTP = 2
     };
+    virtual ~ICoreSettings() = default;
 
     virtual bool getEnableIPv6() const = 0;
     virtual void setEnableIPv6(bool enable) = 0;

--- a/src/model/about/iaboutfriend.h
+++ b/src/model/about/iaboutfriend.h
@@ -28,6 +28,7 @@
 class IAboutFriend
 {
 public:
+    virtual ~IAboutFriend() = default;
     virtual QString getName() const = 0;
     virtual QString getStatusMessage() const = 0;
     virtual ToxPk getPublicKey() const = 0;

--- a/src/model/dialogs/idialogs.h
+++ b/src/model/dialogs/idialogs.h
@@ -27,6 +27,7 @@ class ToxPk;
 class IDialogs
 {
 public:
+    virtual ~IDialogs() = default;
     virtual bool hasContact(const ContactId& contactId) const = 0;
     virtual bool isContactActive(const ContactId& contactId) const = 0;
 

--- a/src/model/dialogs/idialogsmanager.h
+++ b/src/model/dialogs/idialogsmanager.h
@@ -28,6 +28,7 @@ class ToxPk;
 class IDialogsManager
 {
 public:
+    virtual ~IDialogsManager() = default;
     virtual IDialogs* getFriendDialogs(const ToxPk& friendPk) const = 0;
     virtual IDialogs* getGroupDialogs(const GroupId& groupId) const = 0;
 };

--- a/src/model/profile/iprofileinfo.h
+++ b/src/model/profile/iprofileinfo.h
@@ -37,6 +37,7 @@ public:
     enum class SetAvatarResult {
         OK, EmptyPath, CanNotOpen, CanNotRead, TooLarge
     };
+    virtual ~IProfileInfo() = default;
 
     virtual bool setPassword(const QString& password) = 0;
     virtual bool deletePassword() = 0;

--- a/src/persistence/ifriendsettings.h
+++ b/src/persistence/ifriendsettings.h
@@ -39,6 +39,8 @@ public:
     };
     Q_DECLARE_FLAGS(AutoAcceptCallFlags, AutoAcceptCall)
 
+    virtual ~IFriendSettings() = default;
+
     virtual QString getContactNote(const ToxPk& pk) const = 0;
     virtual void setContactNote(const ToxPk& pk, const QString& note) = 0;
 

--- a/src/video/ivideosettings.h
+++ b/src/video/ivideosettings.h
@@ -27,6 +27,8 @@
 
 class IVideoSettings {
 public:
+    virtual ~IVideoSettings() = default;
+
     virtual QString getVideoDev() const = 0;
     virtual void setVideoDev(const QString& deviceSpecifier) = 0;
 


### PR DESCRIPTION
Avoids memory leak if derived classes are deleted through interface pointer.

Fix #6006

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6029)
<!-- Reviewable:end -->
