### PR TITLE
Sqlcipher half upgraded fix

### DIFF
--- a/src/persistence/db/rawdatabase.cpp
+++ b/src/persistence/db/rawdatabase.cpp
@@ -175,7 +175,7 @@ bool RawDatabase::open(const QString& path, const QString& hexKey)
     }
 
     if (!hexKey.isEmpty()) {
-        if (!openEncryptedDatabaseAtLatestVersion(hexKey)) {
+        if (!openEncryptedDatabaseAtLatestSupportedVersion(hexKey)) {
             close();
             return false;
         }
@@ -183,31 +183,27 @@ bool RawDatabase::open(const QString& path, const QString& hexKey)
     return true;
 }
 
-bool RawDatabase::openEncryptedDatabaseAtLatestVersion(const QString& hexKey)
+bool RawDatabase::openEncryptedDatabaseAtLatestSupportedVersion(const QString& hexKey)
 {
-    // old qTox database are saved with SQLCipher 3.x defaults. New qTox (and for a period during 1.16.3 master) are stored
-    // with 4.x defaults. We need to support opening both databases saved with 3.x defaults and 4.x defaults
-    // so upgrade from 3.x default to 4.x defaults while we're at it
+    // old qTox database are saved with SQLCipher 3.x defaults. For a period after 1.16.3 but before 1.17.0, databases
+    // could be partially upgraded to SQLCipher 4.0 defaults, since SQLCipher 3.x isn't capable of setitng all the same
+    // params. If SQLCipher 4.x happened to be used, they would have been fully upgraded to 4.0 default params.
+    // We need to support all three of these cases, so also upgrade to the latest possible params while we're here
     if (!setKey(hexKey)) {
         return false;
     }
 
-    if (setCipherParameters(SqlCipherParams::p4_0)) {
+    auto highestSupportedVersion = highestSupportedParams();
+    if (setCipherParameters(highestSupportedVersion)) {
         if (testUsable()) {
-            qInfo() << "Opened database with SQLCipher 4.x parameters";
+            qInfo() << "Opened database with SQLCipher" << toString(highestSupportedVersion) << "parameters";
             return true;
         } else {
-            return updateSavedCipherParameters(hexKey);
+            return updateSavedCipherParameters(hexKey, highestSupportedVersion);
         }
     } else {
-        // setKey again to clear old bad cipher settings
-        if (setKey(hexKey) && setCipherParameters(SqlCipherParams::p3_0) && testUsable()) {
-            qInfo() << "Opened database with SQLCipher 3.x parameters";
-            return true;
-        } else {
-            qCritical() << "Failed to open database with SQLCipher 3.x parameters";
-            return false;
-        }
+        qCritical() << "Failed to set latest supported SQLCipher params!";
+        return false;
     }
 }
 
@@ -220,10 +216,11 @@ bool RawDatabase::testUsable()
 /**
  * @brief Changes stored db encryption from SQLCipher 3.x defaults to 4.x defaults
  */
-bool RawDatabase::updateSavedCipherParameters(const QString& hexKey)
+bool RawDatabase::updateSavedCipherParameters(const QString& hexKey, SqlCipherParams newParams)
 {
+    auto currentParams = readSavedCipherParams(hexKey, newParams);
     setKey(hexKey); // setKey again because a SELECT has already been run, causing crypto settings to take effect
-    if (!setCipherParameters(SqlCipherParams::p3_0)) {
+    if (!setCipherParameters(currentParams)) {
         return false;
     }
 
@@ -231,25 +228,26 @@ bool RawDatabase::updateSavedCipherParameters(const QString& hexKey)
     if (user_version < 0) {
         return false;
     }
-    if (!execNow("ATTACH DATABASE '" + path + ".tmp' AS sqlcipher4 KEY \"x'" + hexKey + "'\";")) {
+    if (!execNow("ATTACH DATABASE '" + path + ".tmp' AS newParams KEY \"x'" + hexKey + "'\";")) {
         return false;
     }
-    if (!setCipherParameters(SqlCipherParams::p4_0, "sqlcipher4")) {
+    if (!setCipherParameters(newParams, "newParams")) {
         return false;
     }
-    if (!execNow("SELECT sqlcipher_export('sqlcipher4');")) {
+    if (!execNow("SELECT sqlcipher_export('newParams');")) {
         return false;
     }
-    if (!execNow(QString("PRAGMA sqlcipher4.user_version = %1;").arg(user_version))) {
+    if (!execNow(QString("PRAGMA newParams.user_version = %1;").arg(user_version))) {
         return false;
     }
-    if (!execNow("DETACH DATABASE sqlcipher4;")) {
+    if (!execNow("DETACH DATABASE newParams;")) {
         return false;
     }
     if (!commitDbSwap(hexKey)) {
         return false;
     }
-    qInfo() << "Upgraded database from SQLCipher 3.x defaults to SQLCipher 4.x defaults";
+    qInfo() << "Upgraded database from SQLCipher" << toString(currentParams) << "params to" <<
+        toString(newParams) << "params complete";
     return true;
 }
 
@@ -290,8 +288,58 @@ bool RawDatabase::setCipherParameters(SqlCipherParams params, const QString& dat
             break;
         }
     }
-    qDebug() << "Setting SQLCipher" << static_cast<int>(params) << "parameters";
+
+    qDebug() << "Setting SQLCipher" << toString(params) << "parameters";
     return execNow(defaultParams.replace("database.", prefix));
+}
+
+RawDatabase::SqlCipherParams RawDatabase::highestSupportedParams()
+{
+    // Note: This is just calling into the sqlcipher library, not touching the database.
+    QString cipherVersion;
+    if (!execNow(RawDatabase::Query("PRAGMA cipher_version", [&](const QVector<QVariant>& row) {
+            cipherVersion = row[0].toString();
+        }))) {
+        qCritical() << "Failed to read cipher_version";
+        return SqlCipherParams::p3_0;
+    }
+
+    auto majorVersion = cipherVersion.split('.')[0].toInt();
+
+    SqlCipherParams highestSupportedParams;
+    switch (majorVersion) {
+        case 3:
+            highestSupportedParams = SqlCipherParams::halfUpgradedTo4;
+            break;
+        case 4:
+            highestSupportedParams = SqlCipherParams::p4_0;
+            break;
+        default:
+            qCritical() << "Unsupported SQLCipher version detected!";
+            return SqlCipherParams::p3_0;
+    }
+    qDebug() << "Highest supported SQLCipher params on this system are" << toString(highestSupportedParams);
+    return highestSupportedParams;
+}
+
+RawDatabase::SqlCipherParams RawDatabase::readSavedCipherParams(const QString& hexKey, SqlCipherParams newParams)
+{
+    for (int i = static_cast<int>(SqlCipherParams::p3_0); i < static_cast<int>(newParams); ++i)
+    {
+        if (!setKey(hexKey)) {
+            break;
+        }
+
+        if (!setCipherParameters(static_cast<SqlCipherParams>(i))) {
+            break;
+        }
+
+        if (testUsable()) {
+            return static_cast<SqlCipherParams>(i);
+        }
+    }
+    qCritical() << "Failed to check saved SQLCipher params";
+    return SqlCipherParams::p3_0;
 }
 
 bool RawDatabase::setKey(const QString& hexKey)

--- a/src/persistence/db/rawdatabase.h
+++ b/src/persistence/db/rawdatabase.h
@@ -136,9 +136,11 @@ protected slots:
 
 private:
     QString anonymizeQuery(const QByteArray& query);
-    bool openEncryptedDatabaseAtLatestVersion(const QString& hexKey);
-    bool updateSavedCipherParameters(const QString& hexKey);
+    bool openEncryptedDatabaseAtLatestSupportedVersion(const QString& hexKey);
+    bool updateSavedCipherParameters(const QString& hexKey, SqlCipherParams newParams);
     bool setCipherParameters(SqlCipherParams params, const QString& database = {});
+    SqlCipherParams highestSupportedParams();
+    SqlCipherParams readSavedCipherParams(const QString& hexKey, SqlCipherParams newParams);
     bool setKey(const QString& hexKey);
     int getUserVersion();
     bool encryptDatabase(const QString& newHexKey);

--- a/src/persistence/db/rawdatabase.h
+++ b/src/persistence/db/rawdatabase.h
@@ -20,6 +20,8 @@
 #ifndef RAWDATABASE_H
 #define RAWDATABASE_H
 
+#include "src/util/strongtype.h"
+
 #include <QByteArray>
 #include <QMutex>
 #include <QPair>
@@ -29,10 +31,11 @@
 #include <QVariant>
 #include <QVector>
 #include <QRegularExpression>
+
 #include <atomic>
+#include <cassert>
 #include <functional>
 #include <memory>
-#include "src/util/strongtype.h"
 
 /// The two following defines are required to use SQLCipher
 /// They are used by the sqlite3.h header
@@ -82,6 +85,16 @@ public:
     };
 
 public:
+    enum class SqlCipherParams {
+        // keep these sorted in upgrade order
+        p3_0, // SQLCipher 3.0 default encryption params
+        // SQLCipher 4.0 default params where SQLCipher 3.0 supports them, but 3.0 params where not possible.
+        // We accidentally got to this state when attemption to update all databases to 4.0 defaults even when using
+        // SQLCipher 3.x, but might as well keep using these for people with SQLCipher 3.x.
+        halfUpgradedTo4,
+        p4_0 // SQLCipher 4.0 default encryption params
+    };
+
     RawDatabase(const QString& path, const QString& password, const QByteArray& salt);
     ~RawDatabase();
     bool isOpen();
@@ -95,6 +108,21 @@ public:
     void execLater(const QVector<Query>& statements);
 
     void sync();
+
+    static QString toString(SqlCipherParams params)
+    {
+        switch (params)
+        {
+        case SqlCipherParams::p3_0:
+            return "3.0 default";
+        case SqlCipherParams::halfUpgradedTo4:
+            return "3.x max compatible";
+        case SqlCipherParams::p4_0:
+            return "4.0 default";
+        }
+        assert(false);
+        return {};
+    }
 
 public slots:
     bool setPassword(const QString& password);
@@ -110,7 +138,7 @@ private:
     QString anonymizeQuery(const QByteArray& query);
     bool openEncryptedDatabaseAtLatestVersion(const QString& hexKey);
     bool updateSavedCipherParameters(const QString& hexKey);
-    bool setCipherParameters(int majorVersion, const QString& database = {});
+    bool setCipherParameters(SqlCipherParams params, const QString& database = {});
     bool setKey(const QString& hexKey);
     int getUserVersion();
     bool encryptDatabase(const QString& newHexKey);


### PR DESCRIPTION
Our previous SQLCiper upgrade code attempted to set SQLCipher 4.0
default params. If SQLCipher 3.x was used at that time, it would result
in only half upgrading the params, since SQLCipher 3.x doesn't support
PRAGMA cipher_hmac_algorithm or PRAGMA cipher_kdf_algorithm. This means
that our databases could be saved with any of three sets of SQLCipher
params.

Fix #5952.
- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6084)
<!-- Reviewable:end -->
