### PR TITLE
refactor(ui): separation of responsibility for sorting the contact list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,6 +277,9 @@ set(${PROJECT_NAME}_SOURCES
   src/model/dialogs/idialogs.h
   src/model/exiftransform.cpp
   src/model/exiftransform.h
+  src/model/friendlist/friendlistmanager.cpp
+  src/model/friendlist/friendlistmanager.h
+  src/model/friendlist/ifriendlistitem.h
   src/model/friendmessagedispatcher.cpp
   src/model/friendmessagedispatcher.h
   src/model/friend.cpp

--- a/src/model/friendlist/friendlistmanager.cpp
+++ b/src/model/friendlist/friendlistmanager.cpp
@@ -20,8 +20,6 @@
 #include "friendlistmanager.h"
 #include "src/widget/genericchatroomwidget.h"
 
-#include <QApplication>
-
 bool FriendListManager::groupsOnTop = true;
 
 FriendListManager::FriendListManager(QObject *parent) : QObject(parent)
@@ -46,8 +44,7 @@ void FriendListManager::addFriendItem(IFriendListItem *item)
     if (item->isGroup()) {
         items.push_back(IFriendItemPtr(item, [](IFriendListItem* groupItem){
                             groupItem->getWidget()->deleteLater();}));
-    }
-    else {
+    } else {
         items.push_back(IFriendItemPtr(item));
     }
 
@@ -104,8 +101,7 @@ void FriendListManager::applyFilter()
     for (IFriendItemPtr itemTmp : items) {
         if (searchString.isEmpty()) {
             itemTmp->getWidget()->setVisible(true);
-        }
-        else {
+        } else {
             QString tmp_name = itemTmp->getNameItem();
             itemTmp->getWidget()->setVisible(tmp_name.contains(searchString, Qt::CaseInsensitive));
         }
@@ -127,8 +123,7 @@ void FriendListManager::applyFilter()
 
     if (filterParams.hideOnline && filterParams.hideOffline) {
         hideCircles = true;
-    }
-    else {
+    } else {
         hideCircles = false;
     }
 }
@@ -137,8 +132,7 @@ void FriendListManager::updatePositions()
 {
     if (byName) {
         std::sort(items.begin(), items.end(), cmpByName);
-    }
-    else {
+    } else {
         std::sort(items.begin(), items.end(), cmpByActivity);
     }
 }

--- a/src/model/friendlist/friendlistmanager.cpp
+++ b/src/model/friendlist/friendlistmanager.cpp
@@ -1,0 +1,216 @@
+/*
+    Copyright © 2021 by The qTox Project Contributors
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "friendlistmanager.h"
+#include "src/widget/genericchatroomwidget.h"
+
+#include <QApplication>
+
+bool FriendListManager::groupsOnTop = true;
+
+FriendListManager::FriendListManager(QObject *parent) : QObject(parent)
+{
+
+}
+
+QVector<FriendListManager::IFriendItemPtr> FriendListManager::getItems() const
+{
+    return items;
+}
+
+bool FriendListManager::needHideCircles() const
+{
+    return hideCircles;
+}
+
+void FriendListManager::addFriendItem(IFriendListItem *item)
+{
+    removeAll(item);
+
+    if (item->isGroup()) {
+        items.push_back(IFriendItemPtr(item, [](IFriendListItem* groupItem){
+                            groupItem->getWidget()->deleteLater();}));
+    }
+    else {
+        items.push_back(IFriendItemPtr(item));
+    }
+
+    updatePositions();
+    emit itemsChanged();
+}
+
+void FriendListManager::removeFriendItem(IFriendListItem *item)
+{
+    removeAll(item);
+    updatePositions();
+    emit itemsChanged();
+}
+
+void FriendListManager::sortByName()
+{
+    byName = true;
+    updatePositions();
+}
+
+void FriendListManager::sortByActivity()
+{
+    byName = false;
+    updatePositions();
+}
+
+void FriendListManager::resetParents()
+{
+    for (int i = 0; i < items.size(); ++i) {
+        IFriendListItem* itemTmp = items[i].get();
+        itemTmp->getWidget()->setParent(nullptr);
+    }
+}
+
+void FriendListManager::setFilter(const QString &searchString, bool hideOnline, bool hideOffline,
+                                  bool hideGroups)
+{
+    if (filterParams.searchString == searchString && filterParams.hideOnline == hideOnline &&
+        filterParams.hideOffline == hideOffline && filterParams.hideGroups == hideGroups) {
+        return;
+    }
+    filterParams.searchString = searchString;
+    filterParams.hideOnline = hideOnline;
+    filterParams.hideOffline = hideOffline;
+    filterParams.hideGroups = hideGroups;
+
+    emit itemsChanged();
+}
+
+void FriendListManager::applyFilter()
+{
+    QString searchString = filterParams.searchString;
+
+    for (IFriendItemPtr itemTmp : items) {
+        if (searchString.isEmpty()) {
+            itemTmp->getWidget()->setVisible(true);
+        }
+        else {
+            QString tmp_name = itemTmp->getNameItem();
+            itemTmp->getWidget()->setVisible(tmp_name.contains(searchString, Qt::CaseInsensitive));
+        }
+
+        if (filterParams.hideOnline && itemTmp->isOnline()) {
+            if (itemTmp->isFriend()) {
+                itemTmp->getWidget()->setVisible(false);
+            }
+        }
+
+        if (filterParams.hideOffline && !itemTmp->isOnline()) {
+            itemTmp->getWidget()->setVisible(false);
+        }
+
+        if (filterParams.hideGroups && itemTmp->isGroup()) {
+            itemTmp->getWidget()->setVisible(false);
+        }
+    }
+
+    if (filterParams.hideOnline && filterParams.hideOffline) {
+        hideCircles = true;
+    }
+    else {
+        hideCircles = false;
+    }
+}
+
+void FriendListManager::updatePositions()
+{
+    if (byName) {
+        std::sort(items.begin(), items.end(), cmpByName);
+    }
+    else {
+        std::sort(items.begin(), items.end(), cmpByActivity);
+    }
+}
+
+void FriendListManager::setGroupsOnTop(bool v)
+{
+    groupsOnTop = v;
+}
+
+void FriendListManager::removeAll(IFriendListItem* item)
+{
+    for (int i = 0; i < items.size(); ++i) {
+        if (items[i].get() == item) {
+            items.remove(i);
+            --i;
+        }
+    }
+}
+
+bool FriendListManager::cmpByName(const IFriendItemPtr &a, const IFriendItemPtr &b)
+{
+    if (a->isGroup() && !b->isGroup()) {
+        if (groupsOnTop) {
+            return true;
+        }
+        return !b->isOnline();
+    }
+
+    if (!a->isGroup() && b->isGroup()) {
+        if (groupsOnTop) {
+            return false;
+        }
+        return a->isOnline();
+    }
+
+    if (a->isOnline() && !b->isOnline()) {
+        return true;
+    }
+
+    if (!a->isOnline() && b->isOnline()) {
+        return false;
+    }
+
+    return a->getNameItem().toUpper() < b->getNameItem().toUpper();
+}
+
+bool FriendListManager::cmpByActivity(const IFriendItemPtr &a, const IFriendItemPtr &b)
+{
+    if (a->isGroup() || b->isGroup()) {
+        if (a->isGroup() && !b->isGroup()) {
+            return true;
+        }
+
+        if (!a->isGroup() && b->isGroup()) {
+            return false;
+        }
+        return a->getNameItem().toUpper() < b->getNameItem().toUpper();
+    }
+
+    QDateTime dateA = a->getLastActivity();
+    QDateTime dateB = b->getLastActivity();
+    if (dateA.date() == dateB.date()) {
+        if (a->isOnline() && !b->isOnline()) {
+            return true;
+        }
+
+        if (!a->isOnline() && b->isOnline()) {
+            return false;
+        }
+        return a->getNameItem().toUpper() < b->getNameItem().toUpper();
+    }
+
+    return a->getLastActivity() > b->getLastActivity();
+}
+

--- a/src/model/friendlist/friendlistmanager.h
+++ b/src/model/friendlist/friendlistmanager.h
@@ -30,15 +30,15 @@ class FriendListManager : public QObject
 {    
     Q_OBJECT
 public:
-    using IFriendItemPtr = std::shared_ptr<IFriendListItem>;
+    using IFriendListItemPtr = std::shared_ptr<IFriendListItem>;
 
     explicit FriendListManager(QObject *parent = nullptr);
 
-    QVector<IFriendItemPtr> getItems() const;
+    QVector<IFriendListItemPtr> getItems() const;
     bool needHideCircles() const;
 
-    void addFriendItem(IFriendListItem* item);
-    void removeFriendItem(IFriendListItem* item);
+    void addFriendListItem(IFriendListItem* item);
+    void removeFriendListItem(IFriendListItem* item);
     void sortByName();
     void sortByActivity();
     void resetParents();
@@ -47,7 +47,7 @@ public:
     void applyFilter();
     void updatePositions();    
 
-    static void setGroupsOnTop(bool v);
+    void setGroupsOnTop(bool v);
 
 signals:
     void itemsChanged();
@@ -61,12 +61,12 @@ private:
     } filterParams;
 
     void removeAll(IFriendListItem*);    
-    static bool cmpByName(const IFriendItemPtr&, const IFriendItemPtr&);
-    static bool cmpByActivity(const IFriendItemPtr&, const IFriendItemPtr&);    
+    bool cmpByName(const IFriendListItemPtr&, const IFriendListItemPtr&, bool groupsOnTop);
+    bool cmpByActivity(const IFriendListItemPtr&, const IFriendListItemPtr&);
 
     bool byName = true;
     bool hideCircles = false;
-    static bool groupsOnTop;
-    QVector<IFriendItemPtr> items;
+    bool groupsOnTop;
+    QVector<IFriendListItemPtr> items;
 
 };

--- a/src/model/friendlist/friendlistmanager.h
+++ b/src/model/friendlist/friendlistmanager.h
@@ -22,6 +22,7 @@
 #include "ifriendlistitem.h"
 
 #include <QObject>
+#include <QVector>
 
 #include <memory>
 

--- a/src/model/friendlist/friendlistmanager.h
+++ b/src/model/friendlist/friendlistmanager.h
@@ -1,0 +1,71 @@
+/*
+    Copyright © 2021 by The qTox Project Contributors
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "ifriendlistitem.h"
+
+#include <QObject>
+
+#include <memory>
+
+class FriendListManager : public QObject
+{    
+    Q_OBJECT
+public:
+    using IFriendItemPtr = std::shared_ptr<IFriendListItem>;
+
+    explicit FriendListManager(QObject *parent = nullptr);
+
+    QVector<IFriendItemPtr> getItems() const;
+    bool needHideCircles() const;
+
+    void addFriendItem(IFriendListItem* item);
+    void removeFriendItem(IFriendListItem* item);
+    void sortByName();
+    void sortByActivity();
+    void resetParents();
+    void setFilter(const QString& searchString, bool hideOnline,
+                   bool hideOffline, bool hideGroups);
+    void applyFilter();
+    void updatePositions();    
+
+    static void setGroupsOnTop(bool v);
+
+signals:
+    void itemsChanged();
+
+private:
+    struct FilterParams {
+        QString searchString = "";
+        bool hideOnline = false;
+        bool hideOffline = false;
+        bool hideGroups = false;
+    } filterParams;
+
+    void removeAll(IFriendListItem*);    
+    static bool cmpByName(const IFriendItemPtr&, const IFriendItemPtr&);
+    static bool cmpByActivity(const IFriendItemPtr&, const IFriendItemPtr&);    
+
+    bool byName = true;
+    bool hideCircles = false;
+    static bool groupsOnTop;
+    QVector<IFriendItemPtr> items;
+
+};

--- a/src/model/friendlist/ifriendlistitem.h
+++ b/src/model/friendlist/ifriendlistitem.h
@@ -1,0 +1,56 @@
+/*
+    Copyright © 2021 by The qTox Project Contributors
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <QDate>
+
+class QWidget;
+
+class IFriendListItem
+{
+public:
+
+    virtual ~IFriendListItem() = default;
+
+    virtual bool isFriend() const = 0;
+    virtual bool isGroup() const = 0;
+    virtual bool isOnline() const = 0;
+    virtual QString getNameItem() const = 0;
+    virtual QDateTime getLastActivity() const = 0;
+    virtual QWidget* getWidget() = 0;
+
+    virtual int getCircleId() const
+    {
+        return -1;
+    }
+
+    int getPosForName() const
+    {
+        return posForName;
+    }
+
+    void setPosForName(int pos)
+    {
+        posForName = pos;
+    }
+
+private:
+    int posForName = -1;
+};

--- a/src/model/friendlist/ifriendlistitem.h
+++ b/src/model/friendlist/ifriendlistitem.h
@@ -41,16 +41,16 @@ public:
         return -1;
     }
 
-    int getPosForName() const
+    int getNameSortedPos() const
     {
-        return posForName;
+        return nameSortedPos;
     }
 
-    void setPosForName(int pos)
+    void setNameSortedPos(int pos)
     {
-        posForName = pos;
+        nameSortedPos = pos;
     }
 
 private:
-    int posForName = -1;
+    int nameSortedPos = -1;
 };

--- a/src/widget/categorywidget.cpp
+++ b/src/widget/categorywidget.cpp
@@ -87,7 +87,12 @@ void CategoryWidget::setExpanded(bool isExpanded, bool save)
     }
     expanded = isExpanded;
     setMouseTracking(true);
+
+    // The listWidget will recieve a enterEvent for some reason if now visible.
+    // Using the following, we prevent that.
+    listWidget->setAttribute(Qt::WA_TransparentForMouseEvents, true);
     listWidget->setVisible(isExpanded);
+    listWidget->setAttribute(Qt::WA_TransparentForMouseEvents, false);
 
     QString pixmapPath;
     if (isExpanded)
@@ -95,11 +100,6 @@ void CategoryWidget::setExpanded(bool isExpanded, bool save)
     else
         pixmapPath = Style::getImagePath("chatArea/scrollBarRightArrow.svg");
     statusPic.setPixmap(QPixmap(pixmapPath));
-    // The listWidget will recieve a enterEvent for some reason if now visible.
-    // Using the following, we prevent that.
-    QApplication::processEvents(QEventLoop::ExcludeSocketNotifiers);
-    container->hide();
-    container->show();
 
     if (save)
         onExpand();

--- a/src/widget/circlewidget.cpp
+++ b/src/widget/circlewidget.cpp
@@ -187,7 +187,6 @@ void CircleWidget::dropEvent(QDropEvent* event)
 
     if (circleWidget != nullptr) {
         circleWidget->updateStatus();
-        emit searchCircle(*circleWidget);
     }
 
     setContainerAttribute(Qt::WA_UnderMouse, false);

--- a/src/widget/circlewidget.h
+++ b/src/widget/circlewidget.h
@@ -36,7 +36,6 @@ public:
 
 signals:
     void renameRequested(CircleWidget* circleWidget, const QString& newName);
-    void searchCircle(CircleWidget& circletWidget);
     void newContentDialog(ContentDialog& contentDialog);
 
 protected:

--- a/src/widget/friendlistwidget.cpp
+++ b/src/widget/friendlistwidget.cpp
@@ -159,15 +159,13 @@ void FriendListWidget::sortByMode(SortingMode mode)
         int posByName = 0; // Needed for scroll contacts
         // Linking a friend with a circle and setting scroll position
         for (int i = 0; i < itemsTmp.size(); ++i) {
-            if (itemsTmp[i]->isFriend()) {
-                if (itemsTmp[i]->getCircleId() >= 0) {
-                    CircleWidget* circleWgt = CircleWidget::getFromID(itemsTmp[i]->getCircleId());
-                    if (circleWgt != nullptr) {
-                        FriendWidget* frndTmp =
-                                qobject_cast<FriendWidget*>((itemsTmp[i].get())->getWidget());
-                        circleWgt->addFriendWidget(frndTmp, frndTmp->getFriend()->getStatus());
-                        continue;
-                    }
+            if (itemsTmp[i]->isFriend() && itemsTmp[i]->getCircleId() >= 0) {
+                CircleWidget* circleWgt = CircleWidget::getFromID(itemsTmp[i]->getCircleId());
+                if (circleWgt != nullptr) {
+                    FriendWidget* frndTmp =
+                            qobject_cast<FriendWidget*>((itemsTmp[i].get())->getWidget());
+                    circleWgt->addFriendWidget(frndTmp, frndTmp->getFriend()->getStatus());
+                    continue;
                 }
             }
             itemsTmp[i]->setPosForName(posByName++);
@@ -273,8 +271,7 @@ void FriendListWidget::cleanMainLayout()
         QWidget* wgt = itemForDel->widget();
         if (wgt != nullptr) {
             wgt->setParent(nullptr);
-        }
-        else if (itemForDel->layout() != nullptr) {
+        } else if (itemForDel->layout() != nullptr) {
             QLayout* layout = itemForDel->layout();
             QLayoutItem* itemTmp;
             while ((itemTmp = layout->takeAt(0)) != nullptr) {
@@ -295,8 +292,7 @@ QWidget* FriendListWidget::getNextWidgetForName(IFriendListItem *currentPos, boo
     int nextPos = forward ? pos + 1 : pos - 1;
     if (nextPos >= manager->getItems().size()) {
         nextPos = 0;
-    }
-    else if (nextPos < 0) {
+    } else if (nextPos < 0) {
         nextPos = manager->getItems().size() - 1;
     }
 
@@ -483,8 +479,7 @@ void FriendListWidget::cycleContacts(GenericChatroomWidget* activeChatroomWidget
 
     if (friendWidget != nullptr) {
         wgt = getNextWidgetForName(friendWidget, forward);
-    }
-    else {
+    } else {
         GroupWidget* groupWidget = qobject_cast<GroupWidget*>(activeChatroomWidget);
         wgt = getNextWidgetForName(groupWidget, forward);
     }

--- a/src/widget/friendlistwidget.h
+++ b/src/widget/friendlistwidget.h
@@ -23,6 +23,7 @@
 #include "src/core/core.h"
 #include "src/model/status.h"
 #include "src/persistence/settings.h"
+
 #include <QWidget>
 
 class QVBoxLayout;
@@ -32,10 +33,11 @@ class Widget;
 class FriendWidget;
 class GroupWidget;
 class CircleWidget;
-class FriendListLayout;
+class FriendListManager;
 class GenericChatroomWidget;
 class CategoryWidget;
 class Friend;
+class IFriendListItem;
 
 class FriendListWidget : public QWidget
 {
@@ -48,7 +50,7 @@ public:
     SortingMode getMode() const;
 
     void addGroupWidget(GroupWidget* widget);
-    void addFriendWidget(FriendWidget* w, Status::Status s, int circleIndex);
+    void addFriendWidget(FriendWidget* w);
     void removeGroupWidget(GroupWidget* w);
     void removeFriendWidget(FriendWidget* w);
     void addCircleWidget(int id);
@@ -60,7 +62,6 @@ public:
     void cycleContacts(GenericChatroomWidget* activeChatroomWidget, bool forward);
 
     void updateActivityTime(const QDateTime& date);
-    void reDraw();
 
 signals:
     void onCompactChanged(bool compact);
@@ -70,9 +71,9 @@ signals:
 public slots:
     void renameGroupWidget(GroupWidget* groupWidget, const QString& newName);
     void renameCircleWidget(CircleWidget* circleWidget, const QString& newName);
-    void onFriendWidgetRenamed(FriendWidget* friendWidget);
     void onGroupchatPositionChanged(bool top);
     void moveWidget(FriendWidget* w, Status::Status s, bool add = false);
+    void itemsChanged();
 
 protected:
     void dragEnterEvent(QDragEnterEvent* event) override;
@@ -83,18 +84,17 @@ private slots:
 
 private:
     CircleWidget* createCircleWidget(int id = -1);
-    QLayout* nextLayout(QLayout* layout, bool forward) const;
-    void moveFriends(QLayout* layout);
     CategoryWidget* getTimeCategoryWidget(const Friend* frd) const;
     void sortByMode(SortingMode mode);
+    void cleanMainLayout();
+    QWidget* getNextWidgetForName(IFriendListItem* currentPos, bool forward) const;
+    QVector<std::shared_ptr<IFriendListItem> > getItemsFromCircle(CircleWidget* circle) const;
 
     SortingMode mode;
-    bool groupsOnTop;
-    FriendListLayout* listLayout;
-    GenericChatItemLayout* circleLayout = nullptr;
-    GenericChatItemLayout groupLayout;
+    QVBoxLayout* listLayout = nullptr;
     QVBoxLayout* activityLayout = nullptr;
     QTimer* dayTimer;
+    FriendListManager* manager;
 
     const Core& core;
 };

--- a/src/widget/friendwidget.h
+++ b/src/widget/friendwidget.h
@@ -21,6 +21,7 @@
 
 #include "genericchatroomwidget.h"
 #include "src/core/toxpk.h"
+#include "src/model/friendlist/ifriendlistitem.h"
 
 #include <memory>
 
@@ -29,7 +30,7 @@ class QPixmap;
 class MaskablePixmapWidget;
 class CircleWidget;
 
-class FriendWidget : public GenericChatroomWidget
+class FriendWidget : public GenericChatroomWidget, public IFriendListItem
 {
     Q_OBJECT
 public:
@@ -44,7 +45,13 @@ public:
     const Friend* getFriend() const final;
     const Contact* getContact() const final;
 
-    void search(const QString& searchString, bool hide = false);
+    bool isFriend() const final;
+    bool isGroup() const final;
+    bool isOnline() const final;
+    QString getNameItem() const final;
+    QDateTime getLastActivity() const final;
+    int getCircleId() const final;
+    QWidget* getWidget() final;
 
 signals:
     void friendWidgetClicked(FriendWidget* widget);
@@ -52,8 +59,6 @@ signals:
     void copyFriendIdToClipboard(const ToxPk& friendPk);
     void contextMenuCalled(QContextMenuEvent* event);
     void friendHistoryRemoved();
-    void friendWidgetRenamed(FriendWidget* friendWidget);
-    void searchCircle(CircleWidget& circleWidget);
     void updateFriendActivity(Friend& frnd);
 
 public slots:

--- a/src/widget/groupwidget.cpp
+++ b/src/widget/groupwidget.cpp
@@ -189,6 +189,36 @@ void GroupWidget::editName()
     nameLabel->editBegin();
 }
 
+bool GroupWidget::isFriend() const
+{
+    return false;
+}
+
+bool GroupWidget::isGroup() const
+{
+    return true;
+}
+
+QString GroupWidget::getNameItem() const
+{
+    return nameLabel->fullText();
+}
+
+bool GroupWidget::isOnline() const
+{
+    return true;
+}
+
+QDateTime GroupWidget::getLastActivity() const
+{
+    return QDateTime::currentDateTime();
+}
+
+QWidget *GroupWidget::getWidget()
+{
+    return this;
+}
+
 // TODO: Remove
 Group* GroupWidget::getGroup() const
 {

--- a/src/widget/groupwidget.h
+++ b/src/widget/groupwidget.h
@@ -22,17 +22,18 @@
 #include "genericchatroomwidget.h"
 
 #include "src/model/chatroom/groupchatroom.h"
+#include "src/model/friendlist/ifriendlistitem.h"
 #include "src/core/groupid.h"
 
 #include <memory>
 
-class GroupWidget final : public GenericChatroomWidget
+class GroupWidget final : public GenericChatroomWidget, public IFriendListItem
 {
     Q_OBJECT
 public:
     GroupWidget(std::shared_ptr<GroupChatroom> chatroom, bool compact);
     ~GroupWidget();
-   void setAsInactiveChatroom() final;
+    void setAsInactiveChatroom() final;
     void setAsActiveChatroom() final;
     void updateStatusLight() final;
     void resetEventFlags() final;
@@ -41,6 +42,13 @@ public:
     const Contact* getContact() const final;
     void setName(const QString& name);
     void editName();
+
+    bool isFriend() const final;
+    bool isGroup() const final;
+    QString getNameItem() const final;
+    bool isOnline() const final;
+    QDateTime getLastActivity() const final;
+    QWidget* getWidget() final;
 
 signals:
     void groupWidgetClicked(GroupWidget* widget);


### PR DESCRIPTION
Reducing FriendListWidget responsibility and fixing some bugs:

- Added FriendListManager class that owns contacts(friends, groups), sorts them by request and provides a sorted list.
- Added abstract class IFriendListItem providing necessary data for FriendListManager. 
- The sort logic is encapsulated in cmpByName and cmpByActivity members. Can be trivial changed or added other logic rules if necessary.

Fix: [6291](https://github.com/qTox/qTox/issues/6291) and place groupchats at top of friend list when switching mode
Looks like this PR might help with: [5595](https://github.com/qTox/qTox/issues/5595), [4891](https://github.com/qTox/qTox/issues/4891)

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6347)
<!-- Reviewable:end -->
