### PR TITLE
Reduce usage of Core::getInstance()

### DIFF
--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -454,8 +454,7 @@ void AVForm::on_videoDevCombobox_currentIndexChanged(int index)
 
     camera.setupDevice(dev, mode);
     if (dev == "none") {
-        // TODO: Use injected `coreAv` currently injected `nullptr`
-        Core::getInstance()->getAv()->sendNoVideo();
+        coreAV->sendNoVideo();
     }
 }
 

--- a/src/widget/form/settings/privacyform.cpp
+++ b/src/widget/form/settings/privacyform.cpp
@@ -39,9 +39,10 @@
 #include "src/widget/translator.h"
 #include "src/widget/widget.h"
 
-PrivacyForm::PrivacyForm()
+PrivacyForm::PrivacyForm(Core* _core)
     : GenericForm(QPixmap(":/img/settings/privacy.png"))
     , bodyUI(new Ui::PrivacySettings)
+    , core{_core}
 {
     bodyUI->setupUi(this);
 
@@ -85,14 +86,15 @@ void PrivacyForm::on_nospamLineEdit_editingFinished()
 
     bool ok;
     uint32_t nospam = newNospam.toLongLong(&ok, 16);
-    if (ok)
-        Core::getInstance()->setNospam(nospam);
+    if (ok) {
+        core->setNospam(nospam);
+    }
 }
 
 void PrivacyForm::showEvent(QShowEvent*)
 {
     const Settings& s = Settings::getInstance();
-    bodyUI->nospamLineEdit->setText(Core::getInstance()->getSelfId().getNoSpamString());
+    bodyUI->nospamLineEdit->setText(core->getSelfId().getNoSpamString());
     bodyUI->cbTypingNotification->setChecked(s.getTypingNotification());
     bodyUI->cbKeepHistory->setChecked(Settings::getInstance().getEnableLogging());
     bodyUI->blackListTextEdit->setText(s.getBlackList().join('\n'));
@@ -115,8 +117,8 @@ void PrivacyForm::on_randomNosapamButton_clicked()
         newNospam = (newNospam << 8) + (qrand() % 256); // Generate byte by byte. For some reason.
 #endif
 
-    Core::getInstance()->setNospam(newNospam);
-    bodyUI->nospamLineEdit->setText(Core::getInstance()->getSelfId().getNoSpamString());
+    core->setNospam(newNospam);
+    bodyUI->nospamLineEdit->setText(core->getSelfId().getNoSpamString());
 }
 
 void PrivacyForm::on_nospamLineEdit_textChanged()

--- a/src/widget/form/settings/privacyform.h
+++ b/src/widget/form/settings/privacyform.h
@@ -22,6 +22,8 @@
 
 #include "genericsettings.h"
 
+class Core;
+
 namespace Ui {
 class PrivacySettings;
 }
