### PR TITLE
feat(chatlog): Add image preview on paste

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -373,6 +373,8 @@ set(${PROJECT_NAME}_SOURCES
   src/widget/extensionstatus.h
   src/widget/flowlayout.cpp
   src/widget/flowlayout.h
+  src/widget/imagepreviewwidget.h
+  src/widget/imagepreviewwidget.cpp
   src/widget/searchform.cpp
   src/widget/searchform.h
   src/widget/searchtypes.h

--- a/src/chatlog/content/filetransferwidget.h
+++ b/src/chatlog/content/filetransferwidget.h
@@ -73,9 +73,6 @@ private slots:
     void onPreviewButtonClicked();
 
 private:
-    static QPixmap scaleCropIntoSquare(const QPixmap& source, int targetSize);
-    static int getExifOrientation(const char* data, const int size);
-    static void applyTransformation(const int oritentation, QImage& image);
     static bool tryRemoveFile(const QString &filepath);
 
     void updateWidget(ToxFile const& file);

--- a/src/chatlog/content/filetransferwidget.ui
+++ b/src/chatlog/content/filetransferwidget.ui
@@ -270,7 +270,7 @@
          </layout>
         </item>
         <item row="1" column="0">
-         <widget class="QPushButton" name="previewButton">
+         <widget class="ImagePreviewButton" name="previewButton">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -296,7 +296,7 @@
            <string notr="true">QPushButton{ border: 2px solid white }</string>
           </property>
           <property name="icon">
-           <iconset resource="../../../res.qrc">
+           <iconset>
             <normaloff>:themes/default/fileTransferInstance/no.svg</normaloff>:themes/default/fileTransferInstance/no.svg</iconset>
           </property>
           <property name="iconSize">
@@ -382,7 +382,7 @@
             <string/>
            </property>
            <property name="icon">
-            <iconset resource="../../../res.qrc">
+            <iconset>
              <normaloff>:themes/default/fileTransferInstance/no.svg</normaloff>:themes/default/fileTransferInstance/no.svg</iconset>
            </property>
            <property name="iconSize">
@@ -420,7 +420,7 @@
             <string/>
            </property>
            <property name="icon">
-            <iconset resource="../../../res.qrc">
+            <iconset>
              <normaloff>:themes/default/fileTransferInstance/no.svg</normaloff>:themes/default/fileTransferInstance/no.svg</iconset>
            </property>
            <property name="iconSize">
@@ -444,6 +444,11 @@
    <class>CroppingLabel</class>
    <extends>QLabel</extends>
    <header location="global">src/widget/tool/croppinglabel.h</header>
+  </customwidget>
+  <customwidget>
+   <class>ImagePreviewButton</class>
+   <extends>QPushButton</extends>
+   <header location="global">src/widget/imagepreviewwidget.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/widget/form/chatform.h
+++ b/src/widget/form/chatform.h
@@ -41,6 +41,7 @@ class OfflineMsgEngine;
 class QPixmap;
 class QHideEvent;
 class QMoveEvent;
+class ImagePreviewButton;
 
 class ChatForm : public GenericChatForm
 {
@@ -96,7 +97,9 @@ private slots:
     void onFriendNameChanged(const QString& name);
     void onStatusMessage(const QString& message);
     void onUpdateTime();
-    void sendImage(const QPixmap& pixmap);
+    void previewImage(const QPixmap& pixmap);
+    void cancelImagePreview();
+    void sendImageFromPreview();
     void doScreenshot();
     void onCopyStatusMessage();
 
@@ -131,6 +134,8 @@ private:
     QTimer typingTimer;
     QElapsedTimer timeElapsed;
     QAction* copyStatusAction;
+    QPixmap imagePreviewSource;
+    ImagePreviewButton* imagePreview;
     bool isTyping;
     bool lastCallIsVideo;
     std::unique_ptr<NetCamView> netcam;

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -309,7 +309,7 @@ GenericChatForm::GenericChatForm(const Core& _core, const Contact* contact, ICha
     mainFootLayout->addWidget(sendButton);
     mainFootLayout->setSpacing(0);
 
-    QVBoxLayout* contentLayout = new QVBoxLayout(contentWidget);
+    contentLayout = new QVBoxLayout(contentWidget);
     contentLayout->addWidget(searchForm);
     contentLayout->addWidget(dateInfo);
     contentLayout->addWidget(chatWidget);

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -168,6 +168,7 @@ protected:
 
     QMenu menu;
 
+    QVBoxLayout* contentLayout;
     QPushButton* emoteButton;
     QPushButton* fileButton;
     QPushButton* screenshotButton;

--- a/src/widget/imagepreviewwidget.cpp
+++ b/src/widget/imagepreviewwidget.cpp
@@ -1,0 +1,125 @@
+/*
+    Copyright © 2020 by The qTox Project Contributors
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "imagepreviewwidget.h"
+#include "src/model/exiftransform.h"
+
+#include <QFile>
+#include <QFileInfo>
+#include <QString>
+#include <QApplication>
+#include <QDesktopWidget>
+#include <QBuffer>
+
+namespace
+{
+QPixmap pixmapFromFile(const QString& filename)
+{
+    static const QStringList previewExtensions = {"png", "jpeg", "jpg", "gif", "svg",
+                                                  "PNG", "JPEG", "JPG", "GIF", "SVG"};
+
+    if (!previewExtensions.contains(QFileInfo(filename).suffix())) {
+        return QPixmap();
+    }
+
+    QFile imageFile(filename);
+    if (!imageFile.open(QIODevice::ReadOnly)) {
+        return QPixmap();
+    }
+
+    const QByteArray imageFileData = imageFile.readAll();
+    QImage image = QImage::fromData(imageFileData);
+    auto orientation = ExifTransform::getOrientation(imageFileData);
+    image = ExifTransform::applyTransformation(image, orientation);
+
+    return QPixmap::fromImage(image);
+}
+
+QPixmap scaleCropIntoSquare(const QPixmap& source, const int targetSize)
+{
+    QPixmap result;
+
+    // Make sure smaller-than-icon images (at least one dimension is smaller) will not be
+    // upscaled
+    if (source.width() < targetSize || source.height() < targetSize) {
+        result = source;
+    } else {
+        result = source.scaled(targetSize, targetSize, Qt::KeepAspectRatioByExpanding,
+                               Qt::SmoothTransformation);
+    }
+
+    // Then, image has to be cropped (if needed) so it will not overflow rectangle
+    // Only one dimension will be bigger after Qt::KeepAspectRatioByExpanding
+    if (result.width() > targetSize) {
+        return result.copy((result.width() - targetSize) / 2, 0, targetSize, targetSize);
+    } else if (result.height() > targetSize) {
+        return result.copy(0, (result.height() - targetSize) / 2, targetSize, targetSize);
+    }
+
+    // Picture was rectangle in the first place, no cropping
+    return result;
+}
+
+QString getToolTipDisplayingImage(const QPixmap& image)
+{
+    // Show mouseover preview, but make sure it's not larger than 50% of the screen
+    // width/height
+    const QRect desktopSize = QApplication::desktop()->geometry();
+    const int maxPreviewWidth{desktopSize.width() / 2};
+    const int maxPreviewHeight{desktopSize.height() / 2};
+    const QPixmap previewImage = [&image, maxPreviewWidth, maxPreviewHeight]() {
+        if (image.width() > maxPreviewWidth || image.height() > maxPreviewHeight) {
+            return image.scaled(maxPreviewWidth, maxPreviewHeight, Qt::KeepAspectRatio,
+                                Qt::SmoothTransformation);
+        } else {
+            return image;
+        }
+    }();
+
+    QByteArray imageData;
+    QBuffer buffer(&imageData);
+    buffer.open(QIODevice::WriteOnly);
+    previewImage.save(&buffer, "PNG");
+    buffer.close();
+
+    return "<img src=data:image/png;base64," + imageData.toBase64() + "/>";
+}
+
+} // namespace
+
+void ImagePreviewButton::initialize(const QPixmap& image)
+{
+    auto desiredSize = qMin(width(), height()); // Assume widget is a square
+    desiredSize = qMax(desiredSize, 4) - 4; // Leave some room for a border
+
+    auto croppedImage = scaleCropIntoSquare(image, desiredSize);
+    setIcon(QIcon(croppedImage));
+    setIconSize(croppedImage.size());
+    setToolTip(getToolTipDisplayingImage(image));
+}
+
+void ImagePreviewButton::setIconFromFile(const QString& filename)
+{
+    initialize(pixmapFromFile(filename));
+}
+
+void ImagePreviewButton::setIconFromPixmap(const QPixmap& pixmap)
+{
+    initialize(pixmap);
+}

--- a/src/widget/imagepreviewwidget.h
+++ b/src/widget/imagepreviewwidget.h
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2014-2019 by The qTox Project Contributors
+    Copyright © 2020 by The qTox Project Contributors
 
     This file is part of qTox, a Qt-based graphical interface for Tox.
 
@@ -19,31 +19,19 @@
 
 #pragma once
 
-#include <QTextEdit>
+#include <QPushButton>
+#include <QPixmap>
+#include <QString>
 
-class ChatTextEdit final : public QTextEdit
+class ImagePreviewButton : public QPushButton
 {
-    Q_OBJECT
 public:
-    explicit ChatTextEdit(QWidget* parent = nullptr);
-    ~ChatTextEdit();
-    void setLastMessage(QString lm);
-    void sendKeyEvent(QKeyEvent* event);
+    ImagePreviewButton(QWidget* parent = nullptr)
+        : QPushButton(parent)
+    {}
 
-signals:
-    void enterPressed();
-    void escapePressed();
-    void tabPressed();
-    void keyPressed();
-    void pasteImage(const QPixmap& pixmap);
-
-protected:
-    void keyPressEvent(QKeyEvent* event) final;
-
+    void setIconFromFile(const QString& filename);
+    void setIconFromPixmap(const QPixmap& image);
 private:
-    void retranslateUi();
-    bool pasteIfImage(QKeyEvent* event);
-
-private:
-    QString lastMessage;
+    void initialize(const QPixmap& image);
 };

--- a/src/widget/tool/chattextedit.cpp
+++ b/src/widget/tool/chattextedit.cpp
@@ -48,6 +48,10 @@ void ChatTextEdit::keyPressEvent(QKeyEvent* event)
         emit enterPressed();
         return;
     }
+    if (key == Qt::Key_Escape) {
+        emit escapePressed();
+        return;
+    }
     if (key == Qt::Key_Tab) {
         if (event->modifiers())
             event->ignore();


### PR DESCRIPTION
Reuse code from the file transfer widget to provide an image preview
on paste/grab. This prevents users from accidentally sending images they
did not mean to when their clipboard is not in the state they thought it
was.

Implementation exposes the genericchatlog vbox to the child classes and
chatform injects the imagepreview into it.

Demo of feature

![image preview](https://user-images.githubusercontent.com/1069811/84576469-cc5c6500-ad69-11ea-83cf-968c84803427.gif)

**edit**: I forgot to show hover in the gif, but it works just like the file transfer widget does. When you hover over it puts the image into a tooltip at full size.

[x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6175)
<!-- Reviewable:end -->
