### PR TITLE
Fix gdb not being cached on Travis, resulting in it rebuilding every time

### DIFF
--- a/windows/cross-compile/build.sh
+++ b/windows/cross-compile/build.sh
@@ -297,7 +297,7 @@ then
   # which happens when building Qt
   CONFIGURE_EXTRA=""
   set +u
-  if [[ "$TRAVIS_CI_STAGE" == "stage1" ]]
+  if [[ -n "$TRAVIS_CI_STAGE" ]]
   then
     CONFIGURE_EXTRA="-silent"
   fi
@@ -1186,8 +1186,9 @@ echo "
     SET(CMAKE_FIND_ROOT_PATH /usr/$ARCH-w64-mingw32 $CMAKE_FIND_ROOT_PATH)
 " > toolchain.cmake
 
+# Run tests using Wine
 set +u
-if [[ "$TRAVIS_CI_STAGE" == "stage3" ]]
+if [[ -n "$TRAVIS_CI_STAGE" ]]
 then
   echo "SET(TEST_CROSSCOMPILING_EMULATOR /usr/bin/wine)" >> toolchain.cmake
 fi
@@ -1283,9 +1284,9 @@ do
 done < /tmp/$ARCH-qtox-dll-find
 
 
-# Run tests
+# Run tests (only on Travis)
 set +u
-if [[ "$TRAVIS_CI_STAGE" == "stage3" ]]
+if [[ -n "$TRAVIS_CI_STAGE" ]]
 then
   # Add libgcc_s_*.dll, libwinpthread-1.dll, QtTest.dll, etc. into PATH env var of wine
   export WINEPATH=`cd $QTOX_PREFIX_DIR ; winepath -w $(pwd)`\;`winepath -w $QT_PREFIX_DIR/bin/`

--- a/windows/cross-compile/build.sh
+++ b/windows/cross-compile/build.sh
@@ -974,8 +974,10 @@ else
 fi
 
 
-if [[ "$BUILD_TYPE" == "debug" ]]
+set +u
+if [[ -n "$TRAVIS_CI_STAGE" ]] || [[ "$BUILD_TYPE" == "debug" ]]
 then
+set -u
 
   # mingw-w64-debug-scripts
 
@@ -1071,7 +1073,9 @@ then
     echo "Using cached build of GDB `cat $GDB_PREFIX_DIR/done`"
   fi
 
+set +u
 fi
+set -u
 
 
 # NSIS ShellExecAsUser plugin


### PR DESCRIPTION
- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

I have made a silly mistake in the last PR https://github.com/qTox/qTox/pull/6169. gdb was meant to be built during stage2, but instead it is being built during stage3 which doesn't cache the deps, so gdb isn't getting cached and Travis keeps re-building it on every run. This additional `[[ -n "$TRAVIS_CI_STAGE" ]]` check should fix it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6180)
<!-- Reviewable:end -->
