### PR TITLE
Push-to-talk using Libuiohook

### DIFF
--- a/.travis/build-ubuntu-16-04.sh
+++ b/.travis/build-ubuntu-16-04.sh
@@ -46,6 +46,7 @@ sudo apt-get install -y --force-yes \
     qttools5-dev \
     libqt5opengl5-dev \
     libqt5svg5-dev \
+    libxtst-dev \
     pkg-config || yes
 
 # ffmpeg
@@ -124,6 +125,16 @@ git checkout tags/1.0.18
 CC="ccache $CC" CXX="ccache $CXX" ./configure
 CC="ccache $CC" CXX="ccache $CXX" make -j$(nproc)
 sudo checkinstall --install --pkgname libsodium --pkgversion 1.0.8 --nodoc -y
+sudo ldconfig
+cd ..
+# libuiohook
+git clone https://github.com/kwhat/libuiohook.git
+cd libuiohook
+git checkout tags/1.0.3
+./bootstrap.sh
+CC="ccache $CC" CXX="ccache $CXX" ./configure
+CC="ccache $CC" CXX="ccache $CXX" make -j$(nproc)
+sudo make install
 sudo ldconfig
 cd ..
 # toxcore

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -406,6 +406,8 @@ set(${PROJECT_NAME}_SOURCES
   src/widget/form/settings/generalform.h
   src/widget/form/settings/genericsettings.cpp
   src/widget/form/settings/genericsettings.h
+  src/widget/form/settings/hotkeyinput.cpp
+  src/widget/form/settings/hotkeyinput.h
   src/widget/form/settings/privacyform.cpp
   src/widget/form/settings/privacyform.h
   src/widget/form/settings/userinterfaceform.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,6 +261,10 @@ set(${PROJECT_NAME}_SOURCES
   src/grouplist.h
   src/ipc.cpp
   src/ipc.h
+  src/globalshortcut.cpp
+  src/globalshortcut.h
+  src/hookmanager.cpp
+  src/hookmanager.h
   src/model/about/aboutfriend.cpp
   src/model/about/aboutfriend.h
   src/model/about/iaboutfriend.h

--- a/audio/include/audio/iaudiosettings.h
+++ b/audio/include/audio/iaudiosettings.h
@@ -26,6 +26,12 @@
 
 class IAudioSettings {
 public:
+    enum class AudioCaptureMode {
+        Continuous = 0,
+        VoiceActivation = 1,
+        PushToTalk = 2
+    };
+
     virtual ~IAudioSettings() = default;
 
     virtual QString getInDev() const = 0;
@@ -51,9 +57,9 @@ public:
     virtual int getOutVolumeMax() const = 0;
     virtual void setOutVolume(int volume) = 0;
 
-    virtual int getAudioCaptureMode() const = 0;
-    virtual void setAudioCaptureMode(int mode) = 0;
-    
+    virtual AudioCaptureMode getAudioCaptureMode() const = 0;
+    virtual void setAudioCaptureMode(AudioCaptureMode mode) = 0;
+
     virtual QList<int> getPttShortcutKeys() const = 0;
     virtual void setPttShortcutKeys(QList<int> keys) = 0;
     
@@ -72,7 +78,7 @@ public:
     DECLARE_SIGNAL(audioInGainDecibelChanged, qreal dB);
     DECLARE_SIGNAL(audioThresholdChanged, qreal dB);
     DECLARE_SIGNAL(outVolumeChanged, int volume);
-    DECLARE_SIGNAL(audioCaptureModeChanged, int mode);
+    DECLARE_SIGNAL(audioCaptureModeChanged, AudioCaptureMode mode);
     DECLARE_SIGNAL(pttShortcutKeysChanged, QList<int> keys);
     DECLARE_SIGNAL(audioBitrateChanged, int bitrate);
     DECLARE_SIGNAL(enableTestSoundChanged, bool newValue);

--- a/audio/include/audio/iaudiosettings.h
+++ b/audio/include/audio/iaudiosettings.h
@@ -22,6 +22,7 @@
 #include "util/interface.h"
 
 #include <QString>
+#include <QList>
 
 class IAudioSettings {
 public:
@@ -50,6 +51,12 @@ public:
     virtual int getOutVolumeMax() const = 0;
     virtual void setOutVolume(int volume) = 0;
 
+    virtual int getAudioCaptureMode() const = 0;
+    virtual void setAudioCaptureMode(int mode) = 0;
+    
+    virtual QList<int> getPttShortcutKeys() const = 0;
+    virtual void setPttShortcutKeys(QList<int> keys) = 0;
+    
     virtual int getAudioBitrate() const = 0;
     virtual void setAudioBitrate(int bitrate) = 0;
 
@@ -65,6 +72,8 @@ public:
     DECLARE_SIGNAL(audioInGainDecibelChanged, qreal dB);
     DECLARE_SIGNAL(audioThresholdChanged, qreal dB);
     DECLARE_SIGNAL(outVolumeChanged, int volume);
+    DECLARE_SIGNAL(audioCaptureModeChanged, int mode);
+    DECLARE_SIGNAL(pttShortcutKeysChanged, QList<int> keys);
     DECLARE_SIGNAL(audioBitrateChanged, int bitrate);
     DECLARE_SIGNAL(enableTestSoundChanged, bool newValue);
 };

--- a/audio/include/audio/iaudiosettings.h
+++ b/audio/include/audio/iaudiosettings.h
@@ -62,7 +62,10 @@ public:
 
     virtual QList<int> getPttShortcutKeys() const = 0;
     virtual void setPttShortcutKeys(QList<int> keys) = 0;
-    
+
+    virtual QList<int> getPttShortcutNames() const = 0;
+    virtual void setPttShortcutNames(QList<int> keys) = 0;   
+
     virtual int getAudioBitrate() const = 0;
     virtual void setAudioBitrate(int bitrate) = 0;
 
@@ -80,6 +83,7 @@ public:
     DECLARE_SIGNAL(outVolumeChanged, int volume);
     DECLARE_SIGNAL(audioCaptureModeChanged, AudioCaptureMode mode);
     DECLARE_SIGNAL(pttShortcutKeysChanged, QList<int> keys);
+    DECLARE_SIGNAL(pttShortcutNamesChanged, QList<int> names);
     DECLARE_SIGNAL(audioBitrateChanged, int bitrate);
     DECLARE_SIGNAL(enableTestSoundChanged, bool newValue);
 };

--- a/src/globalshortcut.cpp
+++ b/src/globalshortcut.cpp
@@ -1,0 +1,68 @@
+/*
+    Copyright © 2020 by The qTox Project Contributors
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "src/globalshortcut.h"
+
+#include <QObject>
+#include <QThread>
+#include <QDebug>
+#include <QMutex>
+#include <QMutexLocker>
+
+#include <memory>
+
+GlobalShortcut::GlobalShortcut(QObject *parent)
+    : QObject(parent)
+    , thread(new QThread())
+    , hookManager{new HookManager{this}}
+{
+    connect(thread, &QThread::started, hookManager.get(), &HookManager::onStarted);
+    hookManager->moveToThread(thread);
+    thread->setObjectName("qTox global shortcut");
+    thread->start();
+}
+
+void GlobalShortcut::onPttShortcutKeysChanged(QList<int> keys)
+{
+    QMutexLocker lock(&keysMutex);
+    shortcutKeys = std::vector<int>(keys.begin(), keys.end());
+}
+
+std::unique_ptr<std::vector<int>> GlobalShortcut::getShortcutKeys()
+{
+    if (!keysMutex.tryLock()) {
+        // we don't want to block the hook thread and cause system-wide stuttering.
+        // failing to read and using a stale value will only happen when the shortcut was
+        // just changed, in which case hook using the stale list for one extra key and
+        // getting the new list on the next key stroke is fine
+        return {};
+    }
+
+    auto ret = std::unique_ptr<std::vector<int>>{new std::vector<int>{shortcutKeys}};
+    // Qt doesn't have a nice RAII wrapper like std::unique_lock, but std::mutex isn't working under mingw
+    keysMutex.unlock();
+    return ret;
+}
+
+GlobalShortcut::~GlobalShortcut()
+{
+    hookManager.reset(); // destroy hookmanager first to stop hook before stopping the thread
+    thread->exit(0);
+    thread->wait();
+}

--- a/src/globalshortcut.h
+++ b/src/globalshortcut.h
@@ -32,12 +32,19 @@ class GlobalShortcut : public QObject
 {
 Q_OBJECT
 public:
+    struct ShortcutKeys {
+        std::unique_ptr<std::vector<int>> keyCombo;
+        bool blockKeys = false;
+    };
+
     GlobalShortcut(QObject *parent = 0);
     ~GlobalShortcut();
-    std::unique_ptr<std::vector<int>> getShortcutKeys();
+    ShortcutKeys getShortcutKeys();
 
 public slots:
     void onPttShortcutKeysChanged(QList<int> keys);
+    void onPauseKeyBlocking();
+    void onResumeKeyBlocking();
 
 signals:
     void toggled();
@@ -47,4 +54,5 @@ private:
     QThread* thread;
     std::vector<int> shortcutKeys;
     QMutex keysMutex;
+    bool blockKeys = false;
 };

--- a/src/globalshortcut.h
+++ b/src/globalshortcut.h
@@ -1,0 +1,50 @@
+/*
+    Copyright © 2020 by The qTox Project Contributors
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <memory>
+
+#include <QObject>
+#include <QMutex>
+
+#include "src/hookmanager.h"
+
+class QThread;
+
+class GlobalShortcut : public QObject
+{
+Q_OBJECT
+public:
+    GlobalShortcut(QObject *parent = 0);
+    ~GlobalShortcut();
+    std::unique_ptr<std::vector<int>> getShortcutKeys();
+
+public slots:
+    void onPttShortcutKeysChanged(QList<int> keys);
+
+signals:
+    void toggled();
+
+private:
+    std::unique_ptr<HookManager> hookManager;
+    QThread* thread;
+    std::vector<int> shortcutKeys;
+    QMutex keysMutex;
+};

--- a/src/hookmanager.cpp
+++ b/src/hookmanager.cpp
@@ -1,0 +1,259 @@
+/*
+    Copyright © 2020 by The qTox Project Contributors
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <algorithm>
+#include <cstdarg>
+
+#include <QLibrary>
+#include <QDebug>
+
+#include "src/globalshortcut.h"
+#include "src/hookmanager.h"
+
+namespace {
+    GlobalShortcut* globalShortcut = nullptr;
+#if defined(Q_OS_WIN)
+    const char* hookLibName = "libuiohook-0";
+#else
+    const char* hookLibName = "libuiohook";
+#endif
+    void logError(int hookStatus)
+    {
+        const char* errorString = nullptr;
+        switch (hookStatus)
+        {
+        case UIOHOOK_SUCCESS:
+            return;
+        
+        // System level errors. 
+        case UIOHOOK_ERROR_OUT_OF_MEMORY:
+            errorString = "Failed to allocate memory.";
+            break;
+
+        // Unix specific errors.
+        case UIOHOOK_ERROR_X_OPEN_DISPLAY:
+            errorString = "Failed to open X11 display.";
+            break;
+        case UIOHOOK_ERROR_X_RECORD_NOT_FOUND:
+            errorString = "Unable to locate XRecord extension.";
+            break;
+        case UIOHOOK_ERROR_X_RECORD_ALLOC_RANGE:
+            errorString = "Unable to allocate XRecord range.";
+            break;
+        case UIOHOOK_ERROR_X_RECORD_CREATE_CONTEXT:
+            errorString = "Unable to allocate XRecord context.";
+            break;
+        case UIOHOOK_ERROR_X_RECORD_ENABLE_CONTEXT:
+            errorString = "Failed to enable XRecord context.";
+            break;
+        case UIOHOOK_ERROR_X_RECORD_GET_CONTEXT:
+            errorString = "Failed to get XRecord context.";
+            break;
+
+        // Windows specific errors.
+        case UIOHOOK_ERROR_SET_WINDOWS_HOOK_EX:
+            errorString = "Failed to register low level windows hook.";
+            break;
+
+        // Windows specific errors.
+        case UIOHOOK_ERROR_AXAPI_DISABLED:
+            errorString = "Failed to enable access for assistive devices.";
+            break;
+        case UIOHOOK_ERROR_CREATE_EVENT_PORT:
+            errorString = "Failed to create apple event port.";
+            break;
+        case UIOHOOK_ERROR_CREATE_RUN_LOOP_SOURCE:
+            errorString = "Failed to create apple run loop source.";
+            break;
+        case UIOHOOK_ERROR_GET_RUNLOOP:
+            errorString = "Failed to acquire apple run loop.";
+            break;
+        case UIOHOOK_ERROR_CREATE_OBSERVER:
+            errorString = "Failed to create apple run loop observer.";
+            break;
+
+        // Generic
+        case UIOHOOK_FAILURE: // fallthrough
+        default:
+            errorString = "An unknown hook error occurred.";
+            break;
+        }
+        qCritical().nospace() << errorString << " (0x" << QString::number(hookStatus, 16) << ")";
+    }
+
+    bool onHookLog(unsigned int level, const char *format, ...)
+    {
+        // arbitrary size that _should_ be big enough for any logs
+        // faster and easier than mallocing on each log
+        const static int bufferSize = 200;
+        char buffer[bufferSize]; 
+        va_list args;
+        switch (level) {
+            case HookManager::LOG_LEVEL_WARN:
+            case HookManager::LOG_LEVEL_ERROR:
+                va_start(args, format);
+                int length = vsnprintf(buffer, bufferSize, format, args);
+                va_end(args);
+                if (length > bufferSize) {
+                    qWarning() << "Failed to handle hook log";
+                    return -1;
+                }
+                if (length < 0) {
+                    qWarning() << "Encoding error in hook log";
+                    return length;
+                }
+                qWarning() << buffer;
+                return false;
+        }
+        return false;
+    }
+
+    void getNewKeys(std::vector<int>& keys, std::vector<bool>& pressed)
+    {
+        const auto newKeys = globalShortcut->getShortcutKeys();
+        if (!newKeys) {
+            return;
+        }
+        if (*newKeys == keys) {
+            return;
+        }
+        
+        keys = *newKeys;
+        pressed = std::vector<bool>(keys.size(), false);
+    }
+
+    bool setKeyPressed(std::vector<int>& keys, std::vector<bool>& pressed, int rawcode, bool newState)
+    {
+        auto it = std::find(keys.begin(), keys.end(), rawcode);
+        if (it == keys.end()) {
+            return false;
+        }
+
+        auto idx = std::distance(keys.begin(), it);
+        pressed[idx] = newState;
+        return true;
+    }
+
+    void blockKeyPropagation(HookManager::uiohook_event* const event)
+    {
+        // note: this does not work on X11. https://github.com/kwhat/libuiohook/issues/57#issuecomment-366757355
+        event->reserved = 0x1;
+    }
+
+    void handleKeyChange(HookManager::uiohook_event* const event, bool keyState)
+    {
+        static bool active = false;
+        static std::vector<int> keys;
+        static std::vector<bool> pressed;
+
+        getNewKeys(keys, pressed);
+        if (!setKeyPressed(keys, pressed, event->data.keyboard.rawcode, keyState)) {
+            return;
+        }
+
+        blockKeyPropagation(event);
+        bool newActive = std::all_of(pressed.begin(), pressed.end(), [](bool val){return val == true;});
+        if (active != newActive) {
+            active = newActive;
+            emit globalShortcut->toggled();
+        }
+    }
+
+    // NOTE: The following callback executes on the same thread that hook_run() is called
+    // from.  This is important because hook_run() attaches to the operating systems
+    // event dispatcher and may delay event delivery to the target application.
+    // Furthermore, some operating systems may choose to disable your hook if it
+    // takes to long to process.  If you need to do any extended processing, please
+    // do so by copying the event to your own queued dispatch thread.
+    void onHookEvent(HookManager::uiohook_event* const event)
+    {
+        switch (event->type) {
+            case HookManager::EVENT_KEY_PRESSED:
+                handleKeyChange(event, true);
+                break;
+            case HookManager::EVENT_KEY_RELEASED:
+                handleKeyChange(event, false);
+                break;
+            default:
+                break;
+        }
+    }
+}
+
+HookManager::HookManager(GlobalShortcut* _globalShortcut, QObject* parent)
+    : QObject(parent)
+{
+    // Note: hook_run blocks. This class cannot receive any signals because of that.
+    // Note: It's not really safe to call hook_stop off of hook's thread, but it's also not possible
+    // to call if from hook's thread unless we call it from a key event callback, which leads
+    // to us requiring mouse or keyboard movement to stop it.
+    // It's still not _that_ unsafe because hook_run should be stuck in an Xlib call soon
+    // after starting, not touching any lib state.
+    globalShortcut = _globalShortcut;
+    loadHookSymbols();
+}
+
+HookManager::~HookManager()
+{
+    if (!hookSymbolsLoaded) {
+        return;
+    }
+
+    int status = hookStop();
+    logError(status);
+}
+
+void HookManager::onStarted()
+{
+    if (!hookSymbolsLoaded) {
+        return;
+    }
+
+    // Set the logger callback for library output.
+    hookSetLoggerProc(&onHookLog);
+
+    // Set the event callback for uiohook events.
+    hookSetDispatchProc(&onHookEvent);
+
+    process();
+}
+
+void HookManager::process()
+{
+    // Start the hook and block.
+    int status = hookRun();
+    logError(status);
+};
+
+void HookManager::loadHookSymbols()
+{
+    hookLib.setFileName(hookLibName);
+    hookSetLoggerProc = reinterpret_cast<HookSetLoggerProcFunc>(hookLib.resolve("hook_set_logger_proc"));
+    hookSetDispatchProc = reinterpret_cast<HookSetDispatchProcFunc>(hookLib.resolve("hook_set_dispatch_proc"));
+    hookRun = reinterpret_cast<HookRunFunc>(hookLib.resolve("hook_run"));
+    hookStop = reinterpret_cast<HookStopFunc>(hookLib.resolve("hook_stop"));
+    if (hookSetLoggerProc &&
+        hookSetDispatchProc &&
+        hookRun &&
+        hookStop) {
+        hookSymbolsLoaded = true;
+    } else {
+        qCritical() << "Failed to load libuiohook symbols";
+    }
+}

--- a/src/hookmanager.cpp
+++ b/src/hookmanager.cpp
@@ -196,6 +196,12 @@ namespace {
     }
 }
 
+bool HookManager::isPttSupported()
+{
+    QLibrary lib{hookLibName};
+    return lib.load();
+}
+
 HookManager::HookManager(GlobalShortcut* _globalShortcut, QObject* parent)
     : QObject(parent)
 {

--- a/src/hookmanager.h
+++ b/src/hookmanager.h
@@ -1,0 +1,135 @@
+/*
+    Copyright © 2020 by The qTox Project Contributors
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <QObject>
+#include <QLibrary>
+
+class GlobalShortcut;
+
+class HookManager : public QObject
+{
+Q_OBJECT
+public:
+    HookManager(GlobalShortcut* _globalShortcut, QObject* parent = nullptr);
+    ~HookManager();
+    static bool isPttSupported();
+public slots:
+    void onStarted();
+public:
+    // Needed definitions from uiohook.h, since we don't want to depent on uiohook directly
+    /* Begin Error Codes */
+    #define UIOHOOK_SUCCESS                          0x00
+    #define UIOHOOK_FAILURE                          0x01
+
+    // System level errors.
+    #define UIOHOOK_ERROR_OUT_OF_MEMORY              0x02
+
+    // Unix specific errors.
+    #define UIOHOOK_ERROR_X_OPEN_DISPLAY             0x20
+    #define UIOHOOK_ERROR_X_RECORD_NOT_FOUND         0x21
+    #define UIOHOOK_ERROR_X_RECORD_ALLOC_RANGE       0x22
+    #define UIOHOOK_ERROR_X_RECORD_CREATE_CONTEXT    0x23
+    #define UIOHOOK_ERROR_X_RECORD_ENABLE_CONTEXT    0x24
+    #define UIOHOOK_ERROR_X_RECORD_GET_CONTEXT       0x25
+
+    // Windows specific errors.
+    #define UIOHOOK_ERROR_SET_WINDOWS_HOOK_EX        0x30
+    #define UIOHOOK_ERROR_GET_MODULE_HANDLE          0x31
+
+    // Darwin specific errors.
+    #define UIOHOOK_ERROR_AXAPI_DISABLED             0x40
+    #define UIOHOOK_ERROR_CREATE_EVENT_PORT          0x41
+    #define UIOHOOK_ERROR_CREATE_RUN_LOOP_SOURCE     0x42
+    #define UIOHOOK_ERROR_GET_RUNLOOP                0x43
+    #define UIOHOOK_ERROR_CREATE_OBSERVER            0x44
+
+    typedef enum _log_level {
+        LOG_LEVEL_DEBUG = 1,
+        LOG_LEVEL_INFO,
+        LOG_LEVEL_WARN,
+        LOG_LEVEL_ERROR
+    } log_level;
+
+    typedef enum _event_type {
+        EVENT_HOOK_ENABLED = 1,
+        EVENT_HOOK_DISABLED,
+        EVENT_KEY_TYPED,
+        EVENT_KEY_PRESSED,
+        EVENT_KEY_RELEASED,
+        EVENT_MOUSE_CLICKED,
+        EVENT_MOUSE_PRESSED,
+        EVENT_MOUSE_RELEASED,
+        EVENT_MOUSE_MOVED,
+        EVENT_MOUSE_DRAGGED,
+        EVENT_MOUSE_WHEEL
+    } event_type;
+
+    typedef struct _keyboard_event_data {
+        uint16_t keycode;
+        uint16_t rawcode;
+        uint16_t keychar;
+    } keyboard_event_data;
+
+    typedef struct _mouse_event_data {
+        uint16_t button;
+        uint16_t clicks;
+        int16_t x;
+        int16_t y;
+    } mouse_event_data;
+
+    typedef struct _mouse_wheel_event_data {
+        uint16_t clicks;
+        int16_t x;
+        int16_t y;
+        uint8_t type;
+        uint16_t amount;
+        int16_t rotation;
+        uint8_t direction;
+    } mouse_wheel_event_data;
+
+    typedef struct _uiohook_event {
+        event_type type;
+        uint64_t time;
+        uint16_t mask;
+        uint16_t reserved;
+        union {
+            keyboard_event_data keyboard;
+            mouse_event_data mouse;
+            mouse_wheel_event_data wheel;
+        } data;
+    } uiohook_event;
+
+private:
+    typedef void (*dispatcher_t)(uiohook_event *const);
+    typedef bool (*logger_t)(unsigned int, const char *, ...);
+    typedef int (*HookStopFunc)();
+    typedef int (*HookRunFunc)();
+    typedef void (*HookSetDispatchProcFunc)(dispatcher_t dispatch_proc);
+    typedef void (*HookSetLoggerProcFunc)(logger_t dispatch_proc);
+    void process();
+    void loadHookSymbols();
+    QLibrary hookLib;
+    HookStopFunc hookStop = nullptr;
+    HookRunFunc hookRun = nullptr;
+    HookSetDispatchProcFunc hookSetDispatchProc = nullptr;
+    HookSetLoggerProcFunc hookSetLoggerProc = nullptr;
+    bool hookSymbolsLoaded = false;
+};

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -243,7 +243,7 @@ void Settings::loadGlobal()
         audioThreshold = s.value("audioThreshold", 0).toReal();
         outVolume = s.value("outVolume", 100).toInt();
         enableTestSound = s.value("enableTestSound", true).toBool();
-        audioCaptureMode = s.value("audioCaptureMode", 0).toInt();
+        audioCaptureMode = static_cast<AudioCaptureMode>(s.value("audioCaptureMode", 0).toInt());
 
         int pttShortcutKeysSize = s.beginReadArray("pttShortcutKeys");
         for (int i = 0; i < pttShortcutKeysSize; i++) {
@@ -720,15 +720,13 @@ void Settings::saveGlobal()
         s.setValue("audioThreshold", audioThreshold);
         s.setValue("outVolume", outVolume);
         s.setValue("enableTestSound", enableTestSound);
-        s.setValue("audioCaptureMode", audioCaptureMode);
-
-	s.beginWriteArray("pttShortcutKeys", pttShortcutKeys.size());
-        for (int i = 0; i < pttShortcutKeys.size(); i++) {
-            s.setArrayIndex(i);
-            s.setValue("pttKey" + QString::number(i), pttShortcutKeys[i]);
-        }
-        s.endArray();
-
+        s.setValue("audioCaptureMode", static_cast<int>(audioCaptureMode));
+        s.beginWriteArray("pttShortcutKeys", pttShortcutKeys.size());
+            for (int i = 0; i < pttShortcutKeys.size(); i++) {
+                s.setArrayIndex(i);
+                s.setValue("pttKey" + QString::number(i), pttShortcutKeys[i]);
+            }
+            s.endArray();
         s.setValue("audioBitrate", audioBitrate);
     }
     s.endGroup();
@@ -1814,13 +1812,13 @@ void Settings::setOutVolume(int volume)
     }
 }
 
