### PR TITLE
fix(preview): Don't log a warning on missing exif orientation metadata

### DIFF
--- a/src/model/exiftransform.cpp
+++ b/src/model/exiftransform.cpp
@@ -45,6 +45,11 @@ namespace ExifTransform
         exif_data_free(exifData);
 
         switch (orientation){
+        case 0:
+            // Exif spec defines 1-8 only, but when the orientation field isn't explcitly defined, we read 0 from
+            // libexif. It seems like exif_data_get_entry should return null in that case rather than saying the entry
+            // is present but with a value of zero.
+            return Orientation::TopLeft;
         case 1:
             return Orientation::TopLeft;
         case 2:


### PR DESCRIPTION
libexif returns 0 for the orientation when orientation metadata isn't present.
Treat this the same as 1, i.e. no orientation change.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6160)
<!-- Reviewable:end -->
