### PR TITLE
chore(cleanup): don't std::move for return statement

### DIFF
--- a/src/persistence/profile.cpp
+++ b/src/persistence/profile.cpp
@@ -117,7 +117,7 @@ std::unique_ptr<ToxEncrypt> loadToxData(const QString& password, const QString& 
 
     saveFile.close();
     error = LoadToxDataError::OK;
-    return std::move(tmpKey);
+    return tmpKey;
 fail:
     saveFile.close();
     return nullptr;


### PR DESCRIPTION
std::moveing prevents RVO, and even in cases where RVO can't take place, move
will be used if possible.

Fix #6011

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6030)
<!-- Reviewable:end -->
