### PR TITLE
fix(ui): add group widgets on start with "Activity" mode

### DIFF
--- a/src/widget/friendlistwidget.cpp
+++ b/src/widget/friendlistwidget.cpp
@@ -115,8 +115,10 @@ FriendListWidget::FriendListWidget(const Core &_core, Widget* parent, bool group
 
     mode = Settings::getInstance().getFriendSortingMode();
     sortByMode(mode);
+    if (mode != SortingMode::Name) {
+        listLayout->insertLayout(0, groupLayout.getLayout());
+    }
 
-    onGroupchatPositionChanged(groupsOnTop);
     dayTimer = new QTimer(this);
     dayTimer->setTimerType(Qt::VeryCoarseTimer);
     connect(dayTimer, &QTimer::timeout, this, &FriendListWidget::dayTimeout);


### PR DESCRIPTION
On start qTox with the "By Activity" mode, groups open on a separate window.
This is because group widgets are added to the contact layout only for the "Name" mode.

This PR additionally adds group widgets to the contact layout for the "By Activity" mode.

Fix: [5685](https://github.com/qTox/qTox/issues/5685)

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6304)
<!-- Reviewable:end -->