@@ -30,7 +32,7 @@ class PrivacyForm : public GenericForm
 {
     Q_OBJECT
 public:
-    PrivacyForm();
+    PrivacyForm(Core* _core);
     ~PrivacyForm();
     QString getFormName() final
     {
@@ -54,6 +56,7 @@ private:
 
 private:
     Ui::PrivacySettings* bodyUI;
+    Core* core;
 };
 
 #endif

--- a/src/widget/form/settingswidget.cpp
+++ b/src/widget/form/settingswidget.cpp
@@ -41,10 +41,10 @@
 
 #include <memory>
 
-SettingsWidget::SettingsWidget(UpdateCheck* updateCheck, IAudioControl& audio, Widget* parent)
+SettingsWidget::SettingsWidget(UpdateCheck* updateCheck, IAudioControl& audio, Core* core, Widget* parent)
     : QWidget(parent, Qt::Window)
 {
-    CoreAV* coreAV = Core::getInstance()->getAv();
+    CoreAV* coreAV = core->getAv();
     IAudioSettings* audioSettings = &Settings::getInstance();
     IVideoSettings* videoSettings = &Settings::getInstance();
     CameraSource& camera = CameraSource::getInstance();

--- a/src/widget/form/settingswidget.cpp
+++ b/src/widget/form/settingswidget.cpp
@@ -61,7 +61,7 @@ SettingsWidget::SettingsWidget(UpdateCheck* updateCheck, IAudioControl& audio, C
     connect(gfrm.get(), &GeneralForm::updateIcons, parent, &Widget::updateIcons);
 
     std::unique_ptr<UserInterfaceForm> uifrm(new UserInterfaceForm(this));
-    std::unique_ptr<PrivacyForm> pfrm(new PrivacyForm());
+    std::unique_ptr<PrivacyForm> pfrm(new PrivacyForm(core));
     connect(pfrm.get(), &PrivacyForm::clearAllReceipts, parent, &Widget::clearAllReceipts);
 
     AVForm* rawAvfrm = new AVForm(audio, coreAV, camera, audioSettings, videoSettings);

--- a/src/widget/form/settingswidget.h
+++ b/src/widget/form/settingswidget.h
@@ -28,6 +28,7 @@
 #include <memory>
 
 class Camera;
+class Core;
 class GenericForm;
 class GeneralForm;
 class IAudioControl;
@@ -43,7 +44,7 @@ class SettingsWidget : public QWidget
 {
     Q_OBJECT
 public:
-    SettingsWidget(UpdateCheck* updateCheck, IAudioControl& audio, Widget* parent = nullptr);
+    SettingsWidget(UpdateCheck* updateCheck, IAudioControl& audio, Core *core, Widget* parent = nullptr);
     ~SettingsWidget();
 
     bool isShown() const;

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -107,8 +107,9 @@ bool tryRemoveFile(const QString& filepath)
     tmp.remove();
     return writable;
 }
+} // namespace
 
-void acceptFileTransfer(const ToxFile& file, const QString& path)
+void Widget::acceptFileTransfer(const ToxFile& file, const QString& path)
 {
     QString filepath;
     int number = 0;
@@ -127,13 +128,12 @@ void acceptFileTransfer(const ToxFile& file, const QString& path)
     // Do not automatically accept the file-transfer if the path is not writable.
     // The user can still accept it manually.
     if (tryRemoveFile(filepath)) {
-        CoreFile* coreFile = Core::getInstance()->getCoreFile();
+        CoreFile* coreFile = core->getCoreFile();
         coreFile->acceptFileRecvRequest(file.friendId, file.fileNum, filepath);
     } else {
         qWarning() << "Cannot write to " << filepath;
     }
 }
-} // namespace
 
 Widget* Widget::instance{nullptr};
 
@@ -1077,7 +1077,7 @@ void Widget::dispatchFile(ToxFile file)
 
     if (file.status == ToxFile::INITIALIZING && file.direction == ToxFile::RECEIVING) {
         auto sender =
-            (file.direction == ToxFile::SENDING) ? Core::getInstance()->getSelfPublicKey() : pk;
+            (file.direction == ToxFile::SENDING) ? core->getSelfPublicKey() : pk;
 
         const Settings& settings = Settings::getInstance();
         QString autoAcceptDir = settings.getAutoAcceptDir(f->getPublicKey());

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -276,16 +276,18 @@ void Widget::init()
     filesForm = new FilesForm();
     addFriendForm = new AddFriendForm;
     groupInviteForm = new GroupInviteForm;
+
+    core = Nexus::getCore();
+
 #if UPDATE_CHECK_ENABLED
     updateCheck = std::unique_ptr<UpdateCheck>(new UpdateCheck(settings));
     connect(updateCheck.get(), &UpdateCheck::updateAvailable, this, &Widget::onUpdateAvailable);
 #endif
-    settingsWidget = new SettingsWidget(updateCheck.get(), audio, this);
+    settingsWidget = new SettingsWidget(updateCheck.get(), audio, core, this);
 #if UPDATE_CHECK_ENABLED
     updateCheck->checkForUpdate();
 #endif
 
-    core = Nexus::getCore();
     CoreFile* coreFile = core->getCoreFile();
     Profile* profile = Nexus::getProfile();
     profileInfo = new ProfileInfo(core, profile);

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -275,6 +275,7 @@ private:
     void openDialog(GenericChatroomWidget* widget, bool newWindow);
     void playNotificationSound(IAudioSink::Sound sound, bool loop = false);
     void cleanupNotificationSound();
+    void acceptFileTransfer(const ToxFile &file, const QString &path);
 
 private:
     std::unique_ptr<QSystemTrayIcon> icon;


### PR DESCRIPTION
This is pretty much search and replace work, so an added requirement is that `Core` must outlive most of the other modules, which should be no issue I think.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6124)
<!-- Reviewable:end -->
