### PR TITLE
fix(chathistory): file transfers sometimes show wrong author name

### DIFF
--- a/src/model/chathistory.cpp
+++ b/src/model/chathistory.cpp
@@ -215,13 +215,16 @@ void ChatHistory::onFileUpdated(const ToxPk& sender, const ToxFile& file)
     if (canUseHistory()) {
         switch (file.status) {
         case ToxFile::INITIALIZING: {
+            auto selfPk = coreIdHandler.getSelfPublicKey();
+            QString username(selfPk == sender ? coreIdHandler.getUsername() : f.getDisplayedName());
+
             // Note: There is some implcit coupling between history and the current
             // chat log. Both rely on generating a new id based on the state of
             // initializing. If this is changed in the session chat log we'll end up
             // with a different order when loading from history
             history->addNewFileMessage(f.getPublicKey(), file.resumeFileId, file.fileName,
                                        file.filePath, file.filesize, sender,
-                                       QDateTime::currentDateTime(), f.getDisplayedName());
+                                       QDateTime::currentDateTime(), username);
             break;
         }
         case ToxFile::CANCELED:


### PR DESCRIPTION
Sets the name of the file sender, by analogy with: ChatHistory::onMessageReceived and ChatHistory::onMessageSent

Fixes: [6147](https://github.com/qTox/qTox/issues/6147)

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6154)
<!-- Reviewable:end -->
