### PR TITLE
Revert dynamic chatlog

### DIFF
--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -947,12 +947,10 @@ void ChatLog::onWorkerTimeout()
         updateMultiSelectionRect();
 
         // scroll
-        if (workerStb) {
+        if (workerStb)
             scrollToBottom();
-            workerStb = false;
-        } else {
+        else
             scrollToLine(workerAnchorLine);
-        }
 
         // don't keep a Ptr to the anchor line
         workerAnchorLine = ChatLine::Ptr();

--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -52,8 +52,8 @@ T clamp(T x, T min, T max)
     return x;
 }
 
-ChatLog::ChatLog(const bool canRemove, QWidget* parent)
-    : QGraphicsView(parent), canRemove(canRemove)
+ChatLog::ChatLog(QWidget* parent)
+    : QGraphicsView(parent)
 {
     // Create the scene
     busyScene = new QGraphicsScene(this);
@@ -394,7 +394,7 @@ void ChatLog::insertChatlineAtBottom(const QList<ChatLine::Ptr>& newLines)
     if (newLines.isEmpty())
         return;
 
-    if (canRemove && lines.size() + DEF_NUM_MSG_TO_LOAD >= maxMessages) {
+    if (lines.size() + DEF_NUM_MSG_TO_LOAD >= maxMessages) {
         removeFirsts(DEF_NUM_MSG_TO_LOAD);
     }
 
@@ -445,7 +445,7 @@ void ChatLog::insertChatlinesOnTop(const QList<ChatLine::Ptr>& newLines)
         combLines.push_back(l);
     }
 
-    if (canRemove && lines.size() + DEF_NUM_MSG_TO_LOAD >= maxMessages) {
+    if (lines.size() + DEF_NUM_MSG_TO_LOAD >= maxMessages) {
         removeLasts(DEF_NUM_MSG_TO_LOAD);
     }
 
@@ -815,6 +815,7 @@ void ChatLog::checkVisibility(bool causedWheelEvent)
     }
 
     if (causedWheelEvent) {
+        qDebug() << "causedWheelEvent";
         if (lowerBound != lines.cend() && lowerBound->get()->row == 0) {
             emit loadHistoryLower();
         } else if (upperBound == lines.cend()) {

--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -688,7 +688,7 @@ void ChatLog::scrollToLine(ChatLine::Ptr line)
         workerStb = false;
     } else {
         updateSceneRect();
-        verticalScrollBar()->setValue(line->sceneBoundingRect().top());
+        verticalScrollBar()->setValue(line->sceneBoundingRect().top()); // NOTE: start here
     }
 }
 

--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -171,9 +171,8 @@ void ChatLog::updateSceneRect()
 
 void ChatLog::layout(int start, int end, qreal width)
 {
-    if (lines.empty()) {
+    if (lines.empty())
         return;
-    }
 
     qreal h = 0.0;
 
@@ -316,9 +315,8 @@ void ChatLog::mouseMoveEvent(QMouseEvent* ev)
 // Much faster than QGraphicsScene::itemAt()!
 ChatLineContent* ChatLog::getContentFromPos(QPointF scenePos) const
 {
-    if (lines.empty()) {
+    if (lines.empty())
         return nullptr;
-    }
 
     auto itr =
         std::lower_bound(lines.cbegin(), lines.cend(), scenePos.y(), ChatLine::lessThanBSRectBottom);
@@ -461,9 +459,8 @@ void ChatLog::scrollToBottom()
 
 void ChatLog::startResizeWorker()
 {
-    if (lines.empty()) {
+    if (lines.empty())
         return;
-    }
 
     // (re)start the worker
     if (!workerTimer->isActive()) {
@@ -664,9 +661,8 @@ void ChatLog::scrollToLine(ChatLine::Ptr line)
 
 void ChatLog::selectAll()
 {
-    if (lines.empty()) {
+    if (lines.empty())
         return;
-    }
 
     clearSelection();
 
@@ -728,9 +724,8 @@ void ChatLog::forceRelayout()
 
 void ChatLog::checkVisibility(bool causedWheelEvent)
 {
-    if (lines.empty()) {
+    if (lines.empty())
         return;
-    }
 
     // find first visible line
     auto lowerBound = std::lower_bound(lines.cbegin(), lines.cend(), getVisibleRect().top(),
@@ -829,9 +824,8 @@ void ChatLog::updateTypingNotification()
 
     qreal posY = 0.0;
 
-    if (!lines.empty()) {
+    if (!lines.empty())
         posY = lines.last()->sceneBoundingRect().bottom() + lineSpacing;
-    }
 
     notification->layout(useableWidth(), QPointF(0.0, posY));
 }

--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -698,7 +698,7 @@ void ChatLog::forceRelayout()
     startResizeWorker();
 }
 
-void ChatLog::checkVisibility(bool causedWheelEvent)
+void ChatLog::checkVisibility(bool causedByScroll)
 {
     if (lines.empty())
         return;
@@ -743,10 +743,10 @@ void ChatLog::checkVisibility(bool causedWheelEvent)
         emit firstVisibleLineChanged(lastLineBeforeVisible, visibleLines.at(0));
     }
 
-    if (causedWheelEvent) {
+    if (causedByScroll) {
         if (lowerBound != lines.cend() && lowerBound->get()->row == 0) {
             emit loadHistoryLower();
-        } else if (upperBound == lines.cend()) {
+        } else if (upperBound != lines.cend() && upperBound->get()->row >= lines.size() - 10) {
             emit loadHistoryUpper();
         }
     }
@@ -755,7 +755,7 @@ void ChatLog::checkVisibility(bool causedWheelEvent)
 void ChatLog::scrollContentsBy(int dx, int dy)
 {
     QGraphicsView::scrollContentsBy(dx, dy);
-    checkVisibility();
+    checkVisibility(true);
 }
 
 void ChatLog::resizeEvent(QResizeEvent* ev)
@@ -949,12 +949,6 @@ void ChatLog::focusOutEvent(QFocusEvent* ev)
         for (int i = selFirstRow; i <= selLastRow; ++i)
             lines[i]->selectionFocusChanged(false);
     }
-}
-
-void ChatLog::wheelEvent(QWheelEvent *event)
-{
-    QGraphicsView::wheelEvent(event);
-    checkVisibility(true);
 }
 
 void ChatLog::retranslateUi()

--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -693,30 +693,6 @@ void ChatLog::reloadTheme()
     }
 }
 
-void ChatLog::removeFirsts(const int num)
-{
-    if (lines.size() > num) {
-        lines.erase(lines.begin(), lines.begin()+num);
-    } else {
-        lines.clear();
-    }
-
-    for (int i = 0; i < lines.size(); ++i) {
-        lines[i]->setRow(i);
-    }
-
-    moveSelectionRectUpIfSelected(num);
-}
-
-void ChatLog::removeLasts(const int num)
-{
-    if (lines.size() > num) {
-        lines.erase(lines.end()-num, lines.end());
-    } else {
-        lines.clear();
-    }
-}
-
 void ChatLog::forceRelayout()
 {
     startResizeWorker();

--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -52,8 +52,8 @@ T clamp(T x, T min, T max)
     return x;
 }
 
-ChatLog::ChatLog(QWidget* parent)
-    : QGraphicsView(parent)
+ChatLog::ChatLog(const bool canRemove, QWidget* parent)
+    : QGraphicsView(parent), canRemove(canRemove)
 {
     // Create the scene
     busyScene = new QGraphicsScene(this);
@@ -394,7 +394,7 @@ void ChatLog::insertChatlineAtBottom(const QList<ChatLine::Ptr>& newLines)
     if (newLines.isEmpty())
         return;
 
-    if (lines.size() + DEF_NUM_MSG_TO_LOAD >= maxMessages) {
+    if (canRemove && lines.size() + DEF_NUM_MSG_TO_LOAD >= maxMessages) {
         removeFirsts(DEF_NUM_MSG_TO_LOAD);
     }
 
@@ -444,7 +444,7 @@ void ChatLog::insertChatlinesOnTop(const QList<ChatLine::Ptr>& newLines)
         combLines.push_back(l);
     }
 
-    if (lines.size() + DEF_NUM_MSG_TO_LOAD >= maxMessages) {
+    if (canRemove && lines.size() + DEF_NUM_MSG_TO_LOAD >= maxMessages) {
         removeLasts(DEF_NUM_MSG_TO_LOAD);
     }
 

--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -385,22 +385,6 @@ void ChatLog::insertChatlineAtBottom(ChatLine::Ptr l)
     updateTypingNotification();
 }
 
-void ChatLog::insertChatlineAtBottom(const QList<ChatLine::Ptr>& newLines)
-{
-    if (newLines.isEmpty())
-        return;
-
-    for (ChatLine::Ptr l : newLines) {
-        l->setRow(lines.size());
-        l->addToScene(scene);
-        l->visibilityChanged(false);
-        lines.append(l);
-    }
-
-    layout(lines.last()->getRow(), lines.size(), useableWidth());
-    startResizeWorker();
-}
-
 void ChatLog::insertChatlineOnTop(ChatLine::Ptr l)
 {
     if (!l.get())
@@ -743,12 +727,8 @@ void ChatLog::checkVisibility(bool causedByScroll)
         emit firstVisibleLineChanged(lastLineBeforeVisible, visibleLines.at(0));
     }
 
-    if (causedByScroll) {
-        if (lowerBound != lines.cend() && lowerBound->get()->row == 0) {
-            emit loadHistoryLower();
-        } else if (upperBound != lines.cend() && upperBound->get()->row >= lines.size() - 10) {
-            emit loadHistoryUpper();
-        }
+    if (causedByScroll && lowerBound != lines.cend() && lowerBound->get()->row == 0) {
+        emit loadHistoryLower();
     }
 }
 

--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -35,8 +35,6 @@ class QTimer;
 class ChatLineContent;
 struct ToxFile;
 
-static const auto DEF_NUM_MSG_TO_LOAD = 100;
-
 class ChatLog : public QGraphicsView
 {
     Q_OBJECT
@@ -60,8 +58,6 @@ public:
     void reloadTheme();
     void removeFirsts(const int num);
     void removeLasts(const int num);
-    void setScroll(const bool scroll);
-    int getNumRemove() const;
 
     QString getSelectedText() const;
 
@@ -105,7 +101,7 @@ protected:
     void updateSceneRect();
     void checkVisibility(bool causedWheelEvent = false);
     void scrollToBottom();
-    void startResizeWorker(ChatLine::Ptr anchorLine = nullptr);
+    void startResizeWorker();
 
     virtual void mouseDoubleClickEvent(QMouseEvent* ev) final override;
     virtual void mousePressEvent(QMouseEvent* ev) final override;
@@ -175,7 +171,6 @@ private:
     int clickCount = 0;
     QPoint lastClickPos;
     Qt::MouseButton lastClickButton;
-    bool isScroll{true};
 
     // worker vars
     int workerLastIndex = 0;
@@ -185,9 +180,6 @@ private:
     // layout
     QMargins margins = QMargins(10, 10, 10, 10);
     qreal lineSpacing = 5.0f;
-
-    int numRemove{0};
-    const int maxMessages{300};
 };
 
 #endif // CHATLOG_H

--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -105,7 +105,7 @@ protected:
     void updateSceneRect();
     void checkVisibility(bool causedWheelEvent = false);
     void scrollToBottom();
-    void startResizeWorker(bool stick, ChatLine::Ptr anchorLine = nullptr);
+    void startResizeWorker(ChatLine::Ptr anchorLine = nullptr);
 
     virtual void mouseDoubleClickEvent(QMouseEvent* ev) final override;
     virtual void mousePressEvent(QMouseEvent* ev) final override;

--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -41,7 +41,7 @@ class ChatLog : public QGraphicsView
 {
     Q_OBJECT
 public:
-    explicit ChatLog(QWidget* parent = nullptr);
+    explicit ChatLog(const bool canRemove, QWidget* parent = nullptr);
     virtual ~ChatLog();
 
     void insertChatlineAtBottom(ChatLine::Ptr l);
@@ -188,6 +188,7 @@ private:
 
     int numRemove{0};
     const int maxMessages{300};
+    bool canRemove;
 };
 
 #endif // CHATLOG_H

--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -56,8 +56,6 @@ public:
     void selectAll();
     void fontChanged(const QFont& font);
     void reloadTheme();
-    void removeFirsts(const int num);
-    void removeLasts(const int num);
 
     QString getSelectedText() const;
 

--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -43,7 +43,6 @@ public:
     virtual ~ChatLog();
 
     void insertChatlineAtBottom(ChatLine::Ptr l);
-    void insertChatlineAtBottom(const QList<ChatLine::Ptr>& newLines);
     void insertChatlineOnTop(ChatLine::Ptr l);
     void insertChatlinesOnTop(const QList<ChatLine::Ptr>& newLines);
     void clearSelection();
@@ -74,7 +73,6 @@ signals:
     void workerTimeoutFinished();
     void firstVisibleLineChanged(const ChatLine::Ptr& prevLine, const ChatLine::Ptr& firstLine);
     void loadHistoryLower();
-    void loadHistoryUpper();
 
 public slots:
     void forceRelayout();

--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -41,7 +41,7 @@ class ChatLog : public QGraphicsView
 {
     Q_OBJECT
 public:
-    explicit ChatLog(const bool canRemove, QWidget* parent = nullptr);
+    explicit ChatLog(QWidget* parent = nullptr);
     virtual ~ChatLog();
 
     void insertChatlineAtBottom(ChatLine::Ptr l);
@@ -188,7 +188,6 @@ private:
 
     int numRemove{0};
     const int maxMessages{300};
-    bool canRemove;
 };
 
 #endif // CHATLOG_H

--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -97,7 +97,7 @@ protected:
 
     void reposition(int start, int end, qreal deltaY);
     void updateSceneRect();
-    void checkVisibility(bool causedWheelEvent = false);
+    void checkVisibility(bool causedByScroll = false);
     void scrollToBottom();
     void startResizeWorker();
 
@@ -110,7 +110,6 @@ protected:
     virtual void showEvent(QShowEvent*) final override;
     virtual void focusInEvent(QFocusEvent* ev) final override;
     virtual void focusOutEvent(QFocusEvent* ev) final override;
-    virtual void wheelEvent(QWheelEvent *event) final override;
 
     void updateMultiSelectionRect();
     void updateTypingNotification();

--- a/src/chatlog/content/text.cpp
+++ b/src/chatlog/content/text.cpp
@@ -66,11 +66,9 @@ void Text::selectText(const QString& txt, const std::pair<int, int>& point)
         return;
     }
 
-    selectCursor = doc->find(txt, point.first);
-    selectPoint = point;
+    auto cursor = doc->find(txt, point.first);
 
-    regenerate();
-    update();
+    selectText(cursor, point);
 }
 
 void Text::selectText(const QRegularExpression &exp, const std::pair<int, int>& point)
@@ -81,20 +79,14 @@ void Text::selectText(const QRegularExpression &exp, const std::pair<int, int>& 
         return;
     }
 
-    selectCursor = doc->find(exp, point.first);
-    selectPoint = point;
+    auto cursor = doc->find(exp, point.first);
 
-    regenerate();
-    update();
+    selectText(cursor, point);
 }
 
 void Text::deselectText()
 {
     dirty = true;
-
-    selectCursor = QTextCursor();
-    selectPoint = {0, 0};
-
     regenerate();
     update();
 }
@@ -363,10 +355,6 @@ void Text::regenerate()
         dirty = false;
     }
 
