### PR TITLE
fix(video): only list video devices with video capture capability

### DIFF
--- a/src/platform/camera/v4l2.cpp
+++ b/src/platform/camera/v4l2.cpp
@@ -206,7 +206,8 @@ QVector<QPair<QString, QString>> v4l2::getDeviceList()
         ioctl(fd, VIDIOC_QUERYCAP, &caps);
         close(fd);
 
-        devices += {file, reinterpret_cast<const char*>(caps.card)};
+        if (caps.device_caps & V4L2_CAP_VIDEO_CAPTURE)
+            devices += {file, reinterpret_cast<const char*>(caps.card)};
     }
     return devices;
 }


### PR DESCRIPTION
This change adds a check for the V4L2_CAP_VIDEO_CAPTURE capability of
the video device found on devfs. This will filter out 'metadata' device
nodes that may be present on devfs at some  /dev/videoN path.

Fixes #6276


**Background**
As of linux kernel commit [088ead2552458](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=088ead25524583e2200aa99111bea2f66a86545a) (introduced in v4.16) some uvc cameras will provide metadata on a different dev node.

> Some UVC video cameras contain metadata in their payload headers. This
    patch extracts that data, adding more clock synchronisation information,
    on both bulk and isochronous endpoints and makes it available to the user
    space on a separate video node, using the V4L2_CAP_META_CAPTURE capability
    and the V4L2_BUF_TYPE_META_CAPTURE buffer queue type

As noticed in #6276, qTox detects this extra 'video' device and shows it in the list of webcams on the AV dialog. This change adds the extra check that the device node has video capture capabilities.

Reference:
* [Kernel.org bug tracker on topic (not a bug)](https://bugzilla.kernel.org/show_bug.cgi?id=199575)
* [Video Device Caps documentation](https://github.com/torvalds/linux/blob/5695e51619745d4fe3ec2506a2f0cd982c5e27a4/include/uapi/linux/videodev2.h#L430)


- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6309)
<!-- Reviewable:end -->
