### PR TITLE
[WIP] fix(build): don't build with -Werror by default

### DIFF
--- a/.travis/build-osx.sh
+++ b/.travis/build-osx.sh
@@ -34,6 +34,11 @@ install_ccache() {
 
 # Build OSX
 build() {
+	# Add all warning flags we can
+	export CFLAGS="-Wall -Wextra -Wpedantic -pedantic-errors -Wconversion"
+	export CFLAGS+=" -Werror" # make all warnings fatal
+	export CXXFLAGS="$CFLAGS"
+
     bash ./osx/qTox-Mac-Deployer-ULTIMATE.sh -i
     bash ./osx/qTox-Mac-Deployer-ULTIMATE.sh -b
     bash ./osx/qTox-Mac-Deployer-ULTIMATE.sh -d

--- a/.travis/build-ubuntu-16-04.sh
+++ b/.travis/build-ubuntu-16-04.sh
@@ -23,7 +23,7 @@ sudo apt-get update -qq
 
 # install needed Qt, OpenAL, opus, qrencode, GTK tray deps, sqlcipher
 # `--force-yes` since we don't care about GPG failing to work with short IDs
-sudo apt-get install -y --force-yes \
+sudo apt-get install --no-install-recommends -y --force-yes \
     automake \
     autotools-dev \
     build-essential \
@@ -162,7 +162,7 @@ build_qtox() {
     local BUILDDIR=_build
 
 	# Add all warning flags we can
-	export CFLAGS="-Wall -Wextra -Wpedantic -pedantic-errors -Wconversion"
+	export CFLAGS="-Wall -Wconversion"
 	export CFLAGS+=" -Werror" # make all warnings fatal
 	export CXXFLAGS="$CFLAGS"
 
@@ -172,7 +172,8 @@ build_qtox() {
         -DSMILEYS=DISABLED \
         -DENABLE_STATUSNOTIFIER=False \
         -DENABLE_GTK_SYSTRAY=False \
-        -DSPELL_CHECK=OFF
+        -DSPELL_CHECK=OFF || \
+		cat /home/travis/build/qTox/qTox/_build/CMakeFiles/CMakeOutput.log /home/travis/build/qTox/qTox/_build/CMakeFiles/CMakeError.log
 
     bdir
 

--- a/.travis/build-ubuntu-16-04.sh
+++ b/.travis/build-ubuntu-16-04.sh
@@ -161,6 +161,11 @@ build_qtox() {
 
     local BUILDDIR=_build
 
+	# Add all warning flags we can
+	export CFLAGS="-Wall -Wextra -Wpedantic -pedantic-errors -Wconversion"
+	export CFLAGS+=" -Werror" # make all warnings fatal
+	export CXXFLAGS="$CFLAGS"
+
     # first build qTox without support for optional dependencies
     echo '*** BUILDING "MINIMAL" VERSION ***'
     cmake -H. -B"$BUILDDIR" \

--- a/.travis/build-windows.sh
+++ b/.travis/build-windows.sh
@@ -113,11 +113,17 @@ sudo apt-get update -qq
 # to support functionality used by Qt's configure
 sudo apt-get install libseccomp2 -y --force-yes
 
+# Add all warning flags we can
+CFLAGS="-Wall -Wextra -Wpedantic -pedantic-errors -Wconversion"
+CFLAGS+=" -Werror" # make all warnings fatal
+CXXFLAGS="$CFLAGS"
+
 # Build
 sudo docker run --rm \
                 -v "$PWD/workspace":/workspace \
                 -v "$PWD":/qtox \
                 -e TRAVIS_CI_STAGE="$STAGE" \
+				-e CFLAGS="$CFLAGS" -e CXXFLAGS="$CXXFLAGS" \
                 debian:buster-slim \
                 /bin/bash /qtox/windows/cross-compile/build.sh "$ARCH" "$BUILD_TYPE"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,6 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wstrict-aliasing")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wold-style-cast")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wsign-compare")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wunknown-pragmas")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
 
 # avoid timestamps in binary for reproducible builds, not added until GCC 4.9
 include(CheckCXXCompilerFlag)


### PR DESCRIPTION
There's no reason to turn warnings into errors by default.

Generally, nobody else but you wants this flag to be set. In essence,
nobody building from source will have the same compiler as you do which 
makes it very likely to throw warnings along the build. So it's just an
annoyance for everyone else who then has to remove this line...

Related: https://github.com/qTox/qTox/issues/4707#issue-261965122

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6065)
<!-- Reviewable:end -->
