### PR TITLE
fix: Replace deprecated QMutex::Recursive with QRecursiveMutex

### DIFF
--- a/audio/src/backend/alsink.cpp
+++ b/audio/src/backend/alsink.cpp
@@ -101,7 +101,6 @@ void AlSink::kill()
 AlSink::AlSink(OpenAL& al, uint sourceId)
     : audio(al)
     , sourceId{sourceId}
-    , killLock(QMutex::Recursive)
 {}
 
 AlSink::operator bool() const

--- a/audio/src/backend/alsink.h
+++ b/audio/src/backend/alsink.h
@@ -23,6 +23,7 @@
 #include <QObject>
 
 #include "util/interface.h"
+#include "util/compatiblerecursivemutex.h"
 #include "audio/iaudiosink.h"
 
 class OpenAL;
@@ -55,5 +56,5 @@ private:
     OpenAL& audio;
     uint sourceId;
     bool killed = false;
-    mutable QMutex killLock;
+    mutable CompatibleRecursiveMutex killLock;
 };

--- a/audio/src/backend/alsource.cpp
+++ b/audio/src/backend/alsource.cpp
@@ -30,7 +30,6 @@
  */
 AlSource::AlSource(OpenAL& al)
     : audio(al)
-    , killLock(QMutex::Recursive)
 {}
 
 AlSource::~AlSource()

--- a/audio/src/backend/openal.h
+++ b/audio/src/backend/openal.h
@@ -23,6 +23,7 @@
 #include "audio/iaudiocontrol.h"
 #include "alsink.h"
 #include "alsource.h"
+#include "util/compatiblerecursivemutex.h"
 
 #include <memory>
 #include <unordered_set>
@@ -132,7 +133,7 @@ private:
 protected:
     IAudioSettings& settings;
     QThread* audioThread;
-    mutable QMutex audioLock{QMutex::Recursive};
+    mutable CompatibleRecursiveMutex audioLock;
     QString inDev{};
     QString outDev{};
 

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -33,6 +33,7 @@
 #include "src/model/ibootstraplistgenerator.h"
 #include "src/persistence/profile.h"
 #include "util/strongtype.h"
+#include "util/compatiblerecursivemutex.h"
 
 #include <QCoreApplication>
 #include <QDateTime>
@@ -715,7 +716,7 @@ Tox* Core::getTox() const
     return tox.get();
 }
 
-QMutex &Core::getCoreLoopLock() const
+CompatibleRecursiveMutex &Core::getCoreLoopLock() const
 {
     return coreLoopLock;
 }

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -31,6 +31,7 @@
 #include "toxpk.h"
 
 #include "util/strongtype.h"
+#include "util/compatiblerecursivemutex.h"
 #include "src/model/status.h"
 #include <tox/tox.h>
 
@@ -78,7 +79,7 @@ public:
 
     CoreFile* getCoreFile() const;
     Tox* getTox() const;
-    QMutex& getCoreLoopLock() const;
+    CompatibleRecursiveMutex& getCoreLoopLock() const;
 
     const CoreExt* getExt() const;
     CoreExt* getExt();
@@ -258,7 +259,7 @@ private:
     std::unique_ptr<CoreExt> ext;
     QTimer* toxTimer = nullptr;
     // recursive, since we might call our own functions
-    mutable QMutex coreLoopLock{QMutex::Recursive};
+    mutable CompatibleRecursiveMutex coreLoopLock;
 
     std::unique_ptr<QThread> coreThread;
     IBootstrapListGenerator& bootstrapNodes;

--- a/src/core/coreav.cpp
+++ b/src/core/coreav.cpp
@@ -26,6 +26,7 @@
 #include "src/persistence/igroupsettings.h"
 #include "src/video/corevideosource.h"
 #include "src/video/videoframe.h"
+#include "util/compatiblerecursivemutex.h"
 #include <QCoreApplication>
 #include <QDebug>
 #include <QThread>
@@ -69,7 +70,7 @@
  * deadlock.
  */
 
