### PR TITLE
fix(apparmor): Allow spellchecking

### DIFF
--- a/security/apparmor/2.12.1/usr.bin.qtox
+++ b/security/apparmor/2.12.1/usr.bin.qtox
@@ -276,12 +276,15 @@ profile qtox /usr{,/local}/bin/qtox {
   /sys/devices/system/node/ r,  # for ld-linux-x86-64.so -> libnuma1.so
   /sys/devices/system/node/node[0-9]*/meminfo r, # for ld-linux-x86-64.so -> libnuma1.so
   /usr/share/emoticons/{,**} r,
+  /usr/share/hspell/* r, # for spellcheking
   /usr/share/hwdata/pnp.ids r, # For OpenSUSE only?
   /usr/share/icu/[0-9]*.[0-9]*/icudt[0-9]*.dat r, # For OpenSUSE only?
+  /usr/share/kf5/sonnet/* r, # for spellcheking
   /usr/share/kservices5/{,**} r, # file dialog
   /usr/share/mime/ r, # file dialog
   /usr/share/plasma/look-and-feel/*/contents/defaults r, # TODO: move to kde abstraction?
   /usr/share/sounds/ r, # file dialog (alert)
+  /var/lib/aspell/* r, # for spellcheking
   /{,var/}run/udev/data/* r, # file dialog
 
   # User files

--- a/security/apparmor/2.13.2/usr.bin.qtox
+++ b/security/apparmor/2.13.2/usr.bin.qtox
@@ -283,12 +283,15 @@ profile qtox /usr{,/local}/bin/qtox {
   /sys/devices/system/node/ r,  # for ld-linux-x86-64.so -> libnuma1.so
   /sys/devices/system/node/node[0-9]*/meminfo r, # for ld-linux-x86-64.so -> libnuma1.so
   /usr/share/emoticons/{,**} r,
+  /usr/share/hspell/* r, # for spellchecking
   /usr/share/hwdata/pnp.ids r, # For OpenSUSE only?
   /usr/share/icu/[0-9]*.[0-9]*/icudt[0-9]*.dat r, # For OpenSUSE only?
+  /usr/share/kf5/sonnet/* r, # for spellchecking
   /usr/share/kservices5/{,**} r, # file dialog
   /usr/share/mime/ r, # file dialog
   /usr/share/plasma/look-and-feel/*/contents/defaults r, # TODO: move to kde abstraction?
   /usr/share/sounds/ r, # file dialog (alert)
+  /var/lib/aspell/* r, # for spellchecking
   /{,var/}run/udev/data/* r, # file dialog
 
   # User files

--- a/security/apparmor/2.13.3/usr.bin.qtox
+++ b/security/apparmor/2.13.3/usr.bin.qtox
@@ -282,12 +282,15 @@ profile qtox /usr{,/local}/bin/qtox {
   /sys/devices/system/node/ r,  # for ld-linux-x86-64.so -> libnuma1.so
   /sys/devices/system/node/node[0-9]*/meminfo r, # for ld-linux-x86-64.so -> libnuma1.so
   /usr/share/emoticons/{,**} r,
+  /usr/share/hspell/* r, # for spellchecking
   /usr/share/hwdata/pnp.ids r, # For OpenSUSE only?
   /usr/share/icu/[0-9]*.[0-9]*/icudt[0-9]*.dat r, # For OpenSUSE only?
+  /usr/share/kf5/sonnet/* r, # for spellchecking
   /usr/share/kservices5/{,**} r, # file dialog
   /usr/share/mime/ r, # file dialog
   /usr/share/plasma/look-and-feel/*/contents/defaults r, # TODO: move to kde abstraction?
   /usr/share/sounds/ r, # file dialog (alert)
+  /var/lib/aspell/* r, # for spellchecking
   /{,var/}run/udev/data/* r, # file dialog
 
   # User files


### PR DESCRIPTION
qTox 1.17.2 produces these DENIED messages on Debian Sid:

```
type=AVC msg=audit(1588944857.534:854): apparmor="DENIED"
operation="open" profile="qtox"
name="/usr/share/hspell/hebrew.wgz.sizes" pid=29172 comm="qtox"
requested_mask="r" denied_mask="r" fsuid=1000 ouid=0
```

```
type=AVC msg=audit(1588945073.014:885): apparmor="DENIED"
operation="open" profile="qtox"
name="/usr/share/kf5/sonnet/trigrams.map" pid=29334 comm="qtox" req
uested_mask="r" denied_mask="r" fsuid=1000 ouid=0
```

```
type=AVC msg=audit(1588945273.590:905): apparmor="DENIED"
operation="open" profile="qtox" name="/var/lib/aspell/sl.rws" pid=29391
comm="qtox" requested_mask=
"r" denied_mask="r" fsuid=1000 ouid=0
```

Add file read rules to allow reading spellcheck-related files.

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6136)
<!-- Reviewable:end -->
