### PR TITLE
fix(build): make pkg-config verbose about why it fails

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -58,7 +58,7 @@ function(search_dependency pkg)
 
   # Try pkg-config first.
   if(NOT ${pkg}_FOUND AND arg_PACKAGE)
-    pkg_search_module(${pkg} ${arg_PACKAGE})
+    pkg_check_modules(${pkg} ${arg_PACKAGE})
   endif()
 
   # Then, try OSX frameworks.


### PR DESCRIPTION
Switch from `pkg_search_module` to `pkg_check_modules` to find .pc and
evaluate .pc files of dependencies. Now, in case of any errors, a clear
message is issued about what is wrong, making it obvious what to do.

As of c-toxcore-0.2.11, my system's toxcore.pc file contains this line:
```
Requires.private: libsodium opus vpx
```

Previously, with opus missing, cmake/Dependencies.cmake through an error
about toxcore not being found, but never actually told why (also it was
misleading, because opus was missing, not toxcore).

Before:
```
<...>
-- Checking for one of the modules 'toxcore'
-- TOXCORE not found
-- Checking for one of the modules 'toxav'
-- TOXAV not found
<...>
```

After:
```
<...>
-- Checking for module 'toxcore'
--   Package 'opus', required by 'toxcore', not found
-- TOXCORE not found
-- Checking for module 'toxav'
--   No package 'toxav' found
-- TOXAV not found
<...>
```

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6064)
<!-- Reviewable:end -->