-CoreAV::CoreAV(std::unique_ptr<ToxAV, ToxAVDeleter> toxav, QMutex& toxCoreLock,
+CoreAV::CoreAV(std::unique_ptr<ToxAV, ToxAVDeleter> toxav, CompatibleRecursiveMutex& toxCoreLock,
                IAudioSettings& _audioSettings, IGroupSettings& _groupSettings)
     : audio{nullptr}
     , toxav{std::move(toxav)}
@@ -109,7 +110,7 @@ void CoreAV::connectCallbacks(ToxAV& toxav)
  * @param core pointer to the Tox instance
  * @return CoreAV instance on success, {} on failure
  */
-CoreAV::CoreAVPtr CoreAV::makeCoreAV(Tox* core, QMutex& toxCoreLock,
+CoreAV::CoreAVPtr CoreAV::makeCoreAV(Tox* core, CompatibleRecursiveMutex& toxCoreLock,
                                      IAudioSettings& audioSettings, IGroupSettings& groupSettings)
 {
     Toxav_Err_New err;

--- a/src/core/coreav.h
+++ b/src/core/coreav.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "src/core/toxcall.h"
+#include "util/compatiblerecursivemutex.h"
 
 #include <QObject>
 #include <QMutex>
@@ -49,7 +50,7 @@ class CoreAV : public QObject
 
 public:
     using CoreAVPtr = std::unique_ptr<CoreAV>;
-    static CoreAVPtr makeCoreAV(Tox* core, QMutex& toxCoreLock,
+    static CoreAVPtr makeCoreAV(Tox* core, CompatibleRecursiveMutex& toxCoreLock,
                                 IAudioSettings& audioSettings, IGroupSettings& groupSettings);
 
     void setAudio(IAudioControl& newAudio);
@@ -116,7 +117,7 @@ private:
         }
     };
 
-    CoreAV(std::unique_ptr<ToxAV, ToxAVDeleter> tox, QMutex &toxCoreLock,
+    CoreAV(std::unique_ptr<ToxAV, ToxAVDeleter> tox, CompatibleRecursiveMutex &toxCoreLock,
            IAudioSettings& _audioSettings, IGroupSettings& _groupSettings);
     void connectCallbacks(ToxAV& toxav);
 
@@ -160,7 +161,7 @@ private:
      *        must not execute at the same time as tox_iterate()
      * @note This must be a recursive mutex as we're going to lock it in callbacks
      */
-    QMutex& coreLock;
+    CompatibleRecursiveMutex& coreLock;
 
     IAudioSettings& audioSettings;
     IGroupSettings& groupSettings;

--- a/src/core/corefile.cpp
+++ b/src/core/corefile.cpp
@@ -25,6 +25,7 @@
 #include "src/persistence/settings.h"
 #include "src/model/status.h"
 #include "src/model/toxclientstandards.h"
+#include "util/compatiblerecursivemutex.h"
 #include <QDebug>
 #include <QDir>
 #include <QFile>
@@ -38,7 +39,7 @@
  * @brief Manages the file transfer service of toxcore
  */
 
-CoreFilePtr CoreFile::makeCoreFile(Core *core, Tox *tox, QMutex &coreLoopLock)
+CoreFilePtr CoreFile::makeCoreFile(Core *core, Tox *tox, CompatibleRecursiveMutex &coreLoopLock)
 {
     assert(core != nullptr);
     assert(tox != nullptr);
@@ -49,7 +50,7 @@ CoreFilePtr CoreFile::makeCoreFile(Core *core, Tox *tox, QMutex &coreLoopLock)
     return result;
 }
 
-CoreFile::CoreFile(Tox *core, QMutex &coreLoopLock)
+CoreFile::CoreFile(Tox *core, CompatibleRecursiveMutex &coreLoopLock)
     : tox{core}
     , coreLoopLock{&coreLoopLock}
 {

--- a/src/core/corefile.h
+++ b/src/core/corefile.h
@@ -27,6 +27,8 @@
 #include "src/core/toxpk.h"
 #include "src/model/status.h"
 
+#include "util/compatiblerecursivemutex.h"
+
 #include <QHash>
 #include <QMutex>
 #include <QObject>
@@ -47,7 +49,7 @@ class CoreFile : public QObject
 
 public:
     void handleAvatarOffer(uint32_t friendId, uint32_t fileId, bool accept);
-    static CoreFilePtr makeCoreFile(Core* core, Tox* tox, QMutex& coreLoopLock);
+    static CoreFilePtr makeCoreFile(Core* core, Tox* tox, CompatibleRecursiveMutex& coreLoopLock);
 
     void sendFile(uint32_t friendId, QString filename, QString filePath,
                          long long filesize);
@@ -77,7 +79,7 @@ signals:
     void fileSendFailed(uint32_t friendId, const QString& fname);
 
 private:
-    CoreFile(Tox* core, QMutex& coreLoopLock);
+    CoreFile(Tox* core, CompatibleRecursiveMutex& coreLoopLock);
 
     ToxFile* findFile(uint32_t friendId, uint32_t fileId);
     void addFile(uint32_t friendId, uint32_t fileId, const ToxFile& file);
@@ -106,5 +108,5 @@ private slots:
 private:
     QHash<uint64_t, ToxFile> fileMap;
     Tox* tox;
-    QMutex* coreLoopLock = nullptr;
+    CompatibleRecursiveMutex* coreLoopLock = nullptr;
 };

--- a/src/persistence/offlinemsgengine.cpp
+++ b/src/persistence/offlinemsgengine.cpp
@@ -29,10 +29,6 @@
 #include <QCoreApplication>
 #include <chrono>
 
-OfflineMsgEngine::OfflineMsgEngine()
-    : mutex(QMutex::Recursive)
-{}
-
 /**
 * @brief Notification that the message is now delivered.
 *

--- a/src/persistence/offlinemsgengine.h
+++ b/src/persistence/offlinemsgengine.h
@@ -23,6 +23,9 @@
 #include "src/core/core.h"
 #include "src/model/message.h"
 #include "src/persistence/db/rawdatabase.h"
+
+#include "util/compatiblerecursivemutex.h"
+
 #include <QDateTime>
 #include <QMap>
 #include <QMutex>
@@ -36,7 +39,7 @@ class OfflineMsgEngine : public QObject
     Q_OBJECT
 public:
     using CompletionFn = std::function<void(bool)>;
-    OfflineMsgEngine();
+    OfflineMsgEngine() = default;
     void addUnsentMessage(Message const& message, CompletionFn completionCallback);
     void addSentCoreMessage(ReceiptNum receipt, Message const& message, CompletionFn completionCallback);
     void addSentExtendedMessage(ExtendedReceiptNum receipt, Message const& message, CompletionFn completionCallback);
@@ -60,7 +63,7 @@ private:
         CompletionFn completionFn;
     };
 
-    QMutex mutex;
+    CompatibleRecursiveMutex mutex;
 
     template <class ReceiptT>
     class ReceiptResolver

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -33,6 +33,8 @@
 #endif
 #include "src/ipc.h"
 
+#include "util/compatiblerecursivemutex.h"
+
 #include <QApplication>
 #include <QCryptographicHash>
 #include <QDebug>
@@ -57,7 +59,7 @@
 
 const QString Settings::globalSettingsFile = "qtox.ini";
 Settings* Settings::settings{nullptr};
-QMutex Settings::bigLock{QMutex::Recursive};
+CompatibleRecursiveMutex Settings::bigLock;
 QThread* Settings::settingsThread{nullptr};
 
 Settings::Settings()

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -30,6 +30,8 @@
 #include "src/persistence/inotificationsettings.h"
 #include "src/video/ivideosettings.h"
 
+#include "util/compatiblerecursivemutex.h"
+
 #include <QDateTime>
 #include <QFlags>
 #include <QFont>
@@ -706,7 +708,7 @@ private:
 
     int themeColor;
 
-    static QMutex bigLock;
+    static CompatibleRecursiveMutex bigLock;
     static Settings* settings;
     static const QString globalSettingsFile;
     static QThread* settingsThread;

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -15,6 +15,7 @@
 #   along with qTox.  If not, see <http://www.gnu.org/licenses/>
 
 set(HEADER_LIST
+    "include/util/compatiblerecursivemutex.h"
     "include/util/interface.h"
     "include/util/strongtype.h")
 

--- a/util/include/util/compatiblerecursivemutex.h
+++ b/util/include/util/compatiblerecursivemutex.h
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2019 by The qTox Project Contributors
+    Copyright © 2021 by The qTox Project Contributors
 
     This file is part of qTox, a Qt-based graphical interface for Tox.
 
@@ -19,29 +19,18 @@
 
 #pragma once
 
-#include "audio/iaudiosource.h"
-#include "util/compatiblerecursivemutex.h"
+#include <QtGlobal>
 #include <QMutex>
-#include <QObject>
 
-class OpenAL;
-class AlSource : public IAudioSource
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+class CompatibleRecursiveMutex : public QRecursiveMutex
+{};
+#else
+class CompatibleRecursiveMutex : public QMutex
 {
-    Q_OBJECT
 public:
-    AlSource(OpenAL& al);
-    AlSource(AlSource& src) = delete;
-    AlSource& operator=(const AlSource&) = delete;
-    AlSource(AlSource&& other) = delete;
-    AlSource& operator=(AlSource&& other) = delete;
-    ~AlSource();
-
-    operator bool() const;
-
-    void kill();
-
-private:
-    OpenAL& audio;
-    bool killed = false;
-    mutable CompatibleRecursiveMutex killLock;
+    CompatibleRecursiveMutex()
+        : QMutex(QMutex::Recursive)
+    {}
 };
+#endif


### PR DESCRIPTION
- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6341)
<!-- Reviewable:end -->