-int Settings::getAudioCaptureMode() const
+IAudioSettings::AudioCaptureMode Settings::getAudioCaptureMode() const
 {
     const QMutexLocker locker{&bigLock};
     return audioCaptureMode;
 }
 
-void Settings::setAudioCaptureMode(int mode)
+void Settings::setAudioCaptureMode(AudioCaptureMode mode)
 {
     const QMutexLocker locker{&bigLock};
 

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -244,7 +244,15 @@ void Settings::loadGlobal()
         outVolume = s.value("outVolume", 100).toInt();
         enableTestSound = s.value("enableTestSound", true).toBool();
         audioCaptureMode = s.value("audioCaptureMode", 0).toInt();
-        pttShortcutKeys = s.value("pttShortcutKeys", QList<int>());
+
+        int pttShortcutKeysSize = s.beginReadArray("pttShortcutKeys");
+        for (int i = 0; i < pttShortcutKeysSize; i++) {
+            s.setArrayIndex(i);
+            const int key = s.value("pttKey" + QString::number(i), 0).toInt();
+            pttShortcutKeys << key;
+        }
+        s.endArray();
+
         audioBitrate = s.value("audioBitrate", 64).toInt();
     }
     s.endGroup();
@@ -713,7 +721,14 @@ void Settings::saveGlobal()
         s.setValue("outVolume", outVolume);
         s.setValue("enableTestSound", enableTestSound);
         s.setValue("audioCaptureMode", audioCaptureMode);
