### PR TITLE
chore(cleanup): don't add semicolon to Q_DECLARE_METATYPE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wstrict-overflow")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wstrict-aliasing")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wold-style-cast")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wsign-compare")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wunknown-pragmas")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
 
 # avoid timestamps in binary for reproducible builds, not added until GCC 4.9

--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -107,7 +107,7 @@ void CoreAV::connectCallbacks(ToxAV& toxav)
  */
 CoreAV::CoreAVPtr CoreAV::makeCoreAV(Tox* core, QMutex &toxCoreLock)
 {
-    TOXAV_ERR_NEW err;
+    Toxav_Err_New err;
     std::unique_ptr<ToxAV, ToxAVDeleter> toxav{toxav_new(core, &err)};
     switch (err) {
     case TOXAV_ERR_NEW_OK:
@@ -248,7 +248,7 @@ bool CoreAV::answerCall(uint32_t friendNum, bool video)
     qDebug() << QString("Answering call %1").arg(friendNum);
     auto it = calls.find(friendNum);
     assert(it != calls.end());
-    TOXAV_ERR_ANSWER err;
+    Toxav_Err_Answer err;
 
     const uint32_t videoBitrate = video ? VIDEO_DEFAULT_BITRATE : 0;
     if (toxav_answer(toxav.get(), friendNum, Settings::getInstance().getAudioBitrate(),
@@ -346,7 +346,7 @@ bool CoreAV::sendCallAudio(uint32_t callId, const int16_t* pcm, size_t samples, 
     }
 
     // TOXAV_ERR_SEND_FRAME_SYNC means toxav failed to lock, retry 5 times in this case
-    TOXAV_ERR_SEND_FRAME err;
+    Toxav_Err_Send_Frame err;
     int retries = 0;
     do {
         if (!toxav_audio_send_frame(toxav.get(), callId, pcm, samples, chans, rate, &err)) {
@@ -398,7 +398,7 @@ void CoreAV::sendCallVideo(uint32_t callId, std::shared_ptr<VideoFrame> vframe)
 
     // TOXAV_ERR_SEND_FRAME_SYNC means toxav failed to lock, retry 5 times in this case
     // We don't want to be dropping iframes because of some lock held by toxav_iterate
-    TOXAV_ERR_SEND_FRAME err;
+    Toxav_Err_Send_Frame err;
     int retries = 0;
     do {
         if (!toxav_video_send_frame(toxav.get(), callId, frame.width, frame.height, frame.y,

--- a/src/core/receiptnum.h
+++ b/src/core/receiptnum.h
@@ -26,6 +26,6 @@
 #include <cstdint>
 
 using ReceiptNum = NamedType<uint32_t, struct ReceiptNumTag, Orderable>;
-Q_DECLARE_METATYPE(ReceiptNum);
+Q_DECLARE_METATYPE(ReceiptNum)
 
 #endif /* RECEIPT_NUM_H */

--- a/src/core/toxencrypt.cpp
+++ b/src/core/toxencrypt.cpp
@@ -26,10 +26,10 @@
 #include <memory>
 
 // functions for nice debug output
-static QString getKeyDerivationError(TOX_ERR_KEY_DERIVATION error);
-static QString getEncryptionError(TOX_ERR_ENCRYPTION error);
-static QString getDecryptionError(TOX_ERR_DECRYPTION error);
-static QString getSaltError(TOX_ERR_GET_SALT error);
+static QString getKeyDerivationError(Tox_Err_Key_Derivation error);
+static QString getEncryptionError(Tox_Err_Encryption error);
+static QString getDecryptionError(Tox_Err_Decryption error);
+static QString getSaltError(Tox_Err_Get_Salt error);
 
 /**
   * @class ToxEncrypt
@@ -95,7 +95,7 @@ QByteArray ToxEncrypt::encryptPass(const QString& password, const QByteArray& pl
 
     QByteArray pass = password.toUtf8();
     QByteArray ciphertext(plaintext.length() + TOX_PASS_ENCRYPTION_EXTRA_LENGTH, 0x00);
-    TOX_ERR_ENCRYPTION error;
+    Tox_Err_Encryption error;
     tox_pass_encrypt(reinterpret_cast<const uint8_t*>(plaintext.constData()),
                      static_cast<size_t>(plaintext.size()),
                      reinterpret_cast<const uint8_t*>(pass.constData()),
@@ -130,7 +130,7 @@ QByteArray ToxEncrypt::decryptPass(const QString& password, const QByteArray& ci
 
     QByteArray pass = password.toUtf8();
     QByteArray plaintext(ciphertext.length() - TOX_PASS_ENCRYPTION_EXTRA_LENGTH, 0x00);
-    TOX_ERR_DECRYPTION error;
+    Tox_Err_Decryption error;
     tox_pass_decrypt(reinterpret_cast<const uint8_t*>(ciphertext.constData()),
                      static_cast<size_t>(ciphertext.size()),
                      reinterpret_cast<const uint8_t*>(pass.constData()),
@@ -156,7 +156,7 @@ QByteArray ToxEncrypt::decryptPass(const QString& password, const QByteArray& ci
 std::unique_ptr<ToxEncrypt> ToxEncrypt::makeToxEncrypt(const QString& password)
 {
     const QByteArray pass = password.toUtf8();
-    TOX_ERR_KEY_DERIVATION error;
+    Tox_Err_Key_Derivation error;
     Tox_Pass_Key* const passKey = tox_pass_key_derive(
         reinterpret_cast<const uint8_t*>(pass.constData()),
         static_cast<size_t>(pass.length()), &error);
@@ -223,7 +223,7 @@ QByteArray ToxEncrypt::encrypt(const QByteArray& plaintext) const
     }
 
     QByteArray ciphertext(plaintext.length() + TOX_PASS_ENCRYPTION_EXTRA_LENGTH, 0x00);
-    TOX_ERR_ENCRYPTION error;
+    Tox_Err_Encryption error;
     tox_pass_key_encrypt(passKey, reinterpret_cast<const uint8_t*>(plaintext.constData()),
                          static_cast<size_t>(plaintext.size()),
                          reinterpret_cast<uint8_t*>(ciphertext.data()), &error);
@@ -250,7 +250,7 @@ QByteArray ToxEncrypt::decrypt(const QByteArray& ciphertext) const
     }
 
     QByteArray plaintext(ciphertext.length() - TOX_PASS_ENCRYPTION_EXTRA_LENGTH, 0x00);
-    TOX_ERR_DECRYPTION error;
+    Tox_Err_Decryption error;
     tox_pass_key_decrypt(passKey, reinterpret_cast<const uint8_t*>(ciphertext.constData()),
                          static_cast<size_t>(ciphertext.size()),
                          reinterpret_cast<uint8_t*>(plaintext.data()), &error);
@@ -264,11 +264,11 @@ QByteArray ToxEncrypt::decrypt(const QByteArray& ciphertext) const
 }
 
 /**
- * @brief Gets the error string for TOX_ERR_KEY_DERIVATION errors.
+ * @brief Gets the error string for Tox_Err_Key_Derivation errors.
  * @param error The error number.
  * @return The verbose error message.
  */
-QString getKeyDerivationError(TOX_ERR_KEY_DERIVATION error)
+QString getKeyDerivationError(Tox_Err_Key_Derivation error)
 {
     switch (error) {
     case TOX_ERR_KEY_DERIVATION_OK:
@@ -285,11 +285,11 @@ QString getKeyDerivationError(TOX_ERR_KEY_DERIVATION error)
 }
 
 /**
- * @brief Gets the error string for TOX_ERR_ENCRYPTION errors.
+ * @brief Gets the error string for Tox_Err_Encryption errors.
  * @param error The error number.
  * @return The verbose error message.
  */
-QString getEncryptionError(TOX_ERR_ENCRYPTION error)
+QString getEncryptionError(Tox_Err_Encryption error)
 {
     switch (error) {
     case TOX_ERR_ENCRYPTION_OK:
@@ -308,11 +308,11 @@ QString getEncryptionError(TOX_ERR_ENCRYPTION error)
 }
 
 /**
- * @brief Gets the error string for TOX_ERR_DECRYPTION errors.
+ * @brief Gets the error string for Tox_Err_Decryption errors.
  * @param error The error number.
  * @return The verbose error message.
  */
-QString getDecryptionError(TOX_ERR_DECRYPTION error)
+QString getDecryptionError(Tox_Err_Decryption error)
 {
     switch (error) {
     case TOX_ERR_DECRYPTION_OK:
@@ -335,11 +335,11 @@ QString getDecryptionError(TOX_ERR_DECRYPTION error)
 }
 
 /**
- * @brief Gets the error string for TOX_ERR_GET_SALT errors.
+ * @brief Gets the error string for Tox_Err_Get_Salt errors.
  * @param error The error number.
  * @return The verbose error message.
  */
-QString getSaltError(TOX_ERR_GET_SALT error)
+QString getSaltError(Tox_Err_Get_Salt error)
 {
     switch (error) {
     case TOX_ERR_GET_SALT_OK:

--- a/src/model/ichatlog.h
+++ b/src/model/ichatlog.h
@@ -37,7 +37,7 @@
 
 using ChatLogIdx =
     NamedType<size_t, struct ChatLogIdxTag, Orderable, UnderlyingAddable, UnitlessDifferencable, Incrementable>;
-Q_DECLARE_METATYPE(ChatLogIdx);
+Q_DECLARE_METATYPE(ChatLogIdx)
 
 struct SearchPos
 {

--- a/src/model/imessagedispatcher.h
+++ b/src/model/imessagedispatcher.h
@@ -29,7 +29,7 @@
 #include <cstdint>
 
 using DispatchedMessageId = NamedType<size_t, struct SentMessageIdTag, Orderable, Incrementable>;
-Q_DECLARE_METATYPE(DispatchedMessageId);
+Q_DECLARE_METATYPE(DispatchedMessageId)
 
 class IMessageDispatcher : public QObject
 {

--- a/src/persistence/db/rawdatabase.h
+++ b/src/persistence/db/rawdatabase.h
@@ -45,7 +45,7 @@
 #pragma GCC diagnostic pop
 
 using RowId = NamedType<int64_t, struct RowIdTag, Orderable>;
-Q_DECLARE_METATYPE(RowId);
+Q_DECLARE_METATYPE(RowId)
 
 class RawDatabase : QObject
 {

--- a/src/persistence/history.h
+++ b/src/persistence/history.h
@@ -103,7 +103,7 @@ struct FileDbInsertionData
     int64_t size;
     int direction;
 };
-Q_DECLARE_METATYPE(FileDbInsertionData);
+Q_DECLARE_METATYPE(FileDbInsertionData)
 
 enum class MessageState
 {

--- a/src/util/strongtype.h
+++ b/src/util/strongtype.h
@@ -106,7 +106,7 @@ struct Orderable : EqualityComparible<T, Underlying>
  * in signals/slots. For queued connections, registering the metatype is also
  * required before the type is used.
  *   using ReceiptNum = NamedType<uint32_t, struct ReceiptNumTag>;
- *   Q_DECLARE_METATYPE(ReceiptNum);
+ *   Q_DECLARE_METATYPE(ReceiptNum)
  *   qRegisterMetaType<ReceiptNum>();
  */
 

--- a/src/video/cameradevice.cpp
+++ b/src/video/cameradevice.cpp
@@ -26,7 +26,7 @@ extern "C" {
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #include <libavdevice/avdevice.h>
 #include <libavformat/avformat.h>
-#pragma GCC disagnostic pop
+#pragma GCC diagnostic pop
 }
 #include "cameradevice.h"
 #include "src/persistence/settings.h"

--- a/src/video/corevideosource.cpp
+++ b/src/video/corevideosource.cpp
@@ -22,7 +22,7 @@ extern "C" {
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #include <libavcodec/avcodec.h>
 #include <libavutil/imgutils.h>
-#pragma GCC disagnostic pop
+#pragma GCC diagnostic pop
 }
 
 #include "corevideosource.h"


### PR DESCRIPTION
It is uneeded and prevents enabling of warnings for uneeded semicolons after
classes or namespaces

Fix #6007

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6033)
<!-- Reviewable:end -->
