### PR TITLE
fix(apparmor): Allow access to Aspell personal dictionaries

### DIFF
--- a/security/apparmor/2.12.1/usr.bin.qtox
+++ b/security/apparmor/2.12.1/usr.bin.qtox
@@ -301,6 +301,7 @@ profile qtox /usr{,/local}/bin/qtox {
 
   owner /{,var/}run/user/[0-9]*[0-9]/#[0-9]*[0-9] rw, # file dialog
   owner /{,var/}run/user/[0-9]*[0-9]/qTox*.slave-socket rwl -> /{,var/}run/user/[0-9]*[0-9]/#[0-9]*[0-9], # file dialog
+  owner @{HOME}/.aspell.??.{pws,prepl} rk, # for spellchecking
   owner @{HOME}/.cache/Tox/ w,
   owner @{HOME}/.cache/Tox/qTox/{,**} rw,
   owner @{HOME}/.cache/fontconfig/** rwk,

--- a/security/apparmor/2.13.2/usr.bin.qtox
+++ b/security/apparmor/2.13.2/usr.bin.qtox
@@ -308,6 +308,7 @@ profile qtox /usr{,/local}/bin/qtox {
 
   owner /{,var/}run/user/@{uid}/#[0-9]*[0-9] rw, # file dialog
   owner /{,var/}run/user/@{uid}/qTox*.slave-socket rwl -> /{,var/}run/user/@{uid}/#[0-9]*[0-9], # file dialog
+  owner @{HOME}/.aspell.??.{pws,prepl} rk, # for spellchecking
   owner @{HOME}/.cache/Tox/ w,
   owner @{HOME}/.cache/Tox/qTox/{,**} rw,
   owner @{HOME}/.cache/fontconfig/** rwk,

--- a/security/apparmor/2.13.3/usr.bin.qtox
+++ b/security/apparmor/2.13.3/usr.bin.qtox
@@ -307,6 +307,7 @@ profile qtox /usr{,/local}/bin/qtox {
 
   owner /{,var/}run/user/@{uid}/#[0-9]*[0-9] rw, # file dialog
   owner /{,var/}run/user/@{uid}/qTox*.slave-socket rwl -> /{,var/}run/user/@{uid}/#[0-9]*[0-9], # file dialog
+  owner @{HOME}/.aspell.??.{pws,prepl} rk, # for spellchecking
   owner @{HOME}/.cache/Tox/ w,
   owner @{HOME}/.cache/Tox/qTox/{,**} rw,
   owner @{HOME}/.cache/fontconfig/** rwk,


### PR DESCRIPTION
Running qTox under AppArmor confinement produces these `DENIED` messages:

```
type=AVC msg=audit(1589897925.045:793): apparmor="DENIED"
operation="open" profile="qtox" name="/home/vincas/.aspell.en.pws"
pid=36671 comm="qtox" requested_mask="r" denied_mask="r" fsuid=1000
ouid=1000
```
```
type=AVC msg=audit(1589897925.045:794): apparmor="DENIED"
operation="open" profile="qtox" name="/home/vincas/.aspell.en.prepl"
pid=36671 comm="qtox" requested_mask="r" denied_mask="r" fsuid=1000
ouid=1000
```
```
type=AVC msg=audit(1589996245.245:1193): apparmor="DENIED"
operation="file_lock" profile="qtox" name="/home/vincas/.aspell.en.pws"
pid=53202 comm="qtox" requested_mask="k" denied_mask="k" fsuid=1000
ouid=1000
```
```
type=AVC msg=audit(1589996245.245:1194): apparmor="DENIED"
operation="file_lock" profile="qtox"
name="/home/vincas/.aspell.en.prepl" pid=53202 comm="qtox"
requested_mask="k" denied_mask="k" fsuid=1000 ouid=1000
```

Add file rule to allow reading and locking Aspell-specific user files [0].

[0] http://aspell.net/man-html/Format-of-the-Personal-and-Replacement-Dictionaries.html

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6149)
<!-- Reviewable:end -->
