### PR TITLE
chore(build): fix implicit narrowing warning by making it explicit

### DIFF
--- a/src/widget/tool/identicon.cpp
+++ b/src/widget/tool/identicon.cpp
@@ -109,7 +109,7 @@ float Identicon::bytesToColor(QByteArray bytes)
 
     // normalize to 0.0 ... 1.0
     return (static_cast<float>(hue))
-           / (((static_cast<uint64_t>(1)) << (8 * IDENTICON_COLOR_BYTES)) - 1);
+           / (static_cast<float>(((static_cast<uint64_t>(1)) << (8 * IDENTICON_COLOR_BYTES)) - 1));
 }
 
 /**


### PR DESCRIPTION
Exact accuracy isn't needed for the normalized value, being off by one part per
quadrillion is ok.

Fix #6000 

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6031)
<!-- Reviewable:end -->
