### PR TITLE
chore(release): Merge flathub flatpak manifest with local

### DIFF
--- a/flatpak/io.github.qtox.qTox.json
+++ b/flatpak/io.github.qtox.qTox.json
@@ -45,11 +45,7 @@
             "build-options": {
                 "no-debuginfo": true
             },
-            "cleanup": [
-                "/bin",
-                "/lib",
-                "/man"
-            ],
+            "cleanup": [ '*' ],
             "sources": [
                 {
                     "type": "archive",
@@ -82,18 +78,6 @@
             ]
         },
         {
-            "name": "snorenotify",
-            "buildsystem": "cmake-ninja",
-            "sources": [
-                {
-                    "type": "git",
-                    "url": "https://github.com/KDE/snorenotify",
-                    "tag": "v0.7.0",
-                    "commit": "9124e016f4f7615af5e8fca962994f7ed85de3cc"
-                }
-            ]
-        },
-        {
             "name": "libsodium",
             "sources": [
                 {
@@ -107,6 +91,11 @@
         {
             "name": "c-toxcore",
             "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DDHT_BOOTSTRAP=OFF",
+                "-DBOOTSTRAP_DAEMON=OFF",
+                "-DENABLE_STATIC=OFF"
+            ],
             "sources": [
                 {
                     "type": "git",


### PR DESCRIPTION
Remove snorenotify dep because it was accidentally included.

This should have been done prior to v1.17.3 release, updated in #6264.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)


Note that this commit is already in repo since it was merged to master as part of https://github.com/qTox/qTox/pull/6265, this PR is just moving the branch forward one commit, and our github checks block be from doing that without a PR (despite what I thought earlier)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6266)
<!-- Reviewable:end -->