-        s.setValue("pttShortcutKeys", pttShortcutKeys);
+
+	s.beginWriteArray("pttShortcutKeys", pttShortcutKeys.size());
+        for (int i = 0; i < pttShortcutKeys.size(); i++) {
+            s.setArrayIndex(i);
+            s.setValue("pttKey" + QString::number(i), pttShortcutKeys[i]);
+        }
+        s.endArray();
+
         s.setValue("audioBitrate", audioBitrate);
     }
     s.endGroup();

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -253,6 +253,14 @@ void Settings::loadGlobal()
         }
         s.endArray();
 
+        int pttShortcutNamesSize = s.beginReadArray("pttShortcutNames");
+        for (int i = 0; i < pttShortcutNamesSize; i++) {
+            s.setArrayIndex(i);
+            const int key = s.value("pttName" + QString::number(i), 0).toInt();
+            pttShortcutNames << key;
+        }
+        s.endArray();
+
         audioBitrate = s.value("audioBitrate", 64).toInt();
     }
     s.endGroup();
@@ -725,6 +733,12 @@ void Settings::saveGlobal()
             for (int i = 0; i < pttShortcutKeys.size(); i++) {
                 s.setArrayIndex(i);
                 s.setValue("pttKey" + QString::number(i), pttShortcutKeys[i]);
+            }
+            s.endArray();
+        s.beginWriteArray("pttShortcutNames", pttShortcutNames.size());
+            for (int i = 0; i < pttShortcutNames.size(); i++) {
+                s.setArrayIndex(i);
+                s.setValue("pttName" + QString::number(i), pttShortcutNames[i]);
             }
             s.endArray();
         s.setValue("audioBitrate", audioBitrate);
@@ -1841,6 +1855,22 @@ void Settings::setPttShortcutKeys(QList<int> keys)
     if (keys != pttShortcutKeys) {
         pttShortcutKeys = keys;
         emit pttShortcutKeysChanged(pttShortcutKeys);
+    }
+}
+
+QList<int> Settings::getPttShortcutNames() const
+{
+   const QMutexLocker locker{&bigLock};
+   return pttShortcutNames; 
+}
+
+void Settings::setPttShortcutNames(QList<int> names)
+{
+    const QMutexLocker locker{&bigLock};
+
+    if (names != pttShortcutNames) {
+        pttShortcutNames = names;
+        emit pttShortcutNamesChanged(pttShortcutNames);
     }
 }
 

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -243,6 +243,8 @@ void Settings::loadGlobal()
         audioThreshold = s.value("audioThreshold", 0).toReal();
         outVolume = s.value("outVolume", 100).toInt();
         enableTestSound = s.value("enableTestSound", true).toBool();
