### PR TITLE
fix(ui): passing arguments from the CircleWidget constructor

### DIFF
--- a/src/widget/circlewidget.cpp
+++ b/src/widget/circlewidget.cpp
@@ -41,7 +41,7 @@
 QHash<int, CircleWidget*> CircleWidget::circleList;
 
 CircleWidget::CircleWidget(const Core &_core, FriendListWidget* parent, int id)
-    : CategoryWidget(parent)
+    : CategoryWidget(Settings::getInstance().getCompactLayout(), parent)
     , id(id)
     , core{_core}
 {

--- a/src/widget/circlewidget.cpp
+++ b/src/widget/circlewidget.cpp
@@ -41,7 +41,7 @@
 QHash<int, CircleWidget*> CircleWidget::circleList;
 
 CircleWidget::CircleWidget(const Core &_core, FriendListWidget* parent, int id)
-    : CategoryWidget(Settings::getInstance().getCompactLayout(), parent)
+    : CategoryWidget(isCompact(), parent)
     , id(id)
     , core{_core}
 {


### PR DESCRIPTION
Circles can be displayed separately at startup if parent widget from CircleWidget constructor is not passed

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6338)
<!-- Reviewable:end -->