-    if (!selectCursor.isNull()) {
-        selectText(selectCursor, selectPoint);
-    }
-
     // if we are not visible -> free mem
     if (!keepInMemory)
         freeResources();
@@ -474,6 +462,9 @@ void Text::selectText(QTextCursor& cursor, const std::pair<int, int>& point)
         QTextCharFormat format;
         format.setBackground(QBrush(Style::getColor(Style::SearchHighlighted)));
         cursor.mergeCharFormat(format);
+
+        regenerate();
+        update();
     }
 }
 

--- a/src/chatlog/content/text.h
+++ b/src/chatlog/content/text.h
@@ -24,7 +24,6 @@
 #include "src/widget/style.h"
 
 #include <QFont>
-#include <QTextCursor>
 
 class QTextDocument;
 
@@ -111,9 +110,6 @@ private:
     TextType textType;
     QColor color;
     QColor customColor;
-
-    QTextCursor selectCursor;
-    std::pair<int, int> selectPoint{0, 0};
 };
 
 #endif // TEXT_H

--- a/src/model/chathistory.cpp
+++ b/src/model/chathistory.cpp
@@ -204,15 +204,6 @@ std::vector<IChatLog::DateChatLogIdxPair> ChatHistory::getDateIdxs(const QDate& 
     }
 }
 
