### PR TITLE
fix(build): disable Werror by default, keep enabled on CI

### DIFF
--- a/.travis/build-ubuntu-16-04.sh
+++ b/.travis/build-ubuntu-16-04.sh
@@ -167,6 +167,7 @@ build_qtox() {
         -DSMILEYS=DISABLED \
         -DENABLE_STATUSNOTIFIER=False \
         -DENABLE_GTK_SYSTRAY=False \
+        -DSTRICT_OPTIONS=ON \
         -DSPELL_CHECK=OFF
 
     bdir
@@ -175,7 +176,9 @@ build_qtox() {
     rm -rf "$BUILDDIR"
 
     echo '*** BUILDING "FULL" VERSION ***'
-    cmake -H. -B"$BUILDDIR" -DUPDATE_CHECK=ON
+    cmake -H. -B"$BUILDDIR" \
+        -DUPDATE_CHECK=ON \
+        -DSTRICT_OPTIONS=ON
     bdir
 }
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ option(SPELL_CHECK "Enable spell cheching support" ON)
 option(SVGZ_ICON "Compress the SVG icon of qTox" ON)
 option(ASAN "Compile with AddressSanitizer" OFF)
 option(DESKTOP_NOTIFICATIONS "Use snorenotify for desktop notifications" OFF)
+option(STRICT_OPTIONS "Enable strict compile options, used by CI" OFF)
 
 # process generated files if cmake >= 3.10
 if(POLICY CMP0071)
@@ -84,12 +85,16 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
 set(POSITION_INDEPENDENT_CODE True)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wstrict-overflow")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wstrict-aliasing")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+
+# Extra-strict compile options that we don't want to subject all users to by default
+if (STRICT_OPTIONS)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+endif()
 
 # avoid timestamps in binary for reproducible builds, not added until GCC 4.9
 include(CheckCXXCompilerFlag)
 CHECK_CXX_COMPILER_FLAG(-Wdate-time COMPILER_SUPPORTS_WDATE_TIME)
-if(COMPILER_SUPPORTS_WDATE_TIME)
+if (COMPILER_SUPPORTS_WDATE_TIME)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wdate-time")
 endif()
 

--- a/appimage/build.sh
+++ b/appimage/build.sh
@@ -107,6 +107,7 @@ cd _build
 # need to build with -DDESKTOP_NOTIFICATIONS=True for snorenotify
 cmake -DDESKTOP_NOTIFICATIONS=True \
       -DUPDATE_CHECK=True \
+      -DSTRICT_OPTIONS=True \
       ../
 
 make

--- a/flatpak/io.github.qtox.qTox.json
+++ b/flatpak/io.github.qtox.qTox.json
@@ -133,7 +133,10 @@
         {
             "name": "qTox",
             "buildsystem": "cmake-ninja",
-            "config-opts": ["-DSVGZ_ICON=OFF"],
+            "config-opts": [
+                "-DSVGZ_ICON=OFF",
+                "-DSTRICT_OPTIONS=ON"
+            ],
             "sources": [
                 {
                     "type": "dir",
@@ -143,4 +146,3 @@
         }
     ]
 }
-

--- a/osx/qTox-Mac-Deployer-ULTIMATE.sh
+++ b/osx/qTox-Mac-Deployer-ULTIMATE.sh
@@ -262,7 +262,14 @@ build() {
     fcho "Now working in ${PWD}"
     fcho "Starting cmake ..."
     export CMAKE_PREFIX_PATH=$(brew --prefix qt5)
-    cmake -H$QTOX_DIR -B. -DUPDATE_CHECK=ON -DSPELL_CHECK=OFF
+
+    if [[ $TRAVIS = true ]]
+    then
+        STRICT_OPTIONS="ON"
+    else
+        STRICT_OPTIONS="OFF"
+    fi
+    cmake -H$QTOX_DIR -B. -DUPDATE_CHECK=ON -DSPELL_CHECK=OFF -DSTRICT_OPTIONS="${STRICT_OPTIONS}"
     make -j$(sysctl -n hw.ncpu)
 }
 

--- a/windows/cross-compile/build.sh
+++ b/windows/cross-compile/build.sh
@@ -977,6 +977,7 @@ then
         -DCMAKE_BUILD_TYPE=Release \
         -DSPELL_CHECK=OFF \
         -DUPDATE_CHECK=ON \
+        -DSTRICT_OPTIONS=ON \
         ..
 elif [[ "$BUILD_TYPE" == "debug" ]]
 then
@@ -984,6 +985,7 @@ then
         -DCMAKE_BUILD_TYPE=Debug \
         -DSPELL_CHECK=OFF \
         -DUPDATE_CHECK=ON \
+        -DSTRICT_OPTIONS=ON \
         ..
 fi
 


### PR DESCRIPTION
To allow for easier building with different compilers on user systems. Keep
strict checks on CI to make sure new warnings aren't ignored.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6083)
<!-- Reviewable:end -->
