### PR TITLE
fix(core): extend RAII locker lifetime until end of function

### DIFF
--- a/audio/src/backend/alsink.cpp
+++ b/audio/src/backend/alsink.cpp
@@ -30,7 +30,7 @@
 
 AlSink::~AlSink()
 {
-    QMutexLocker{&killLock};
+    QMutexLocker locker{&killLock};
 
     // unsubscribe only if not already killed
     if (!killed) {
@@ -41,7 +41,7 @@ AlSink::~AlSink()
 
 void AlSink::playAudioBuffer(const int16_t* data, int samples, unsigned channels, int sampleRate) const
 {
-    QMutexLocker{&killLock};
+    QMutexLocker locker{&killLock};
 
     if (killed) {
         qCritical() << "Trying to play audio on an invalid sink";
@@ -52,7 +52,7 @@ void AlSink::playAudioBuffer(const int16_t* data, int samples, unsigned channels
 
 void AlSink::playMono16Sound(const IAudioSink::Sound& sound)
 {
-    QMutexLocker{&killLock};
+    QMutexLocker locker{&killLock};
 
     if (killed) {
         qCritical() << "Trying to play sound on an invalid sink";
@@ -63,7 +63,7 @@ void AlSink::playMono16Sound(const IAudioSink::Sound& sound)
 
 void AlSink::startLoop()
 {
-    QMutexLocker{&killLock};
+    QMutexLocker locker{&killLock};
 
     if (killed) {
         qCritical() << "Trying to start loop on an invalid sink";
@@ -74,7 +74,7 @@ void AlSink::startLoop()
 
 void AlSink::stopLoop()
 {
-    QMutexLocker{&killLock};
+    QMutexLocker locker{&killLock};
 
     if (killed) {
         qCritical() << "Trying to stop loop on an invalid sink";
@@ -105,7 +105,7 @@ AlSink::AlSink(OpenAL& al, uint sourceId)
 
 AlSink::operator bool() const
 {
-    QMutexLocker{&killLock};
+    QMutexLocker locker{&killLock};
 
     return !killed;
 }

--- a/audio/src/backend/alsource.cpp
+++ b/audio/src/backend/alsource.cpp
@@ -34,7 +34,7 @@ AlSource::AlSource(OpenAL& al)
 
 AlSource::~AlSource()
 {
-    QMutexLocker{&killLock};
+    QMutexLocker locker{&killLock};
 
     // unsubscribe only if not already killed
     if (!killed) {
@@ -45,7 +45,7 @@ AlSource::~AlSource()
 
 AlSource::operator bool() const
 {
-    QMutexLocker{&killLock};
+    QMutexLocker locker{&killLock};
     return !killed;
 }
 

--- a/src/core/corefile.cpp
+++ b/src/core/corefile.cpp
@@ -91,7 +91,7 @@ void CoreFile::connectCallbacks(Tox &tox)
 
 void CoreFile::sendAvatarFile(uint32_t friendId, const QByteArray& data)
 {
-    QMutexLocker{coreLoopLock};
+    QMutexLocker locker{coreLoopLock};
 
     uint64_t filesize = 0;
     uint8_t *file_id = nullptr;
@@ -145,7 +145,7 @@ void CoreFile::sendAvatarFile(uint32_t friendId, const QByteArray& data)
 void CoreFile::sendFile(uint32_t friendId, QString filename, QString filePath,
                         long long filesize)
 {
-    QMutexLocker{coreLoopLock};
+    QMutexLocker locker{coreLoopLock};
 
     ToxString fileName(filename);
     Tox_Err_File_Send sendErr;
@@ -174,7 +174,7 @@ void CoreFile::sendFile(uint32_t friendId, QString filename, QString filePath,
 
 void CoreFile::pauseResumeFile(uint32_t friendId, uint32_t fileId)
 {
-    QMutexLocker{coreLoopLock};
+    QMutexLocker locker{coreLoopLock};
 
     ToxFile* file = findFile(friendId, fileId);
     if (!file) {
@@ -208,7 +208,7 @@ void CoreFile::pauseResumeFile(uint32_t friendId, uint32_t fileId)
 
 void CoreFile::cancelFileSend(uint32_t friendId, uint32_t fileId)
 {
-    QMutexLocker{coreLoopLock};
+    QMutexLocker locker{coreLoopLock};
 
     ToxFile* file = findFile(friendId, fileId);
     if (!file) {
@@ -224,7 +224,7 @@ void CoreFile::cancelFileSend(uint32_t friendId, uint32_t fileId)
 
 void CoreFile::cancelFileRecv(uint32_t friendId, uint32_t fileId)
 {
-    QMutexLocker{coreLoopLock};
+    QMutexLocker locker{coreLoopLock};
 
     ToxFile* file = findFile(friendId, fileId);
     if (!file) {
@@ -239,7 +239,7 @@ void CoreFile::cancelFileRecv(uint32_t friendId, uint32_t fileId)
 
 void CoreFile::rejectFileRecvRequest(uint32_t friendId, uint32_t fileId)
 {
-    QMutexLocker{coreLoopLock};
+    QMutexLocker locker{coreLoopLock};
 
     ToxFile* file = findFile(friendId, fileId);
     if (!file) {
@@ -254,7 +254,7 @@ void CoreFile::rejectFileRecvRequest(uint32_t friendId, uint32_t fileId)
 
 void CoreFile::acceptFileRecvRequest(uint32_t friendId, uint32_t fileId, QString path)
 {
-    QMutexLocker{coreLoopLock};
+    QMutexLocker locker{coreLoopLock};
 
     ToxFile* file = findFile(friendId, fileId);
     if (!file) {
@@ -273,7 +273,7 @@ void CoreFile::acceptFileRecvRequest(uint32_t friendId, uint32_t fileId, QString
 
 ToxFile* CoreFile::findFile(uint32_t friendId, uint32_t fileId)
 {
-    QMutexLocker{coreLoopLock};
+    QMutexLocker locker{coreLoopLock};
 
     uint64_t key = getFriendKey(friendId, fileId);
     if (fileMap.contains(key)) {


### PR DESCRIPTION
Before it was being constructed then destroyed immediately, not
actually keeping the mutex locked.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6340)
<!-- Reviewable:end -->
