### PR TITLE
chore(travis): add code coverage report generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,18 @@ jobs:
     - stage: Linux
       os: linux
       env: JOB=build-ubuntu-16-04
+      addons:
+        apt:
+          packages: 
+            - lcov
       script: "./.travis/$JOB.sh"
+      after_success:
+        # Create lcov report
+        - lcov --directory _debug --capture --output-file coverage.info
+        # Filter out system headers and test sources
+        - lcov --remove coverage.info '/usr/*' '*/test/*' '*/*_autogen/*' --output-file coverage.info
+        # Upload report to codecov.io 
+        - bash <(curl -s https://codecov.io/bash) -f coverage.info || echo "Codecov did not collect coverage reports"
     - stage: "Windows Stage 1: Dependencies (OpenSSL, Qt)"
       os: linux
       # Makes the cache this job creates avaiable only to jobs with WINDOWS_BUILD_ARCH_CACHE_TRICK_VARIABLE=i686,

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,12 +47,12 @@ jobs:
       env: JOB=build-ubuntu-16-04
       addons:
         apt:
-          packages: 
+          packages:
             - lcov
       script: "./.travis/$JOB.sh"
       after_success:
         # Create lcov report
-        - lcov --directory _debug --capture --output-file coverage.info
+        - lcov --directory _build --capture --output-file coverage.info
         # Filter out system headers and test sources
         - lcov --remove coverage.info '/usr/*' '*/test/*' '*/*_autogen/*' --output-file coverage.info
         # Upload report to codecov.io 

--- a/.travis/build-ubuntu-16-04.sh
+++ b/.travis/build-ubuntu-16-04.sh
@@ -203,9 +203,15 @@ build_qtox() {
 }
 
 test_qtox() {
-    local BUILDDIR=_build
+    local BUILDDIR=_debug
+
+    cmake -H. -B"$BUILDDIR" \
+        -DUPDATE_CHECK=ON \
+        -DSTRICT_OPTIONS=ON \
+        -DCODE_COVERAGE=ON
 
     cd $BUILDDIR
+    make -j$(nproc)
     make test
     cd -
 }

--- a/.travis/build-ubuntu-16-04.sh
+++ b/.travis/build-ubuntu-16-04.sh
@@ -198,20 +198,15 @@ build_qtox() {
     echo '*** BUILDING "FULL" VERSION ***'
     cmake -H. -B"$BUILDDIR" \
         -DUPDATE_CHECK=ON \
-        -DSTRICT_OPTIONS=ON
+        -DSTRICT_OPTIONS=ON \
+        -DCODE_COVERAGE=ON
     bdir
 }
 
 test_qtox() {
-    local BUILDDIR=_debug
-
-    cmake -H. -B"$BUILDDIR" \
-        -DUPDATE_CHECK=ON \
-        -DSTRICT_OPTIONS=ON \
-        -DCODE_COVERAGE=ON
+    local BUILDDIR=_build
 
     cd $BUILDDIR
-    make -j$(nproc)
     make test
     cd -
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -579,6 +579,20 @@ MESSAGE( STATUS "CMAKE_C_FLAGS: " ${CMAKE_C_FLAGS} )
 # the compiler flags for compiling C++ sources
 MESSAGE( STATUS "CMAKE_CXX_FLAGS: " ${CMAKE_CXX_FLAGS} )
 
+# Interface library to propagate code coverage flags if enabled
+add_library(coverage_config INTERFACE)
+option(CODE_COVERAGE "Enable coverage reporting" OFF)
+if (CODE_COVERAGE AND CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+  target_compile_options(coverage_config INTERFACE -O0 -g --coverage)
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.13)
+    target_link_options(coverage_config INTERFACE --coverage)
+  else()
+    target_link_libraries(coverage_config INTERFACE --coverage)
+  endif()
+endif()
+
+link_libraries(coverage_config)
+
 add_subdirectory(util)
 add_subdirectory(audio)
 add_subdirectory(translations)
@@ -589,7 +603,8 @@ add_library(${PROJECT_NAME}_static
   ${${PROJECT_NAME}_SOURCES})
 target_link_libraries(${PROJECT_NAME}_static
   ${CMAKE_REQUIRED_LIBRARIES}
-  ${ALL_LIBRARIES})
+  ${ALL_LIBRARIES}
+  coverage_config)
 
 target_link_libraries(${PROJECT_NAME}_static util_library)
 target_link_libraries(${PROJECT_NAME}_static audio_library)


### PR DESCRIPTION
This change adds a cmake configuration switch to enable code coverage
instrumentation during the compilation of the project. When tests are
executed, the instrumentation outputs coverage data to output files in
the build directory. Programs such as lcov/gcovr can turn that data into
reports.

This change also adds steps to the travis CI configuration to build with
this configuration switch and then use lcov to generate the consolidated
report and publish to codecov.io

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6317)
<!-- Reviewable:end -->
