### PR TITLE
refactor(chatform): Move typing notification creation into ChatLog

### DIFF
--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -51,8 +51,8 @@ public:
     void clear();
     void copySelectedText(bool toSelectionBuffer = false) const;
     void setBusyNotification(ChatLine::Ptr notification);
-    void setTypingNotification(ChatLine::Ptr notification);
     void setTypingNotificationVisible(bool visible);
+    void setTypingNotificationName(const QString& displayName);
     void scrollToLine(ChatLine::Ptr line);
     void selectAll();
     void fontChanged(const QFont& font);
@@ -65,8 +65,6 @@ public:
 
     bool isEmpty() const;
     bool hasTextToBeCopied() const;
-
-    ChatLine::Ptr getTypingNotification() const;
     ChatLineContent* getContentFromGlobalPos(QPoint pos) const;
     const uint repNameAfter = 5 * 60;
 
@@ -130,6 +128,7 @@ private:
     void movePreciseSelectionUp(int offset);
     void moveMultiSelectionUp(int offset);
     void moveMultiSelectionDown(int offset);
+    void setTypingNotification();
 
 private:
     enum class SelectionMode

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -126,7 +126,6 @@ ChatForm::ChatForm(Profile& profile, Friend* chatFriend, IChatLog& chatLog, IMes
 
     callDurationTimer = nullptr;
 
-    chatWidget->setTypingNotification(ChatMessage::createTypingNotification());
     chatWidget->setMinimumHeight(CHAT_WIDGET_MIN_HEIGHT);
 
     callDuration = new QLabel();
@@ -673,10 +672,8 @@ void ChatForm::onUpdateTime()
 void ChatForm::setFriendTyping(bool isTyping)
 {
     chatWidget->setTypingNotificationVisible(isTyping);
-    Text* text = static_cast<Text*>(chatWidget->getTypingNotification()->getContent(1));
-    QString typingDiv = "<div class=typing>%1</div>";
     QString name = f->getDisplayedName();
-    text->setText(typingDiv.arg(tr("%1 is typing").arg(name)));
+    chatWidget->setTypingNotificationName(name);
 }
 
 void ChatForm::show(ContentLayout* contentLayout)
@@ -686,7 +683,6 @@ void ChatForm::show(ContentLayout* contentLayout)
 
 void ChatForm::reloadTheme()
 {
-    chatWidget->setTypingNotification(ChatMessage::createTypingNotification());
     GenericChatForm::reloadTheme();
 }
 


### PR DESCRIPTION
Part of attempt to reduce interdependencies between ChatForm<->ChatLog. (#6223)

Ideally we'd probably notify of name changes instead of setting the string every time... but that can be a problem to tackle another day. At this point I'm only trying to reduce dependencies between the two classes without modifying behavior.

Did a quick sanity test that the typing notification behavior matched what I saw on v1.17.3

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6293)
<!-- Reviewable:end -->
