### PR TITLE
chore: remove extra ;

### DIFF
--- a/src/chatlog/chatlinecontent.cpp
+++ b/src/chatlog/chatlinecontent.cpp
@@ -76,7 +76,7 @@ QString ChatLineContent::getSelectedText() const
 
 void ChatLineContent::fontChanged(const QFont& font)
 {
-    Q_UNUSED(font);
+    Q_UNUSED(font)
 }
 
 qreal ChatLineContent::getAscent() const

--- a/src/chatlog/content/broken.cpp
+++ b/src/chatlog/content/broken.cpp
@@ -47,12 +47,12 @@ void Broken::paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
 
 void Broken::setWidth(qreal width)
 {
-    Q_UNUSED(width);
+    Q_UNUSED(width)
 }
 
 void Broken::visibilityChanged(bool visible)
 {
-    Q_UNUSED(visible);
+    Q_UNUSED(visible)
 }
 
 qreal Broken::getAscent() const

--- a/src/chatlog/content/text.cpp
+++ b/src/chatlog/content/text.cpp
@@ -218,8 +218,8 @@ QRectF Text::boundingRect() const
 
 void Text::paint(QPainter* painter, const QStyleOptionGraphicsItem* option, QWidget* widget)
 {
-    Q_UNUSED(option);
-    Q_UNUSED(widget);
+    Q_UNUSED(option)
+    Q_UNUSED(widget)
 
     if (!doc)
         return;

--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -469,7 +469,7 @@ void CoreAV::groupCallCallback(void* tox, uint32_t group, uint32_t peer, const i
      * See https://github.com/TokTok/c-toxcore/issues/1364 for details.
      */
 
-    Q_UNUSED(tox);
+    Q_UNUSED(tox)
     Core* c = static_cast<Core*>(core);
     CoreAV* cav = c->getAv();
 
@@ -746,7 +746,7 @@ void CoreAV::callCallback(ToxAV* toxav, uint32_t friendNum, bool audio, bool vid
 
 void CoreAV::stateCallback(ToxAV* toxav, uint32_t friendNum, uint32_t state, void* vSelf)
 {
-    Q_UNUSED(toxav);
+    Q_UNUSED(toxav)
     CoreAV* self = static_cast<CoreAV*>(vSelf);
 
     // we must unlock this lock before emitting any signals
@@ -807,8 +807,8 @@ void CoreAV::bitrateCallback(ToxAV* toxav, uint32_t friendNum, uint32_t arate, u
                              void* vSelf)
 {
     CoreAV* self = static_cast<CoreAV*>(vSelf);
-    Q_UNUSED(self);
-    Q_UNUSED(toxav);
+    Q_UNUSED(self)
+    Q_UNUSED(toxav)
 
     qDebug() << "Recommended bitrate with" << friendNum << " is now " << arate << "/" << vrate
              << ", ignoring it";
@@ -818,8 +818,8 @@ void CoreAV::bitrateCallback(ToxAV* toxav, uint32_t friendNum, uint32_t arate, u
 void CoreAV::audioBitrateCallback(ToxAV* toxav, uint32_t friendNum, uint32_t rate, void* vSelf)
 {
     CoreAV* self = static_cast<CoreAV*>(vSelf);
-    Q_UNUSED(self);
-    Q_UNUSED(toxav);
+    Q_UNUSED(self)
+    Q_UNUSED(toxav)
 
     qDebug() << "Recommended audio bitrate with" << friendNum << " is now " << rate << ", ignoring it";
 }
@@ -828,8 +828,8 @@ void CoreAV::audioBitrateCallback(ToxAV* toxav, uint32_t friendNum, uint32_t rat
 void CoreAV::videoBitrateCallback(ToxAV* toxav, uint32_t friendNum, uint32_t rate, void* vSelf)
 {
     CoreAV* self = static_cast<CoreAV*>(vSelf);
-    Q_UNUSED(self);
-    Q_UNUSED(toxav);
+    Q_UNUSED(self)
+    Q_UNUSED(toxav)
 
     qDebug() << "Recommended video bitrate with" << friendNum << " is now " << rate << ", ignoring it";
 }

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -388,7 +388,7 @@ bool Settings::applyCommandLineOptions(const QCommandLineParser& parser)
 {
     if (!verifyProxySettings(parser)) {
         return false;
-    };
+    }
 
     QString IPv6Setting = parser.value("I").toUpper();
     QString LANSetting = parser.value("L").toUpper();
@@ -1005,7 +1005,7 @@ void Settings::setAutorun(bool newValue)
         emit autorunChanged(autorun);
     }
 #else
-    Q_UNUSED(newValue);
+    Q_UNUSED(newValue)
 #endif
 }
 
@@ -2145,7 +2145,7 @@ void Settings::setFriendActivity(const ToxPk& id, const QDateTime& activity)
 
 void Settings::saveFriendSettings(const ToxPk& id)
 {
-    Q_UNUSED(id);
+    Q_UNUSED(id)
     savePersonal();
 }
 

--- a/src/video/cameradevice.cpp
+++ b/src/video/cameradevice.cpp
@@ -229,7 +229,7 @@ CameraDevice* CameraDevice::open(QString devName, VideoMode mode)
 #endif
     else if (mode) {
         qWarning().nospace() << "No known options for " << iformat->name << ", using defaults.";
-        Q_UNUSED(mode);
+        Q_UNUSED(mode)
     }
 
     CameraDevice* dev = open(devName, &options);
@@ -447,7 +447,7 @@ QVector<VideoMode> CameraDevice::getScreenModes()
  */
 QVector<VideoMode> CameraDevice::getVideoModes(QString devName)
 {
-    Q_UNUSED(devName);
+    Q_UNUSED(devName)
 
     if (!iformat)
         ;

--- a/src/video/netcamview.cpp
+++ b/src/video/netcamview.cpp
@@ -197,7 +197,7 @@ void NetCamView::setTitle(const QString& title)
 
 void NetCamView::showEvent(QShowEvent* event)
 {
-    Q_UNUSED(event);
+    Q_UNUSED(event)
     selfFrame->resetBoundary(videoSurface->getBoundingRect());
 }
 

--- a/src/video/videosurface.cpp
+++ b/src/video/videosurface.cpp
@@ -201,7 +201,7 @@ void VideoSurface::resizeEvent(QResizeEvent* event)
 
 void VideoSurface::showEvent(QShowEvent* e)
 {
-    Q_UNUSED(e);
+    Q_UNUSED(e)
     // emit ratioChanged();
 }
 

--- a/src/widget/categorywidget.cpp
+++ b/src/widget/categorywidget.cpp
@@ -251,7 +251,7 @@ void CategoryWidget::onCompactChanged(bool _compact)
     topLayout->setSpacing(0);
     topLayout->setMargin(0);
 
-    Q_UNUSED(_compact);
+    Q_UNUSED(_compact)
     setCompact(true);
 
     nameLabel->minimizeMaximumWidth();

--- a/src/widget/form/settings/privacyform.cpp
+++ b/src/widget/form/settings/privacyform.cpp
@@ -127,7 +127,7 @@ void PrivacyForm::on_nospamLineEdit_textChanged()
         str = QString("00000000").replace(0, str.length(), str);
         bodyUI->nospamLineEdit->setText(str);
         bodyUI->nospamLineEdit->setCursorPosition(curs);
-    };
+    }
 }
 
 void PrivacyForm::on_blackListTextEdit_textChanged()

--- a/src/widget/friendlistwidget.cpp
+++ b/src/widget/friendlistwidget.cpp
@@ -295,7 +295,7 @@ void FriendListWidget::addGroupWidget(GroupWidget* widget)
     groupLayout.addSortedWidget(widget);
     Group* g = widget->getGroup();
     connect(g, &Group::titleChanged, [=](const QString& author, const QString& name) {
-        Q_UNUSED(author);
+        Q_UNUSED(author)
         renameGroupWidget(widget, name);
     });
 }
@@ -525,7 +525,7 @@ void FriendListWidget::cycleContacts(GenericChatroomWidget* activeChatroomWidget
             index = groupLayout.indexOfSortedWidget(groupWidget);
         } else {
             return;
-        };
+        }
     }
 
     index += forward ? 1 : -1;

