### PR TITLE
feat(ui): Make auto-accept size 0 wording less ambiguous

### DIFF
--- a/src/widget/form/settings/generalsettings.ui
+++ b/src/widget/form/settings/generalsettings.ui
@@ -310,7 +310,7 @@ instead of closing entirely.</string>
             <item row="4" column="0">
              <widget class="QLabel" name="maxAutoAcceptSizeLabel">
               <property name="text">
-               <string>Max auto-accept file size (0 to disable):</string>
+               <string>Max auto-accept file size (0 for unlimited):</string>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
0 disables the max size, but doesn't disable auto-accept in its entirety.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6224)
<!-- Reviewable:end -->
