### PR TITLE
refactor(core): make construction independent of CoreAV

### DIFF
--- a/src/core/core.h
+++ b/src/core/core.h
@@ -73,7 +73,12 @@ public:
                                   IBootstrapListGenerator& bootstrapNodes, ToxCoreErrors* err = nullptr);
     const CoreAV* getAv() const;
     CoreAV* getAv();
+    void setAv(CoreAV* coreAv);
+
     CoreFile* getCoreFile() const;
+    Tox* getTox() const;
+    QMutex& getCoreLoopLock() const;
+
     ~Core();
 
     static const QString TOX_EXT;
@@ -149,8 +154,6 @@ signals:
     void failedToSetStatusMessage(const QString& message);
     void failedToSetStatus(Status::Status status);
     void failedToSetTyping(bool typing);
-
-    void avReady();
 
     void saveRequest();
 
@@ -245,7 +248,7 @@ private:
     ToxPtr tox;
 
     std::unique_ptr<CoreFile> file;
-    std::unique_ptr<CoreAV> av;
+    CoreAV* av = nullptr;
     QTimer* toxTimer = nullptr;
     // recursive, since we might call our own functions
     mutable QMutex coreLoopLock{QMutex::Recursive};

--- a/src/core/coreav.h
+++ b/src/core/coreav.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "src/core/toxcall.h"
+
 #include <QObject>
 #include <QMutex>
 #include <QReadWriteLock>
@@ -31,6 +32,8 @@
 class Friend;
 class Group;
 class IAudioControl;
+class IAudioSettings;
+class IGroupSettings;
 class QThread;
 class QTimer;
 class CoreVideoSource;
@@ -46,7 +49,8 @@ class CoreAV : public QObject
 
 public:
     using CoreAVPtr = std::unique_ptr<CoreAV>;
-    static CoreAVPtr makeCoreAV(Tox* core, QMutex& coreLock);
+    static CoreAVPtr makeCoreAV(Tox* core, QMutex& toxCoreLock,
+                                IAudioSettings& audioSettings, IGroupSettings& groupSettings);
 
     void setAudio(IAudioControl& newAudio);
     IAudioControl* getAudio();
@@ -112,7 +116,8 @@ private:
         }
     };
 
-    CoreAV(std::unique_ptr<ToxAV, ToxAVDeleter> tox, QMutex &toxCoreLock);
+    CoreAV(std::unique_ptr<ToxAV, ToxAVDeleter> tox, QMutex &toxCoreLock,
+           IAudioSettings& _audioSettings, IGroupSettings& _groupSettings);
     void connectCallbacks(ToxAV& toxav);
 
     void process();
@@ -156,4 +161,7 @@ private:
      * @note This must be a recursive mutex as we're going to lock it in callbacks
      */
     QMutex& coreLock;
+
+    IAudioSettings& audioSettings;
+    IGroupSettings& groupSettings;
 };

--- a/src/persistence/profile.h
+++ b/src/persistence/profile.h
@@ -104,15 +104,16 @@ private slots:
     void onAvatarOfferReceived(uint32_t friendId, uint32_t fileId, const QByteArray& avatarHash);
 
 private:
-    Profile(const QString& name, const QString& password, std::unique_ptr<ToxEncrypt> passkey, Paths& paths);
+    Profile(const QString& name, std::unique_ptr<ToxEncrypt> passkey, Paths& paths);
     static QStringList getFilesByExt(QString extension);
     QString avatarPath(const ToxPk& owner, bool forceUnencrypted = false);
     bool saveToxSave(QByteArray data);
-    void initCore(const QByteArray& toxsave, const ICoreSettings& s, bool isNewProfile);
+    void initCore(const QByteArray& toxsave, Settings &s, bool isNewProfile);
 
 private:
     std::unique_ptr<AvatarBroadcaster> avatarBroadcaster;
     std::unique_ptr<Core> core;
+    std::unique_ptr<CoreAV> coreAv;
     QString name;
     std::unique_ptr<ToxEncrypt> passkey;
     std::shared_ptr<RawDatabase> database;


### PR DESCRIPTION
Allows to construct a Core object without also starting CoreAV.

This happened because I wanted to free `CoreAV` from a direct dependency on `Settings`, but didn't want to write mock objects for `IAudioSettings` and `IGroupSettings` for the existing `Core` unit tests. It's the correct thing to do anyway.

This is a requirement for a future split of the core files into their own subproject.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6225)
<!-- Reviewable:end -->
