### PR TITLE
chore(cleanup): replace remaining deprecated toxcore enums with newer…

### DIFF
--- a/src/core/corefile.cpp
+++ b/src/core/corefile.cpp
@@ -146,7 +146,7 @@ void CoreFile::sendFile(uint32_t friendId, QString filename, QString filePath,
     QMutexLocker{coreLoopLock};
 
     ToxString fileName(filename);
-    TOX_ERR_FILE_SEND sendErr;
+    Tox_Err_File_Send sendErr;
     uint32_t fileNum = tox_file_send(tox, friendId, TOX_FILE_KIND_DATA, filesize,
                                      nullptr, fileName.data(), fileName.size(), &sendErr);
     if (sendErr != TOX_ERR_FILE_SEND_OK) {

--- a/src/core/toxencrypt.cpp
+++ b/src/core/toxencrypt.cpp
@@ -186,7 +186,7 @@ std::unique_ptr<ToxEncrypt> ToxEncrypt::makeToxEncrypt(const QString& password, 
         return std::unique_ptr<ToxEncrypt>{};
     }
 
-    TOX_ERR_GET_SALT saltError;
+    Tox_Err_Get_Salt saltError;
     uint8_t salt[TOX_PASS_SALT_LENGTH];
     tox_get_salt(reinterpret_cast<const uint8_t*>(toxSave.constData()), salt, &saltError);
 
@@ -196,7 +196,7 @@ std::unique_ptr<ToxEncrypt> ToxEncrypt::makeToxEncrypt(const QString& password, 
     }
 
     QByteArray pass = password.toUtf8();
-    TOX_ERR_KEY_DERIVATION keyError;
+    Tox_Err_Key_Derivation keyError;
     Tox_Pass_Key* const passKey = tox_pass_key_derive_with_salt(
         reinterpret_cast<const uint8_t*>(pass.constData()),
         static_cast<size_t>(pass.length()), salt, &keyError);


### PR DESCRIPTION
… versions

Some were missed in 5ae738f8184f1afafa9d404b14d8c7ea0a09885d.

Fix #5997

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6088)
<!-- Reviewable:end -->