--- a/src/widget/groupwidget.cpp
+++ b/src/widget/groupwidget.cpp
@@ -69,7 +69,7 @@ GroupWidget::~GroupWidget()
 
 void GroupWidget::updateTitle(const QString& author, const QString& newName)
 {
-    Q_UNUSED(author);
+    Q_UNUSED(author)
     nameLabel->setText(newName);
 }
 

--- a/src/widget/tool/screengrabberchooserrectitem.cpp
+++ b/src/widget/tool/screengrabberchooserrectitem.cpp
@@ -177,14 +177,14 @@ void ScreenGrabberChooserRectItem::mouseRelease(QGraphicsSceneMouseEvent* event)
 
 void ScreenGrabberChooserRectItem::mouseDoubleClick(QGraphicsSceneMouseEvent* event)
 {
-    Q_UNUSED(event);
+    Q_UNUSED(event)
     emit doubleClicked();
 }
 
 void ScreenGrabberChooserRectItem::mousePressHandle(int x, int y, QGraphicsSceneMouseEvent* event)
 {
-    Q_UNUSED(x);
-    Q_UNUSED(y);
+    Q_UNUSED(x)
+    Q_UNUSED(y)
 
     if (event->button() == Qt::LeftButton)
         this->state = HandleResizing;
@@ -223,8 +223,8 @@ void ScreenGrabberChooserRectItem::mouseMoveHandle(int x, int y, QGraphicsSceneM
 
 void ScreenGrabberChooserRectItem::mouseReleaseHandle(int x, int y, QGraphicsSceneMouseEvent* event)
 {
-    Q_UNUSED(x);
-    Q_UNUSED(y);
+    Q_UNUSED(x)
+    Q_UNUSED(y)
 
     if (event->button() == Qt::LeftButton)
         this->state = None;

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1430,11 +1430,11 @@ void Widget::addFriendDialog(const Friend* frnd, ContentDialog* dialog)
             [=](QContextMenuEvent* event) { emit widget->contextMenuCalled(event); });
 
     connect(friendWidget, &FriendWidget::chatroomWidgetClicked, [=](GenericChatroomWidget* w) {
-        Q_UNUSED(w);
+        Q_UNUSED(w)
         emit widget->chatroomWidgetClicked(widget);
     });
     connect(friendWidget, &FriendWidget::newWindowOpened, [=](GenericChatroomWidget* w) {
-        Q_UNUSED(w);
+        Q_UNUSED(w)
         emit widget->newWindowOpened(widget);
     });
     // FIXME: emit should be removed
@@ -1482,12 +1482,12 @@ void Widget::addGroupDialog(Group* group, ContentDialog* dialog)
     // ContentDialog) to the `widget` (which shown in main widget)
     // FIXME: emit should be removed
     connect(groupWidget, &GroupWidget::chatroomWidgetClicked, [=](GenericChatroomWidget* w) {
-        Q_UNUSED(w);
+        Q_UNUSED(w)
         emit widget->chatroomWidgetClicked(widget);
     });
 
     connect(groupWidget, &GroupWidget::newWindowOpened, [=](GenericChatroomWidget* w) {
-        Q_UNUSED(w);
+        Q_UNUSED(w)
         emit widget->newWindowOpened(widget);
     });
 
@@ -2351,8 +2351,8 @@ void Widget::saveSplitterGeometry()
 
 void Widget::onSplitterMoved(int pos, int index)
 {
-    Q_UNUSED(pos);
-    Q_UNUSED(index);
+    Q_UNUSED(pos)
+    Q_UNUSED(index)
     saveSplitterGeometry();
 }
 


### PR DESCRIPTION
These are misleading in some cases, or at least not useful in others.
Most cases of Q_UNUSED in qtox don't have a ;, so this seems acceptable.

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6107)
<!-- Reviewable:end -->
