### PR TITLE
chore(ci): don't use git --no-merges for git commit message checking

### DIFF
--- a/verify-commit-messages.sh
+++ b/verify-commit-messages.sh
@@ -36,11 +36,10 @@ ARG="$1"
 echo "" # ← formatting
 
 grep_for_invalid() {
-    # differentiate what is allowed for commit messages and merge messages
-    git log --no-merges --format=format:'%s' "$ARG" \
-        | grep -v -E '^(feat|fix|docs|style|refactor|perf|revert|test|chore)(\(.{,12}\))?:.{1,68}$' \
-        || git log --merges --format=format:'%s' "$ARG" \
-            | grep -v -E '^Merge .{1,70}$'
+    # we can't rely on differentiating merge and normal commits since short clones that travis does may not be able
+    # to tell if the oldest commit is a merge commit or not
+    git log --format=format:'%s' "$ARG" \
+        | grep -v -E '^((feat|fix|docs|style|refactor|perf|revert|test|chore)(\(.{,12}\))?:.{1,68})|(Merge .{1,70})$'
 }
 
 # Conform, /OR ELSE/.


### PR DESCRIPTION
When doing a short clone, like travis does, git can't tell if the
oldest commit is a merge of not. Just allow either commit message
format for all commits, and rely on reviewers and common sense to not
name normal commits "Merge.*"

Fix #6051

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6086)
<!-- Reviewable:end -->
