### PR TITLE
fix(tools): use a subdirectory for release source archives

### DIFF
--- a/tools/create-tarballs.sh
+++ b/tools/create-tarballs.sh
@@ -36,7 +36,7 @@ set -eu -o pipefail
 
 
 archive() {
-    git archive --format=tar "${@%%.tar.*}" \
+    git archive --format=tar --prefix=qTox/ "${@%%.tar.*}" \
     | "${@##*.tar.}"ip --best \
     > "$@"
     echo "$@ archive has been created."


### PR DESCRIPTION
Fix #6203

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6205)
<!-- Reviewable:end -->
