### PR TITLE
fix(osx): Fix product name when prompting for mic and camera permissions

### DIFF
--- a/osx/info.plist
+++ b/osx/info.plist
@@ -88,9 +88,9 @@
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>NSCameraUsageDescription</key>
-	<string>$(PRODUCT_NAME) needs access to the camera for video calls.</string>
+	<string>qTox needs access to the camera for video calls.</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>$(PRODUCT_NAME) needs access to the microphone for audio calls.</string>
+	<string>qTox needs access to the microphone for audio calls.</string>
 	<key>UTImportedTypeDeclarations</key>
 	<array>
 		<dict>


### PR DESCRIPTION
Because we don't build with xcode with an xcode project, I think that causes
these variables to not be expanded.

Fix #6261

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

Note that I'm not 100% sure of this fix since I'm overall not very familiar with the macOS build ecosystem, but this fits with what I found online, and even if this isn't the correct fix, it doesn't cause much duplication of the string, and this is the only variable in the whole plist.

Image of the permission post-fix, showing the name show up correctly, unlike in the linked issue:
![image](https://user-images.githubusercontent.com/10469203/100535724-58573180-31d0-11eb-875f-ed57cf82cae8.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6267)
<!-- Reviewable:end -->
