### PR TITLE
refactor(history): Remove peerId caching from history

### DIFF
--- a/src/persistence/history.h
+++ b/src/persistence/history.h
@@ -206,7 +206,6 @@ private:
     std::shared_ptr<RawDatabase> db;
 
 
-    QHash<ToxPk, int64_t> peers;
     struct FileInfo
     {
         bool finished = false;


### PR DESCRIPTION
In history we cache peers to avoid extra DB lookups, this code is not
pretty and seems to provide little benefit. This reduces the cognitive
load when trying to reason about history.

* Removed peerId table from history
* Replaced peerId lookups with generated select statement
* Benchmarked on a profile with ~100 peers in the db and saw no
  noticible change in transaction time (6-30 ms both before and after
  the changes)

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6288)
<!-- Reviewable:end -->
