### PR TITLE
chore(ci): Migrate PR CI from travis-ci.org and circleci to GitHub Actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,118 @@
+name: test
+on: pull_request
+jobs:
+  verify-commit-format:
+    name: Verify Commit Format
+    runs-on: ubuntu-18.04
+    env:
+      GITHUB_CONTEXT: ${{ github.event.pull_request.commits_url }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # so that we can see the full commit range
+      - name: Run
+        run: ./.travis/verify-commit-format.sh
+  build-docs:
+    name: Docs
+    runs-on: ubuntu-18.04
+    env:
+      DOXYGEN_CONFIG_FILE: doxygen.conf
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run
+        run: ./.travis/build-docs.sh
+  build-gitstats:
+    name: Gitstats
+    runs-on: ubuntu-18.04
+    env:
+      GITSTATS_DIR: gitstats
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install gitstats
+        run: sudo apt-get install gitstats
+      - name: Run
+        run: ./.travis/build-gitstats.sh
+  build-qtox:
+    name: Linux
+    runs-on: ubuntu-18.04
+    env:
+      CC: gcc
+      CXX: g++
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install deps
+        run: sudo apt-get install ccache lcov
+      - name: Run
+        run: ./.travis/build-ubuntu-16-04.sh
+      - name: Code test coverage
+        run: |
+          # Create lcov report
+          lcov --directory _build --capture --output-file coverage.info
+          # Filter out system headers and test sources
+          lcov --remove coverage.info '/usr/*' '*/test/*' '*/*_autogen/*' --output-file coverage.info
+          # Upload report to codecov.io
+          bash <(curl -s https://codecov.io/bash) -f coverage.info || echo "Codecov did not collect coverage reports"
+  build-osx:
+    name: macOS
+    runs-on: macos-10.15
+    env:
+      TRAVIS: true
+      TRAVIS_BUILD_DIR: ${{ github.workspace }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: homebrew
+        run: brew upgrade && brew bundle --file ./osx/Brewfile
+      - name: Run
+        run: ./.travis/build-osx.sh
+  APPIMAGE:
+    name: AppImage
+    runs-on: ubuntu-18.04
+    env:
+      TRAVIS_TAG:
+      TRAVIS_COMMIT: ${{ github.sha }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run
+        run: ./appimage/build-appimage.sh
+  FLATPAK:
+    name: Flatpak
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run
+        run: ./flatpak/build-flatpak.sh
+  win:
+    name: Windows
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [i686, x86_64]
+        type: [debug, release]
+    env:
+      BUILD__: ${{ matrix.arch }}
+      BTYPE__: ${{ matrix.type }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: cache
+          key: deps-${{ matrix.arch }}-${{ hashFiles('windows/cross-compile/build.sh') }}-${{ hashFiles('.travis/build-windows.sh') }}
+      - name: Install deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install zip tree
+      - name: Deps build stage 1
+        run: |
+          ./.travis/build-windows.sh "$BUILD__" "release" "cache/${BUILD__}" stage1
+      - name: Deps build stage 2
+        run: |
+          ./.travis/build-windows.sh "$BUILD__" "release" "cache/${BUILD__}" stage2
+          ls -al cache
+      - name: qTox build
+        run: |
+          ./.travis/build-windows.sh "$BUILD__" "$BTYPE__" "cache/${BUILD__}" stage3
+      - name: Debug info
+        run: |
+          ls -al ~/
+          tree ~/project/workspace -L 4

--- a/.travis/build-ubuntu-16-04.sh
+++ b/.travis/build-ubuntu-16-04.sh
@@ -56,8 +56,9 @@ cd libs/
 export PREFIX_DIR="$PWD"
 #
 cd ../ffmpeg
-wget http://ffmpeg.org/releases/ffmpeg-2.8.5.tar.bz2
-tar xf ffmpeg*
+curl -o ffmpeg.bz2 http://ffmpeg.org/releases/ffmpeg-2.8.5.tar.bz2
+tar xf ffmpeg.bz2
+rm ffmpeg.bz2
 cd ffmpeg*
 # enabled:
 # v4l2 -> webcam

--- a/.travis/verify-commit-format.sh
+++ b/.travis/verify-commit-format.sh
@@ -20,4 +20,6 @@
 set -eu -o pipefail
 
 # Verify commit messages
+readarray -t COMMITS <<<$(curl -s ${GITHUB_CONTEXT} | jq -r '.[0,-1].sha')
+TRAVIS_COMMIT_RANGE="${COMMITS[0]}..${COMMITS[1]}"
 bash ./verify-commit-messages.sh "$TRAVIS_COMMIT_RANGE"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -537,6 +537,17 @@ endif()
 add_definitions(-DQT_MESSAGELOGCONTEXT=1)
 
 if(AVFOUNDATION_FOUND)
+  # used for AVFoundation compile time deprecation check
+  execute_process(
+    COMMAND sw_vers -productVersion
+    OUTPUT_VARIABLE MACOS_VER
+  )
+  string(REPLACE "." ";" VERSION_LIST ${MACOS_VER})
+  list(GET VERSION_LIST 0 MACOS_VERSION_MAJOR)
+  list(GET VERSION_LIST 1 MACOS_VERSION_MINOR)
+  add_definitions(-DMACOS_VERSION_MAJOR=${MACOS_VERSION_MAJOR})
+  add_definitions(-DMACOS_VERSION_MINOR=${MACOS_VERSION_MINOR})
+
   set(${PROJECT_NAME}_SOURCES ${${PROJECT_NAME}_SOURCES}
     src/platform/camera/avfoundation.mm
     src/platform/camera/avfoundation.h)

--- a/src/platform/camera/avfoundation.mm
+++ b/src/platform/camera/avfoundation.mm
@@ -27,7 +27,15 @@ QVector<QPair<QString, QString> > avfoundation::getDeviceList()
 {
     QVector<QPair<QString, QString> > result;
 
+#if MACOS_VERSION_MAJOR > 10 || (MACOS_VERSION_MAJOR == 10 && MACOS_VERSION_MINOR > 14)
+    AVCaptureDevice* device = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo];
+    id objects[] = {device};
+    NSUInteger count = sizeof(objects) / sizeof(id);
+    NSArray* devices = [NSArray arrayWithObjects:objects count:count];
+#else
     NSArray* devices = [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo];
+#endif
+
     for (AVCaptureDevice* device in devices) {
         result.append({ QString::fromNSString([device uniqueID]), QString::fromNSString([device localizedName]) });
     }


### PR DESCRIPTION
- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

Unlike travis, we're not caching our brew packages. `actions/cache` doesn't
update the cache on cache hit, making it hard to use a rolling cache like
before. We also don't know what cache key we should use before running, since
it relies on the live package list of brew.

Using a docker image containing brew packages seems like a better option if we
need the speedup going forward. ATM a full build with deps only takes about 12
minutes. Windows builds don't have this issue, since deps there are keyed off of
known versions in our repo.

Current Windows matrix form works, but causes a double-build on dep change due
to both debug/release rebuilding the release deps. Instead, should probably
separate the dep jobs, block build on the dep jobs, and update the cache on dep
jobs, guaranteeing a cache hit on build jobs?

Windows stage 1 and stage 2 can probably be recombined, if they were split due
to travis single build length limits, since GH actions allows much longer single
builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6350)
<!-- Reviewable:end -->
