### PR TITLE
fix(avatar): reject avatars that are larger than 64KB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -370,6 +370,7 @@ set(${PROJECT_NAME}_SOURCES
   src/model/sessionchatlog.cpp
   src/model/chathistory.h
   src/model/chathistory.cpp
+  src/model/toxclientstandards.h
   src/net/bootstrapnodeupdater.cpp
   src/net/bootstrapnodeupdater.h
   src/net/avatarbroadcaster.cpp

--- a/src/core/corefile.cpp
+++ b/src/core/corefile.cpp
@@ -24,6 +24,7 @@
 #include "toxstring.h"
 #include "src/persistence/settings.h"
 #include "src/model/status.h"
+#include "src/model/toxclientstandards.h"
 #include <QDebug>
 #include <QDir>
 #include <QFile>
@@ -330,6 +331,13 @@ void CoreFile::onFileReceiveCallback(Tox* tox, uint32_t friendId, uint32_t fileI
             emit core->friendAvatarRemoved(core->getFriendPublicKey(friendId));
             return;
         } else {
+            if (!ToxClientStandards::IsValidAvatarSize(filesize)) {
+                qWarning() <<
+                    QString("Received avatar request from %1 with size %2.").arg(friendId).arg(filesize) +
+                    QString(" The max size allowed for avatars is %3. Cancelling transfer.").arg(ToxClientStandards::MaxAvatarSize);
+                tox_file_control(tox, friendId, fileId, TOX_FILE_CONTROL_CANCEL, nullptr);
+                return;
+            }
             static_assert(TOX_HASH_LENGTH <= TOX_FILE_ID_LENGTH,
                           "TOX_HASH_LENGTH > TOX_FILE_ID_LENGTH!");
             uint8_t avatarHash[TOX_FILE_ID_LENGTH];

--- a/src/model/profile/profileinfo.cpp
+++ b/src/model/profile/profileinfo.cpp
@@ -22,6 +22,7 @@
 #include "src/nexus.h"
 #include "src/persistence/profile.h"
 #include "src/persistence/settings.h"
+#include "src/model/toxclientstandards.h"
 
 #include <QApplication>
 #include <QBuffer>
@@ -358,13 +359,11 @@ IProfileInfo::SetAvatarResult ProfileInfo::byteArrayToPng(QByteArray inData, QBy
  */
 IProfileInfo::SetAvatarResult ProfileInfo::scalePngToAvatar(QByteArray& avatar)
 {
-    // https://tox.gitbooks.io/tox-client-standard/content/user_identification/avatar.html
-    constexpr int maxSize = 65535;
     // We do a first rescale to 256x256 in case the image was huge, then keep tryng from here
     constexpr int scaleSizes[] = {256, 128, 64, 32};
 
     for (auto scaleSize : scaleSizes) {
-        if (avatar.size() <= maxSize)
+        if (ToxClientStandards::IsValidAvatarSize(avatar.size()))
             break;
         QImage image;
         image.loadFromData(avatar);
@@ -373,7 +372,7 @@ IProfileInfo::SetAvatarResult ProfileInfo::scalePngToAvatar(QByteArray& avatar)
     }
 
     // If this happens, you're really doing it on purpose.
-    if (avatar.size() > maxSize) {
+    if (!ToxClientStandards::IsValidAvatarSize(avatar.size())) {
         return SetAvatarResult::TooLarge;
     }
     return SetAvatarResult::OK;

--- a/src/model/toxclientstandards.h
+++ b/src/model/toxclientstandards.h
@@ -1,0 +1,35 @@
+/*
+    Copyright © 2020 by The qTox Project Contributors
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef TOXCLIENTSTANDARDS_H
+#define TOXCLIENTSTANDARDS_H
+
+#include <cstdint>
+
+namespace ToxClientStandards
+{
+    // From TCS 2.2.4, max valid avatar size is 64KiB
+    constexpr static uint64_t MaxAvatarSize = 64 * 1024;
+    constexpr bool IsValidAvatarSize(uint64_t fileSize)
+    {
+        return fileSize <= MaxAvatarSize;
+    }
+} // ToxClientStandards
+
+#endif // TOXCLIENTSTANDARDS_H


### PR DESCRIPTION
This will prevent qTox from auto-accepting arbitrarily large avatars. Avatars
are already limited by TCS 2.2.4 to 64KB, so we would only receive larger
avatars from badly behaving clients.


- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6075)
<!-- Reviewable:end -->
