### PR TITLE
chore(interface): avoid gnu extensions in macros

### DIFF
--- a/src/audio/backend/alsink.h
+++ b/src/audio/backend/alsink.h
@@ -49,8 +49,8 @@ public:
     uint getSourceId() const;
     void kill();
 
-    SIGNAL_IMPL(AlSink, finishedPlaying)
-    SIGNAL_IMPL(AlSink, invalidated)
+    SIGNAL_IMPL(AlSink, finishedPlaying, void)
+    SIGNAL_IMPL(AlSink, invalidated, void)
 
 private:
     OpenAL& audio;

--- a/src/audio/iaudiosink.h
+++ b/src/audio/iaudiosink.h
@@ -107,8 +107,8 @@ public:
     virtual operator bool() const = 0;
 
 signals:
-    DECLARE_SIGNAL(finishedPlaying);
-    DECLARE_SIGNAL(invalidated);
+    DECLARE_SIGNAL(finishedPlaying, void);
+    DECLARE_SIGNAL(invalidated, void);
 };
 
 #endif // IAUDIOSINK_H


### PR DESCRIPTION
In Standard C++, the `__VA_ARGS__` (`...`) part of variadic macros must
have at least one argument. `(void)` is a valid way to declare
parameterless functions, so we're using that here, even though it's not
idiomatic (but then again, nor is the whole macro).

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6109)
<!-- Reviewable:end -->
