### PR TITLE
Update flatpak

### DIFF
--- a/flatpak/io.github.qtox.qTox.json
+++ b/flatpak/io.github.qtox.qTox.json
@@ -45,11 +45,7 @@
             "build-options": {
                 "no-debuginfo": true
             },
-            "cleanup": [
-                "/bin",
-                "/lib",
-                "/man"
-            ],
+            "cleanup": [ '*' ],
             "sources": [
                 {
                     "type": "archive",
@@ -82,18 +78,6 @@
             ]
         },
         {
-            "name": "snorenotify",
-            "buildsystem": "cmake-ninja",
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://github.com/KDE/snorenotify",
-                    "tag": "v0.7.0",
-                    "commit": "9124e016f4f7615af5e8fca962994f7ed85de3cc"
-                }
-            ]
-        },
-        {
             "name": "libsodium",
             "sources": [
                 {
@@ -107,6 +91,11 @@
         {
             "name": "c-toxcore",
             "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DDHT_BOOTSTRAP=OFF",
+                "-DBOOTSTRAP_DAEMON=OFF",
+                "-DENABLE_STATIC=OFF"
+            ],
             "sources": [
                 {
                     "type": "git",


### PR DESCRIPTION
- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

First commit should have been prior to release, and has the version that was sent to flathub. Second commit returns it to build off release branch, and merge commit changes it to build off master branch. I believe this 3 commit change with 1 before release is how we should handle flatpak going forward, which I've included in https://github.com/qTox/qTox/pull/6264

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6265)
<!-- Reviewable:end -->
