### PR TITLE
fix(chatlog): fixed rendering of new messages when scrolling up

### DIFF
--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -410,6 +410,8 @@ void ChatLog::insertChatlineAtBottom(const QList<ChatLine::Ptr>& newLines)
     // redo layout only when scrolled down
     if(stickToBottom()) {
         startResizeWorker(true);
+    } else {
+        updateSceneRect();
     }
 }
 


### PR DESCRIPTION
This PR fixes [6025](https://github.com/qTox/qTox/issues/6025)

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6074)
<!-- Reviewable:end -->
