### PR TITLE
fix(chatform): Scroll to bottom on load, broken on refactor

### DIFF
--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -128,6 +128,7 @@ ChatLog::ChatLog(QWidget* parent)
     reloadTheme();
     retranslateUi();
     Translator::registerHandler(std::bind(&ChatLog::retranslateUi, this), this);
+    scrollToBottom();
 }
 
 ChatLog::~ChatLog()


### PR DESCRIPTION
Fix #6314

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6342)
<!-- Reviewable:end -->
