### PR TITLE
chore(cleanup): don't add semicolon to Q_DECLARE_METATYPE

### DIFF
--- a/test/core/core_test.cpp
+++ b/test/core/core_test.cpp
@@ -29,7 +29,7 @@
 #include <src/persistence/settings.h>
 #include <iostream>
 
-Q_DECLARE_METATYPE(QList<DhtServer>);
+Q_DECLARE_METATYPE(QList<DhtServer>)
 
 class MockSettings : public QObject, public ICoreSettings
 {

--- a/test/net/bsu_test.cpp
+++ b/test/net/bsu_test.cpp
@@ -25,7 +25,7 @@
 #include <QtTest/QtTest>
 
 // Needed to make this type known to Qt
-Q_DECLARE_METATYPE(QList<DhtServer>);
+Q_DECLARE_METATYPE(QList<DhtServer>)
 
 class TestBootstrapNodesUpdater : public QObject
 {


### PR DESCRIPTION
Remove missed cases from ad042b09e00da16c85c0963cef59a841a7417c90.

Fix #6007

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6087)
<!-- Reviewable:end -->
