### PR TITLE
chore(build): stop using removed cmake options

### DIFF
--- a/.travis/build-ubuntu-16-04.sh
+++ b/.travis/build-ubuntu-16-04.sh
@@ -165,8 +165,6 @@ build_qtox() {
     echo '*** BUILDING "MINIMAL" VERSION ***'
     cmake -H. -B"$BUILDDIR" \
         -DSMILEYS=DISABLED \
-        -DENABLE_STATUSNOTIFIER=False \
-        -DENABLE_GTK_SYSTRAY=False \
         -DSPELL_CHECK=OFF
 
     bdir

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -611,10 +611,6 @@ endif()
 
 add_definitions(-DQT_MESSAGELOGCONTEXT=1)
 
-if (NOT DEFINED ENABLE_STATUSNOTIFIER AND UNIX AND NOT APPLE)
-  set(ENABLE_STATUSNOTIFIER True)
-endif()
-
 if(AVFOUNDATION_FOUND)
   set(${PROJECT_NAME}_SOURCES ${${PROJECT_NAME}_SOURCES}
     src/platform/camera/avfoundation.mm


### PR DESCRIPTION
Options were removed in https://github.com/qTox/qTox/pull/5888

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6082)
<!-- Reviewable:end -->
