### PR TITLE
fix(ui): system translation not being updated

### DIFF
--- a/src/widget/translator.h
+++ b/src/widget/translator.h
@@ -38,5 +38,6 @@ private:
     using Callback = QPair<void*, std::function<void()>>;
     static QVector<Callback> callbacks;
     static QMutex lock;
-    static QTranslator* translator;
+    static QTranslator* core_translator;
+    static QTranslator* app_translator;
 };


### PR DESCRIPTION
This commit fixes an issue when switching from any language back to English,
the system translations remain to be the last language even if the application
translations have switched back to English.

Example for the issue:

![Screenshot 2020-11-22 161818](https://user-images.githubusercontent.com/74188410/99906512-42cd9d80-2ce0-11eb-8304-abc2614d6e42.png)

- [X] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6258)
<!-- Reviewable:end -->
