### PR TITLE
feat(logging): check if current code is tagged

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -214,6 +214,24 @@ add_definitions(
   -DGIT_VERSION="${GIT_VERSION}"
 )
 
+if (NOT GIT_DESCRIBE_EXACT)
+  execute_process(
+    COMMAND git describe --exact-match --tags HEAD
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_DESCRIBE_EXACT
+    ERROR_QUIET
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+
+  if(NOT GIT_DESCRIBE_EXACT)
+    set(GIT_DESCRIBE_EXACT "Nightly")
+  endif()
+endif()
+
+add_definitions(
+  -DGIT_DESCRIBE_EXACT="${GIT_DESCRIBE_EXACT}"
+)
+
 set(APPLE_EXT False)
 if (FOUNDATION_FOUND AND IOKIT_FOUND)
   set(APPLE_EXT True)

--- a/src/net/updatecheck.cpp
+++ b/src/net/updatecheck.cpp
@@ -121,6 +121,10 @@ void UpdateCheck::checkForUpdate()
 
 void UpdateCheck::handleResponse(QNetworkReply* reply)
 {
+    if (isCurrentVersionStable() == false) {
+      qWarning() << "qTox is running an unstable version";
+    }
+
     assert(reply != nullptr);
     if (reply == nullptr) {
         qWarning() << "Update check returned null reply, ignoring";
@@ -155,10 +159,6 @@ void UpdateCheck::handleResponse(QNetworkReply* reply)
     } else {
         qInfo() << "qTox is up to date";
         emit upToDate();
-    }
-
-    if (isCurrentVersionStable() == false) {
-      qWarning() << "qTox is running an unstable version";
     }
 
     reply->deleteLater();

--- a/src/net/updatecheck.cpp
+++ b/src/net/updatecheck.cpp
@@ -29,10 +29,9 @@
 #include <QTimer>
 #include <cassert>
 
-#define VERSION_REGEX_STRING   "v([0-9]+)\\.([0-9]+)\\.([0-9]+)"
-
 namespace {
 const QString versionUrl{QStringLiteral("https://api.github.com/repos/qTox/qTox/releases/latest")};
+const QString versionRegexString{QStringLiteral("v([0-9]+)\\.([0-9]+)\\.([0-9]+)")};
 
 struct Version {
     int major;
@@ -43,7 +42,7 @@ struct Version {
 Version tagToVersion(QString tagName)
 {
     // capture tag name to avoid showing update available on dev builds which include hash as part of describe
-    QRegularExpression versionFormat{QStringLiteral(VERSION_REGEX_STRING)};
+    QRegularExpression versionFormat(versionRegexString);
     auto matches = versionFormat.match(tagName);
     assert(matches.lastCapturedIndex() == 3);
 
@@ -89,7 +88,7 @@ bool isUpdateAvailable(Version current, Version available)
 
 bool isCurrentVersionStable()
 {
-  QRegularExpression versionRegex{QStringLiteral(VERSION_REGEX_STRING)};
+  QRegularExpression versionRegex(versionRegexString);
   auto currentVer = versionRegex.match(GIT_DESCRIBE_EXACT);
   if (currentVer.hasMatch()){
     return true;


### PR DESCRIPTION
This commit adds a new define called "GIT_DESCRIBE_EXACT" through cmake.
It is checked with a regex in "updatecheck.cpp" for a version number after the
check for new updates. If there is no version number,
a warning is output to log.

The reason for the new define is to avoid doing too much regex on
"GET_DESCRIBE", since "GIT_DESCRIBE_EXACT" will not contain a version number if
the code is not tagged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6250)
<!-- Reviewable:end -->