+        audioCaptureMode = s.value("audioCaptureMode", 0).toInt();
+        pttShortcutKeys = s.value("pttShortcutKeys", QList<int>());
         audioBitrate = s.value("audioBitrate", 64).toInt();
     }
     s.endGroup();
@@ -710,6 +712,8 @@ void Settings::saveGlobal()
         s.setValue("audioThreshold", audioThreshold);
         s.setValue("outVolume", outVolume);
         s.setValue("enableTestSound", enableTestSound);
+        s.setValue("audioCaptureMode", audioCaptureMode);
+        s.setValue("pttShortcutKeys", pttShortcutKeys);
         s.setValue("audioBitrate", audioBitrate);
     }
     s.endGroup();
@@ -1792,6 +1796,38 @@ void Settings::setOutVolume(int volume)
 {
     if (setVal(outVolume, volume)) {
         emit outVolumeChanged(volume);
+    }
+}
+
+int Settings::getAudioCaptureMode() const
+{
+    const QMutexLocker locker{&bigLock};
+    return audioCaptureMode;
+}
+
+void Settings::setAudioCaptureMode(int mode)
+{
+    const QMutexLocker locker{&bigLock};
+
+    if (mode != audioCaptureMode) {
+        audioCaptureMode = mode;
+        emit audioCaptureModeChanged(mode);
+    }
+}
+
+QList<int> Settings::getPttShortcutKeys() const
+{
+    const QMutexLocker locker{&bigLock};
+    return pttShortcutKeys;
+}
+
+void Settings::setPttShortcutKeys(QList<int> keys)
+{
+    const QMutexLocker locker{&bigLock};
+
+    if (keys != pttShortcutKeys) {
+        pttShortcutKeys = keys;
+        emit pttShortcutKeysChanged(pttShortcutKeys);
     }
 }
 

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -370,6 +370,9 @@ public:
     
     QList<int> getPttShortcutKeys() const override;
     void setPttShortcutKeys(QList<int> keys) override;    
+
+    QList<int> getPttShortcutNames() const override;
+    void setPttShortcutNames(QList<int> keys) override;   
     
     int getAudioBitrate() const override;
     void setAudioBitrate(int bitrate) override;
@@ -388,6 +391,7 @@ public:
     SIGNAL_IMPL(Settings, outVolumeChanged, int volume)
     SIGNAL_IMPL(Settings, audioCaptureModeChanged, AudioCaptureMode mode)
     SIGNAL_IMPL(Settings, pttShortcutKeysChanged, QList<int> keys)
+    SIGNAL_IMPL(Settings, pttShortcutNamesChanged, QList<int> names)
     SIGNAL_IMPL(Settings, audioBitrateChanged, int bitrate)
     SIGNAL_IMPL(Settings, enableTestSoundChanged, bool newValue)
 
@@ -680,6 +684,7 @@ private:
     int outVolume;
     AudioCaptureMode audioCaptureMode;
     QList<int> pttShortcutKeys;
+    QList<int> pttShortcutNames;
     int audioBitrate;
     bool enableTestSound;
 

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -119,7 +119,7 @@ class Settings : public QObject,
     Q_PROPERTY(bool audioOutDevEnabled READ getAudioOutDevEnabled WRITE setAudioOutDevEnabled NOTIFY
                    audioOutDevEnabledChanged FINAL)
     Q_PROPERTY(int outVolume READ getOutVolume WRITE setOutVolume NOTIFY outVolumeChanged FINAL)
-    Q_PROPERTY(int audioCaptureMode READ getAudioCaptureMode WRITE setAudioCaptureMode NOTIFY audioCaptureModeChanged FINAL)
+    Q_PROPERTY(AudioCaptureMode audioCaptureMode READ getAudioCaptureMode WRITE setAudioCaptureMode NOTIFY audioCaptureModeChanged FINAL)
     Q_PROPERTY(QList<int> pttShortcutKeys READ getPttShortcutKeys WRITE setPttShortcutKeys NOTIFY pttShortcutKeysChanged FINAL)
     Q_PROPERTY(int audioBitrate READ getAudioBitrate WRITE setAudioBitrate NOTIFY audioBitrateChanged FINAL)
 
@@ -365,8 +365,8 @@ public:
     }
     void setOutVolume(int volume) override;
     
-    int getAudioCaptureMode() const override;
-    void setAudioCaptureMode(int mode) override;
+    AudioCaptureMode getAudioCaptureMode() const override;
+    void setAudioCaptureMode(AudioCaptureMode mode) override;
     
     QList<int> getPttShortcutKeys() const override;
     void setPttShortcutKeys(QList<int> keys) override;    
@@ -386,7 +386,7 @@ public:
     SIGNAL_IMPL(Settings, audioInGainDecibelChanged, qreal dB)
     SIGNAL_IMPL(Settings, audioThresholdChanged, qreal percent)
     SIGNAL_IMPL(Settings, outVolumeChanged, int volume)
-    SIGNAL_IMPL(Settings, audioCaptureModeChanged, int mode)
+    SIGNAL_IMPL(Settings, audioCaptureModeChanged, AudioCaptureMode mode)
     SIGNAL_IMPL(Settings, pttShortcutKeysChanged, QList<int> keys)
     SIGNAL_IMPL(Settings, audioBitrateChanged, int bitrate)
     SIGNAL_IMPL(Settings, enableTestSoundChanged, bool newValue)
@@ -678,7 +678,7 @@ private:
     QString outDev;
     bool audioOutDevEnabled;
     int outVolume;
-    int audioCaptureMode;
+    AudioCaptureMode audioCaptureMode;
     QList<int> pttShortcutKeys;
     int audioBitrate;
     bool enableTestSound;

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -119,6 +119,8 @@ class Settings : public QObject,
     Q_PROPERTY(bool audioOutDevEnabled READ getAudioOutDevEnabled WRITE setAudioOutDevEnabled NOTIFY
                    audioOutDevEnabledChanged FINAL)
     Q_PROPERTY(int outVolume READ getOutVolume WRITE setOutVolume NOTIFY outVolumeChanged FINAL)
+    Q_PROPERTY(int audioCaptureMode READ getAudioCaptureMode WRITE setAudioCaptureMode NOTIFY audioCaptureModeChanged FINAL)
+    Q_PROPERTY(QList<int> pttShortcutKeys READ getPttShortcutKeys WRITE setPttShortcutKeys NOTIFY pttShortcutKeysChanged FINAL)
     Q_PROPERTY(int audioBitrate READ getAudioBitrate WRITE setAudioBitrate NOTIFY audioBitrateChanged FINAL)
 
     // Video
@@ -362,7 +364,13 @@ public:
         return 100;
     }
     void setOutVolume(int volume) override;
-
+    
+    int getAudioCaptureMode() const override;
+    void setAudioCaptureMode(int mode) override;
+    
+    QList<int> getPttShortcutKeys() const override;
+    void setPttShortcutKeys(QList<int> keys) override;    
+    
     int getAudioBitrate() const override;
     void setAudioBitrate(int bitrate) override;
 
@@ -378,6 +386,8 @@ public:
     SIGNAL_IMPL(Settings, audioInGainDecibelChanged, qreal dB)
     SIGNAL_IMPL(Settings, audioThresholdChanged, qreal percent)
     SIGNAL_IMPL(Settings, outVolumeChanged, int volume)
+    SIGNAL_IMPL(Settings, audioCaptureModeChanged, int mode)
+    SIGNAL_IMPL(Settings, pttShortcutKeysChanged, QList<int> keys)
     SIGNAL_IMPL(Settings, audioBitrateChanged, int bitrate)
     SIGNAL_IMPL(Settings, enableTestSoundChanged, bool newValue)
 
@@ -668,6 +678,8 @@ private:
     QString outDev;
     bool audioOutDevEnabled;
     int outVolume;
+    int audioCaptureMode;
+    QList<int> pttShortcutKeys;
     int audioBitrate;
     bool enableTestSound;
 

--- a/src/widget/form/chatform.h
+++ b/src/widget/form/chatform.h
@@ -76,6 +76,7 @@ public slots:
     void onShowMessagesClicked();
     void onSplitterMoved(int pos, int index);
     void reloadTheme() final;
+    void onMicMuteToggle();
 
 private slots:
     void updateFriendActivityForFile(const ToxFile& file);
@@ -87,7 +88,7 @@ private slots:
     void onVideoCallTriggered();
     void onAnswerCallTriggered(bool video);
     void onRejectCallTriggered();
-    void onMicMuteToggle();
+
     void onVolMuteToggle();
 
     void onFriendStatusChanged(quint32 friendId, Status::Status status);

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -576,7 +576,7 @@ void AVForm::showPttShortcutKeys()
         keyString += QString::number(keys[i]) + "+";
     }
 
