### PR TITLE
fix(cmake): use the 'STATIC' argument for 'translations_library'

### DIFF
--- a/translations/CMakeLists.txt
+++ b/translations/CMakeLists.txt
@@ -81,7 +81,7 @@ endfunction()
 generate_translation_resource()
 configure_file(${CMAKE_CURRENT_BINARY_DIR}/translations.qrc.in ./translations.qrc COPYONLY)
 
-add_library(translations_library ${CMAKE_CURRENT_BINARY_DIR}/translations.qrc)
+add_library(translations_library STATIC ${CMAKE_CURRENT_BINARY_DIR}/translations.qrc)
 
 # An explicit dependency is needed or AUTORCC will run before the translation files are created
 set_target_properties(translations_library PROPERTIES AUTOGEN_TARGET_DEPENDS "${translations_FILES}")


### PR DESCRIPTION
- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6184)
<!-- Reviewable:end -->
