### PR TITLE
refactor(chatlog): remove getInstance from ChatlogItem and remove Core::getInstance()

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -29,7 +29,6 @@
 #include "src/model/groupinvite.h"
 #include "src/model/status.h"
 #include "src/model/ibootstraplistgenerator.h"
-#include "src/nexus.h"
 #include "src/persistence/profile.h"
 #include "util/strongtype.h"
 
@@ -703,15 +702,6 @@ void Core::onStarted()
 void Core::start()
 {
     coreThread->start();
-}
-
-
-/**
- * @brief Returns the global widget's Core instance
- */
-Core* Core::getInstance()
-{
-    return Nexus::getCore();
 }
 
 const CoreAV* Core::getAv() const

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -71,7 +71,6 @@ public:
 
     static ToxCorePtr makeToxCore(const QByteArray& savedata, const ICoreSettings* const settings,
                                   IBootstrapListGenerator& bootstrapNodes, ToxCoreErrors* err = nullptr);
-    static Core* getInstance();
     const CoreAV* getAv() const;
     CoreAV* getAv();
     CoreFile* getCoreFile() const;

--- a/src/model/chatlogitem.h
+++ b/src/model/chatlogitem.h
@@ -50,8 +50,8 @@ public:
         fileTransfer,
     };
 
-    ChatLogItem(ToxPk sender, ChatLogFile file);
-    ChatLogItem(ToxPk sender, ChatLogMessage message);
+    ChatLogItem(ToxPk sender, const QString& displayName, ChatLogFile file);
+    ChatLogItem(ToxPk sender, const QString& displayName, ChatLogMessage message);
     const ToxPk& getSender() const;
     ContentType getContentType() const;
     ChatLogFile& getContentAsFile();
@@ -63,7 +63,7 @@ public:
     const QString& getDisplayName() const;
 
 private:
-    ChatLogItem(ToxPk sender, ContentType contentType, ContentPtr content);
+    ChatLogItem(ToxPk sender, const QString &displayName_, ContentType contentType, ContentPtr content);
 
     ToxPk sender;
     QString displayName;

--- a/src/model/sessionchatlog.h
+++ b/src/model/sessionchatlog.h
@@ -45,13 +45,13 @@ public:
     ChatLogIdx getNextIdx() const override;
     std::vector<DateChatLogIdxPair> getDateIdxs(const QDate& startDate, size_t maxDates) const override;
 
-    void insertCompleteMessageAtIdx(ChatLogIdx idx, const ToxPk& sender, const QString& senderName,
+    void insertCompleteMessageAtIdx(ChatLogIdx idx, const ToxPk& sender, QString senderName,
                                     const ChatLogMessage& message);
-    void insertIncompleteMessageAtIdx(ChatLogIdx idx, const ToxPk& sender, const QString& senderName,
+    void insertIncompleteMessageAtIdx(ChatLogIdx idx, const ToxPk& sender, QString senderName,
                                       const ChatLogMessage& message, DispatchedMessageId dispatchId);
-    void insertBrokenMessageAtIdx(ChatLogIdx idx, const ToxPk& sender, const QString& senderName,
+    void insertBrokenMessageAtIdx(ChatLogIdx idx, const ToxPk& sender, QString senderName,
                                   const ChatLogMessage& message);
-    void insertFileAtIdx(ChatLogIdx idx, const ToxPk& sender, const QString& senderName, const ChatLogFile& file);
+    void insertFileAtIdx(ChatLogIdx idx, const ToxPk& sender, QString senderName, const ChatLogFile& file);
 
 public slots:
     void onMessageReceived(const ToxPk& sender, const Message& message);
@@ -61,6 +61,10 @@ public slots:
     void onFileUpdated(const ToxPk& sender, const ToxFile& file);
     void onFileTransferRemotePausedUnpaused(const ToxPk& sender, const ToxFile& file, bool paused);
     void onFileTransferBrokenUnbroken(const ToxPk& sender, const ToxFile& file, bool broken);
+
+private:
+    QString resolveSenderNameFromSender(const ToxPk &sender);
+
 
 private:
     const ICoreIdHandler& coreIdHandler;

--- a/test/model/sessionchatlog_test.cpp
+++ b/test/model/sessionchatlog_test.cpp
@@ -24,6 +24,8 @@
 #include <QtTest/QtTest>
 
 namespace {
+static const QString TEST_USERNAME = "qTox Tester #1";
+
 Message createMessage(const QString& content)
 {
     Message message;
@@ -50,8 +52,7 @@ public:
 
     QString getUsername() const override
     {
-        std::terminate();
-        return QString();
+        return TEST_USERNAME;
     }
 };
 } // namespace


### PR DESCRIPTION
- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

Goal is to finally remove all users of `Core::getInstance()`.

The problem is currently where to do the lookup of `ToxPk` -> `displayedName´.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6216)
<!-- Reviewable:end -->
