### PR TITLE
reafctor(chatform): Use IChatLog to get date in GenericChatForm

### DIFF
--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -595,27 +595,6 @@ ChatLine::Ptr ChatLog::getTypingNotification() const
     return typingNotification;
 }
 
-QVector<ChatLine::Ptr> ChatLog::getLines()
-{
-    return lines;
-}
-
-ChatLine::Ptr ChatLog::getLatestLine() const
-{
-    if (!lines.empty()) {
-        return lines.last();
-    }
-    return nullptr;
-}
-
-ChatLine::Ptr ChatLog::getFirstLine() const
-{
-    if (!lines.empty()) {
-        return lines.first();
-    }
-    return nullptr;
-}
-
 /**
  * @brief Finds the chat line object at a position on screen
  * @param pos Position on screen in global coordinates

--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -67,9 +67,6 @@ public:
     bool hasTextToBeCopied() const;
 
     ChatLine::Ptr getTypingNotification() const;
-    QVector<ChatLine::Ptr> getLines();
-    ChatLine::Ptr getLatestLine() const;
-    ChatLine::Ptr getFirstLine() const;
     ChatLineContent* getContentFromGlobalPos(QPoint pos) const;
     const uint repNameAfter = 5 * 60;
 

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -402,12 +402,10 @@ void GenericChatForm::hideFileMenu()
 
 QDateTime GenericChatForm::getLatestTime() const
 {
-    return getTime(chatWidget->getLatestLine());
-}
+    if (chatLog.getFirstIdx() == chatLog.getNextIdx())
+        return QDateTime();
 
-QDateTime GenericChatForm::getFirstTime() const
-{
-    return getTime(chatWidget->getFirstLine());
+    return chatLog.at(chatLog.getNextIdx() - 1).getTimestamp();
 }
 
 void GenericChatForm::reloadTheme()

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -80,7 +80,6 @@ public:
                               const QDateTime& datetime);
     static QString resolveToxPk(const ToxPk& pk);
     QDateTime getLatestTime() const;
-    QDateTime getFirstTime() const;
 
 signals:
     void messageInserted();


### PR DESCRIPTION
* Allows for deletion of APIs returning ChatLine::Ptr from ChatLog
* Bonus removal of unused "getFirstTime" function from GenericChatForm

Part of the effort in #6223 to reduce interdependencies between ChatLog and ChatForm. I think ideally GenericChatForm shouldn't be involved here at all, but moving this into Widget doesn't seem much better so I just left it as is.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6294)
<!-- Reviewable:end -->
