### PR TITLE
fix(video): Close video device after checking V4L video modes

### DIFF
--- a/src/platform/camera/v4l2.cpp
+++ b/src/platform/camera/v4l2.cpp
@@ -177,6 +177,7 @@ QVector<VideoMode> v4l2::getDeviceModes(QString devName)
         }
     }
 
+    close(fd);
     return modes;
 }
 


### PR DESCRIPTION
Fix #6346

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6348)
<!-- Reviewable:end -->
