### PR TITLE
fix(preview): handle libexif missing fields, don't accept 0-value orientation

### DIFF
--- a/src/model/exiftransform.cpp
+++ b/src/model/exiftransform.cpp
@@ -36,20 +36,18 @@ namespace ExifTransform
             return Orientation::TopLeft;
         }
 
-        int orientation = 0;
         const ExifByteOrder byteOrder = exif_data_get_byte_order(exifData);
         const ExifEntry* const exifEntry = exif_data_get_entry(exifData, EXIF_TAG_ORIENTATION);
-        if (exifEntry) {
-            orientation = exif_get_short(exifEntry->data, byteOrder);
+
+        if (!exifEntry) {
+            exif_data_free(exifData);
+            return Orientation::TopLeft;
         }
+
+        const int orientation = exif_get_short(exifEntry->data, byteOrder);
         exif_data_free(exifData);
 
         switch (orientation){
-        case 0:
-            // Exif spec defines 1-8 only, but when the orientation field isn't explcitly defined, we read 0 from
-            // libexif. It seems like exif_data_get_entry should return null in that case rather than saying the entry
-            // is present but with a value of zero.
-            return Orientation::TopLeft;
         case 1:
             return Orientation::TopLeft;
         case 2:

--- a/src/persistence/profile.cpp
+++ b/src/persistence/profile.cpp
@@ -244,8 +244,11 @@ void Profile::initCore(const QByteArray& toxsave, const ICoreSettings& s, bool i
         emit failedToStart();
     }
 
+    bootstrapNodes = std::unique_ptr<BootstrapNodeUpdater>(
+        new BootstrapNodeUpdater(Settings::getInstance().getProxy(), paths));
+
     Core::ToxCoreErrors err;
-    core = Core::makeToxCore(toxsave, &s, bootstrapNodes, &err);
+    core = Core::makeToxCore(toxsave, &s, *bootstrapNodes, &err);
     if (!core) {
         switch (err) {
         case Core::ToxCoreErrors::BAD_PROXY:
@@ -279,12 +282,12 @@ void Profile::initCore(const QByteArray& toxsave, const ICoreSettings& s, bool i
     avatarBroadcaster = std::unique_ptr<AvatarBroadcaster>(new AvatarBroadcaster(*core));
 }
 
-Profile::Profile(const QString& name, const QString& password, std::unique_ptr<ToxEncrypt> passkey, Paths& paths)
+Profile::Profile(const QString& name, const QString& password, std::unique_ptr<ToxEncrypt> passkey, Paths& paths_)
     : name{name}
     , passkey{std::move(passkey)}
     , isRemoved{false}
     , encrypted{this->passkey != nullptr}
-    , bootstrapNodes(Settings::getInstance().getProxy(), paths)
+    , paths{paths_}
 {}
 
 /**

--- a/src/persistence/profile.h
+++ b/src/persistence/profile.h
@@ -120,5 +120,6 @@ private:
     bool isRemoved;
     bool encrypted = false;
     static QStringList profiles;
-    BootstrapNodeUpdater bootstrapNodes;
+    std::unique_ptr<BootstrapNodeUpdater> bootstrapNodes;
+    Paths& paths;
 };


### PR DESCRIPTION
Last fix was a hack when the error was actually us using the default 0 value of
orientation since the returned ExifData was null.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6168)
<!-- Reviewable:end -->
