### PR TITLE
fix(osx): Add camera and microphone usage description.

### DIFF
--- a/osx/info.plist
+++ b/osx/info.plist
@@ -87,6 +87,10 @@
 	<string>1.16.3</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSCameraUsageDescription</key>
+	<string>$(PRODUCT_NAME) needs access to the camera for video calls.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>$(PRODUCT_NAME) needs access to the microphone for audio calls.</string>
 	<key>UTImportedTypeDeclarations</key>
 	<array>
 		<dict>


### PR DESCRIPTION
NSCameraUsageDescription and NSMicrophoneUsageDescription are needed on
newer macOS versions (10.14+) to get access to camera/microphone. This
text is shown to the user when they need to press the "allow" button.

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6092)
<!-- Reviewable:end -->
