### PR TITLE
fix(settings): Unlock Settings mutex before emitting setting changed signals

### DIFF
--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -1084,7 +1084,7 @@ void Settings::setSpellCheckingEnabled(bool newValue)
 
     if (newValue != spellCheckingEnabled) {
         spellCheckingEnabled = newValue;
-        emit statusChangeNotificationEnabledChanged(statusChangeNotificationEnabled);
+        emit spellCheckingEnabledChanged(spellCheckingEnabled);
     }
 }
 

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -858,11 +858,8 @@ bool Settings::getEnableTestSound() const
 
 void Settings::setEnableTestSound(bool newValue)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (newValue != enableTestSound) {
-        enableTestSound = newValue;
-        emit enableTestSoundChanged(enableTestSound);
+    if (setVal(enableTestSound, newValue)) {
+        emit enableTestSoundChanged(newValue);
     }
 }
 
@@ -874,11 +871,8 @@ bool Settings::getEnableIPv6() const
 
 void Settings::setEnableIPv6(bool enabled)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (enabled != enableIPv6) {
-        enableIPv6 = enabled;
-        emit enableIPv6Changed(enableIPv6);
+    if (setVal(enableIPv6, enabled)) {
+        emit enableIPv6Changed(enabled);
     }
 }
 
@@ -890,14 +884,20 @@ bool Settings::getMakeToxPortable() const
 
 void Settings::setMakeToxPortable(bool newValue)
 {
-    QMutexLocker locker{&bigLock};
+    bool changed = false;
+    {
+        QMutexLocker locker{&bigLock};
 
-    if (newValue != makeToxPortable) {
-        QFile(paths.getSettingsDirPath() + globalSettingsFile).remove();
-        makeToxPortable = newValue;
-        saveGlobal();
+        if (newValue != makeToxPortable) {
+            QFile(paths.getSettingsDirPath() + globalSettingsFile).remove();
+            makeToxPortable = newValue;
+            saveGlobal();
 
-        emit makeToxPortableChanged(makeToxPortable);
+            changed = true;
+        }
+    }
+    if (changed) {
+        emit makeToxPortableChanged(newValue);
     }
 }
 
@@ -915,8 +915,6 @@ bool Settings::getAutorun() const
 void Settings::setAutorun(bool newValue)
 {
 #ifdef QTOX_PLATFORM_EXT
-    QMutexLocker locker{&bigLock};
-
     bool autorun = Platform::getAutorun();
 
     if (newValue != autorun) {
@@ -942,10 +940,7 @@ QString Settings::getStyle() const
 
 void Settings::setStyle(const QString& newStyle)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (newStyle != style) {
-        style = newStyle;
+    if (setVal(style, newStyle)) {
         emit styleChanged(style);
     }
 }
@@ -958,21 +953,15 @@ bool Settings::getShowSystemTray() const
 
 void Settings::setShowSystemTray(bool newValue)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (newValue != showSystemTray) {
-        showSystemTray = newValue;
+    if (setVal(showSystemTray, newValue)) {
         emit showSystemTrayChanged(newValue);
     }
 }
 
 void Settings::setUseEmoticons(bool newValue)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (newValue != useEmoticons) {
-        useEmoticons = newValue;
-        emit useEmoticonsChanged(useEmoticons);
+    if (setVal(useEmoticons, newValue)) {
+        emit useEmoticonsChanged(newValue);
     }
 }
 
@@ -984,11 +973,8 @@ bool Settings::getUseEmoticons() const
 
 void Settings::setAutoSaveEnabled(bool newValue)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (newValue != autoSaveEnabled) {
-        autoSaveEnabled = newValue;
-        emit autoSaveEnabledChanged(autoSaveEnabled);
+    if (setVal(autoSaveEnabled, newValue)) {
+        emit autoSaveEnabledChanged(newValue);
     }
 }
 
@@ -1000,11 +986,8 @@ bool Settings::getAutoSaveEnabled() const
 
 void Settings::setAutostartInTray(bool newValue)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (newValue != autostartInTray) {
-        autostartInTray = newValue;
-        emit autostartInTrayChanged(autostartInTray);
+    if (setVal(autostartInTray, newValue)) {
+        emit autostartInTrayChanged(newValue);
     }
 }
 
@@ -1016,10 +999,7 @@ bool Settings::getCloseToTray() const
 
 void Settings::setCloseToTray(bool newValue)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (newValue != closeToTray) {
-        closeToTray = newValue;
+    if (setVal(closeToTray, newValue)) {
         emit closeToTrayChanged(newValue);
     }
 }
@@ -1032,11 +1012,8 @@ bool Settings::getMinimizeToTray() const
 
 void Settings::setMinimizeToTray(bool newValue)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (newValue != minimizeToTray) {
-        minimizeToTray = newValue;
-        emit minimizeToTrayChanged(minimizeToTray);
+    if (setVal(minimizeToTray, newValue)) {
+        emit minimizeToTrayChanged(newValue);
     }
 }
 
@@ -1048,11 +1025,8 @@ bool Settings::getLightTrayIcon() const
 
 void Settings::setLightTrayIcon(bool newValue)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (newValue != lightTrayIcon) {
-        lightTrayIcon = newValue;
-        emit lightTrayIconChanged(lightTrayIcon);
+    if (setVal(lightTrayIcon, newValue)) {
+        emit lightTrayIconChanged(newValue);
     }
 }
 
@@ -1064,11 +1038,8 @@ bool Settings::getStatusChangeNotificationEnabled() const
 
 void Settings::setStatusChangeNotificationEnabled(bool newValue)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (newValue != statusChangeNotificationEnabled) {
-        statusChangeNotificationEnabled = newValue;
-        emit statusChangeNotificationEnabledChanged(statusChangeNotificationEnabled);
+    if (setVal(statusChangeNotificationEnabled, newValue)) {
+        emit statusChangeNotificationEnabledChanged(newValue);
     }
 }
 
@@ -1080,11 +1051,8 @@ bool Settings::getSpellCheckingEnabled() const
 
 void Settings::setSpellCheckingEnabled(bool newValue)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (newValue != spellCheckingEnabled) {
-        spellCheckingEnabled = newValue;
-        emit spellCheckingEnabledChanged(spellCheckingEnabled);
+    if (setVal(spellCheckingEnabled, newValue)) {
+        emit spellCheckingEnabledChanged(newValue);
     }
 }
 
@@ -1096,11 +1064,8 @@ bool Settings::getNotifySound() const
 
 void Settings::setNotifySound(bool newValue)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (newValue != notifySound) {
-        notifySound = newValue;
-        emit notifySoundChanged(notifySound);
+    if (setVal(notifySound, newValue)) {
+        emit notifySoundChanged(newValue);
     }
 }
 
@@ -1112,11 +1077,8 @@ bool Settings::getNotifyHide() const
 
 void Settings::setNotifyHide(bool newValue)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (newValue != notifyHide) {
-        notifyHide = newValue;
-        emit notifyHideChanged(notifyHide);
+    if (setVal(notifyHide, newValue)) {
+        emit notifyHideChanged(newValue);
     }
 }
 
@@ -1128,11 +1090,8 @@ bool Settings::getBusySound() const
 
 void Settings::setBusySound(bool newValue)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (newValue != busySound) {
-        busySound = newValue;
-        emit busySoundChanged(busySound);
+    if (setVal(busySound, newValue)) {
+        emit busySoundChanged(newValue);
     }
 }
 
@@ -1144,11 +1103,8 @@ bool Settings::getGroupAlwaysNotify() const
 
 void Settings::setGroupAlwaysNotify(bool newValue)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (newValue != groupAlwaysNotify) {
-        groupAlwaysNotify = newValue;
-        emit groupAlwaysNotifyChanged(groupAlwaysNotify);
+    if (setVal(groupAlwaysNotify, newValue)) {
+        emit groupAlwaysNotifyChanged(newValue);
     }
 }
 
@@ -1160,11 +1116,8 @@ QString Settings::getTranslation() const
 
 void Settings::setTranslation(const QString& newValue)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (newValue != translation) {
-        translation = newValue;
-        emit translationChanged(translation);
+    if (setVal(translation, newValue)) {
+        emit translationChanged(newValue);
     }
 }
 
@@ -1176,11 +1129,8 @@ bool Settings::getForceTCP() const
 
 void Settings::setForceTCP(bool enabled)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (enabled != forceTCP) {
-        forceTCP = enabled;
-        emit forceTCPChanged(forceTCP);
+    if (setVal(forceTCP, enabled)) {
+        emit forceTCPChanged(enabled);
     }
 }
 
@@ -1192,11 +1142,8 @@ bool Settings::getEnableLanDiscovery() const
 
 void Settings::setEnableLanDiscovery(bool enabled)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (enabled != enableLanDiscovery) {
-        enableLanDiscovery = enabled;
-        emit enableLanDiscoveryChanged(enableLanDiscovery);
+    if (setVal(enableLanDiscovery, enabled)) {
+        emit enableLanDiscoveryChanged(enabled);
     }
 }
 
@@ -1234,11 +1181,8 @@ Settings::ProxyType Settings::getProxyType() const
 
 void Settings::setProxyType(ProxyType newValue)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (newValue != proxyType) {
-        proxyType = newValue;
-        emit proxyTypeChanged(proxyType);
+    if (setVal(proxyType, newValue)) {
+        emit proxyTypeChanged(newValue);
     }
 }
 
@@ -1250,11 +1194,8 @@ QString Settings::getProxyAddr() const
 
 void Settings::setProxyAddr(const QString& address)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (address != proxyAddr) {
-        proxyAddr = address;
-        emit proxyAddressChanged(proxyAddr);
+    if (setVal(proxyAddr, address)) {
+        emit proxyAddressChanged(address);
     }
 }
 
@@ -1266,11 +1207,8 @@ quint16 Settings::getProxyPort() const
 
 void Settings::setProxyPort(quint16 port)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (port != proxyPort) {
-        proxyPort = port;
-        emit proxyPortChanged(proxyPort);
+    if (setVal(proxyPort, port)) {
+        emit proxyPortChanged(port);
     }
 }
 
@@ -1288,13 +1226,20 @@ uint32_t Settings::getCurrentProfileId() const
 
 void Settings::setCurrentProfile(const QString& profile)
 {
-    QMutexLocker locker{&bigLock};
+    bool updated = false;
+    uint32_t newProfileId = 0;
+    {
+        QMutexLocker locker{&bigLock};
 
-    if (profile != currentProfile) {
-        currentProfile = profile;
-        currentProfileId = makeProfileId(currentProfile);
-
-        emit currentProfileIdChanged(currentProfileId);
+        if (profile != currentProfile) {
+            currentProfile = profile;
+            currentProfileId = makeProfileId(currentProfile);
+            newProfileId = currentProfileId;
+            updated = true;
+        }
+    }
+    if (updated) {
+        emit currentProfileIdChanged(newProfileId);
     }
 }
 
@@ -1306,11 +1251,8 @@ bool Settings::getEnableLogging() const
 
 void Settings::setEnableLogging(bool newValue)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (newValue != enableLogging) {
-        enableLogging = newValue;
-        emit enableLoggingChanged(enableLogging);
+    if (setVal(enableLogging, newValue)) {
+        emit enableLoggingChanged(newValue);
     }
 }
 
@@ -1327,14 +1269,12 @@ int Settings::getAutoAwayTime() const
  */
 void Settings::setAutoAwayTime(int newValue)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (newValue < 0)
+    if (newValue < 0) {
         newValue = 10;
+    }
 
-    if (newValue != autoAwayTime) {
-        autoAwayTime = newValue;
-        emit autoAwayTimeChanged(autoAwayTime);
+    if (setVal(autoAwayTime, newValue)) {
+        emit autoAwayTimeChanged(newValue);
     }
 }
 
@@ -1351,12 +1291,18 @@ QString Settings::getAutoAcceptDir(const ToxPk& id) const
 
 void Settings::setAutoAcceptDir(const ToxPk& id, const QString& dir)
 {
-    QMutexLocker locker{&bigLock};
+    bool updated = false;
+    {
+        QMutexLocker locker{&bigLock};
 
-    auto& frnd = getOrInsertFriendPropRef(id);
+        auto& frnd = getOrInsertFriendPropRef(id);
 
-    if (frnd.autoAcceptDir != dir) {
-        frnd.autoAcceptDir = dir;
+        if (frnd.autoAcceptDir != dir) {
+            frnd.autoAcceptDir = dir;
+            updated = true;
+        }
+    }
+    if (updated) {
         emit autoAcceptDirChanged(id, dir);
     }
 }
@@ -1374,12 +1320,18 @@ Settings::AutoAcceptCallFlags Settings::getAutoAcceptCall(const ToxPk& id) const
 
 void Settings::setAutoAcceptCall(const ToxPk& id, AutoAcceptCallFlags accept)
 {
-    QMutexLocker locker{&bigLock};
+    bool updated = false;
+    {
+        QMutexLocker locker{&bigLock};
 
-    auto& frnd = getOrInsertFriendPropRef(id);
+        auto& frnd = getOrInsertFriendPropRef(id);
 
-    if (frnd.autoAcceptCall != accept) {
-        frnd.autoAcceptCall = accept;
+        if (frnd.autoAcceptCall != accept) {
+            frnd.autoAcceptCall = accept;
+            updated = true;
+        }
+    }
+    if (updated) {
         emit autoAcceptCallChanged(id, accept);
     }
 }
@@ -1398,12 +1350,19 @@ bool Settings::getAutoGroupInvite(const ToxPk& id) const
 
 void Settings::setAutoGroupInvite(const ToxPk& id, bool accept)
 {
-    QMutexLocker locker{&bigLock};
+    bool updated = false;
+    {
+        QMutexLocker locker{&bigLock};
 
-    auto& frnd = getOrInsertFriendPropRef(id);
+        auto& frnd = getOrInsertFriendPropRef(id);
 
-    if (frnd.autoGroupInvite != accept) {
-        frnd.autoGroupInvite = accept;
+        if (frnd.autoGroupInvite != accept) {
+            frnd.autoGroupInvite = accept;
+            updated = true;
+        }
+    }
+
+    if (updated) {
         emit autoGroupInviteChanged(id, accept);
     }
 }
@@ -1421,12 +1380,18 @@ QString Settings::getContactNote(const ToxPk& id) const
 
 void Settings::setContactNote(const ToxPk& id, const QString& note)
 {
-    QMutexLocker locker{&bigLock};
+    bool updated = false;
+    {
+        QMutexLocker locker{&bigLock};
 
-    auto& frnd = getOrInsertFriendPropRef(id);
+        auto& frnd = getOrInsertFriendPropRef(id);
 
-    if (frnd.note != note) {
-        frnd.note = note;
+        if (frnd.note != note) {
+            frnd.note = note;
+            updated = true;
+        }
+    }
+    if (updated) {
         emit contactNoteChanged(id, note);
     }
 }
@@ -1439,11 +1404,8 @@ QString Settings::getGlobalAutoAcceptDir() const
 
 void Settings::setGlobalAutoAcceptDir(const QString& newValue)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (newValue != globalAutoAcceptDir) {
-        globalAutoAcceptDir = newValue;
-        emit globalAutoAcceptDirChanged(globalAutoAcceptDir);
+    if (setVal(globalAutoAcceptDir, newValue)) {
+        emit globalAutoAcceptDirChanged(newValue);
     }
 }
 
@@ -1455,11 +1417,8 @@ size_t Settings::getMaxAutoAcceptSize() const
 
 void Settings::setMaxAutoAcceptSize(size_t size)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (size != autoAcceptMaxSize) {
-        autoAcceptMaxSize = size;
-        emit autoAcceptMaxSizeChanged(autoAcceptMaxSize);
+    if (setVal(autoAcceptMaxSize, size)) {
+        emit autoAcceptMaxSizeChanged(size);
     }
 }
 
@@ -1471,20 +1430,23 @@ const QFont& Settings::getChatMessageFont() const
 
 void Settings::setChatMessageFont(const QFont& font)
 {
-    QMutexLocker locker(&bigLock);
-
-    if (font != chatMessageFont) {
-        chatMessageFont = font;
-        emit chatMessageFontChanged(chatMessageFont);
+    if (setVal(chatMessageFont, font)) {
+        emit chatMessageFontChanged(font);
     }
 }
 
 void Settings::setWidgetData(const QString& uniqueName, const QByteArray& data)
 {
-    QMutexLocker locker{&bigLock};
+    bool updated = false;
+    {
+        QMutexLocker locker{&bigLock};
 
-    if (!widgetSettings.contains(uniqueName) || widgetSettings[uniqueName] != data) {
-        widgetSettings[uniqueName] = data;
+        if (!widgetSettings.contains(uniqueName) || widgetSettings[uniqueName] != data) {
+            widgetSettings[uniqueName] = data;
+            updated = true;
+        }
+    }
+    if (updated) {
         emit widgetDataChanged(uniqueName);
     }
 }
@@ -1503,11 +1465,8 @@ QString Settings::getSmileyPack() const
 
 void Settings::setSmileyPack(const QString& value)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (value != smileyPack) {
-        smileyPack = value;
-        emit smileyPackChanged(smileyPack);
+    if (setVal(smileyPack, value)) {
+        emit smileyPackChanged(value);
     }
 }
 
@@ -1519,11 +1478,8 @@ int Settings::getEmojiFontPointSize() const
 
 void Settings::setEmojiFontPointSize(int value)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (value != emojiFontPointSize) {
-        emojiFontPointSize = value;
-        emit emojiFontPointSizeChanged(emojiFontPointSize);
+    if (setVal(emojiFontPointSize, value)) {
+        emit emojiFontPointSizeChanged(value);
     }
 }
 
@@ -1535,11 +1491,8 @@ const QString& Settings::getTimestampFormat() const
 
 void Settings::setTimestampFormat(const QString& format)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (format != timestampFormat) {
-        timestampFormat = format;
-        emit timestampFormatChanged(timestampFormat);
+    if (setVal(timestampFormat, format)) {
+        emit timestampFormatChanged(format);
     }
 }
 
@@ -1551,11 +1504,8 @@ const QString& Settings::getDateFormat() const
 
 void Settings::setDateFormat(const QString& format)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (format != dateFormat) {
-        dateFormat = format;
-        emit dateFormatChanged(dateFormat);
+    if (setVal(dateFormat, format)) {
+        emit dateFormatChanged(format);
     }
 }
 
@@ -1567,11 +1517,8 @@ Settings::StyleType Settings::getStylePreference() const
 
 void Settings::setStylePreference(StyleType newValue)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (newValue != stylePreference) {
-        stylePreference = newValue;
-        emit stylePreferenceChanged(stylePreference);
+    if (setVal(stylePreference, newValue)) {
+        emit stylePreferenceChanged(newValue);
     }
 }
 
@@ -1583,11 +1530,8 @@ QByteArray Settings::getWindowGeometry() const
 
 void Settings::setWindowGeometry(const QByteArray& value)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (value != windowGeometry) {
-        windowGeometry = value;
-        emit windowGeometryChanged(windowGeometry);
+    if (setVal(windowGeometry, value)) {
+        emit windowGeometryChanged(value);
     }
 }
 
@@ -1599,11 +1543,8 @@ QByteArray Settings::getWindowState() const
 
 void Settings::setWindowState(const QByteArray& value)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (value != windowState) {
-        windowState = value;
-        emit windowStateChanged(windowState);
+    if (setVal(windowState, value)) {
+        emit windowStateChanged(value);
     }
 }
 
@@ -1615,11 +1556,8 @@ bool Settings::getCheckUpdates() const
 
 void Settings::setCheckUpdates(bool newValue)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (newValue != checkUpdates) {
-        checkUpdates = newValue;
-        emit checkUpdatesChanged(checkUpdates);
+    if (setVal(checkUpdates, newValue)) {
+        emit checkUpdatesChanged(newValue);
     }
 }
 
@@ -1631,10 +1569,8 @@ bool Settings::getNotify() const
 
 void Settings::setNotify(bool newValue)
 {
-    QMutexLocker locker{&bigLock};
-    if (newValue != notify) {
-        notify = newValue;
-        emit notifyChanged(notify);
+    if (setVal(notify, newValue)) {
+        emit notifyChanged(newValue);
     }
 }
 
@@ -1646,11 +1582,8 @@ bool Settings::getShowWindow() const
 
 void Settings::setShowWindow(bool newValue)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (newValue != showWindow) {
-        showWindow = newValue;
-        emit showWindowChanged(showWindow);
+    if (setVal(showWindow, newValue)) {
+        emit showWindowChanged(newValue);
     }
 }
 
@@ -1662,11 +1595,8 @@ bool Settings::getDesktopNotify() const
 
 void Settings::setDesktopNotify(bool enabled)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (enabled != desktopNotify) {
-        desktopNotify = enabled;
-        emit desktopNotifyChanged(desktopNotify);
+    if (setVal(desktopNotify, enabled)) {
+        emit desktopNotifyChanged(enabled);
     }
 }
 
@@ -1678,11 +1608,8 @@ QByteArray Settings::getSplitterState() const
 
 void Settings::setSplitterState(const QByteArray& value)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (value != splitterState) {
-        splitterState = value;
-        emit splitterStateChanged(splitterState);
+    if (setVal(splitterState, value)) {
+        emit splitterStateChanged(value);
     }
 }
 
@@ -1694,11 +1621,8 @@ QByteArray Settings::getDialogGeometry() const
 
 void Settings::setDialogGeometry(const QByteArray& value)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (value != dialogGeometry) {
-        dialogGeometry = value;
-        emit dialogGeometryChanged(dialogGeometry);
+    if (setVal(dialogGeometry, value)) {
+        emit dialogGeometryChanged(value);
     }
 }
 
@@ -1710,11 +1634,8 @@ QByteArray Settings::getDialogSplitterState() const
 
 void Settings::setDialogSplitterState(const QByteArray& value)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (value != dialogSplitterState) {
-        dialogSplitterState = value;
-        emit dialogSplitterStateChanged(dialogSplitterState);
+    if (setVal(dialogSplitterState, value)) {
+        emit dialogSplitterStateChanged(value);
     }
 }
 
@@ -1726,11 +1647,8 @@ QByteArray Settings::getDialogSettingsGeometry() const
 
 void Settings::setDialogSettingsGeometry(const QByteArray& value)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (value != dialogSettingsGeometry) {
-        dialogSettingsGeometry = value;
-        emit dialogSettingsGeometryChanged(dialogSettingsGeometry);
+    if (setVal(dialogSettingsGeometry, value)) {
+        emit dialogSettingsGeometryChanged(value);
     }
 }
 
@@ -1742,11 +1660,8 @@ bool Settings::getMinimizeOnClose() const
 
 void Settings::setMinimizeOnClose(bool newValue)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (newValue != minimizeOnClose) {
-        minimizeOnClose = newValue;
-        emit minimizeOnCloseChanged(minimizeOnClose);
+    if (setVal(minimizeOnClose, newValue)) {
+        emit minimizeOnCloseChanged(newValue);
     }
 }
 
@@ -1758,11 +1673,8 @@ bool Settings::getTypingNotification() const
 
 void Settings::setTypingNotification(bool enabled)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (enabled != typingNotification) {
-        typingNotification = enabled;
-        emit typingNotificationChanged(typingNotification);
+    if (setVal(typingNotification, enabled)) {
+        emit typingNotificationChanged(enabled);
     }
 }
 
@@ -1774,11 +1686,8 @@ QStringList Settings::getBlackList() const
 
 void Settings::setBlackList(const QStringList& blist)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (blist != blackList) {
-        blackList = blist;
-        emit blackListChanged(blackList);
+    if (setVal(blackList, blist)) {
+        emit blackListChanged(blist);
     }
 }
 
@@ -1790,11 +1699,8 @@ QString Settings::getInDev() const
 
 void Settings::setInDev(const QString& deviceSpecifier)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (deviceSpecifier != inDev) {
-        inDev = deviceSpecifier;
-        emit inDevChanged(inDev);
+    if (setVal(inDev, deviceSpecifier)) {
+        emit inDevChanged(deviceSpecifier);
     }
 }
 
@@ -1806,10 +1712,7 @@ bool Settings::getAudioInDevEnabled() const
 
 void Settings::setAudioInDevEnabled(bool enabled)
 {
-    QMutexLocker locker(&bigLock);
-
-    if (enabled != audioInDevEnabled) {
-        audioInDevEnabled = enabled;
+    if (setVal(audioInDevEnabled, enabled)) {
         emit audioInDevEnabledChanged(enabled);
     }
 }
@@ -1822,10 +1725,7 @@ qreal Settings::getAudioInGainDecibel() const
 
 void Settings::setAudioInGainDecibel(qreal dB)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (dB < audioInGainDecibel || dB > audioInGainDecibel) {
-        audioInGainDecibel = dB;
+    if (setVal(audioInGainDecibel, dB)) {
         emit audioInGainDecibelChanged(audioInGainDecibel);
     }
 }
@@ -1838,11 +1738,8 @@ qreal Settings::getAudioThreshold() const
 
 void Settings::setAudioThreshold(qreal percent)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (percent < audioThreshold || percent > audioThreshold) {
-        audioThreshold = percent;
-        emit audioThresholdChanged(audioThreshold);
+    if (setVal(audioThreshold, percent)) {
+        emit audioThresholdChanged(percent);
     }
 }
 
@@ -1854,11 +1751,8 @@ QString Settings::getVideoDev() const
 
 void Settings::setVideoDev(const QString& deviceSpecifier)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (deviceSpecifier != videoDev) {
-        videoDev = deviceSpecifier;
-        emit videoDevChanged(videoDev);
+    if (setVal(videoDev, deviceSpecifier)) {
+        emit videoDevChanged(deviceSpecifier);
     }
 }
 
@@ -1870,11 +1764,8 @@ QString Settings::getOutDev() const
 
 void Settings::setOutDev(const QString& deviceSpecifier)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (deviceSpecifier != outDev) {
-        outDev = deviceSpecifier;
-        emit outDevChanged(outDev);
+    if (setVal(outDev, deviceSpecifier)) {
+        emit outDevChanged(deviceSpecifier);
     }
 }
 
@@ -1886,11 +1777,8 @@ bool Settings::getAudioOutDevEnabled() const
 
 void Settings::setAudioOutDevEnabled(bool enabled)
 {
-    QMutexLocker locker(&bigLock);
-
-    if (enabled != audioOutDevEnabled) {
-        audioOutDevEnabled = enabled;
-        emit audioOutDevEnabledChanged(audioOutDevEnabled);
+    if (setVal(audioOutDevEnabled, enabled)) {
+        emit audioOutDevEnabledChanged(enabled);
     }
 }
 
@@ -1902,11 +1790,8 @@ int Settings::getOutVolume() const
 
 void Settings::setOutVolume(int volume)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (volume != outVolume) {
-        outVolume = volume;
-        emit outVolumeChanged(outVolume);
+    if (setVal(outVolume, volume)) {
+        emit outVolumeChanged(volume);
     }
 }
 
@@ -1918,11 +1803,8 @@ int Settings::getAudioBitrate() const
 
 void Settings::setAudioBitrate(int bitrate)
 {
-    const QMutexLocker locker{&bigLock};
-
-    if (bitrate != audioBitrate) {
-        audioBitrate = bitrate;
-        emit audioBitrateChanged(audioBitrate);
+    if (setVal(audioBitrate, bitrate)) {
+        emit audioBitrateChanged(bitrate);
     }
 }
 
@@ -1934,11 +1816,8 @@ QRect Settings::getScreenRegion() const
 
 void Settings::setScreenRegion(const QRect& value)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (value != screenRegion) {
-        screenRegion = value;
-        emit screenRegionChanged(screenRegion);
+    if (setVal(screenRegion, value)) {
+        emit screenRegionChanged(value);
     }
 }
 
@@ -1950,11 +1829,8 @@ bool Settings::getScreenGrabbed() const
 
 void Settings::setScreenGrabbed(bool value)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (value != screenGrabbed) {
-        screenGrabbed = value;
-        emit screenGrabbedChanged(screenGrabbed);
+    if (setVal(screenGrabbed, value)) {
+        emit screenGrabbedChanged(value);
     }
 }
 
@@ -1966,11 +1842,8 @@ QRect Settings::getCamVideoRes() const
 
 void Settings::setCamVideoRes(QRect newValue)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (newValue != camVideoRes) {
-        camVideoRes = newValue;
-        emit camVideoResChanged(camVideoRes);
+    if (setVal(camVideoRes, newValue)) {
+        emit camVideoResChanged(newValue);
     }
 }
 
@@ -1982,11 +1855,8 @@ float Settings::getCamVideoFPS() const
 
 void Settings::setCamVideoFPS(float newValue)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (newValue != camVideoFPS) {
-        camVideoFPS = newValue;
-        emit camVideoFPSChanged(camVideoFPS);
+    if (setVal(camVideoFPS, newValue)) {
+        emit camVideoFPSChanged(newValue);
     }
 }
 
@@ -2082,10 +1952,7 @@ bool Settings::getCompactLayout() const
 
 void Settings::setCompactLayout(bool value)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (value != compactLayout) {
-        compactLayout = value;
+    if (setVal(compactLayout, value)) {
         emit compactLayoutChanged(value);
     }
 }
@@ -2098,11 +1965,8 @@ Settings::FriendListSortingMode Settings::getFriendSortingMode() const
 
 void Settings::setFriendSortingMode(FriendListSortingMode mode)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (mode != sortingMode) {
-        sortingMode = mode;
-        emit sortingModeChanged(sortingMode);
+    if (setVal(sortingMode, mode)) {
+        emit sortingModeChanged(mode);
     }
 }
 
@@ -2114,10 +1978,7 @@ bool Settings::getSeparateWindow() const
 
 void Settings::setSeparateWindow(bool value)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (value != separateWindow) {
-        separateWindow = value;
+    if (setVal(separateWindow, value)) {
         emit separateWindowChanged(value);
     }
 }
@@ -2130,11 +1991,8 @@ bool Settings::getDontGroupWindows() const
 
 void Settings::setDontGroupWindows(bool value)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (value != dontGroupWindows) {
-        dontGroupWindows = value;
-        emit dontGroupWindowsChanged(dontGroupWindows);
+    if (setVal(dontGroupWindows, value)) {
+        emit dontGroupWindowsChanged(value);
     }
 }
 
@@ -2146,10 +2004,7 @@ bool Settings::getGroupchatPosition() const
 
 void Settings::setGroupchatPosition(bool value)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (value != groupchatPosition) {
-        groupchatPosition = value;
+    if (setVal(groupchatPosition, value)) {
         emit groupchatPositionChanged(value);
     }
 }
@@ -2162,10 +2017,7 @@ bool Settings::getShowIdenticons() const
 
 void Settings::setShowIdenticons(bool value)
 {
-    const QMutexLocker locker{&bigLock};
-
-    if (value != showIdenticons) {
-        showIdenticons = value;
+    if (setVal(showIdenticons, value)) {
         emit showIdenticonsChanged(value);
     }
 }
@@ -2300,11 +2152,8 @@ int Settings::getThemeColor() const
 
 void Settings::setThemeColor(int value)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (value != themeColor) {
-        themeColor = value;
-        emit themeColorChanged(themeColor);
+    if (setVal(themeColor, value)) {
+        emit themeColorChanged(value);
     }
 }
 
@@ -2316,20 +2165,15 @@ bool Settings::getAutoLogin() const
 
 void Settings::setAutoLogin(bool state)
 {
-    QMutexLocker locker{&bigLock};
-
-    if (state != autoLogin) {
-        autoLogin = state;
-        emit autoLoginChanged(autoLogin);
+    if (setVal(autoLogin, state)) {
+        emit autoLoginChanged(state);
     }
 }
 
 void Settings::setEnableGroupChatsColor(bool state)
 {
-    QMutexLocker locker{&bigLock};
-    if (state != nameColors) {
-        nameColors = state;
-        emit nameColorsChanged(nameColors);
+    if (setVal(nameColors, state)) {
+        emit nameColorsChanged(state);
     }
 }
 
@@ -2413,4 +2257,14 @@ ICoreSettings::ProxyType Settings::fixInvalidProxyType(ICoreSettings::ProxyType 
         qWarning() << "Repairing invalid ProxyType, UDP will be enabled";
         return ICoreSettings::ProxyType::ptNone;
     }
+}
+
+template <typename T>
+bool Settings::setVal(T& savedVal, T newVal) {
+    QMutexLocker locker{&bigLock};
+    if (savedVal != newVal) {
+        savedVal = newVal;
+        return true;
+    }
+    return false;
 }

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -230,7 +230,7 @@ signals:
     // Privacy
     void typingNotificationChanged(bool enabled);
     void dbSyncTypeChanged(Db::syncType type);
-    void blackListChanged(QStringList& blist);
+    void blackListChanged(QStringList const& blist);
 
 public:
     bool applyCommandLineOptions(const QCommandLineParser& parser);
@@ -571,6 +571,9 @@ private:
     void savePersonal(QString profileName, const ToxEncrypt* passkey);
     friendProp& getOrInsertFriendPropRef(const ToxPk& id);
     ICoreSettings::ProxyType fixInvalidProxyType(ICoreSettings::ProxyType proxyType);
+
+    template <typename T>
+    bool setVal(T& savedVal, T newVal);
 
 public slots:
     void savePersonal(Profile* profile);


### PR DESCRIPTION
When a setting is set it locks the Settings mutex and emits a signal for that
setting. If a slot is connected to that signal and lives on the same thread as
Settings, it is executed immediately with the Settings mutex still locked. That
slot can then lock a series of other mutexes. During this time another thread
can lock a mutex and then try to read settings, which will cause a deadlock due
to the opposite order of multiple mutex locking. By making all Settings
connectiong queued, the Settings setter will return and unlock the Settings
mutex, ensuring that getters won't ever be blocked indefinitely.

Fix #6218

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6219)
<!-- Reviewable:end -->
