### PR TITLE
chore(docker): add missing deps to dockerfiles

### DIFF
--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -57,6 +57,20 @@ RUN git checkout v0.2.12 && \
         echo '/usr/local/lib/' >> /etc/ld.so.conf.d/locallib.conf && \
         ldconfig
 
+RUN git clone https://github.com/toxext/toxext.git /toxext
+WORKDIR /toxext
+RUN git checkout v0.0.2 && \
+        cmake . && \
+        cmake --build . -- -j $(nproc) && \
+        cmake --build . --target install
+
+RUN git clone https://github.com/toxext/tox_extension_messages.git /tox_extension_messages
+WORKDIR /tox_extension_messages
+RUN git checkout v0.0.2 && \
+        cmake . && \
+        cmake --build . -- -j $(nproc) && \
+        cmake --build . --target install
+
 COPY . /qtox
 WORKDIR /qtox
 RUN cmake . && cmake --build .

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -54,6 +54,20 @@ RUN git checkout v0.2.12 && \
         echo '/usr/local/lib/' >> /etc/ld.so.conf.d/locallib.conf && \
         ldconfig
 
+RUN git clone https://github.com/toxext/toxext.git /toxext
+WORKDIR /toxext
+RUN git checkout v0.0.2 && \
+        cmake . && \
+        cmake --build . -- -j $(nproc) && \
+        cmake --build . --target install
+
+RUN git clone https://github.com/toxext/tox_extension_messages.git /tox_extension_messages
+WORKDIR /tox_extension_messages
+RUN git checkout v0.0.2 && \
+        cmake . && \
+        cmake --build . -- -j $(nproc) && \
+        cmake --build . --target install
+
 COPY . /qtox
 WORKDIR /qtox
 RUN cmake . && cmake --build .


### PR DESCRIPTION
After the addition of dependencies toxext and tox_extension_messages in [5903808](https://github.com/qTox/qTox/commit/59038088cb804f20e19af6bc809a9843d6dbf6e7
), these dockerfiles no longer successfully built qTox. This change adds the build of those dependencies to the docker image.
- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6308)
<!-- Reviewable:end -->
