### PR TITLE
fix(ui): don't notify of available update if local version is newer

### DIFF
--- a/src/net/updatecheck.cpp
+++ b/src/net/updatecheck.cpp
@@ -31,6 +31,60 @@
 
 namespace {
 const QString versionUrl{QStringLiteral("https://api.github.com/repos/qTox/qTox/releases/latest")};
+
+struct Version {
+    int major;
+    int minor;
+    int patch;
+};
+
+Version tagToVersion(QString tagName)
+{
+    // capture tag name to avoid showing update available on dev builds which include hash as part of describe
+    QRegularExpression versionFormat{QStringLiteral("v([0-9]+)\\.([0-9]+)\\.([0-9]+)")};
+    auto matches = versionFormat.match(tagName);
+    assert(matches.lastCapturedIndex() == 3);
+
+    bool ok;
+    auto major = matches.captured(1).toInt(&ok);
+    assert(ok);
+    auto minor = matches.captured(2).toInt(&ok);
+    assert(ok);
+    auto patch = matches.captured(3).toInt(&ok);
+    assert(ok);
+
+    return {major, minor, patch};
+}
+
+bool isUpdateAvailable(Version current, Version available)
+{
+    // A user may have a version greater than our latest release in the time between a tag being pushed and the release
+    // being published. Don't notify about an update in that case.
+
+    if (current.major < available.major) {
+        return true;
+    }
+    if (current.major > available.major) {
+        return false;
+    }
+
+    if (current.minor < available.minor) {
+        return true;
+    }
+    if (current.minor > available.minor) {
+        return false;
+    }
+
+    if (current.patch < available.patch) {
+        return true;
+    }
+    if (current.patch > available.patch) {
+        return false;
+    }
+
+    return false;
+}
+
 } // namespace
 
 UpdateCheck::UpdateCheck(const Settings& settings)
@@ -78,10 +132,10 @@ void UpdateCheck::handleResponse(QNetworkReply* reply)
         return;
     }
 
-    // capture tag name to avoid showing update available on dev builds which include hash as part of describe
-    QRegularExpression versionFormat{QStringLiteral("v[0-9]+.[0-9]+.[0-9]+")};
-    QString curVer = versionFormat.match(GIT_DESCRIBE).captured(0);
-    if (latestVersion != curVer) {
+    auto currentVer = tagToVersion(GIT_DESCRIBE);
+    auto availableVer = tagToVersion(latestVersion);
+
+    if (isUpdateAvailable(currentVer, availableVer)) {
         qInfo() << "Update available to version" << latestVersion;
         QUrl link{mainMap["html_url"].toString()};
         emit updateAvailable(latestVersion, link);


### PR DESCRIPTION
This could happen between the time when the release tag is pushed and the time
when the release binaries are published.

Fix #6112

Lower version:
![old](https://user-images.githubusercontent.com/10469203/80482354-f3b9b880-8908-11ea-874d-c29f821ee646.png)

Same version:
![current](https://user-images.githubusercontent.com/10469203/80482365-f7e5d600-8908-11ea-8ab9-0bdf896154ae.png)

Newer version:
![new](https://user-images.githubusercontent.com/10469203/80482385-fd432080-8908-11ea-86f1-9c5149ddcff6.png)


- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6118)
<!-- Reviewable:end -->
