### PR TITLE
Refactor/coreav calls

### DIFF
--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -489,7 +489,7 @@ bool CoreAV::sendGroupCallAudio(int groupNum, const int16_t* pcm, size_t samples
 {
     QReadLocker locker{&callsLock};
 
-    auto it = groupCalls.find(groupId);
+    auto it = groupCalls.find(groupNum);
     if (it == groupCalls.end()) {
         return false;
     }

--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -196,43 +196,6 @@ void CoreAV::process()
 }
 
 /**
- * @brief Checks the call status for a Tox friend.
- * @param f the friend to check
- * @return true, if call is started for the friend, false otherwise
- */
-bool CoreAV::isCallStarted(const Friend* f) const
-{
-    QReadLocker locker{&callsLock};
-    return f && (calls.find(f->getId()) != calls.end());
-}
-
-/**
- * @brief Checks the call status for a Tox group.
- * @param g the group to check
- * @return true, if call is started for the group, false otherwise
- */
-bool CoreAV::isCallStarted(const Group* g) const
-{
-    QReadLocker locker{&callsLock};
-    return g && (groupCalls.find(g->getId()) != groupCalls.end());
-}
-
-/**
- * @brief Checks the call status for a Tox friend.
- * @param f the friend to check
- * @return true, if call is active for the friend, false otherwise
- */
-bool CoreAV::isCallActive(const Friend* f) const
-{
-    QReadLocker locker{&callsLock};
-    auto it = calls.find(f->getId());
-    if (it == calls.end()) {
-        return false;
-    }
-    return isCallStarted(f) && it->second->isActive();
-}
-
-/**
  * @brief Checks the call status for a Tox group.
  * @param g the group to check
  * @return true, if the call is active for the group, false otherwise
@@ -244,17 +207,10 @@ bool CoreAV::isCallActive(const Group* g) const
     if (it == groupCalls.end()) {
         return false;
     }
-    return isCallStarted(g) && it->second->isActive();
+    return it->second->isActive();
 }
 
-bool CoreAV::isCallVideoEnabled(const Friend* f) const
-{
-    QReadLocker locker{&callsLock};
-    auto it = calls.find(f->getId());
-    return isCallStarted(f) && it->second->getVideoEnabled();
-}
-
-bool CoreAV::answerCall(uint32_t friendNum, bool video)
+CoreAV::ToxFriendCallPtr CoreAV::answerCall(uint32_t friendNum, bool video)
 {
     QWriteLocker locker{&callsLock};
     QMutexLocker coreLocker{&coreLock};
@@ -268,18 +224,18 @@ bool CoreAV::answerCall(uint32_t friendNum, bool video)
     if (toxav_answer(toxav.get(), friendNum, audioSettings.getAudioBitrate(),
                      videoBitrate, &err)) {
         it->second->setActive(true);
-        return true;
+        return it->second;
     } else {
         qWarning() << "Failed to answer call with error" << err;
         Toxav_Err_Call_Control controlErr;
         toxav_call_control(toxav.get(), friendNum, TOXAV_CALL_CONTROL_CANCEL, &controlErr);
         PARSE_ERR(controlErr);
         calls.erase(it);
-        return false;
+        return {};
     }
 }
 
-bool CoreAV::startCall(uint32_t friendNum, bool video)
+CoreAV::ToxFriendCallPtr CoreAV::startCall(uint32_t friendNum, bool video)
 {
     QWriteLocker locker{&callsLock};
     QMutexLocker coreLocker{&coreLock};
@@ -288,7 +244,7 @@ bool CoreAV::startCall(uint32_t friendNum, bool video)
     auto it = calls.find(friendNum);
     if (it != calls.end()) {
         qWarning() << QString("Can't start call with %1, we're already in this call!").arg(friendNum);
-        return false;
+        return {};
     }
 
     uint32_t videoBitrate = video ? VIDEO_DEFAULT_BITRATE : 0;
@@ -296,7 +252,7 @@ bool CoreAV::startCall(uint32_t friendNum, bool video)
     toxav_call(toxav.get(), friendNum, audioSettings.getAudioBitrate(), videoBitrate,
                     &err);
     if (!PARSE_ERR(err)) {
-        return false;
+        return {};
     }
 
     // Audio backend must be set before making a call
@@ -306,14 +262,20 @@ bool CoreAV::startCall(uint32_t friendNum, bool video)
     // Call object must be owned by this thread or there will be locking problems with Audio
     call->moveToThread(thread());
     assert(call != nullptr);
-    calls.emplace(friendNum, std::move(call));
-    return true;
+    calls.emplace(friendNum, call);
+    return call;
 }
 
 bool CoreAV::cancelCall(uint32_t friendNum)
 {
     QWriteLocker locker{&callsLock};
     QMutexLocker coreLocker{&coreLock};
+
+    auto it = calls.find(friendNum);
+    if (it == calls.end()) {
+        qWarning() << QString("Can't cancel call with %1, it doesn't exist!").arg(friendNum);
+        return false;
+    }
 
     qDebug() << QString("Cancelling call with %1").arg(friendNum);
     Toxav_Err_Call_Control err;
@@ -322,22 +284,14 @@ bool CoreAV::cancelCall(uint32_t friendNum)
         return false;
     }
 
+    // Set inactive for others
+    it->second->setActive(false);
+
     calls.erase(friendNum);
     locker.unlock();
 
     emit avEnd(friendNum);
     return true;
-}
-
-void CoreAV::timeoutCall(uint32_t friendNum)
-{
-    QWriteLocker locker{&callsLock};
-
-    if (!cancelCall(friendNum)) {
-        qWarning() << QString("Failed to timeout call with %1").arg(friendNum);
-        return;
-    }
-    qDebug() << "Call with friend" << friendNum << "timed out";
 }
 
 /**
@@ -442,36 +396,6 @@ void CoreAV::sendCallVideo(uint32_t callId, std::shared_ptr<VideoFrame> vframe)
 }
 
 /**
- * @brief Toggles the mute state of the call's input (microphone).
- * @param f The friend assigned to the call
- */
-void CoreAV::toggleMuteCallInput(const Friend* f)
-{
-    QWriteLocker locker{&callsLock};
-
-    auto it = calls.find(f->getId());
-    if (f && (it != calls.end())) {
-        ToxCall& call = *it->second;
-        call.setMuteMic(!call.getMuteMic());
-    }
-}
-
-/**
- * @brief Toggles the mute state of the call's output (speaker).
- * @param f The friend assigned to the call
- */
-void CoreAV::toggleMuteCallOutput(const Friend* f)
-{
-    QWriteLocker locker{&callsLock};
-
-    auto it = calls.find(f->getId());
-    if (f && (it != calls.end())) {
-        ToxCall& call = *it->second;
-        call.setMuteVol(!call.getMuteVol());
-    }
-}
-
-/**
  * @brief Called from Tox API when group call receives audio data.
  *
  * @param[in] tox          the Tox object
@@ -536,24 +460,6 @@ void CoreAV::invalidateGroupCallPeerSource(const Group& group, ToxPk peerPk)
         return;
     }
     it->second->removePeer(peerPk);
-}
-
-/**
- * @brief Get a call's video source.
- * @param friendNum Id of friend in call list.
- * @return Video surface to show
- */
-VideoSource* CoreAV::getVideoSourceFromCall(int friendNum) const
-{
-    QReadLocker locker{&callsLock};
-
-    auto it = calls.find(friendNum);
-    if (it == calls.end()) {
-        qWarning() << "CoreAV::getVideoSourceFromCall: No such call, possibly cancelled";
-        return nullptr;
-    }
-
-    return it->second->getVideoSource();
 }
 
 /**
@@ -683,40 +589,6 @@ bool CoreAV::isGroupCallOutputMuted(const Group* g) const
 }
 
 /**
- * @brief Returns the calls input (microphone) mute state.
- * @param f The friend to check
- * @return true when muted, false otherwise
- */
-bool CoreAV::isCallInputMuted(const Friend* f) const
-{
-    QReadLocker locker{&callsLock};
-
-    if (!f) {
-        return false;
-    }
-    const uint32_t friendId = f->getId();
-    auto it = calls.find(friendId);
-    return (it != calls.end()) && it->second->getMuteMic();
-}
-
-/**
- * @brief Returns the calls output (speaker) mute state.
- * @param friendId The friend to check
- * @return true when muted, false otherwise
- */
-bool CoreAV::isCallOutputMuted(const Friend* f) const
-{
-    QReadLocker locker{&callsLock};
-
-    if (!f) {
-        return false;
-    }
-    const uint32_t friendId = f->getId();
-    auto it = calls.find(friendId);
-    return (it != calls.end()) && it->second->getMuteVol();
-}
-
-/**
  * @brief Signal to all peers that we're not sending video anymore.
  * @note The next frame sent cancels this.
  */
@@ -793,11 +665,15 @@ void CoreAV::stateCallback(ToxAV* toxav, uint32_t friendNum, uint32_t state, voi
 
     if (state & TOXAV_FRIEND_CALL_STATE_ERROR) {
         qWarning() << "Call with friend" << friendNum << "died of unnatural causes!";
+        // Set inactive for others
+        it->second->setActive(false);
         self->calls.erase(friendNum);
         locker.unlock();
         emit self->avEnd(friendNum, true);
     } else if (state & TOXAV_FRIEND_CALL_STATE_FINISHED) {
         qDebug() << "Call with friend" << friendNum << "finished quietly";
+        // Set inactive for others
+        it->second->setActive(false);
         self->calls.erase(friendNum);
         locker.unlock();
         emit self->avEnd(friendNum);

--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -284,9 +284,6 @@ bool CoreAV::cancelCall(uint32_t friendNum)
         return false;
     }
 
-    // Set inactive for others
-    it->second->setActive(false);
-
     calls.erase(friendNum);
     locker.unlock();
 
@@ -437,7 +434,7 @@ void CoreAV::groupCallCallback(void* tox, uint32_t group, uint32_t peer, const i
         return;
     }
 
-    ToxGroupCall& call = *it->second;
+    auto& call = *it->second;
 
     if (call.getMuteVol() || !call.isActive()) {
         return;
@@ -462,14 +459,14 @@ CoreAV::ToxGroupCallPtr CoreAV::joinGroupCall(const Group& group)
 
     ToxGroupCallPtr groupcall = ToxGroupCallPtr(new ToxGroupCall{group, *this, *audio});
     // Call Objects must be owned by CoreAV or there will be locking problems with Audio
-    groupcall->moveToThread(thread());
     assert(groupcall != nullptr);
-    auto ret = groupCalls.emplace(group.getId(), groupcall);
+    groupcall->moveToThread(this->thread());
+    auto ret = groupCalls.emplace(group.getId(), groupcall.get());
     if (ret.second == false) {
         qWarning() << "This group call already exists, not joining!";
         return {};
     }
-    ret.first->second->setActive(true);
+    groupcall->setActive(true);
     return groupcall;
 }
 
@@ -492,7 +489,7 @@ bool CoreAV::sendGroupCallAudio(int groupNum, const int16_t* pcm, size_t samples
 {
     QReadLocker locker{&callsLock};
 
-    std::map<int, ToxGroupCallPtr>::const_iterator it = groupCalls.find(groupNum);
+    auto it = groupCalls.find(groupId);
     if (it == groupCalls.end()) {
         return false;
     }
@@ -584,15 +581,11 @@ void CoreAV::stateCallback(ToxAV* toxav, uint32_t friendNum, uint32_t state, voi
 
     if (state & TOXAV_FRIEND_CALL_STATE_ERROR) {
         qWarning() << "Call with friend" << friendNum << "died of unnatural causes!";
-        // Set inactive for others
-        it->second->setActive(false);
         self->calls.erase(friendNum);
         locker.unlock();
         emit self->avEnd(friendNum, true);
     } else if (state & TOXAV_FRIEND_CALL_STATE_FINISHED) {
         qDebug() << "Call with friend" << friendNum << "finished quietly";
-        // Set inactive for others
-        it->second->setActive(false);
         self->calls.erase(friendNum);
         locker.unlock();
         emit self->avEnd(friendNum);

--- a/src/core/coreav.h
+++ b/src/core/coreav.h
@@ -51,6 +51,7 @@ class CoreAV : public QObject
 public:
     using CoreAVPtr = std::unique_ptr<CoreAV>;
     using ToxFriendCallPtr = std::shared_ptr<ToxFriendCall>;
+    using ToxGroupCallPtr = std::shared_ptr<ToxGroupCall>;
 
     static CoreAVPtr makeCoreAV(Tox* core, CompatibleRecursiveMutex& toxCoreLock,
                                 IAudioSettings& audioSettings, IGroupSettings& groupSettings,
@@ -70,17 +71,12 @@ public:
 
     void sendNoVideo();
 
-    void joinGroupCall(const Group& group);
+    ToxGroupCallPtr joinGroupCall(const Group& group);
     void leaveGroupCall(int groupNum);
-    void muteCallInput(const Group* g, bool mute);
-    void muteCallOutput(const Group* g, bool mute);
-    bool isGroupCallInputMuted(const Group* g) const;
-    bool isGroupCallOutputMuted(const Group* g) const;
 
     static void groupCallCallback(void* tox, uint32_t group, uint32_t peer, const int16_t* data,
                                   unsigned samples, uint8_t channels, uint32_t sample_rate,
                                   void* core);
-    void invalidateGroupCallPeerSource(const Group& group, ToxPk peerPk);
 
 public slots:
     ToxFriendCallPtr startCall(uint32_t friendNum, bool video);
@@ -137,8 +133,6 @@ private:
      */
     std::map<uint32_t, ToxFriendCallPtr> calls;
 
-
-    using ToxGroupCallPtr = std::shared_ptr<ToxGroupCall>;
     /**
      * @brief Maps group IDs to ToxGroupCalls.
      * @note Need to use STL container here, because Qt containers need a copy constructor.

--- a/src/core/coreav.h
+++ b/src/core/coreav.h
@@ -24,6 +24,7 @@
 #include "util/compatiblerecursivemutex.h"
 
 #include <QObject>
+#include <QMetaType>
 #include <QMutex>
 #include <QReadWriteLock>
 #include <atomic>
@@ -44,14 +45,17 @@ class VideoFrame;
 class Core;
 struct vpx_image;
 
+Q_DECLARE_METATYPE(std::shared_ptr<ToxFriendCall>)
+
 class CoreAV : public QObject
 {
     Q_OBJECT
 
 public:
     using CoreAVPtr = std::unique_ptr<CoreAV>;
+    // must be shared for signal avInvites signal, even though ownership is not shared
     using ToxFriendCallPtr = std::shared_ptr<ToxFriendCall>;
-    using ToxGroupCallPtr = std::shared_ptr<ToxGroupCall>;
+    using ToxGroupCallPtr = std::unique_ptr<ToxGroupCall>;
 
     static CoreAVPtr makeCoreAV(Tox* core, CompatibleRecursiveMutex& toxCoreLock,
                                 IAudioSettings& audioSettings, IGroupSettings& groupSettings,
@@ -80,12 +84,12 @@ public:
 
 public slots:
     ToxFriendCallPtr startCall(uint32_t friendNum, bool video);
-    ToxFriendCallPtr answerCall(uint32_t friendNum, bool video);
+    bool answerCall(uint32_t friendNum, bool video);
     bool cancelCall(uint32_t friendNum);
     void start();
 
 signals:
-    void avInvite(uint32_t friendId, bool video);
+    void avInvite(uint32_t friendId, bool video, ToxFriendCallPtr call);
     void avStart(uint32_t friendId, bool video);
     void avEnd(uint32_t friendId, bool error = false);
 
@@ -131,13 +135,13 @@ private:
      * @brief Maps friend IDs to ToxFriendCall.
      * @note Need to use STL container here, because Qt containers need a copy constructor.
      */
-    std::map<uint32_t, ToxFriendCallPtr> calls;
+    std::map<uint32_t, ToxFriendCall*> calls;
 
     /**
      * @brief Maps group IDs to ToxGroupCalls.
      * @note Need to use STL container here, because Qt containers need a copy constructor.
      */
-    std::map<int, ToxGroupCallPtr> groupCalls;
+    std::map<int, ToxGroupCall*> groupCalls;
 
     // protect 'calls' and 'groupCalls'
     mutable QReadWriteLock callsLock{QReadWriteLock::Recursive};

--- a/src/core/toxcall.cpp
+++ b/src/core/toxcall.cpp
@@ -155,9 +155,7 @@ ToxFriendCall::ToxFriendCall(uint32_t friendNum, bool VideoEnabled, CoreAV& av_,
 
 ToxFriendCall::~ToxFriendCall()
 {
-    if (videoEnabled) {
-        cameraSource.unsubscribe();
-    }
+    av.cancelCall(friendId);
     QObject::disconnect(audioSinkInvalid);
 }
 
@@ -202,11 +200,6 @@ void ToxFriendCall::playAudioBuffer(const int16_t* data, int samples, unsigned c
     }
 }
 
-void ToxFriendCall::endCall()
-{
-    av.cancelCall(friendId);
-}
-
 ToxGroupCall::ToxGroupCall(const Group& group_, CoreAV& av_, IAudioControl& audio_)
     : ToxCall(false, av_, audio_)
     , group{group_}
@@ -226,6 +219,7 @@ ToxGroupCall::ToxGroupCall(const Group& group_, CoreAV& av_, IAudioControl& audi
 
 ToxGroupCall::~ToxGroupCall()
 {
+    av.leaveGroupCall(group.getId());
     // disconnect all Qt connections
     clearPeers();
 }
@@ -307,9 +301,4 @@ void ToxGroupCall::playAudioBuffer(const ToxPk& peer, const int16_t* data, int s
     if (source->second) {
         source->second->playAudioBuffer(data, samples, channels, sampleRate);
     }
-}
-
-void ToxGroupCall::endCall()
-{
-    av.leaveGroupCall(group.getId());
 }

--- a/src/core/toxcall.h
+++ b/src/core/toxcall.h
@@ -71,8 +71,6 @@ public:
     bool getNullVideoBitrate() const;
     void setNullVideoBitrate(bool value);
 
-    virtual void endCall() = 0;
-
     CoreVideoSource* getVideoSource() const;
 
 protected:
@@ -105,10 +103,6 @@ public:
 
     void playAudioBuffer(const int16_t* data, int samples, unsigned channels, int sampleRate) const;
 
-    // ToxCall interface
-public:
-    void endCall() override;
-
 private slots:
     void onAudioSourceInvalidated();
     void onAudioSinkInvalidated();
@@ -135,10 +129,6 @@ public:
 
     void playAudioBuffer(const ToxPk& peer, const int16_t* data, int samples, unsigned channels,
                          int sampleRate);
-
-    // ToxCall interface
-public:
-    void endCall() override;
 
 private:
     void addPeer(ToxPk peerId);

--- a/src/core/toxcall.h
+++ b/src/core/toxcall.h
@@ -29,6 +29,7 @@
 #include <QMetaObject>
 #include <QtGlobal>
 
+#include <atomic>
 #include <cstdint>
 #include <memory>
 
@@ -70,20 +71,22 @@ public:
     bool getNullVideoBitrate() const;
     void setNullVideoBitrate(bool value);
 
+    virtual void endCall() = 0;
+
     CoreVideoSource* getVideoSource() const;
 
 protected:
-    bool active{false};
-    CoreAV* av{nullptr};
+    std::atomic<bool> active{false};
+    CoreAV& av;
     // audio
     IAudioControl& audio;
-    bool muteMic{false};
-    bool muteVol{false};
+    std::atomic<bool> muteMic{false};
+    std::atomic<bool> muteVol{false};
     // video
     CoreVideoSource* videoSource{nullptr};
     QMetaObject::Connection videoInConn;
-    bool videoEnabled{false};
-    bool nullVideoBitrate{false};
+    std::atomic<bool> videoEnabled{false};
+    std::atomic<bool> nullVideoBitrate{false};
     std::unique_ptr<IAudioSource> audioSource;
 };
 
@@ -101,6 +104,10 @@ public:
     void setState(const TOXAV_FRIEND_CALL_STATE& value);
 
     void playAudioBuffer(const int16_t* data, int samples, unsigned channels, int sampleRate) const;
+
+    // ToxCall interface
+public:
+    void endCall() override;
 
 private slots:
     void onAudioSourceInvalidated();
@@ -128,6 +135,10 @@ public:
 
     void playAudioBuffer(const ToxPk& peer, const int16_t* data, int samples, unsigned channels,
                          int sampleRate);
+
+    // ToxCall interface
+public:
+    void endCall() override;
 
 private:
     void addPeer(ToxPk peerId);

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -415,11 +415,7 @@ void ChatForm::onAnswerCallTriggered(bool video)
 void ChatForm::onRejectCallTriggered()
 {
     headWidget->removeCallConfirm();
-    if (call) {
-        call->endCall();
-        call.reset();
-    }
-
+    call.reset();
     emit rejectCall(f->getId());
 }
 
@@ -429,7 +425,6 @@ void ChatForm::onCallTriggered()
     uint32_t friendId = f->getId();
 
     if (call) {
-        call->endCall();
         call.reset();
     } else {
         call = av->startCall(friendId, false);
@@ -447,7 +442,6 @@ void ChatForm::onVideoCallTriggered()
     uint32_t friendId = f->getId();
 
     if (call) {
-        call->endCall();
         call.reset();
     } else {
         call = av->startCall(friendId, true);
@@ -471,6 +465,7 @@ void ChatForm::updateCallButtons()
 
 void ChatForm::onMicMuteToggle()
 {
+    // Technically this is not atomic, but the probability of hitting the non-atomic case is negible
     call->setMuteMic(!call->getMuteMic());
     updateMuteMicButton();
 }

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -34,6 +34,7 @@
 #include "src/persistence/profile.h"
 #include "src/persistence/settings.h"
 #include "src/video/netcamview.h"
+#include "src/video/corevideosource.h"
 #include "src/widget/chatformheader.h"
 #include "src/widget/contentdialogmanager.h"
 #include "src/widget/form/loadhistorydialog.h"
@@ -329,10 +330,8 @@ void ChatForm::onAvInvite(uint32_t friendId, bool video)
     auto testedFlag = video ? Settings::AutoAcceptCall::Video : Settings::AutoAcceptCall::Audio;
     // AutoAcceptCall is set for this friend
     if (settings.getAutoAcceptCall(f->getPublicKey()).testFlag(testedFlag)) {
-        qDebug() << "automatic call answer";
-        CoreAV* coreav = core.getAv();
-        QMetaObject::invokeMethod(coreav, "answerCall", Qt::QueuedConnection,
-                                  Q_ARG(uint32_t, friendId), Q_ARG(bool, video));
+        onAnswerCallTriggered(video);
+        // CoreAV doesn't send a signal when we answer the call
         onAvStart(friendId, video);
     } else {
         headWidget->createCallConfirm(video);
@@ -395,20 +394,32 @@ void ChatForm::onAnswerCallTriggered(bool video)
     emit acceptCall(friendId);
 
     updateCallButtons();
+    if (call) {
+        qDebug() << "Stale call detected";
+    }
+
     CoreAV* av = core.getAv();
-    if (!av->answerCall(friendId, video)) {
+    call = av->answerCall(friendId, video);
+    if (!call) {
+        qDebug() << "Failed to answer call";
         updateCallButtons();
         stopCounter();
         hideNetcam();
         return;
     }
 
-    onAvStart(friendId, av->isCallVideoEnabled(f));
+    // CoreAV doesn't send the avStart() signal when we answer
+    onAvStart(friendId, call->getVideoEnabled());
 }
 
 void ChatForm::onRejectCallTriggered()
 {
     headWidget->removeCallConfirm();
+    if (call) {
+        call->endCall();
+        call.reset();
+    }
+
     emit rejectCall(f->getId());
 }
 
@@ -416,10 +427,17 @@ void ChatForm::onCallTriggered()
 {
     CoreAV* av = core.getAv();
     uint32_t friendId = f->getId();
-    if (av->isCallStarted(f)) {
-        av->cancelCall(friendId);
-    } else if (av->startCall(friendId, false)) {
-        showOutgoingCall(false);
+
+    if (call) {
+        call->endCall();
+        call.reset();
+    } else {
+        call = av->startCall(friendId, false);
+        if (call) {
+            showOutgoingCall(false);
+        } else {
+            qDebug() << "Failed to start Audio call";
+        }
     }
 }
 
@@ -427,21 +445,24 @@ void ChatForm::onVideoCallTriggered()
 {
     CoreAV* av = core.getAv();
     uint32_t friendId = f->getId();
-    if (av->isCallStarted(f)) {
-        // TODO: We want to activate video on the active call.
-        if (av->isCallVideoEnabled(f)) {
-            av->cancelCall(friendId);
+
+    if (call) {
+        call->endCall();
+        call.reset();
+    } else {
+        call = av->startCall(friendId, true);
+        if (call) {
+            showOutgoingCall(true);
+        } else {
+            qDebug() << "Failed to start Video call";
         }
-    } else if (av->startCall(friendId, true)) {
-        showOutgoingCall(true);
     }
 }
 
 void ChatForm::updateCallButtons()
 {
-    CoreAV* av = core.getAv();
-    const bool audio = av->isCallActive(f);
-    const bool video = av->isCallVideoEnabled(f);
+    const bool audio = call ? call->isActive() : false;
+    const bool video = call ? call->getVideoEnabled() : false;
     const bool online = Status::isOnline(f->getStatus());
     headWidget->updateCallButtons(online, audio, video);
     updateMuteMicButton();
@@ -450,15 +471,13 @@ void ChatForm::updateCallButtons()
 
 void ChatForm::onMicMuteToggle()
 {
-    CoreAV* av = core.getAv();
-    av->toggleMuteCallInput(f);
+    call->setMuteMic(!call->getMuteMic());
     updateMuteMicButton();
 }
 
 void ChatForm::onVolMuteToggle()
 {
-    CoreAV* av = core.getAv();
-    av->toggleMuteCallOutput(f);
+    call->setMuteVol(!call->getMuteVol());
     updateMuteVolButton();
 }
 
@@ -515,11 +534,9 @@ void ChatForm::onAvatarChanged(const ToxPk& friendPk, const QPixmap& pic)
 std::unique_ptr<NetCamView> ChatForm::createNetcam()
 {
     qDebug() << "creating netcam";
-    uint32_t friendId = f->getId();
     std::unique_ptr<NetCamView> view = std::unique_ptr<NetCamView>(
         new NetCamView(f->getPublicKey(), cameraSource, settings, style, this));
-    CoreAV* av = core.getAv();
-    VideoSource* source = av->getVideoSourceFromCall(friendId);
+    VideoSource* source = call->getVideoSource();
     view->show(source, f->getDisplayedName());
     connect(view.get(), &NetCamView::videoCallEnd, this, &ChatForm::onVideoCallTriggered);
     connect(view.get(), &NetCamView::volMuteToggle, this, &ChatForm::onVolMuteToggle);
@@ -656,9 +673,8 @@ void ChatForm::onCopyStatusMessage()
 
 void ChatForm::updateMuteMicButton()
 {
-    const CoreAV* av = core.getAv();
-    bool active = av->isCallActive(f);
-    bool inputMuted = av->isCallInputMuted(f);
+    const bool active = call ? call->isActive() : false;
+    const bool inputMuted = call ? call->getMuteMic() : false;
     headWidget->updateMuteMicButton(active, inputMuted);
     if (netcam) {
         netcam->updateMuteMicButton(inputMuted);
@@ -667,9 +683,8 @@ void ChatForm::updateMuteMicButton()
 
 void ChatForm::updateMuteVolButton()
 {
-    const CoreAV* av = core.getAv();
-    bool active = av->isCallActive(f);
-    bool outputMuted = av->isCallOutputMuted(f);
+    const bool active = call ? call->isActive() : false;
+    const bool outputMuted = call ? call->getMuteVol() : false;
     headWidget->updateMuteVolButton(active, outputMuted);
     if (netcam) {
         netcam->updateMuteVolButton(outputMuted);

--- a/src/widget/form/chatform.h
+++ b/src/widget/form/chatform.h
@@ -26,6 +26,7 @@
 
 #include "genericchatform.h"
 #include "src/core/core.h"
+#include "src/core/coreav.h"
 #include "src/model/ichatlog.h"
 #include "src/model/imessagedispatcher.h"
 #include "src/model/status.h"
@@ -152,4 +153,5 @@ private:
     Settings& settings;
     Style& style;
     ContentDialogManager& contentDialogManager;
+    CoreAV::ToxFriendCallPtr call;
 };

--- a/src/widget/form/chatform.h
+++ b/src/widget/form/chatform.h
@@ -79,7 +79,7 @@ signals:
     void updateFriendActivity(Friend& frnd);
 
 public slots:
-    void onAvInvite(uint32_t friendId, bool video);
+    void onAvInvite(uint32_t friendId, bool video, std::shared_ptr<ToxFriendCall> callInvite);
     void onAvStart(uint32_t friendId, bool video);
     void onAvEnd(uint32_t friendId, bool error);
     void onAvatarChanged(const ToxPk& friendPk, const QPixmap& pic);

--- a/src/widget/form/groupchatform.cpp
+++ b/src/widget/form/groupchatform.cpp
@@ -352,8 +352,8 @@ void GroupChatForm::onCallClicked()
     }
 
     headWidget->updateCallButtons(true, call != nullptr);
-    headWidget->updateMuteMicButton(call != nullptr, call->getMuteMic());
-    headWidget->updateMuteVolButton(call != nullptr, call->getMuteVol());
+    headWidget->updateMuteMicButton(call != nullptr, call && call->getMuteMic());
+    headWidget->updateMuteVolButton(call != nullptr, call && call->getMuteVol());
 }
 
 void GroupChatForm::keyPressEvent(QKeyEvent* ev)

--- a/src/widget/form/groupchatform.cpp
+++ b/src/widget/form/groupchatform.cpp
@@ -463,7 +463,6 @@ void GroupChatForm::joinGroupCall()
 
 void GroupChatForm::leaveGroupCall()
 {
-    call->endCall();
     call.reset();
     audioInputFlag = false;
     audioOutputFlag = false;

--- a/src/widget/form/groupchatform.cpp
+++ b/src/widget/form/groupchatform.cpp
@@ -39,6 +39,7 @@
 #include "src/persistence/igroupsettings.h"
 #include "src/persistence/settings.h"
 
+#include <QDebug>
 #include <QDragEnterEvent>
 #include <QMimeData>
 #include <QRegularExpression>
@@ -91,7 +92,6 @@ GroupChatForm::GroupChatForm(Core& core_, Group* chatGroup, IChatLog& chatLog_,
         documentCache_, smileyPack_, settings_, style_, messageBoxManager, friendList_)
     , core{core_}
     , group(chatGroup)
-    , inCall(false)
     , settings(settings_)
     , style{style_}
     , friendList{friendList_}
@@ -259,6 +259,9 @@ void GroupChatForm::onUserLeft(const ToxPk& user, const QString& name)
         addSystemInfoMessage(QDateTime::currentDateTime(), SystemMessageType::userLeftGroup, {name});
     }
     updateUserNames();
+    if (call) {
+        call->removePeer(user);
+    }
 }
 
 void GroupChatForm::onPeerNameChanged(const ToxPk& peer, const QString& oldName, const QString& newName)
@@ -325,48 +328,38 @@ void GroupChatForm::dropEvent(QDropEvent* ev)
 void GroupChatForm::onMicMuteToggle()
 {
     if (audioInputFlag) {
-        CoreAV* av = core.getAv();
-        const bool oldMuteState = av->isGroupCallInputMuted(group);
-        const bool newMute = !oldMuteState;
-        av->muteCallInput(group, newMute);
-        headWidget->updateMuteMicButton(inCall, newMute);
+        const bool muteState = call->getMuteMic();
+        call->setMuteMic(!muteState);
+        headWidget->updateMuteMicButton(true, !muteState);
     }
 }
 
 void GroupChatForm::onVolMuteToggle()
 {
     if (audioOutputFlag) {
-        CoreAV* av = core.getAv();
-        const bool oldMuteState = av->isGroupCallOutputMuted(group);
-        const bool newMute = !oldMuteState;
-        av->muteCallOutput(group, newMute);
-        headWidget->updateMuteVolButton(inCall, newMute);
+        const bool muteState = call->getMuteVol();
+        call->setMuteVol(!muteState);
+        headWidget->updateMuteVolButton(true, !muteState);
     }
 }
 
 void GroupChatForm::onCallClicked()
 {
-    CoreAV* av = core.getAv();
-
-    if (!inCall) {
-        joinGroupCall();
-    } else {
+    if (call) {
         leaveGroupCall();
+    } else {
+        joinGroupCall();
     }
 
-    headWidget->updateCallButtons(true, inCall);
-
-    const bool inMute = av->isGroupCallInputMuted(group);
-    headWidget->updateMuteMicButton(inCall, inMute);
-
-    const bool outMute = av->isGroupCallOutputMuted(group);
-    headWidget->updateMuteVolButton(inCall, outMute);
+    headWidget->updateCallButtons(true, call != nullptr);
+    headWidget->updateMuteMicButton(call != nullptr, call->getMuteMic());
+    headWidget->updateMuteVolButton(call != nullptr, call->getMuteVol());
 }
 
 void GroupChatForm::keyPressEvent(QKeyEvent* ev)
 {
     // Push to talk (CTRL+P)
-    if (ev->key() == Qt::Key_P && (ev->modifiers() & Qt::ControlModifier) && inCall) {
+    if (ev->key() == Qt::Key_P && (ev->modifiers() & Qt::ControlModifier) && (call != nullptr)) {
         onMicMuteToggle();
     }
 
@@ -377,7 +370,7 @@ void GroupChatForm::keyPressEvent(QKeyEvent* ev)
 void GroupChatForm::keyReleaseEvent(QKeyEvent* ev)
 {
     // Push to talk (CTRL+P)
-    if (ev->key() == Qt::Key_P && (ev->modifiers() & Qt::ControlModifier) && inCall) {
+    if (ev->key() == Qt::Key_P && (ev->modifiers() & Qt::ControlModifier) && (call != nullptr)) {
         onMicMuteToggle();
     }
 
@@ -391,7 +384,7 @@ void GroupChatForm::keyReleaseEvent(QKeyEvent* ev)
 void GroupChatForm::updateUserCount(int numPeers)
 {
     nusersLabel->setText(tr("%n user(s) in chat", "Number of users in chat", numPeers));
-    headWidget->updateCallButtons(true, inCall);
+    headWidget->updateCallButtons(true, call != nullptr);
 }
 
 void GroupChatForm::retranslateUi()
@@ -458,17 +451,20 @@ void GroupChatForm::onLabelContextMenuRequested(const QPoint& localPos)
 void GroupChatForm::joinGroupCall()
 {
     CoreAV* av = core.getAv();
-    av->joinGroupCall(*group);
+    call = av->joinGroupCall(*group);
+    if (!call) {
+        qDebug() << "Failed to join group call";
+        return;
+    }
+
     audioInputFlag = true;
     audioOutputFlag = true;
-    inCall = true;
 }
 
 void GroupChatForm::leaveGroupCall()
 {
-    CoreAV* av = core.getAv();
-    av->leaveGroupCall(group->getId());
+    call->endCall();
+    call.reset();
     audioInputFlag = false;
     audioOutputFlag = false;
-    inCall = false;
 }

--- a/src/widget/form/groupchatform.h
+++ b/src/widget/form/groupchatform.h
@@ -22,6 +22,8 @@
 #include "genericchatform.h"
 #include "src/core/toxpk.h"
 #include "src/persistence/igroupsettings.h"
+#include "src/core/toxcall.h"
+#include "src/core/toxpk.h"
 #include <QMap>
 
 namespace Ui {
@@ -87,8 +89,8 @@ private:
     FlowLayout* namesListLayout;
     QLabel* nusersLabel;
     TabCompleter* tabber;
-    bool inCall;
     Settings& settings;
     Style& style;
     FriendList& friendList;
+    std::shared_ptr<ToxGroupCall> call;
 };

--- a/src/widget/form/groupchatform.h
+++ b/src/widget/form/groupchatform.h
@@ -92,5 +92,5 @@ private:
     Settings& settings;
     Style& style;
     FriendList& friendList;
-    std::shared_ptr<ToxGroupCall> call;
+    std::unique_ptr<ToxGroupCall> call;
 };

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1144,12 +1144,6 @@ void Widget::dispatchFileSendFailed(uint32_t friendId, const QString& fileName)
                                            SystemMessageType::fileSendFailed, {fileName});
 }
 
-void Widget::onRejectCall(uint32_t friendId)
-{
-    CoreAV* const av = core->getAv();
-    av->cancelCall(friendId);
-}
-
 void Widget::addFriend(uint32_t friendId, const ToxPk& friendPk)
 {
     assert(core != nullptr);
@@ -1210,7 +1204,6 @@ void Widget::addFriend(uint32_t friendId, const ToxPk& friendPk)
     connect(friendForm, &ChatForm::outgoingNotification, this, &Widget::outgoingNotification);
     connect(friendForm, &ChatForm::stopNotification, this, &Widget::onStopNotification);
     connect(friendForm, &ChatForm::endCallNotification, this, &Widget::onCallEnd);
-    connect(friendForm, &ChatForm::rejectCall, this, &Widget::onRejectCall);
 
     connect(widget, &FriendWidget::newWindowOpened, this, &Widget::openNewDialog);
     connect(widget, &FriendWidget::chatroomWidgetClicked, this, &Widget::onChatroomWidgetClicked);

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -2111,13 +2111,6 @@ Group* Widget::createGroup(uint32_t groupnumber, const GroupId& groupId)
             *friendList);
     assert(newgroup);
 
-    if (enabled) {
-        connect(newgroup, &Group::userLeft, [=](const ToxPk& user){
-            CoreAV *av = core->getAv();
-            assert(av);
-            av->invalidateGroupCallPeerSource(*newgroup, user);
-        });
-    }
     auto rawChatroom = new GroupChatroom(newgroup, contentDialogManager.get(), *core,
         *friendList);
     std::shared_ptr<GroupChatroom> chatroom(rawChatroom);

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -243,7 +243,6 @@ private slots:
     void outgoingNotification();
     void onCallEnd();
     void incomingNotification(uint32_t friendNum);
-    void onRejectCall(uint32_t friendId);
     void onStopNotification();
     void dispatchFile(ToxFile file);
     void dispatchFileWithBool(ToxFile file, bool pausedOrBroken);


### PR DESCRIPTION
- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

@anthonybilinski as we discussed I decided to split this part from #6227 in order to make it easier to merge.

The changes:

- remove functions implemented by `ToxCall` from `CoreAV`, it was mostly just looking up the calls and then forwarding to `ToxCall`
- starting a call returns a `std::shared_pt<ToxCall>`, it must be ended using `endCall()` or there will be a resource leak
- made some properties in `ToxCall` atomic to prevent threading issues, because `ToxCall` objects are used by the Audio, CoreAV and UI threads

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6235)
<!-- Reviewable:end -->
