### PR TITLE
refactor(Qt): fix build with Qt 5.15 again

### DIFF
--- a/src/widget/form/searchsettingsform.cpp
+++ b/src/widget/form/searchsettingsform.cpp
@@ -38,7 +38,7 @@ SearchSettingsForm::SearchSettingsForm(QWidget *parent) :
     reloadTheme();
 
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
-    connect(ui->startSearchComboBox, QOverload<int, const QString &>::of(&QComboBox::currentIndexChanged),
+    connect(ui->startSearchComboBox, QOverload<int>::of(&QComboBox::currentIndexChanged),
 #else
     connect(ui->startSearchComboBox, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
 #endif


### PR DESCRIPTION
A deprecated function was previously replaced with an overload that
also got recently deprecated [1].

1. https://code.qt.io/cgit/qt/qtbase.git/commit/?h=5.15&id=46ebd11e

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6062)
<!-- Reviewable:end -->
