### PR TITLE
fix(travis): Don't call brew update in Travis CI

### DIFF
--- a/.travis/cirp/install.sh
+++ b/.travis/cirp/install.sh
@@ -5,8 +5,6 @@
 # Get Python >=3.5
 if [ "$TRAVIS_OS_NAME" == "osx" ]
 then
-  brew update
-
   # make sha256sum available
   export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
 


### PR DESCRIPTION
Brew disabled updating from shallow clones:
https://github.com/Homebrew/brew/pull/9383

The update is also uneeded since our .travis.yml already has `update: true` for
the brew extension.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6289)
<!-- Reviewable:end -->
