### PR TITLE
chore(travis): revert 8e597ed7361e2828ffc3838e04e460034380d5ec

### DIFF
--- a/osx/qTox-Mac-Deployer-ULTIMATE.sh
+++ b/osx/qTox-Mac-Deployer-ULTIMATE.sh
@@ -189,23 +189,7 @@ install() {
     # needed for kf5-sonnet
     brew tap kde-mac/kde https://invent.kde.org/packaging/homebrew-kde.git
 
-    # brew install qt5 might take a long time to build Qt. Travis kills us if
-    # we don't output for 10 minutes. Travis also kills us if we output too much,
-    # so verbose isn't an option. So just output some dots...
-    if [[ $TRAVIS = true ]]
-    then
-        echo "outputting dots to keep travis from killing us..."
-        while true; do
-            echo -n "."
-            sleep 10
-        done &
-        DOT_PID=$!
-    fi
     brew install ffmpeg libexif qrencode qt5 sqlcipher openal-soft #kf5-sonnet
-    if [[ $TRAVIS = true ]]
-    then
-        kill $DOT_PID
-    fi
 
     QT_VER=($(ls ${QT_DIR} | sed -n -e 's/^\([0-9]*\.([0-9]*\.([0-9]*\).*/\1/' -e '1p;$p'))
     QT_DIR_VER="${QT_DIR}/${QT_VER[1]}"


### PR DESCRIPTION
#5866 both updated our travis xcode version,
and also added the dots in 8e597ed. When macOS
was updated by Apple, older versions aged out of support, and brew also stopped
supporting them. Our travis xcode9.2 at the time stopped getting binary
packages (kegs) from brew because of that, and started having to compile
packages which is what was causing the timeouts.

Updating our xcode version allowed us to get binary packages from brew again,
so the workaround of constant output to avoid timing out while compiling large
packages is no longer needed.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6213)
<!-- Reviewable:end -->