-    keyString.replace(QRegExp("++$"), "");
+    keyString.replace(QRegExp("[+]+$"), "");
     pushToTalkShortcutInput->setText(keyString);
     pushToTalkShortcutInput->blockSignals(previouslyBlocked);
 }

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -95,6 +95,7 @@ AVForm::AVForm(IAudioControl& audio, CoreAV* coreAV, CameraSource& camera,
 
     volumeDisplay->setMaximum(totalSliderSteps);
 
+    fillCaptureModeComboBox();
     fillAudioQualityComboBox();
 
     eventsInit();
@@ -546,6 +547,52 @@ void AVForm::on_inDevCombobox_currentIndexChanged(int deviceIndex)
     if (!inputEnabled) {
         volumeDisplay->setValue(volumeDisplay->minimum());
     }
+}
+
+void AVForm::fillCaptureModeComboBox()
+{
+    const bool previouslyBlocked = inModeComboBox->blockSignals(true);
+
+    inModeComboBox->addItem(tr("Continuous transmission"), 0);
+    inModeComboBox->addItem(tr("Voice activation"), 1);
+    inModeComboBox->addItem(tr("Push to talk"), 2);
+
+    const int mode = audioSettings->getAudioCaptureMode();
+    const int index = inModeComboBox->findData(mode);
+
+    updateCaptureModeUI(mode);
+    inModeComboBox->setCurrentIndex(index);
+    inModeComboBox->blockSignals(previouslyBlocked);
+}
+
+void AVForm::updateCaptureModeUI(int mode)
+{
+    audioThresholdLabel->hide();
+    audioThresholdSlider->hide();
+    pushToTalkShortcutLabel->hide();
+    pushToTalkShortcutInput->hide();
+    
+    switch (mode) {
+        case 0:
+            break;
+        case 1:
+            audioThresholdLabel->show();
+            audioThresholdSlider->show();
+            break;
+        case 2:
+            pushToTalkShortcutLabel->show();
+            pushToTalkShortcutInput->show();
+            break;
+        default:
+            break;
+    }
+}
+
+void AVForm::on_inModeComboBox_currentIndexChanged(int index)
+{
+    const int mode = inModeComboBox->currentData().toInt(); 
+    audioSettings->setAudioCaptureMode(mode);
+    updateCaptureModeUI(mode);
 }
 
 void AVForm::on_outDevCombobox_currentIndexChanged(int deviceIndex)

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -99,6 +99,8 @@ AVForm::AVForm(IAudioControl& audio, CoreAV* coreAV, CameraSource& camera,
 
     fillCaptureModeComboBox();
     pushToTalkShortcutInput->Initialize(*audioSettings);
+    connect(pushToTalkShortcutInput, &HotkeyInput::pauseKeyBlocking, this, &AVForm::pauseKeyBlocking);
+    connect(pushToTalkShortcutInput, &HotkeyInput::resumeKeyBlocking, this, &AVForm::resumeKeyBlocking);
     fillAudioQualityComboBox();
 
     eventsInit();

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -97,7 +97,7 @@ AVForm::AVForm(IAudioControl& audio, CoreAV* coreAV, CameraSource& camera,
     volumeDisplay->setMaximum(totalSliderSteps);
 
     fillCaptureModeComboBox();
-    showPttShortcutKeys();
+    pushToTalkShortcutInput->Initialize(*audioSettings);
     fillAudioQualityComboBox();
 
     eventsInit();
@@ -565,22 +565,6 @@ void AVForm::fillCaptureModeComboBox()
     updateCaptureModeUI(mode);
     inModeComboBox->setCurrentIndex(index);
     inModeComboBox->blockSignals(previouslyBlocked);
-}
-
-void AVForm::showPttShortcutKeys()
-{
-    pushToTalkShortcutInput->Initialize(*audioSettings);
-    const bool previouslyBlocked = pushToTalkShortcutInput->blockSignals(true);
-    const QList<int> keys = audioSettings->getPttShortcutKeys();
-
-    QString keyString = "";
-    for (int i = 0; i < keys.length(); i++) {
-        keyString += QString::number(keys[i]) + "+";
-    }
-
-    keyString.replace(QRegExp("[+]+$"), "");
-    pushToTalkShortcutInput->setText(keyString);
-    pushToTalkShortcutInput->blockSignals(previouslyBlocked);
 }
 
 void AVForm::updateCaptureModeUI(IAudioSettings::AudioCaptureMode mode)

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -96,6 +96,7 @@ AVForm::AVForm(IAudioControl& audio, CoreAV* coreAV, CameraSource& camera,
     volumeDisplay->setMaximum(totalSliderSteps);
 
     fillCaptureModeComboBox();
+    showPttShortcutKeys();
     fillAudioQualityComboBox();
 
     eventsInit();
@@ -563,6 +564,21 @@ void AVForm::fillCaptureModeComboBox()
     updateCaptureModeUI(mode);
     inModeComboBox->setCurrentIndex(index);
     inModeComboBox->blockSignals(previouslyBlocked);
+}
+
+void AVForm::showPttShortcutKeys()
+{
+    const bool previouslyBlocked = pushToTalkShortcutInput->blockSignals(true);
+    const QList<int> keys = audioSettings->getPttShortcutKeys();
+
+    QString keyString = "";
+    for (int i = 0; i < keys.length(); i++) {
+        keyString += QString::number(keys[i]) + "+";
+    }
+
+    keyString.replace(QRegExp("++$"), "");
+    pushToTalkShortcutInput->setText(keyString);
+    pushToTalkShortcutInput->blockSignals(previouslyBlocked);
 }
 
 void AVForm::updateCaptureModeUI(int mode)

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -54,6 +54,7 @@ AVForm::AVForm(IAudioControl& audio, CoreAV* coreAV, CameraSource& camera,
     , camVideoSurface(nullptr)
     , camera(camera)
 {
+    assert(audioSettings);
     setupUi(this);
 
     // block all child signals during initialization
@@ -568,6 +569,7 @@ void AVForm::fillCaptureModeComboBox()
 
 void AVForm::showPttShortcutKeys()
 {
+    pushToTalkShortcutInput->Initialize(*audioSettings);
     const bool previouslyBlocked = pushToTalkShortcutInput->blockSignals(true);
     const QList<int> keys = audioSettings->getPttShortcutKeys();
 

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -554,12 +554,12 @@ void AVForm::fillCaptureModeComboBox()
 {
     const bool previouslyBlocked = inModeComboBox->blockSignals(true);
 
-    inModeComboBox->addItem(tr("Continuous transmission"), 0);
-    inModeComboBox->addItem(tr("Voice activation"), 1);
-    inModeComboBox->addItem(tr("Push to talk"), 2);
+    inModeComboBox->addItem(tr("Continuous transmission"), static_cast<int>(IAudioSettings::AudioCaptureMode::Continuous));
+    inModeComboBox->addItem(tr("Voice activation"), static_cast<int>(IAudioSettings::AudioCaptureMode::VoiceActivation));
+    inModeComboBox->addItem(tr("Push to talk"), static_cast<int>(IAudioSettings::AudioCaptureMode::PushToTalk));
 
-    const int mode = audioSettings->getAudioCaptureMode();
-    const int index = inModeComboBox->findData(mode);
+    const IAudioSettings::AudioCaptureMode mode = audioSettings->getAudioCaptureMode();
+    const int index = inModeComboBox->findData(static_cast<int>(mode));
 
     updateCaptureModeUI(mode);
     inModeComboBox->setCurrentIndex(index);
@@ -581,7 +581,7 @@ void AVForm::showPttShortcutKeys()
     pushToTalkShortcutInput->blockSignals(previouslyBlocked);
 }
 
-void AVForm::updateCaptureModeUI(int mode)
+void AVForm::updateCaptureModeUI(IAudioSettings::AudioCaptureMode mode)
 {
     audioThresholdLabel->hide();
     audioThresholdSlider->hide();
@@ -589,24 +589,22 @@ void AVForm::updateCaptureModeUI(int mode)
     pushToTalkShortcutInput->hide();
     
     switch (mode) {
-        case 0:
+        case IAudioSettings::AudioCaptureMode::Continuous:
             break;
-        case 1:
+        case IAudioSettings::AudioCaptureMode::VoiceActivation:
             audioThresholdLabel->show();
             audioThresholdSlider->show();
             break;
-        case 2:
+        case IAudioSettings::AudioCaptureMode::PushToTalk:
             pushToTalkShortcutLabel->show();
             pushToTalkShortcutInput->show();
-            break;
-        default:
             break;
     }
 }
 
 void AVForm::on_inModeComboBox_currentIndexChanged(int index)
 {
-    const int mode = inModeComboBox->currentData().toInt(); 
+    const IAudioSettings::AudioCaptureMode mode = static_cast<IAudioSettings::AudioCaptureMode>(inModeComboBox->currentData().toInt()); 
     audioSettings->setAudioCaptureMode(mode);
     updateCaptureModeUI(mode);
 }

--- a/src/widget/form/settings/avform.cpp
+++ b/src/widget/form/settings/avform.cpp
@@ -39,6 +39,7 @@
 #include "src/widget/tool/recursivesignalblocker.h"
 #include "src/widget/tool/screenshotgrabber.h"
 #include "src/widget/translator.h"
+#include "src/hookmanager.h"
 
 #ifndef ALC_ALL_DEVICES_SPECIFIER
 #define ALC_ALL_DEVICES_SPECIFIER ALC_DEVICE_SPECIFIER
@@ -557,7 +558,9 @@ void AVForm::fillCaptureModeComboBox()
 
     inModeComboBox->addItem(tr("Continuous transmission"), static_cast<int>(IAudioSettings::AudioCaptureMode::Continuous));
     inModeComboBox->addItem(tr("Voice activation"), static_cast<int>(IAudioSettings::AudioCaptureMode::VoiceActivation));
-    inModeComboBox->addItem(tr("Push to talk"), static_cast<int>(IAudioSettings::AudioCaptureMode::PushToTalk));
+    if (HookManager::isPttSupported()) {
+        inModeComboBox->addItem(tr("Push to talk"), static_cast<int>(IAudioSettings::AudioCaptureMode::PushToTalk));
+    }
 
     const IAudioSettings::AudioCaptureMode mode = audioSettings->getAudioCaptureMode();
     const int index = inModeComboBox->findData(static_cast<int>(mode));

--- a/src/widget/form/settings/avform.h
+++ b/src/widget/form/settings/avform.h
@@ -26,6 +26,7 @@
 #include "genericsettings.h"
 #include "ui_avform.h"
 #include "src/video/videomode.h"
+#include "audio/iaudiosettings.h"
 
 #include <memory>
 
@@ -61,7 +62,7 @@ private:
     void fillCaptureModeComboBox();
     void showPttShortcutKeys();
     void fillAudioQualityComboBox();
-    void updateCaptureModeUI(int mode);
+    void updateCaptureModeUI(IAudioSettings::AudioCaptureMode mode);
     int searchPreferredIndex();
 
     void createVideoSurface();

--- a/src/widget/form/settings/avform.h
+++ b/src/widget/form/settings/avform.h
@@ -60,7 +60,6 @@ private:
     void fillCameraModesComboBox();
     void fillScreenModesComboBox();
     void fillCaptureModeComboBox();
-    void showPttShortcutKeys();
     void fillAudioQualityComboBox();
     void updateCaptureModeUI(IAudioSettings::AudioCaptureMode mode);
     int searchPreferredIndex();

--- a/src/widget/form/settings/avform.h
+++ b/src/widget/form/settings/avform.h
@@ -59,6 +59,8 @@ private:
     void fillCameraModesComboBox();
     void fillScreenModesComboBox();
     void fillAudioQualityComboBox();
+    void fillCaptureModeComboBox();
+    void updateCaptureModeUI(int mode);
     int searchPreferredIndex();
 
     void createVideoSurface();
@@ -75,6 +77,7 @@ private slots:
     void on_microphoneSlider_valueChanged(int sliderSteps);
     void on_audioThresholdSlider_valueChanged(int sliderSteps);
     void on_audioQualityComboBox_currentIndexChanged(int index);
+    void on_inModeComboBox_currentIndexChanged(int index);
 
     // camera
     void on_videoDevCombobox_currentIndexChanged(int index);

--- a/src/widget/form/settings/avform.h
+++ b/src/widget/form/settings/avform.h
@@ -58,8 +58,9 @@ private:
     void selectBestModes(QVector<VideoMode>& allVideoModes);
     void fillCameraModesComboBox();
     void fillScreenModesComboBox();
-    void fillAudioQualityComboBox();
     void fillCaptureModeComboBox();
+    void showPttShortcutKeys();
+    void fillAudioQualityComboBox();
     void updateCaptureModeUI(int mode);
     int searchPreferredIndex();
 

--- a/src/widget/form/settings/avform.h
+++ b/src/widget/form/settings/avform.h
@@ -50,6 +50,10 @@ public:
         return tr("Audio/Video");
     }
 
+signals:
+    void pauseKeyBlocking() const;
+    void resumeKeyBlocking() const;
+
 private:
     void getAudioInDevices();
     void getAudioOutDevices();

--- a/src/widget/form/settings/avform.ui
+++ b/src/widget/form/settings/avform.ui
@@ -102,13 +102,23 @@
            </widget>
           </item>
           <item row="4" column="0">
-           <widget class="QLabel" name="audioThresholdLabel">
+           <widget class="QLabel" name="inModeLabel">
             <property name="text">
-             <string>Threshold</string>
+             <string>Capture mode</string>
             </property>
            </widget>
           </item>
           <item row="4" column="1" colspan="2">
+           <widget class="QComboBox" name="inModeComboBox"></widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="audioThresholdLabel">
+            <property name="text">
+             <string>Activation threshold</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1" colspan="2">
            <widget class="QSlider" name="audioThresholdSlider">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
@@ -116,21 +126,14 @@
            </widget>
           </item>
           <item row="5" column="0">
-           <widget class="QLabel" name="volumeDisplayLabel">
+           <widget class="QLabel" name="pushToTalkShortcutLabel">
             <property name="text">
-             <string>Volume</string>
+             <string>Shortcut</string>
             </property>
            </widget>
           </item>
-          <item row="5" column="1" colspan="2">
-           <widget class="QProgressBar" name="volumeDisplay">
-            <property name="textVisible">
-             <bool>false</bool>
-            </property>
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-           </widget>
+          <item row="5" column="1">
+           <widget class="HotkeyInput" name="pushToTalkShortcutInput"></widget>
           </item>
           <item row="0" column="0">
            <widget class="QLabel" name="outDevLabel">
@@ -156,6 +159,36 @@
             </property>
             <property name="toolTip">
              <string>Transmitted audio quality. Lower this setting if your bandwidth is not high enough or if you want to reduce bandwidth usage.</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="0">
+           <widget class="QLabel" name="volumeDisplayLabel">
+            <property name="text">
+             <string>Volume preview</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="1" colspan="2">
+           <widget class="QProgressBar" name="volumeDisplay">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="textVisible">
+             <bool>false</bool>
+            </property>
+           </widget>
+	   </item> 
+	  <item row="8" column="0" colspan="3">
+           <widget class="QCheckBox" name="cbEnableBackend2">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="toolTip">
+             <string>Enables the experimental audio backend with echo cancelling support, needs qTox restart to take effect.</string>
+            </property>
+            <property name="text">
+             <string>Enable experimental audio backend</string>
             </property>
            </widget>
           </item>
@@ -253,6 +286,11 @@ which may lead to problems with video calls.</string>
    <header>src/widget/form/settings/verticalonlyscroller.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>HotkeyInput</class>
+   <extends>QTextEdit</extends>
+   <header>src/widget/form/settings/hotkeyinput.h</header>
+  </customwidget> 
  </customwidgets>
  <tabstops>
   <tabstop>scrollArea</tabstop>

--- a/src/widget/form/settings/avform.ui
+++ b/src/widget/form/settings/avform.ui
@@ -30,8 +30,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>830</width>
-        <height>495</height>
+        <width>810</width>
+        <height>527</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -109,7 +109,7 @@
            </widget>
           </item>
           <item row="4" column="1" colspan="2">
-           <widget class="QComboBox" name="inModeComboBox"></widget>
+           <widget class="QComboBox" name="inModeComboBox"/>
           </item>
           <item row="5" column="0">
            <widget class="QLabel" name="audioThresholdLabel">
@@ -133,7 +133,11 @@
            </widget>
           </item>
           <item row="5" column="1">
-           <widget class="HotkeyInput" name="pushToTalkShortcutInput"></widget>
+           <widget class="HotkeyInput" name="pushToTalkShortcutInput">
+            <property name="toolTip">
+             <string>Set a push to talk hotkey.</string>
+            </property>
+           </widget>
           </item>
           <item row="0" column="0">
            <widget class="QLabel" name="outDevLabel">
@@ -171,15 +175,15 @@
           </item>
           <item row="7" column="1" colspan="2">
            <widget class="QProgressBar" name="volumeDisplay">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
             <property name="textVisible">
              <bool>false</bool>
             </property>
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
            </widget>
-	   </item> 
-	  <item row="8" column="0" colspan="3">
+          </item>
+          <item row="8" column="0" colspan="3">
            <widget class="QCheckBox" name="cbEnableBackend2">
             <property name="enabled">
              <bool>true</bool>
@@ -288,9 +292,9 @@ which may lead to problems with video calls.</string>
   </customwidget>
   <customwidget>
    <class>HotkeyInput</class>
-   <extends>QTextEdit</extends>
+   <extends>QLineEdit</extends>
    <header>src/widget/form/settings/hotkeyinput.h</header>
-  </customwidget> 
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>scrollArea</tabstop>

--- a/src/widget/form/settings/hotkeyinput.cpp
+++ b/src/widget/form/settings/hotkeyinput.cpp
@@ -27,7 +27,7 @@
 namespace
 {
     static const QString noKeyString = QObject::tr("<no key>");
-    static const QString pressAnyKeyString = QObject::tr("Press any key or Esc to cancel");
+    static const QString pressAnyKeyString = QObject::tr("Press any key combo");
 
     int healUnprintableKeys(int key)
     {
@@ -95,15 +95,6 @@ void HotkeyInput::keyPressEvent(QKeyEvent* event)
     QList<int> keyVals;
     QList<int> keyNames;
 
-    if (event->key() == Qt::Key_Escape) {
-        this->clear();
-        wasCleared = true;
-        settings->setPttShortcutKeys(keyVals);
-        settings->setPttShortcutNames(keyNames);
-        this->clearFocus();
-        return;
-    }
-
     int nativeKey = event->nativeVirtualKey();
     if (!isReadyToOverwrite) {
         keyVals = settings->getPttShortcutKeys();
@@ -142,11 +133,10 @@ void HotkeyInput::focusOutEvent(QFocusEvent* event)
 {
     emit resumeKeyBlocking();
     const QString text = this->text();
-    if (text == "" && !wasCleared) {
+    if (text == "") {
         const QList<int> keyNames = settings->getPttShortcutNames();
         this->setText(keysToLabel(keyNames));
     }
 
-    wasCleared = false;
     setPlaceholderText(noKeyString);
 }

--- a/src/widget/form/settings/hotkeyinput.cpp
+++ b/src/widget/form/settings/hotkeyinput.cpp
@@ -104,7 +104,7 @@ void HotkeyInput::keyPressEvent(QKeyEvent* event)
         return;
     }
 
-    int nativeKey = event->nativeScanCode();
+    int nativeKey = event->nativeVirtualKey();
     if (!isReadyToOverwrite) {
         keyVals = settings->getPttShortcutKeys();
         keyNames = settings->getPttShortcutNames();

--- a/src/widget/form/settings/hotkeyinput.cpp
+++ b/src/widget/form/settings/hotkeyinput.cpp
@@ -1,0 +1,75 @@
+/*
+    Copyright © 2018-2020 by The qTox Project Contributors
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <QKeyEvent>
+#include <QDebug>
+
+#include "hotkeyinput.h"
+#include "audio/iaudiosettings.h"
+#include "src/persistence/settings.h"
+
+HotkeyInput::HotkeyInput(QWidget* parent)
+    : QTextEdit(parent)
+{
+    setAcceptRichText(false);
+    setAcceptDrops(false);
+}
+
+void HotkeyInput::keyPressEvent(QKeyEvent* event)
+{
+    int key = event->key();
+    int nativeKey = event->nativeScanCode();
+    QString keyString;
+    QString modifierString = "";
+
+    if (event->modifiers() & Qt::MetaModifier) {
+        modifierString += "Command+";
+    }
+
+    if (event->modifiers() & Qt::ControlModifier) {
+        modifierString += "Ctrl+";
+    }
+
+    if (event->modifiers() & Qt::ShiftModifier) {
+        modifierString += "Shift+";
+    }
+
+    if (event->modifiers() & Qt::AltModifier) {
+        modifierString += "Alt+";
+    }
+
+    QKeySequence keySequence = QKeySequence(nativeKey);
+    keyString = modifierString;
+
+    if (keySequence != Qt::Key_unknown && keySequence != 0) {
+        keyString += keySequence.toString();
+    }
+    
+    QList<int> keys = Settings::getInstance().getPttShortcutKeys();
+    if (keys.indexOf(nativeKey) == -1)
+    {
+	    keys.append(nativeKey);
+	    Settings::getInstance().setPttShortcutKeys(keys);
+    }
+
+    keyString.replace(QRegExp("++$"), "");
+    this->setText(keyString);
+
+    qDebug() << " " << event->nativeScanCode();
+}

--- a/src/widget/form/settings/hotkeyinput.cpp
+++ b/src/widget/form/settings/hotkeyinput.cpp
@@ -24,10 +24,11 @@
 #include "audio/iaudiosettings.h"
 #include "src/persistence/settings.h"
 
-bool wasCleared = false;
-bool isReadyToOverwrite = false;
-QString noKeyString = QObject::tr("<no key>");
-QString pressAnyKeyString = QObject::tr("Press any key or Esc to cancel");
+namespace
+{
+    static const QString noKeyString = QObject::tr("<no key>");
+    static const QString pressAnyKeyString = QObject::tr("Press any key or Esc to cancel");
+}
 
 HotkeyInput::HotkeyInput(QWidget* parent)
     : QLineEdit(parent)

--- a/src/widget/form/settings/hotkeyinput.cpp
+++ b/src/widget/form/settings/hotkeyinput.cpp
@@ -132,6 +132,7 @@ void HotkeyInput::keyReleaseEvent(QKeyEvent* event)
 
 void HotkeyInput::focusInEvent(QFocusEvent* event)
 {
+    emit pauseKeyBlocking(); // so that the old shortcut doesn't block the new shortcut from being set
     this->clear();
     setPlaceholderText(pressAnyKeyString);
     isReadyToOverwrite = true;
@@ -139,6 +140,7 @@ void HotkeyInput::focusInEvent(QFocusEvent* event)
 
 void HotkeyInput::focusOutEvent(QFocusEvent* event)
 {
+    emit resumeKeyBlocking();
     const QString text = this->text();
     if (text == "" && !wasCleared) {
         const QList<int> keyNames = settings->getPttShortcutNames();

--- a/src/widget/form/settings/hotkeyinput.cpp
+++ b/src/widget/form/settings/hotkeyinput.cpp
@@ -30,11 +30,10 @@ QString noKeyString = QObject::tr("<no key>");
 QString pressAnyKeyString = QObject::tr("Press any key or Esc to cancel");
 
 HotkeyInput::HotkeyInput(QWidget* parent)
-    : QTextEdit(parent)
+    : QLineEdit(parent)
 {
-    setAcceptRichText(false);
-    setAcceptDrops(false);
     setPlaceholderText(noKeyString);
+    setReadOnly(true); // hides the caret
 }
 
 QString keyListToString(QList<int> keys)
@@ -45,13 +44,13 @@ QString keyListToString(QList<int> keys)
         keyString += QString::number(keys[i]) + "+";
     }
 
-    keyString.replace(QRegExp("++$"), "");
+    keyString.replace(QRegExp("[+]+$"), "");
     return keyString;
 }
 
 void HotkeyInput::keyPressEvent(QKeyEvent* event)
 {
-    // we only want to act on key press event, not on key hold event
+    // we only want to act on key press, not on key hold
     if (event->isAutoRepeat()) {
         return;
     }
@@ -97,7 +96,7 @@ void HotkeyInput::focusInEvent(QFocusEvent* event)
 
 void HotkeyInput::focusOutEvent(QFocusEvent* event)
 {
-    const QString text = this->toPlainText();
+    const QString text = this->text();
     if (text == "" && !wasCleared) {
         const QList<int> keys = Settings::getInstance().getPttShortcutKeys();
         this->setText(keyListToString(keys));

--- a/src/widget/form/settings/hotkeyinput.cpp
+++ b/src/widget/form/settings/hotkeyinput.cpp
@@ -37,6 +37,11 @@ HotkeyInput::HotkeyInput(QWidget* parent)
     setReadOnly(true); // hides the caret
 }
 
+void HotkeyInput::Initialize(IAudioSettings& _settings)
+{
+    settings = &_settings;
+}
+
 QString keyListToString(QList<int> keys)
 {
     // TODO: get key names from GlobalHotkey instead of displaying key numbers
@@ -61,19 +66,19 @@ void HotkeyInput::keyPressEvent(QKeyEvent* event)
     if (event->key() == Qt::Key_Escape) {
         this->clear();
         wasCleared = true;
-        Settings::getInstance().setPttShortcutKeys(keys);
+        settings->setPttShortcutKeys(keys);
         this->clearFocus();
         return;
     }
 
     int nativeKey = event->nativeScanCode();
     if (!isReadyToOverwrite) {
-        keys = Settings::getInstance().getPttShortcutKeys();
+        keys = settings->getPttShortcutKeys();
     }
 
     if (keys.indexOf(nativeKey) == -1) {
         keys.append(nativeKey);
-        Settings::getInstance().setPttShortcutKeys(keys);
+        settings->setPttShortcutKeys(keys);
     }
 
     isReadyToOverwrite = false;
@@ -89,7 +94,7 @@ void HotkeyInput::keyReleaseEvent(QKeyEvent* event)
 
 void HotkeyInput::focusInEvent(QFocusEvent* event)
 {
-    const QList<int> keys = Settings::getInstance().getPttShortcutKeys();
+    const QList<int> keys = settings->getPttShortcutKeys();
     this->clear();
     setPlaceholderText(pressAnyKeyString);
     isReadyToOverwrite = true;
@@ -99,7 +104,7 @@ void HotkeyInput::focusOutEvent(QFocusEvent* event)
 {
     const QString text = this->text();
     if (text == "" && !wasCleared) {
-        const QList<int> keys = Settings::getInstance().getPttShortcutKeys();
+        const QList<int> keys = settings->getPttShortcutKeys();
         this->setText(keyListToString(keys));
     }
 

--- a/src/widget/form/settings/hotkeyinput.h
+++ b/src/widget/form/settings/hotkeyinput.h
@@ -31,6 +31,10 @@ public:
     explicit HotkeyInput(QWidget* parent = 0);
     void Initialize(IAudioSettings& _settings);
 
+signals:
+    void pauseKeyBlocking() const;
+    void resumeKeyBlocking() const;
+
 protected:
     virtual void keyPressEvent(QKeyEvent* event) final override;
     virtual void keyReleaseEvent(QKeyEvent* event) final override;

--- a/src/widget/form/settings/hotkeyinput.h
+++ b/src/widget/form/settings/hotkeyinput.h
@@ -1,0 +1,35 @@
+/*
+    Copyright © 2018-2020 by The qTox Project Contributors
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef HOTKEYINPUT_H
+#define HOTKEYINPUT_H
+
+#include <QTextEdit>
+
+class HotkeyInput : public QTextEdit
+{
+    Q_OBJECT
+public:
+    explicit HotkeyInput(QWidget* parent = 0);
+
+protected:
+    virtual void keyPressEvent(QKeyEvent* event) final override;
+};
+
+#endif // HOTKEYINPUT_H

--- a/src/widget/form/settings/hotkeyinput.h
+++ b/src/widget/form/settings/hotkeyinput.h
@@ -43,7 +43,6 @@ protected:
 
 private:
     IAudioSettings* settings = nullptr;
-    bool wasCleared = false;
     bool isReadyToOverwrite = false;
 };
 

--- a/src/widget/form/settings/hotkeyinput.h
+++ b/src/widget/form/settings/hotkeyinput.h
@@ -30,6 +30,9 @@ public:
 
 protected:
     virtual void keyPressEvent(QKeyEvent* event) final override;
+    virtual void keyReleaseEvent(QKeyEvent* event) final override;
+    virtual void focusInEvent(QFocusEvent* event) final override;
+    virtual void focusOutEvent(QFocusEvent* event) final override;
 };
 
 #endif // HOTKEYINPUT_H

--- a/src/widget/form/settings/hotkeyinput.h
+++ b/src/widget/form/settings/hotkeyinput.h
@@ -33,6 +33,10 @@ protected:
     virtual void keyReleaseEvent(QKeyEvent* event) final override;
     virtual void focusInEvent(QFocusEvent* event) final override;
     virtual void focusOutEvent(QFocusEvent* event) final override;
+
+private:
+    bool wasCleared = false;
+    bool isReadyToOverwrite = false;
 };
 
 #endif // HOTKEYINPUT_H

--- a/src/widget/form/settings/hotkeyinput.h
+++ b/src/widget/form/settings/hotkeyinput.h
@@ -20,9 +20,9 @@
 #ifndef HOTKEYINPUT_H
 #define HOTKEYINPUT_H
 
-#include <QTextEdit>
+#include <QLineEdit>
 
-class HotkeyInput : public QTextEdit
+class HotkeyInput : public QLineEdit
 {
     Q_OBJECT
 public:

--- a/src/widget/form/settings/hotkeyinput.h
+++ b/src/widget/form/settings/hotkeyinput.h
@@ -22,11 +22,14 @@
 
 #include <QLineEdit>
 
+class IAudioSettings;
+
 class HotkeyInput : public QLineEdit
 {
     Q_OBJECT
 public:
     explicit HotkeyInput(QWidget* parent = 0);
+    void Initialize(IAudioSettings& _settings);
 
 protected:
     virtual void keyPressEvent(QKeyEvent* event) final override;
@@ -35,6 +38,7 @@ protected:
     virtual void focusOutEvent(QFocusEvent* event) final override;
 
 private:
+    IAudioSettings* settings = nullptr;
     bool wasCleared = false;
     bool isReadyToOverwrite = false;
 };

--- a/src/widget/form/settingswidget.cpp
+++ b/src/widget/form/settingswidget.cpp
@@ -66,6 +66,9 @@ SettingsWidget::SettingsWidget(UpdateCheck* updateCheck, IAudioControl& audio, C
 
     AVForm* rawAvfrm = new AVForm(audio, coreAV, camera, audioSettings, videoSettings);
     std::unique_ptr<AVForm> avfrm(rawAvfrm);
+    connect(rawAvfrm, &AVForm::pauseKeyBlocking, this, &SettingsWidget::pauseKeyBlocking);
+    connect(rawAvfrm, &AVForm::resumeKeyBlocking, this, &SettingsWidget::resumeKeyBlocking);
+
     std::unique_ptr<AdvancedForm> expfrm(new AdvancedForm());
     std::unique_ptr<AboutForm> abtfrm(new AboutForm(updateCheck));
 

--- a/src/widget/form/settingswidget.h
+++ b/src/widget/form/settingswidget.h
@@ -55,6 +55,10 @@ public:
 public slots:
     void onUpdateAvailable(void);
 
+signals:
+    void pauseKeyBlocking() const;
+    void resumeKeyBlocking() const;
+
 private slots:
     void onTabChanged(int);
 

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -80,6 +80,7 @@
 #include "src/widget/style.h"
 #include "src/widget/translator.h"
 #include "tool/removefrienddialog.h"
+#include "src/globalshortcut.h"
 
 bool toxActivateEventHandler(const QByteArray&)
 {
@@ -148,6 +149,7 @@ Widget::Widget(Profile &_profile, IAudioControl& audio, QWidget* parent)
     , eventIcon(false)
     , audio(audio)
     , settings(Settings::getInstance())
+    , globalshortcut{this}
 {
     installEventFilter(this);
     QString locale = settings.getTranslation();
@@ -348,6 +350,9 @@ void Widget::init()
     new QShortcut(Qt::CTRL + Qt::Key_PageUp, this, SLOT(previousContact()));
     new QShortcut(Qt::CTRL + Qt::Key_PageDown, this, SLOT(nextContact()));
     new QShortcut(Qt::Key_F11, this, SLOT(toggleFullscreen()));
+
+    connect(&settings, &Settings::pttShortcutKeysChanged,
+            &globalshortcut, &GlobalShortcut::onPttShortcutKeysChanged);
 
 #ifdef Q_OS_MAC
     QMenuBar* globalMenu = Nexus::getInstance().globalMenuBar;
@@ -1198,6 +1203,7 @@ void Widget::addFriend(uint32_t friendId, const ToxPk& friendPk)
     connect(widget, &FriendWidget::copyFriendIdToClipboard, this, &Widget::copyFriendIdToClipboard);
     connect(widget, &FriendWidget::contextMenuCalled, widget, &FriendWidget::onContextMenuCalled);
     connect(widget, SIGNAL(removeFriend(const ToxPk&)), this, SLOT(removeFriend(const ToxPk&)));
+    connect(&globalshortcut, &GlobalShortcut::toggled, friendForm, &ChatForm::onMicMuteToggle);
 
     connect(&profile, &Profile::friendAvatarSet, widget, &FriendWidget::onAvatarSet);
     connect(&profile, &Profile::friendAvatarRemoved, widget, &FriendWidget::onAvatarRemoved);

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -290,6 +290,8 @@ void Widget::init()
 #if UPDATE_CHECK_ENABLED
     updateCheck->checkForUpdate();
 #endif
+    connect(settingsWidget, &SettingsWidget::pauseKeyBlocking, this, &Widget::pauseKeyBlocking);
+    connect(settingsWidget, &SettingsWidget::resumeKeyBlocking, this, &Widget::resumeKeyBlocking);
 
     CoreFile* coreFile = core->getCoreFile();
     profileInfo = new ProfileInfo(core, &profile);
@@ -2687,6 +2689,8 @@ void Widget::onAudioCaptureModeChanged(IAudioSettings::AudioCaptureMode mode)
         globalshortcut = std::unique_ptr<GlobalShortcut>{new GlobalShortcut{this}};
         connect(&settings, &Settings::pttShortcutKeysChanged, globalshortcut.get(), &GlobalShortcut::onPttShortcutKeysChanged);
         connect(globalshortcut.get(), &GlobalShortcut::toggled, this, &Widget::pttToggled);
+        connect(this, &Widget::pauseKeyBlocking, globalshortcut.get(), &GlobalShortcut::onPauseKeyBlocking);
+        connect(this, &Widget::resumeKeyBlocking, globalshortcut.get(), &GlobalShortcut::onResumeKeyBlocking);
     } else {
         globalshortcut.reset();
     }

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -39,6 +39,7 @@
 #endif
 
 #include "audio/audio.h"
+#include "audio/iaudiosettings.h"
 #include "circlewidget.h"
 #include "contentdialog.h"
 #include "contentlayout.h"

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -30,6 +30,7 @@
 
 #include "audio/iaudiocontrol.h"
 #include "audio/iaudiosink.h"
+#include "audio/iaudiosettings.h"
 #include "src/core/core.h"
 #include "src/core/groupid.h"
 #include "src/core/toxfile.h"
@@ -37,6 +38,7 @@
 #include "src/core/toxpk.h"
 #include "src/model/friendmessagedispatcher.h"
 #include "src/model/groupmessagedispatcher.h"
+#include "src/globalshortcut.h"
 #if DESKTOP_NOTIFICATIONS
 #include "src/model/notificationgenerator.h"
 #include "src/platform/desktop_notifications/desktopnotify.h"
@@ -205,6 +207,7 @@ signals:
     void statusMessageChanged(const QString& statusMessage);
     void resized();
     void windowStateChanged(Qt::WindowStates states);
+    void pttMute();
 
 private slots:
     void onAddClicked();
@@ -357,7 +360,7 @@ private:
     QMap<GroupId, std::shared_ptr<GroupChatroom>> groupChatrooms;
     QMap<GroupId, QSharedPointer<GroupChatForm>> groupChatForms;
     Core* core = nullptr;
-
+    GlobalShortcut globalshortcut;
 
     MessageProcessor::SharedParams sharedMessageProcessorParams;
 #if DESKTOP_NOTIFICATIONS

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -207,7 +207,7 @@ signals:
     void statusMessageChanged(const QString& statusMessage);
     void resized();
     void windowStateChanged(Qt::WindowStates states);
-    void pttMute();
+    void pttToggled() const;
 
 private slots:
     void onAddClicked();
@@ -279,6 +279,7 @@ private:
     void playNotificationSound(IAudioSink::Sound sound, bool loop = false);
     void cleanupNotificationSound();
     void acceptFileTransfer(const ToxFile &file, const QString &path);
+    void onAudioCaptureModeChanged(IAudioSettings::AudioCaptureMode mode);
 
 private:
     Profile& profile;
@@ -360,7 +361,7 @@ private:
     QMap<GroupId, std::shared_ptr<GroupChatroom>> groupChatrooms;
     QMap<GroupId, QSharedPointer<GroupChatForm>> groupChatForms;
     Core* core = nullptr;
-    GlobalShortcut globalshortcut;
+    std::unique_ptr<GlobalShortcut> globalshortcut;
 
     MessageProcessor::SharedParams sharedMessageProcessorParams;
 #if DESKTOP_NOTIFICATIONS

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -208,6 +208,8 @@ signals:
     void resized();
     void windowStateChanged(Qt::WindowStates states);
     void pttToggled() const;
+    void pauseKeyBlocking() const;
+    void resumeKeyBlocking() const;
 
 private slots:
     void onAddClicked();


### PR DESCRIPTION
- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6185)
<!-- Reviewable:end -->

This is currently in a working state. TODOs are
- [X] Add multi-key support on scanning end. Settings/saving already work. This would involve tracking which of the keys are pressed.
- [x] Improve key-setting UI to display key names rather than their numbers.
- [x] Make passing of key list to hook callback threadsafe with some non-blocking locking, failing to lock is better than blocking to avoid hanging whole system.
- [X] Improve logging
- [x] Some code cleanup with inline TODOs
- [x] Dynamically destruct when PTT is not selected in AV settings, construct when it is
- [x] Add build for OSX and Windows, update build instructions for Linux
- [x] Remove singleton Settings from HotkeyInput. Either delay construction until AvForm and pass it in, or move functionality that requires Settings outside of class.
- [x] Clean up HotkeyInput (remove globals etc.)
- [x] Dynamically load Libuiohook since it depends on screen, causing unit tests to fail
- [x] Clean up git history

Overall this is way less work than the previous implementations. A couple limitations using this approach:
1. On X11, shortcut keys are still passed through to the underlying application. All libs I saw either use XGrabKey which causes the application to briefly grab focus, eating all other key strokes that happen while the shortcut is held, or have this behaviour. The keys _are_ blockable on OSX and Windows.
1. We get tons of info, way beyond what we need, e.g. all mouse and keyboard input of any kind. This is a bit of a privacy concern, but is the nature of the OS APIs that are provided. De-registering when PTT is not selected in settings and having it off by default should help with that.
1. Libuiohook has no void* in the callback, so we have no way to get back to our class, meaning our impl needs some gross global state. This isn't that bad since this is conceptually a singleton concept anyway.