-std::size_t ChatHistory::size() const
-{
-    if (canUseHistory()) {
-        return history->getNumMessagesForFriend(f.getPublicKey());
-    }
-
-    return sessionChatLog.size();
-}
-
 void ChatHistory::onFileUpdated(const ToxPk& sender, const ToxFile& file)
 {
     if (canUseHistory()) {

--- a/src/model/chathistory.cpp
+++ b/src/model/chathistory.cpp
@@ -94,9 +94,10 @@ ChatHistory::ChatHistory(Friend& f_, History* history_, const ICoreIdHandler& co
 
     // NOTE: this has to be done _after_ sending all sent messages since initial
     // state of the message has to be marked according to our dispatch state
-    auto firstChatLogIdx = sessionChatLog.getFirstIdx().get() < DEF_NUM_MSG_TO_LOAD
+    constexpr auto defaultNumMessagesToLoad = 100;
+    auto firstChatLogIdx = sessionChatLog.getFirstIdx().get() < defaultNumMessagesToLoad
                                ? ChatLogIdx(0)
-                               : sessionChatLog.getFirstIdx() - DEF_NUM_MSG_TO_LOAD;
+                               : sessionChatLog.getFirstIdx() - defaultNumMessagesToLoad;
 
     if (canUseHistory()) {
         loadHistoryIntoSessionChatLog(firstChatLogIdx);

--- a/src/model/chathistory.cpp
+++ b/src/model/chathistory.cpp
@@ -158,19 +158,13 @@ SearchResult ChatHistory::searchBackward(SearchPos startIdx, const QString& phra
         history->getDateWhereFindPhrase(f.getPublicKey().toString(), earliestMessageDate, phrase,
                                         parameter);
 
-    if (dateWherePhraseFound.isValid()) {
-        auto loadIdx = history->getNumMessagesForFriendBeforeDate(f.getPublicKey(), dateWherePhraseFound);
-        loadHistoryIntoSessionChatLog(ChatLogIdx(loadIdx));
+    auto loadIdx = history->getNumMessagesForFriendBeforeDate(f.getPublicKey(), dateWherePhraseFound);
+    loadHistoryIntoSessionChatLog(ChatLogIdx(loadIdx));
 
-        // Reset search pos to the message we just loaded to avoid a double search
-        startIdx.logIdx = ChatLogIdx(loadIdx);
-        startIdx.numMatches = 0;
-        return sessionChatLog.searchBackward(startIdx, phrase, parameter);
-    }
-
-    SearchResult ret;
-    ret.found = false;
-    return ret;
+    // Reset search pos to the message we just loaded to avoid a double search
+    startIdx.logIdx = ChatLogIdx(loadIdx);
+    startIdx.numMatches = 0;
+    return sessionChatLog.searchBackward(startIdx, phrase, parameter);
 }
 
 ChatLogIdx ChatHistory::getFirstIdx() const

--- a/src/model/chathistory.cpp
+++ b/src/model/chathistory.cpp
@@ -94,10 +94,9 @@ ChatHistory::ChatHistory(Friend& f_, History* history_, const ICoreIdHandler& co
 
     // NOTE: this has to be done _after_ sending all sent messages since initial
     // state of the message has to be marked according to our dispatch state
-    constexpr auto defaultNumMessagesToLoad = 100;
-    auto firstChatLogIdx = sessionChatLog.getFirstIdx().get() < defaultNumMessagesToLoad
+    auto firstChatLogIdx = sessionChatLog.getFirstIdx().get() < DEF_NUM_MSG_TO_LOAD
                                ? ChatLogIdx(0)
-                               : sessionChatLog.getFirstIdx() - defaultNumMessagesToLoad;
+                               : sessionChatLog.getFirstIdx() - DEF_NUM_MSG_TO_LOAD;
 
     if (canUseHistory()) {
         loadHistoryIntoSessionChatLog(firstChatLogIdx);

--- a/src/model/chathistory.h
+++ b/src/model/chathistory.h
@@ -42,7 +42,6 @@ public:
     ChatLogIdx getFirstIdx() const override;
     ChatLogIdx getNextIdx() const override;
     std::vector<DateChatLogIdxPair> getDateIdxs(const QDate& startDate, size_t maxDates) const override;
-    std::size_t size() const override;
 
 public slots:
     void onFileUpdated(const ToxPk& sender, const ToxFile& file);

--- a/src/model/contact.h
+++ b/src/model/contact.h
@@ -37,8 +37,6 @@ public:
     virtual void setEventFlag(bool flag) = 0;
     virtual bool getEventFlag() const = 0;
 
-    virtual bool useHistory() const = 0; // TODO: remove after added history in group chat
-
 signals:
     void displayedNameChanged(const QString& newName);
 };

--- a/src/model/friend.cpp
+++ b/src/model/friend.cpp
@@ -168,8 +168,3 @@ Status::Status Friend::getStatus() const
 {
     return friendStatus;
 }
-
-bool Friend::useHistory() const
-{
-    return true;
-}

--- a/src/model/friend.h
+++ b/src/model/friend.h
@@ -53,7 +53,6 @@ public:
 
     void setStatus(Status::Status s);
     Status::Status getStatus() const;
-    bool useHistory() const override final;
 
 signals:
     void nameChanged(const ToxPk& friendId, const QString& name);

--- a/src/model/group.cpp
+++ b/src/model/group.cpp
@@ -205,11 +205,6 @@ QString Group::getSelfName() const
     return selfName;
 }
 
-bool Group::useHistory() const
-{
-    return false;
-}
-
 void Group::stopAudioOfDepartedPeers(const ToxPk& peerPk)
 {
     if (avGroupchat) {

--- a/src/model/group.h
+++ b/src/model/group.h
@@ -61,8 +61,6 @@ public:
     void setSelfName(const QString& name);
     QString getSelfName() const;
 
-    bool useHistory() const override final;
-
 signals:
     void titleChangedByUser(const QString& title);
     void titleChanged(const QString& author, const QString& title);

--- a/src/model/ichatlog.h
+++ b/src/model/ichatlog.h
@@ -138,8 +138,6 @@ public:
     virtual std::vector<DateChatLogIdxPair> getDateIdxs(const QDate& startDate,
                                                         size_t maxDates) const = 0;
 
-    virtual std::size_t size() const = 0;
-
 signals:
     void itemUpdated(ChatLogIdx idx);
 };

--- a/src/model/ichatlog.h
+++ b/src/model/ichatlog.h
@@ -35,8 +35,6 @@
 
 #include <cassert>
 
-static const auto DEF_NUM_MSG_TO_LOAD = 100;
-
 using ChatLogIdx =
     NamedType<size_t, struct ChatLogIdxTag, Orderable, UnderlyingAddable, UnitlessDifferencable, Incrementable>;
 Q_DECLARE_METATYPE(ChatLogIdx);

--- a/src/model/ichatlog.h
+++ b/src/model/ichatlog.h
@@ -35,6 +35,8 @@
 
 #include <cassert>
 
+static const auto DEF_NUM_MSG_TO_LOAD = 100;
+
 using ChatLogIdx =
     NamedType<size_t, struct ChatLogIdxTag, Orderable, UnderlyingAddable, UnitlessDifferencable, Incrementable>;
 Q_DECLARE_METATYPE(ChatLogIdx);

--- a/src/model/ichatlog.h
+++ b/src/model/ichatlog.h
@@ -70,7 +70,7 @@ struct SearchPos
 
 struct SearchResult
 {
-    bool found{false};
+    bool found;
     SearchPos pos;
     size_t start;
     size_t len;

--- a/src/model/sessionchatlog.cpp
+++ b/src/model/sessionchatlog.cpp
@@ -289,11 +289,6 @@ std::vector<IChatLog::DateChatLogIdxPair> SessionChatLog::getDateIdxs(const QDat
     return ret;
 }
 
-std::size_t SessionChatLog::size() const
-{
-    return items.size();
-}
-
 void SessionChatLog::insertCompleteMessageAtIdx(ChatLogIdx idx, const ToxPk& sender, const QString& senderName,
                                                 const ChatLogMessage& message)
 {

--- a/src/model/sessionchatlog.h
+++ b/src/model/sessionchatlog.h
@@ -45,7 +45,6 @@ public:
     ChatLogIdx getFirstIdx() const override;
     ChatLogIdx getNextIdx() const override;
     std::vector<DateChatLogIdxPair> getDateIdxs(const QDate& startDate, size_t maxDates) const override;
-    std::size_t size() const override;
 
     void insertCompleteMessageAtIdx(ChatLogIdx idx, const ToxPk& sender, const QString& senderName,
                                     const ChatLogMessage& message);

--- a/src/persistence/history.cpp
+++ b/src/persistence/history.cpp
@@ -865,14 +865,14 @@ QDateTime History::getDateWhereFindPhrase(const QString& friendPk, const QDateTi
         break;
     }
 
-    QDateTime time = from;
+    QDateTime date = from;
 
-    if (!time.isValid()) {
-        time = QDateTime::currentDateTime();
+    if (!date.isValid()) {
+        date = QDateTime::currentDateTime();
     }
 
     if (parameter.period == PeriodSearch::AfterDate || parameter.period == PeriodSearch::BeforeDate) {
-        time = parameter.time;
+        date = QDateTime(parameter.date);
     }
 
     QString period;
@@ -882,15 +882,15 @@ QDateTime History::getDateWhereFindPhrase(const QString& friendPk, const QDateTi
         break;
     case PeriodSearch::AfterDate:
         period = QStringLiteral("AND timestamp > '%1' ORDER BY timestamp ASC LIMIT 1;")
-                     .arg(time.toMSecsSinceEpoch());
+                     .arg(date.toMSecsSinceEpoch());
         break;
     case PeriodSearch::BeforeDate:
         period = QStringLiteral("AND timestamp < '%1' ORDER BY timestamp DESC LIMIT 1;")
-                     .arg(time.toMSecsSinceEpoch());
+                     .arg(date.toMSecsSinceEpoch());
         break;
     default:
         period = QStringLiteral("AND timestamp < '%1' ORDER BY timestamp DESC LIMIT 1;")
-                     .arg(time.toMSecsSinceEpoch());
+                     .arg(date.toMSecsSinceEpoch());
         break;
     }
 

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -649,11 +649,6 @@ QDateTime GenericChatForm::getTime(const ChatLine::Ptr &chatLine) const
     return QDateTime();
 }
 
-/**
- * @brief GenericChatForm::loadHistory load history
- * @param time start date
- * @param type indicates the direction of loading history
- */
 void GenericChatForm::loadHistory(const QDateTime &time, const LoadHistoryDialog::LoadType type)
 {
     chatWidget->clear();
@@ -669,10 +664,6 @@ void GenericChatForm::loadHistory(const QDateTime &time, const LoadHistoryDialog
     }
 }
 
-/**
- * @brief GenericChatForm::loadHistoryTo load history before to date "time" or before the first "messages" item
- * @param time start date
- */
 void GenericChatForm::loadHistoryTo(const QDateTime &time)
 {
     chatWidget->setScroll(false);
@@ -699,11 +690,6 @@ void GenericChatForm::loadHistoryTo(const QDateTime &time)
     }
 }
 
-/**
- * @brief GenericChatForm::loadHistoryFrom load history starting from date "time" or from the last "messages" item
- * @param time start date
- * @return true if function loaded history else false
- */
 bool GenericChatForm::loadHistoryFrom(const QDateTime &time)
 {
     chatWidget->setScroll(false);
@@ -716,12 +702,11 @@ bool GenericChatForm::loadHistoryFrom(const QDateTime &time)
 
     int add = DEF_NUM_MSG_TO_LOAD;
     if (begin.get() + DEF_NUM_MSG_TO_LOAD > chatLog.getNextIdx().get()) {
+        auto t = chatLog.getNextIdx();
         add = chatLog.getNextIdx().get() - begin.get();
     }
 
-    // The chatLog.getNextIdx() is usually 1 more than the idx on last "messages" item
-    // so if we have nothing to load, "add" is equal 1
-    if (add <= 1) {
+    if (add  <= 1) {
         chatWidget->setScroll(true);
         return false;
     }
@@ -1166,17 +1151,11 @@ void GenericChatForm::goToCurrentDate()
     renderMessages(begin, end);
 }
 
-/**
- * @brief GenericChatForm::loadHistoryLower load history after scrolling chatlog before first "messages" item
- */
 void GenericChatForm::loadHistoryLower()
 {
     loadHistoryTo(QDateTime());
 }
 
-/**
- * @brief GenericChatForm::loadHistoryUpper load history after scrolling chatlog after last "messages" item
- */
 void GenericChatForm::loadHistoryUpper()
 {
     if (messages.empty()) {

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -690,7 +690,7 @@ void GenericChatForm::loadHistoryTo(const QDateTime &time)
     }
 }
 
-bool GenericChatForm::loadHistoryFrom(const QDateTime &time)
+void GenericChatForm::loadHistoryFrom(const QDateTime &time)
 {
     chatWidget->setScroll(false);
     auto begin = ChatLogIdx(0);
@@ -702,20 +702,10 @@ bool GenericChatForm::loadHistoryFrom(const QDateTime &time)
 
     int add = DEF_NUM_MSG_TO_LOAD;
     if (begin.get() + DEF_NUM_MSG_TO_LOAD > chatLog.getNextIdx().get()) {
-        auto t = chatLog.getNextIdx();
         add = chatLog.getNextIdx().get() - begin.get();
     }
-
-    if (add  <= 1) {
-        chatWidget->setScroll(true);
-        return false;
-    }
-
     auto end = ChatLogIdx(begin.get() + add);
-
     renderMessages(begin, end);
-
-    return true;
 }
 
 void GenericChatForm::removeFirstsMessages(const int num)
@@ -1163,9 +1153,8 @@ void GenericChatForm::loadHistoryUpper()
     }
 
     auto msg = messages.crbegin()->second;
-    if (loadHistoryFrom(QDateTime())) {
-        chatWidget->scrollToLine(msg);
-    }
+    loadHistoryFrom(QDateTime());
+    chatWidget->scrollToLine(msg);
 }
 
 void GenericChatForm::updateShowDateInfo(const ChatLine::Ptr& prevLine, const ChatLine::Ptr& topLine)

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -53,8 +53,6 @@
 #include <QStringBuilder>
 #include <QtGlobal>
 
-#include <QDebug>
-
 #ifdef SPELL_CHECKING
 #include <KF5/SonnetUi/sonnet/spellcheckdecorator.h>
 #endif
@@ -657,7 +655,6 @@ void GenericChatForm::loadHistory(const QDateTime &time, const LoadHistoryDialog
     if (type == LoadHistoryDialog::from) {
         loadHistoryFrom(time);
         auto msg = messages.cbegin()->second;
-        chatWidget->setScroll(true);
         chatWidget->scrollToLine(msg);
     } else {
         loadHistoryTo(time);
@@ -666,10 +663,15 @@ void GenericChatForm::loadHistory(const QDateTime &time, const LoadHistoryDialog
 
 void GenericChatForm::loadHistoryTo(const QDateTime &time)
 {
-    chatWidget->setScroll(false);
     auto end = ChatLogIdx(0);
     if (time.isNull()) {
-        end = messages.begin()->first;
+        if (messages.size() + DEF_NUM_MSG_TO_LOAD >= maxMessages) {
+            end = ChatLogIdx(messages.rbegin()->first.get() - DEF_NUM_MSG_TO_LOAD);
+            chatWidget->removeLasts(DEF_NUM_MSG_TO_LOAD);
+            removeLastsMessages(DEF_NUM_MSG_TO_LOAD);
+        } else {
+            end = messages.begin()->first;
+        }
     } else {
         end = firstItemAfterDate(time.date(), chatLog);
     }
@@ -679,27 +681,28 @@ void GenericChatForm::loadHistoryTo(const QDateTime &time)
         begin = ChatLogIdx(end.get() - DEF_NUM_MSG_TO_LOAD);
     }
 
-    if (begin != end) {
-        renderMessages(begin, end);
-    } else {
-        chatWidget->setScroll(true);
-    }
+    renderMessages(begin, end);
 }
 
 void GenericChatForm::loadHistoryFrom(const QDateTime &time)
 {
-    chatWidget->setScroll(false);
     auto begin = ChatLogIdx(0);
     if (time.isNull()) {
-        begin = messages.rbegin()->first;
+        if (messages.size() + DEF_NUM_MSG_TO_LOAD >= maxMessages) {
+            begin = ChatLogIdx(messages.rbegin()->first.get() + DEF_NUM_MSG_TO_LOAD);
+            chatWidget->removeFirsts(DEF_NUM_MSG_TO_LOAD);
+            removeFirstsMessages(DEF_NUM_MSG_TO_LOAD);
+        } else {
+            begin = messages.rbegin()->first;
+        }
+
     } else {
         begin = firstItemAfterDate(time.date(), chatLog);
     }
 
     int add = DEF_NUM_MSG_TO_LOAD;
     if (begin.get() + DEF_NUM_MSG_TO_LOAD > chatLog.getNextIdx().get()) {
-        auto aTest = chatLog.getNextIdx().get();
-        add = chatLog.getNextIdx().get() - begin.get();
+        add = chatLog.getNextIdx().get() - (begin.get() + DEF_NUM_MSG_TO_LOAD);
     }
     auto end = ChatLogIdx(begin.get() + add);
     renderMessages(begin, end);
@@ -1015,6 +1018,10 @@ void GenericChatForm::handleSearchResult(SearchResult result, SearchDirection di
 
 void GenericChatForm::renderMessage(ChatLogIdx idx)
 {
+    if (chatWidget->getLines().size() >= maxMessages) {
+        chatWidget->removeFirsts(optimalRemove);
+        removeFirstsMessages(optimalRemove);
+    }
     renderMessages(idx, idx + 1);
 }
 
@@ -1041,13 +1048,8 @@ void GenericChatForm::renderMessages(ChatLogIdx begin, ChatLogIdx end,
         }
     }
 
-    if (beforeLines.isEmpty() && afterLines.isEmpty()) {
-        chatWidget->setScroll(true);
-    }
-
-    chatWidget->insertChatlineAtBottom(afterLines);
-    if (chatWidget->getNumRemove()) {
-        removeFirstsMessages(chatWidget->getNumRemove());
+    for (auto const& line : afterLines) {
+        chatWidget->insertChatlineAtBottom(line);
     }
 
     if (!beforeLines.empty()) {
@@ -1064,9 +1066,6 @@ void GenericChatForm::renderMessages(ChatLogIdx begin, ChatLogIdx end,
         }
 
         chatWidget->insertChatlinesOnTop(beforeLines);
-        if (chatWidget->getNumRemove()) {
-            removeLastsMessages(chatWidget->getNumRemove());
-        }
     } else if (onCompletion) {
         onCompletion();
     }
@@ -1076,7 +1075,7 @@ void GenericChatForm::goToCurrentDate()
 {
     chatWidget->clear();
     messages.clear();
-    auto end = ChatLogIdx(chatLog.size());
+    auto end = ChatLogIdx(chatLog.size() - 1);
     auto begin = end.get() > DEF_NUM_MSG_TO_LOAD ? ChatLogIdx(end.get() - DEF_NUM_MSG_TO_LOAD) : ChatLogIdx(0);
 
     renderMessages(begin, end);

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -354,7 +354,6 @@ GenericChatForm::GenericChatForm(const Contact* contact, IChatLog& chatLog,
             &GenericChatForm::onChatContextMenuRequested);
     connect(chatWidget, &ChatLog::firstVisibleLineChanged, this, &GenericChatForm::updateShowDateInfo);
     connect(chatWidget, &ChatLog::loadHistoryLower, this, &GenericChatForm::loadHistoryLower);
-    connect(chatWidget, &ChatLog::loadHistoryUpper, this, &GenericChatForm::loadHistoryUpper);
 
     connect(searchForm, &SearchForm::searchInBegin, this, &GenericChatForm::searchInBegin);
     connect(searchForm, &SearchForm::searchUp, this, &GenericChatForm::onSearchUp);
@@ -807,10 +806,7 @@ void GenericChatForm::onLoadHistory()
     if (dlg.exec()) {
         QDateTime time = dlg.getFromDate();
         auto idx = firstItemAfterDate(dlg.getFromDate().date(), chatLog);
-        auto end = ChatLogIdx(idx.get() + 100);
-        chatWidget->clear();
-        messages.clear();
-        renderMessages(idx, end);
+        renderMessages(idx, chatLog.getNextIdx());
     }
 }
 
@@ -989,18 +985,6 @@ void GenericChatForm::loadHistoryLower()
     }
 
     renderMessages(begin, chatLog.getNextIdx());
-}
-
-void GenericChatForm::loadHistoryUpper()
-{
-    auto begin = messages.end()->first;
-
-    int add = 100;
-    if (begin.get() + 100 > chatLog.getNextIdx().get()) {
-        add = chatLog.getNextIdx().get() - (begin.get() + 100);
-    }
-    auto end = ChatLogIdx(begin.get() + add);
-    renderMessages(begin, end);
 }
 
 void GenericChatForm::updateShowDateInfo(const ChatLine::Ptr& prevLine, const ChatLine::Ptr& topLine)

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -665,13 +665,7 @@ void GenericChatForm::loadHistoryTo(const QDateTime &time)
 {
     auto end = ChatLogIdx(0);
     if (time.isNull()) {
-        if (messages.size() + 100 >= maxMessages) {
-            end = ChatLogIdx(messages.rbegin()->first.get() - 100);
-            chatWidget->removeLasts(100);
-            removeLastsMessages(100);
-        } else {
-            end = messages.begin()->first;
-        }
+        end = messages.begin()->first;
     } else {
         end = firstItemAfterDate(time.date(), chatLog);
     }
@@ -688,14 +682,7 @@ void GenericChatForm::loadHistoryFrom(const QDateTime &time)
 {
     auto begin = ChatLogIdx(0);
     if (time.isNull()) {
-        if (messages.size() + 100 >= maxMessages) {
-            begin = ChatLogIdx(messages.rbegin()->first.get() + 100);
-            chatWidget->removeFirsts(100);
-            removeFirstsMessages(100);
-        } else {
-            begin = messages.rbegin()->first;
-        }
-
+        begin = messages.rbegin()->first;
     } else {
         begin = firstItemAfterDate(time.date(), chatLog);
     }
@@ -706,24 +693,6 @@ void GenericChatForm::loadHistoryFrom(const QDateTime &time)
     }
     auto end = ChatLogIdx(begin.get() + add);
     renderMessages(begin, end);
-}
-
-void GenericChatForm::removeFirstsMessages(const int num)
-{
-    if (messages.size() > num) {
-        messages.erase(messages.begin(), std::next(messages.begin(), num));
-    } else {
-        messages.clear();
-    }
-}
-
-void GenericChatForm::removeLastsMessages(const int num)
-{
-    if (messages.size() > 100) {
-        messages.erase(std::next(messages.end(), -100), messages.end());
-    } else {
-        messages.clear();
-    }
 }
 
 
@@ -1018,10 +987,6 @@ void GenericChatForm::handleSearchResult(SearchResult result, SearchDirection di
 
 void GenericChatForm::renderMessage(ChatLogIdx idx)
 {
-    if (chatWidget->getLines().size() >= maxMessages) {
-        chatWidget->removeFirsts(optimalRemove);
-        removeFirstsMessages(optimalRemove);
-    }
     renderMessages(idx, idx + 1);
 }
 

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -980,10 +980,6 @@ void GenericChatForm::searchInBegin(const QString& phrase, const ParameterSearch
         return;
     }
 
-    if (messages.size() == 0) {
-        return;
-    }
-
     if (chatLog.getNextIdx().get() == messages.rbegin()->first.get() + 1) {
         disableSearchText();
     } else {

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -259,7 +259,7 @@ GenericChatForm::GenericChatForm(const Contact* contact, IChatLog& chatLog,
     headWidget = new ChatFormHeader();
     searchForm = new SearchForm();
     dateInfo = new QLabel(this);
-    chatWidget = new ChatLog(this);
+    chatWidget = new ChatLog(contact->useHistory(), this);
     chatWidget->setBusyNotification(ChatMessage::createBusyNotification());
     searchForm->hide();
     dateInfo->setAlignment(Qt::AlignHCenter);

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -386,7 +386,7 @@ GenericChatForm::GenericChatForm(const Contact* contact, IChatLog& chatLog,
     connect(contact, &Contact::displayedNameChanged, this, &GenericChatForm::setName);
 
     auto chatLogIdxRange = chatLog.getNextIdx() - chatLog.getFirstIdx();
-    auto firstChatLogIdx = (chatLogIdxRange < DEF_NUM_MSG_TO_LOAD) ? chatLog.getFirstIdx() : chatLog.getNextIdx() - DEF_NUM_MSG_TO_LOAD;
+    auto firstChatLogIdx = (chatLogIdxRange < 100) ? chatLog.getFirstIdx() : chatLog.getNextIdx() - 100;
 
     renderMessages(firstChatLogIdx, chatLog.getNextIdx());
 
@@ -665,10 +665,10 @@ void GenericChatForm::loadHistoryTo(const QDateTime &time)
 {
     auto end = ChatLogIdx(0);
     if (time.isNull()) {
-        if (messages.size() + DEF_NUM_MSG_TO_LOAD >= maxMessages) {
-            end = ChatLogIdx(messages.rbegin()->first.get() - DEF_NUM_MSG_TO_LOAD);
-            chatWidget->removeLasts(DEF_NUM_MSG_TO_LOAD);
-            removeLastsMessages(DEF_NUM_MSG_TO_LOAD);
+        if (messages.size() + 100 >= maxMessages) {
+            end = ChatLogIdx(messages.rbegin()->first.get() - 100);
+            chatWidget->removeLasts(100);
+            removeLastsMessages(100);
         } else {
             end = messages.begin()->first;
         }
@@ -677,8 +677,8 @@ void GenericChatForm::loadHistoryTo(const QDateTime &time)
     }
 
     auto begin = ChatLogIdx(0);
-    if (end.get() > DEF_NUM_MSG_TO_LOAD) {
-        begin = ChatLogIdx(end.get() - DEF_NUM_MSG_TO_LOAD);
+    if (end.get() > 100) {
+        begin = ChatLogIdx(end.get() - 100);
     }
 
     renderMessages(begin, end);
@@ -688,10 +688,10 @@ void GenericChatForm::loadHistoryFrom(const QDateTime &time)
 {
     auto begin = ChatLogIdx(0);
     if (time.isNull()) {
-        if (messages.size() + DEF_NUM_MSG_TO_LOAD >= maxMessages) {
-            begin = ChatLogIdx(messages.rbegin()->first.get() + DEF_NUM_MSG_TO_LOAD);
-            chatWidget->removeFirsts(DEF_NUM_MSG_TO_LOAD);
-            removeFirstsMessages(DEF_NUM_MSG_TO_LOAD);
+        if (messages.size() + 100 >= maxMessages) {
+            begin = ChatLogIdx(messages.rbegin()->first.get() + 100);
+            chatWidget->removeFirsts(100);
+            removeFirstsMessages(100);
         } else {
             begin = messages.rbegin()->first;
         }
@@ -700,9 +700,9 @@ void GenericChatForm::loadHistoryFrom(const QDateTime &time)
         begin = firstItemAfterDate(time.date(), chatLog);
     }
 
-    int add = DEF_NUM_MSG_TO_LOAD;
-    if (begin.get() + DEF_NUM_MSG_TO_LOAD > chatLog.getNextIdx().get()) {
-        add = chatLog.getNextIdx().get() - (begin.get() + DEF_NUM_MSG_TO_LOAD);
+    int add = 100;
+    if (begin.get() + 100 > chatLog.getNextIdx().get()) {
+        add = chatLog.getNextIdx().get() - (begin.get() + 100);
     }
     auto end = ChatLogIdx(begin.get() + add);
     renderMessages(begin, end);
@@ -719,8 +719,8 @@ void GenericChatForm::removeFirstsMessages(const int num)
 
 void GenericChatForm::removeLastsMessages(const int num)
 {
-    if (messages.size() > num) {
-        messages.erase(std::next(messages.end(), -num), messages.end());
+    if (messages.size() > 100) {
+        messages.erase(std::next(messages.end(), -100), messages.end());
     } else {
         messages.clear();
     }
@@ -1076,7 +1076,7 @@ void GenericChatForm::goToCurrentDate()
     chatWidget->clear();
     messages.clear();
     auto end = ChatLogIdx(chatLog.size() - 1);
-    auto begin = end.get() > DEF_NUM_MSG_TO_LOAD ? ChatLogIdx(end.get() - DEF_NUM_MSG_TO_LOAD) : ChatLogIdx(0);
+    auto begin = end.get() > 100 ? ChatLogIdx(end.get() - 100) : ChatLogIdx(0);
 
     renderMessages(begin, end);
 }

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -326,13 +326,6 @@ GenericChatForm::GenericChatForm(const Contact* contact, IChatLog& chatLog,
     quoteAction = menu.addAction(QIcon(), QString(), this, SLOT(quoteSelectedText()),
                                  QKeySequence(Qt::ALT + Qt::Key_Q));
     addAction(quoteAction);
-
-    menu.addSeparator();
-
-    goCurrentDateAction = menu.addAction(QIcon(), QString(), this, SLOT(goToCurrentDate()),
-                                  QKeySequence(Qt::CTRL + Qt::Key_G));
-    addAction(goCurrentDateAction);
-
     menu.addSeparator();
 
     searchAction = menu.addAction(QIcon(), QString(), this, SLOT(searchFormShow()),
@@ -1005,16 +998,6 @@ void GenericChatForm::renderMessages(ChatLogIdx begin, ChatLogIdx end,
     }
 }
 
-void GenericChatForm::goToCurrentDate()
-{
-    chatWidget->clear();
-    messages.clear();
-    auto end = ChatLogIdx(chatLog.size() - 1);
-    auto begin = end.get() > 100 ? ChatLogIdx(end.get() - 100) : ChatLogIdx(0);
-
-    renderMessages(begin, end);
-}
-
 void GenericChatForm::loadHistoryLower()
 {
     auto end = messages.begin()->first;
@@ -1066,7 +1049,6 @@ void GenericChatForm::retranslateUi()
     quoteAction->setText(tr("Quote selected text"));
     copyLinkAction->setText(tr("Copy link address"));
     searchAction->setText(tr("Search in text"));
-    goCurrentDateAction->setText(tr("Go to current date"));
     loadHistoryAction->setText(tr("Load chat history..."));
     exportChatAction->setText(tr("Export to file"));
 }

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -680,11 +680,7 @@ void GenericChatForm::loadHistoryTo(const QDateTime &time)
     }
 
     if (begin != end) {
-        if (searchResult.found == true) {
-            renderMessages(begin, searchResult.pos.logIdx, [this]{enableSearchText();});
-        } else {
-            renderMessages(begin, end);
-        }
+        renderMessages(begin, end);
     } else {
         chatWidget->setScroll(true);
     }
@@ -729,21 +725,11 @@ void GenericChatForm::removeLastsMessages(const int num)
 
 void GenericChatForm::disableSearchText()
 {
-    auto msgIt = messages.find(searchResult.pos.logIdx);
+    auto msgIt = messages.find(searchPos.logIdx);
     if (msgIt != messages.end()) {
         auto text = qobject_cast<Text*>(msgIt->second->getContent(1));
         text->deselectText();
     }
-}
-
-void GenericChatForm::enableSearchText()
-{
-    auto msg = messages.at(searchResult.pos.logIdx);
-    chatWidget->scrollToLine(msg);
-
-    auto text = qobject_cast<Text*>(msg->getContent(1));
-    text->visibilityChanged(true);
-    text->selectText(searchResult.exp, std::make_pair(searchResult.start, searchResult.len));
 }
 
 void GenericChatForm::clearChatArea()
@@ -941,7 +927,6 @@ void GenericChatForm::onExportChat()
 void GenericChatForm::onSearchTriggered()
 {
     if (searchForm->isHidden()) {
-        searchResult.found = false;
         searchForm->removeSearchPhrase();
     }
     disableSearchText();
@@ -971,27 +956,27 @@ void GenericChatForm::searchInBegin(const QString& phrase, const ParameterSearch
     switch (parameter.period) {
     case PeriodSearch::WithTheFirst: {
         bForwardSearch = true;
-        searchResult.pos.logIdx = chatLog.getFirstIdx();
-        searchResult.pos.numMatches = 0;
+        searchPos.logIdx = chatLog.getFirstIdx();
+        searchPos.numMatches = 0;
         break;
     }
     case PeriodSearch::WithTheEnd:
     case PeriodSearch::None: {
         bForwardSearch = false;
-        searchResult.pos.logIdx = chatLog.getNextIdx();
-        searchResult.pos.numMatches = 0;
+        searchPos.logIdx = chatLog.getNextIdx();
+        searchPos.numMatches = 0;
         break;
     }
     case PeriodSearch::AfterDate: {
         bForwardSearch = true;
-        searchResult.pos.logIdx = firstItemAfterDate(parameter.time.date(), chatLog);
-        searchResult.pos.numMatches = 0;
+        searchPos.logIdx = firstItemAfterDate(parameter.time.date(), chatLog);
+        searchPos.numMatches = 0;
         break;
     }
     case PeriodSearch::BeforeDate: {
         bForwardSearch = false;
-        searchResult.pos.logIdx = firstItemAfterDate(parameter.time.date(), chatLog);
-        searchResult.pos.numMatches = 0;
+        searchPos.logIdx = firstItemAfterDate(parameter.time.date(), chatLog);
+        searchPos.numMatches = 0;
         break;
     }
     }
@@ -1005,13 +990,13 @@ void GenericChatForm::searchInBegin(const QString& phrase, const ParameterSearch
 
 void GenericChatForm::onSearchUp(const QString& phrase, const ParameterSearch& parameter)
 {
-    auto result = chatLog.searchBackward(searchResult.pos, phrase, parameter);
+    auto result = chatLog.searchBackward(searchPos, phrase, parameter);
     handleSearchResult(result, SearchDirection::Up);
 }
 
 void GenericChatForm::onSearchDown(const QString& phrase, const ParameterSearch& parameter)
 {
-    auto result = chatLog.searchForward(searchResult.pos, phrase, parameter);
+    auto result = chatLog.searchForward(searchPos, phrase, parameter);
 
     if (result.found && result.pos.logIdx.get() > messages.end()->first.get()) {
         const auto dt = chatLog.at(result.pos.logIdx).getTimestamp();
@@ -1030,11 +1015,18 @@ void GenericChatForm::handleSearchResult(SearchResult result, SearchDirection di
 
     disableSearchText();
 
-    searchResult = result;
+    searchPos = result.pos;
 
     auto const firstRenderedIdx = (messages.empty()) ? chatLog.getNextIdx() : messages.begin()->first;
 
-    renderMessages(searchResult.pos.logIdx, firstRenderedIdx, [this]{enableSearchText();});
+    renderMessages(searchPos.logIdx, firstRenderedIdx, [this, result] {
+        auto msg = messages.at(searchPos.logIdx);
+        chatWidget->scrollToLine(msg);
+
+        auto text = qobject_cast<Text*>(msg->getContent(1));
+        text->visibilityChanged(true);
+        text->selectText(result.exp, std::make_pair(result.start, result.len));
+    });
 }
 
 void GenericChatForm::renderMessage(ChatLogIdx idx)

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -934,17 +934,7 @@ void GenericChatForm::onSearchTriggered()
 
 void GenericChatForm::searchInBegin(const QString& phrase, const ParameterSearch& parameter)
 {
-    if (phrase.isEmpty()) {
-        disableSearchText();
-
-        return;
-    }
-
-    if (chatLog.getNextIdx().get() == messages.rbegin()->first.get() + 1) {
-        disableSearchText();
-    } else {
-        goToCurrentDate();
-    }
+    disableSearchText();
 
     if (!parameter.time.isNull()) {
         LoadHistoryDialog::LoadType type = (parameter.period == PeriodSearch::BeforeDate)
@@ -996,7 +986,7 @@ void GenericChatForm::onSearchUp(const QString& phrase, const ParameterSearch& p
 
 void GenericChatForm::onSearchDown(const QString& phrase, const ParameterSearch& parameter)
 {
-    auto result = chatLog.searchForward(searchPos, phrase, parameter);
+    auto result = chatLog.searchForward(searchPos, phrase, parameter);    
 
     if (result.found && result.pos.logIdx.get() > messages.end()->first.get()) {
         const auto dt = chatLog.at(result.pos.logIdx).getTimestamp();

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -652,47 +652,16 @@ void GenericChatForm::loadHistory(const QDateTime &time, const LoadHistoryDialog
     chatWidget->clear();
     messages.clear();
 
+    auto begin = firstItemAfterDate(time.date(), chatLog);
+    auto end = ChatLogIdx(begin.get() + 1);
+
+    renderMessages(begin, end);
+
     if (type == LoadHistoryDialog::from) {
-        loadHistoryFrom(time);
-        auto msg = messages.cbegin()->second;
-        chatWidget->scrollToLine(msg);
+        loadHistoryUpper();
     } else {
-        loadHistoryTo(time);
+        loadHistoryLower();
     }
-}
-
-void GenericChatForm::loadHistoryTo(const QDateTime &time)
-{
-    auto end = ChatLogIdx(0);
-    if (time.isNull()) {
-        end = messages.begin()->first;
-    } else {
-        end = firstItemAfterDate(time.date(), chatLog);
-    }
-
-    auto begin = ChatLogIdx(0);
-    if (end.get() > 100) {
-        begin = ChatLogIdx(end.get() - 100);
-    }
-
-    renderMessages(begin, end);
-}
-
-void GenericChatForm::loadHistoryFrom(const QDateTime &time)
-{
-    auto begin = ChatLogIdx(0);
-    if (time.isNull()) {
-        begin = messages.rbegin()->first;
-    } else {
-        begin = firstItemAfterDate(time.date(), chatLog);
-    }
-
-    int add = 100;
-    if (begin.get() + 100 > chatLog.getNextIdx().get()) {
-        add = chatLog.getNextIdx().get() - (begin.get() + 100);
-    }
-    auto end = ChatLogIdx(begin.get() + add);
-    renderMessages(begin, end);
 }
 
 
@@ -1048,14 +1017,25 @@ void GenericChatForm::goToCurrentDate()
 
 void GenericChatForm::loadHistoryLower()
 {
-    loadHistoryTo(QDateTime());
+    auto end = messages.begin()->first;
+    auto begin = ChatLogIdx(0);
+    if (end.get() > 100) {
+        begin = ChatLogIdx(end.get() - 100);
+    }
+
+    renderMessages(begin, end);
 }
 
 void GenericChatForm::loadHistoryUpper()
 {
-    auto msg = messages.crbegin()->second;
-    loadHistoryFrom(QDateTime());
-    chatWidget->scrollToLine(msg);
+    auto begin = messages.rbegin()->first;
+
+    int add = 100;
+    if (begin.get() + 100 > chatLog.getNextIdx().get()) {
+        add = chatLog.getNextIdx().get() - (begin.get() + 100);
+    }
+    auto end = ChatLogIdx(begin.get() + add);
+    renderMessages(begin, end);
 }
 
 void GenericChatForm::updateShowDateInfo(const ChatLine::Ptr& prevLine, const ChatLine::Ptr& topLine)

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -259,7 +259,7 @@ GenericChatForm::GenericChatForm(const Contact* contact, IChatLog& chatLog,
     headWidget = new ChatFormHeader();
     searchForm = new SearchForm();
     dateInfo = new QLabel(this);
-    chatWidget = new ChatLog(contact->useHistory(), this);
+    chatWidget = new ChatLog(this);
     chatWidget->setBusyNotification(ChatMessage::createBusyNotification());
     searchForm->hide();
     dateInfo->setAlignment(Qt::AlignHCenter);
@@ -698,6 +698,7 @@ void GenericChatForm::loadHistoryFrom(const QDateTime &time)
 
     int add = DEF_NUM_MSG_TO_LOAD;
     if (begin.get() + DEF_NUM_MSG_TO_LOAD > chatLog.getNextIdx().get()) {
+        auto aTest = chatLog.getNextIdx().get();
         add = chatLog.getNextIdx().get() - begin.get();
     }
     auto end = ChatLogIdx(begin.get() + add);

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -986,13 +986,7 @@ void GenericChatForm::onSearchUp(const QString& phrase, const ParameterSearch& p
 
 void GenericChatForm::onSearchDown(const QString& phrase, const ParameterSearch& parameter)
 {
-    auto result = chatLog.searchForward(searchPos, phrase, parameter);    
-
-    if (result.found && result.pos.logIdx.get() > messages.end()->first.get()) {
-        const auto dt = chatLog.at(result.pos.logIdx).getTimestamp();
-        loadHistory(dt, LoadHistoryDialog::from);
-    }
-
+    auto result = chatLog.searchForward(searchPos, phrase, parameter);
     handleSearchResult(result, SearchDirection::Down);
 }
 
@@ -1014,7 +1008,6 @@ void GenericChatForm::handleSearchResult(SearchResult result, SearchDirection di
         chatWidget->scrollToLine(msg);
 
         auto text = qobject_cast<Text*>(msg->getContent(1));
-        text->visibilityChanged(true);
         text->selectText(result.exp, std::make_pair(result.start, result.len));
     });
 }

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -1088,10 +1088,6 @@ void GenericChatForm::loadHistoryLower()
 
 void GenericChatForm::loadHistoryUpper()
 {
-    if (messages.empty()) {
-        return;
-    }
-
     auto msg = messages.crbegin()->second;
     loadHistoryFrom(QDateTime());
     chatWidget->scrollToLine(msg);

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -805,22 +805,12 @@ void GenericChatForm::onLoadHistory()
 {
     LoadHistoryDialog dlg(&chatLog);
     if (dlg.exec()) {
+        QDateTime time = dlg.getFromDate();
+        auto idx = firstItemAfterDate(dlg.getFromDate().date(), chatLog);
+        auto end = ChatLogIdx(idx.get() + 100);
         chatWidget->clear();
         messages.clear();
-
-        QDateTime time = dlg.getFromDate();
-        auto type = dlg.getLoadType();
-
-        auto begin = firstItemAfterDate(dlg.getFromDate().date(), chatLog);
-        auto end = ChatLogIdx(begin.get() + 1);
-
-        renderMessages(begin, end);
-
-        if (type == LoadHistoryDialog::from) {
-            loadHistoryUpper();
-        } else {
-            loadHistoryLower();
-        }
+        renderMessages(idx, end);
     }
 }
 
@@ -990,13 +980,15 @@ void GenericChatForm::renderMessages(ChatLogIdx begin, ChatLogIdx end,
 
 void GenericChatForm::loadHistoryLower()
 {
-    auto end = messages.begin()->first;
-    auto begin = ChatLogIdx(0);
-    if (end.get() > 100) {
-        begin = ChatLogIdx(end.get() - 100);
+    auto begin = messages.begin()->first;
+
+    if (begin.get() > 100) {
+        begin = ChatLogIdx(begin.get() - 100);
+    } else {
+        begin = ChatLogIdx(0);
     }
 
-    renderMessages(begin, end);
+    renderMessages(begin, chatLog.getNextIdx());
 }
 
 void GenericChatForm::loadHistoryUpper()

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -37,6 +37,7 @@
 #include "src/widget/contentlayout.h"
 #include "src/widget/emoticonswidget.h"
 #include "src/widget/form/chatform.h"
+#include "src/widget/form/loadhistorydialog.h"
 #include "src/widget/maskablepixmapwidget.h"
 #include "src/widget/searchform.h"
 #include "src/widget/style.h"
@@ -640,23 +641,6 @@ QDateTime GenericChatForm::getTime(const ChatLine::Ptr &chatLine) const
     return QDateTime();
 }
 
-void GenericChatForm::loadHistory(const QDateTime &time, const LoadHistoryDialog::LoadType type)
-{
-    chatWidget->clear();
-    messages.clear();
-
-    auto begin = firstItemAfterDate(time.date(), chatLog);
-    auto end = ChatLogIdx(begin.get() + 1);
-
-    renderMessages(begin, end);
-
-    if (type == LoadHistoryDialog::from) {
-        loadHistoryUpper();
-    } else {
-        loadHistoryLower();
-    }
-}
-
 
 void GenericChatForm::disableSearchText()
 {
@@ -821,10 +805,22 @@ void GenericChatForm::onLoadHistory()
 {
     LoadHistoryDialog dlg(&chatLog);
     if (dlg.exec()) {
+        chatWidget->clear();
+        messages.clear();
+
         QDateTime time = dlg.getFromDate();
         auto type = dlg.getLoadType();
 
-        loadHistory(time, type);
+        auto begin = firstItemAfterDate(dlg.getFromDate().date(), chatLog);
+        auto end = ChatLogIdx(begin.get() + 1);
+
+        renderMessages(begin, end);
+
+        if (type == LoadHistoryDialog::from) {
+            loadHistoryUpper();
+        } else {
+            loadHistoryLower();
+        }
     }
 }
 
@@ -871,12 +867,6 @@ void GenericChatForm::searchInBegin(const QString& phrase, const ParameterSearch
 {
     disableSearchText();
 
-    if (!parameter.time.isNull()) {
-        LoadHistoryDialog::LoadType type = (parameter.period == PeriodSearch::BeforeDate)
-                ? LoadHistoryDialog::to : LoadHistoryDialog::from;
-        loadHistory(parameter.time, type);
-    }
-
     bool bForwardSearch = false;
     switch (parameter.period) {
     case PeriodSearch::WithTheFirst: {
@@ -894,13 +884,13 @@ void GenericChatForm::searchInBegin(const QString& phrase, const ParameterSearch
     }
     case PeriodSearch::AfterDate: {
         bForwardSearch = true;
-        searchPos.logIdx = firstItemAfterDate(parameter.time.date(), chatLog);
+        searchPos.logIdx = firstItemAfterDate(parameter.date, chatLog);
         searchPos.numMatches = 0;
         break;
     }
     case PeriodSearch::BeforeDate: {
         bForwardSearch = false;
-        searchPos.logIdx = firstItemAfterDate(parameter.time.date(), chatLog);
+        searchPos.logIdx = firstItemAfterDate(parameter.date, chatLog);
         searchPos.numMatches = 0;
         break;
     }
@@ -1011,7 +1001,7 @@ void GenericChatForm::loadHistoryLower()
 
 void GenericChatForm::loadHistoryUpper()
 {
-    auto begin = messages.rbegin()->first;
+    auto begin = messages.end()->first;
 
     int add = 100;
     if (begin.get() + 100 > chatLog.getNextIdx().get()) {

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -199,6 +199,10 @@ protected:
     SearchPos searchPos;
     std::map<ChatLogIdx, ChatMessage::Ptr> messages;
     bool colorizeNames = false;
+
+private:
+    const int maxMessages{300};
+    const int optimalRemove{50};
 };
 
 #endif // GENERICCHATFORM_H

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -127,7 +127,6 @@ protected slots:
                         std::function<void(void)> onCompletion = std::function<void(void)>());
 
     void loadHistoryLower();
-    void loadHistoryUpper();
 
 private:
     void retranslateUi();

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -23,7 +23,6 @@
 #include "src/chatlog/chatmessage.h"
 #include "src/core/toxpk.h"
 #include "src/model/ichatlog.h"
-#include "src/widget/form/loadhistorydialog.h"
 #include "src/widget/searchtypes.h"
 
 #include <QMenu>
@@ -134,7 +133,6 @@ private:
     void retranslateUi();
     void addSystemDateMessage(const QDate& date);
     QDateTime getTime(const ChatLine::Ptr& chatLine) const;
-    void loadHistory(const QDateTime& time, const LoadHistoryDialog::LoadType type);
 
 protected:
     ChatMessage::Ptr createMessage(const ToxPk& author, const QString& message,

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -126,7 +126,6 @@ protected slots:
     void renderMessage(ChatLogIdx idx);
     void renderMessages(ChatLogIdx begin, ChatLogIdx end,
                         std::function<void(void)> onCompletion = std::function<void(void)>());
-    void goToCurrentDate();
 
     void loadHistoryLower();
     void loadHistoryUpper();
@@ -166,7 +165,6 @@ protected:
     QAction* searchAction;
     QAction* loadHistoryAction;
     QAction* exportChatAction;
-    QAction* goCurrentDateAction;
 
     QMenu menu;
 

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -137,7 +137,7 @@ private:
     QDateTime getTime(const ChatLine::Ptr& chatLine) const;
     void loadHistory(const QDateTime& time, const LoadHistoryDialog::LoadType type);
     void loadHistoryTo(const QDateTime& time);
-    bool loadHistoryFrom(const QDateTime& time);
+    void loadHistoryFrom(const QDateTime& time);
     void removeFirstsMessages(const int num);
     void removeLastsMessages(const int num);
 

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -138,8 +138,6 @@ private:
     void loadHistory(const QDateTime& time, const LoadHistoryDialog::LoadType type);
     void loadHistoryTo(const QDateTime& time);
     void loadHistoryFrom(const QDateTime& time);
-    void removeFirstsMessages(const int num);
-    void removeLastsMessages(const int num);
 
 protected:
     ChatMessage::Ptr createMessage(const ToxPk& author, const QString& message,
@@ -199,10 +197,6 @@ protected:
     SearchPos searchPos;
     std::map<ChatLogIdx, ChatMessage::Ptr> messages;
     bool colorizeNames = false;
-
-private:
-    const int maxMessages{300};
-    const int optimalRemove{50};
 };
 
 #endif // GENERICCHATFORM_H

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -156,7 +156,6 @@ protected:
     virtual void resizeEvent(QResizeEvent* event) final override;
     virtual bool eventFilter(QObject* object, QEvent* event) final override;
     void disableSearchText();
-    void enableSearchText();
     bool searchInText(const QString& phrase, const ParameterSearch& parameter, SearchDirection direction);
     std::pair<int, int> indexForSearchInLine(const QString& txt, const QString& phrase, const ParameterSearch& parameter, SearchDirection direction);
 
@@ -197,7 +196,7 @@ protected:
 
     IChatLog& chatLog;
     IMessageDispatcher& messageDispatcher;
-    SearchResult searchResult;
+    SearchPos searchPos;
     std::map<ChatLogIdx, ChatMessage::Ptr> messages;
     bool colorizeNames = false;
 };

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -136,8 +136,6 @@ private:
     void addSystemDateMessage(const QDate& date);
     QDateTime getTime(const ChatLine::Ptr& chatLine) const;
     void loadHistory(const QDateTime& time, const LoadHistoryDialog::LoadType type);
-    void loadHistoryTo(const QDateTime& time);
-    void loadHistoryFrom(const QDateTime& time);
 
 protected:
     ChatMessage::Ptr createMessage(const ToxPk& author, const QString& message,

--- a/src/widget/form/loadhistorydialog.cpp
+++ b/src/widget/form/loadhistorydialog.cpp
@@ -38,15 +38,11 @@ LoadHistoryDialog::LoadHistoryDialog(const IChatLog* chatLog, QWidget* parent)
             &LoadHistoryDialog::highlightDates);
 }
 
-LoadHistoryDialog::LoadHistoryDialog(Mode mode, QWidget* parent)
+LoadHistoryDialog::LoadHistoryDialog(QWidget* parent)
     : QDialog(parent)
     , ui(new Ui::LoadHistoryDialog)
 {
     ui->setupUi(this);
-
-    if (mode == Mode::search) {
-        enableSearchMode();
-    }
 }
 
 LoadHistoryDialog::~LoadHistoryDialog()
@@ -75,7 +71,7 @@ LoadHistoryDialog::LoadType LoadHistoryDialog::getLoadType()
     return LoadType::to;
 }
 
-void LoadHistoryDialog::enableSearchMode()
+void LoadHistoryDialog::turnSearchMode()
 {
     setWindowTitle(tr("Select Date Dialog"));
     ui->fromLabel->setText(tr("Select a date"));

--- a/src/widget/form/loadhistorydialog.cpp
+++ b/src/widget/form/loadhistorydialog.cpp
@@ -62,15 +62,6 @@ QDateTime LoadHistoryDialog::getFromDate()
     return res;
 }
 
-LoadHistoryDialog::LoadType LoadHistoryDialog::getLoadType()
-{
-    if (ui->loadTypeComboBox->currentIndex() == 0) {
-        return LoadType::from;
-    }
-
-    return LoadType::to;
-}
-
 void LoadHistoryDialog::setTitle(const QString& title)
 {
     setWindowTitle(title);

--- a/src/widget/form/loadhistorydialog.cpp
+++ b/src/widget/form/loadhistorydialog.cpp
@@ -71,12 +71,14 @@ LoadHistoryDialog::LoadType LoadHistoryDialog::getLoadType()
     return LoadType::to;
 }
 
-void LoadHistoryDialog::turnSearchMode()
+void LoadHistoryDialog::setTitle(const QString& title)
 {
-    setWindowTitle(tr("Select Date Dialog"));
-    ui->fromLabel->setText(tr("Select a date"));
-    ui->loadTypeComboBox->setVisible(false);
-    ui->infoLabel->setVisible(false);
+    setWindowTitle(title);
+}
+
+void LoadHistoryDialog::setInfoLabel(const QString& info)
+{
+    ui->fromLabel->setText(info);
 }
 
 void LoadHistoryDialog::highlightDates(int year, int month)

--- a/src/widget/form/loadhistorydialog.h
+++ b/src/widget/form/loadhistorydialog.h
@@ -45,7 +45,8 @@ public:
 
     QDateTime getFromDate();
     LoadType getLoadType();
-    void turnSearchMode();
+    void setTitle(const QString& title);
+    void setInfoLabel(const QString& info);
 
 public slots:
     void highlightDates(int year, int month);

--- a/src/widget/form/loadhistorydialog.h
+++ b/src/widget/form/loadhistorydialog.h
@@ -39,24 +39,18 @@ public:
         to
     };
 
-    enum Mode {
-        common,
-        search
-    };
-
     explicit LoadHistoryDialog(const IChatLog* chatLog, QWidget* parent = nullptr);
-    explicit LoadHistoryDialog(Mode mode, QWidget* parent = nullptr);
+    explicit LoadHistoryDialog(QWidget* parent = nullptr);
     ~LoadHistoryDialog();
 
     QDateTime getFromDate();
     LoadType getLoadType();
+    void turnSearchMode();
 
 public slots:
     void highlightDates(int year, int month);
 
 private:
-    void enableSearchMode();
-
     Ui::LoadHistoryDialog* ui;
     const IChatLog* chatLog;
 };

--- a/src/widget/form/loadhistorydialog.h
+++ b/src/widget/form/loadhistorydialog.h
@@ -34,17 +34,11 @@ class LoadHistoryDialog : public QDialog
     Q_OBJECT
 
 public:
-    enum LoadType {
-        from,
-        to
-    };
-
     explicit LoadHistoryDialog(const IChatLog* chatLog, QWidget* parent = nullptr);
     explicit LoadHistoryDialog(QWidget* parent = nullptr);
     ~LoadHistoryDialog();
 
     QDateTime getFromDate();
-    LoadType getLoadType();
     void setTitle(const QString& title);
     void setInfoLabel(const QString& info);
 

--- a/src/widget/form/loadhistorydialog.ui
+++ b/src/widget/form/loadhistorydialog.ui
@@ -41,7 +41,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="infoLabel">
+      <widget class="QLabel" name="label">
        <property name="text">
         <string>(about 100 messages are loaded)</string>
        </property>

--- a/src/widget/form/loadhistorydialog.ui
+++ b/src/widget/form/loadhistorydialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>410</width>
-    <height>332</height>
+    <width>347</width>
+    <height>264</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,60 +16,22 @@
   <property name="modal">
    <bool>true</bool>
   </property>
-  <layout class="QFormLayout" name="formLayout">
-   <item row="0" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QLabel" name="fromLabel">
-       <property name="text">
-        <string>Load history</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="loadTypeComboBox">
-       <item>
-        <property name="text">
-         <string>from</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>to</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>(about 100 messages are loaded)</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>17</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
+  <layout class="QVBoxLayout" name="verticalLayout_3">
+   <item>
+    <widget class="QLabel" name="fromLabel">
+     <property name="text">
+      <string>Load history from:</string>
+     </property>
+    </widget>
    </item>
-   <item row="1" column="0">
+   <item>
     <widget class="QCalendarWidget" name="fromDate">
      <property name="gridVisible">
       <bool>false</bool>
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>

--- a/src/widget/form/searchsettingsform.cpp
+++ b/src/widget/form/searchsettingsform.cpp
@@ -86,7 +86,7 @@ ParameterSearch SearchSettingsForm::getParameterSearch()
         break;
     }
 
-    ps.time = startTime;
+    ps.date = startDate;
     ps.isUpdate = isUpdate;
     isUpdate = false;
 
@@ -101,7 +101,7 @@ void SearchSettingsForm::reloadTheme()
 
 void SearchSettingsForm::updateStartDateLabel()
 {
-    ui->startDateLabel->setText(startTime.toString(Settings::getInstance().getDateFormat()));
+    ui->startDateLabel->setText(startDate.toString(Settings::getInstance().getDateFormat()));
 }
 
 void SearchSettingsForm::setUpdate(const bool isUpdate)
@@ -119,8 +119,8 @@ void SearchSettingsForm::onStartSearchSelected(const int index)
         ui->choiceDateButton->setProperty("state", QStringLiteral("green"));
         ui->choiceDateButton->setStyleSheet(Style::getStylesheet(QStringLiteral("chatForm/buttons.css")));
 
-        if (startTime.isNull()) {
-            startTime = QDateTime::currentDateTime();
+        if (startDate.isNull()) {
+            startDate = QDate::currentDate();
             updateStartDateLabel();
         }
 
@@ -162,9 +162,10 @@ void SearchSettingsForm::onRegularClicked(const bool checked)
 void SearchSettingsForm::onChoiceDate()
 {
     LoadHistoryDialog dlg;
-    dlg.turnSearchMode();
+    dlg.setTitle(tr("Select Date Dialog"));
+    dlg.setInfoLabel(tr("Select a date"));
     if (dlg.exec()) {
-        startTime = dlg.getFromDate();
+        startDate = dlg.getFromDate().date();
         updateStartDateLabel();
     }
 

--- a/src/widget/form/searchsettingsform.cpp
+++ b/src/widget/form/searchsettingsform.cpp
@@ -161,7 +161,8 @@ void SearchSettingsForm::onRegularClicked(const bool checked)
 
 void SearchSettingsForm::onChoiceDate()
 {
-    LoadHistoryDialog dlg(LoadHistoryDialog::search);
+    LoadHistoryDialog dlg;
+    dlg.turnSearchMode();
     if (dlg.exec()) {
         startTime = dlg.getFromDate();
         updateStartDateLabel();

--- a/src/widget/form/searchsettingsform.h
+++ b/src/widget/form/searchsettingsform.h
@@ -40,7 +40,7 @@ public:
 
 private:
     Ui::SearchSettingsForm *ui;
-    QDateTime startTime;
+    QDate startDate;
     bool isUpdate{false};
 
     void updateStartDateLabel();

--- a/src/widget/searchtypes.h
+++ b/src/widget/searchtypes.h
@@ -48,13 +48,13 @@ enum class SearchDirection {
 struct ParameterSearch {
     FilterSearch filter{FilterSearch::None};
     PeriodSearch period{PeriodSearch::None};
-    QDateTime time;
+    QDate date;
     bool isUpdate{false};
 
     bool operator ==(const ParameterSearch& other) {
         return filter == other.filter &&
             period == other.period &&
-            time == other.time;
+            date == other.date;
     }
 
     bool operator !=(const ParameterSearch& other) {


### PR DESCRIPTION
- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

This resolves a large number of chatlog issues, mostly reverting chatlog GUI behaviour to v1.16.3. This removes the following features
1) messages being removed from chatog when messages are added, if the chatlog is large.
1) messages being removed from chatlog when loading history by date.
1) messages being removed from chatlog when searching.

The following functionality is still present in that area
1) scrolling up to top of chatlog loads more history above.
1) loading history by date, but just adds messages from [date, current] rather than [date, just after date]
1) searching, but again loads messages from [found, current] rather than [found, just after found]

The plan for this PR is to merge `v1.17-dev` to `master` first, then merge this PR to `v1.17-dev`, then merge `v1.17-dev` to `master` again, but take master everywhere. This means the backout will only be present for `v1.17.x` release(s), but not on master or v1.18.0. So the longer term plan is still to keep these features and fix the associated problems with them, after the `v1.17.0` release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6070)
<!-- Reviewable:end -->
