### PR TITLE
Chatlog Cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,8 +203,8 @@ set(${PROJECT_NAME}_SOURCES
   src/chatlog/chatline.h
   src/chatlog/chatlinestorage.cpp
   src/chatlog/chatlinestorage.h
-  src/chatlog/chatlog.cpp
-  src/chatlog/chatlog.h
+  src/chatlog/chatwidget.cpp
+  src/chatlog/chatwidget.h
   src/chatlog/chatmessage.cpp
   src/chatlog/chatmessage.h
   src/chatlog/content/filetransferwidget.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,6 +201,8 @@ set(${PROJECT_NAME}_SOURCES
   src/chatlog/chatlinecontentproxy.h
   src/chatlog/chatline.cpp
   src/chatlog/chatline.h
+  src/chatlog/chatlinestorage.cpp
+  src/chatlog/chatlinestorage.h
   src/chatlog/chatlog.cpp
   src/chatlog/chatlog.h
   src/chatlog/chatmessage.cpp

--- a/cmake/Testing.cmake
+++ b/cmake/Testing.cmake
@@ -45,6 +45,7 @@ auto_test(core toxid "")
 auto_test(core toxstring "")
 auto_test(chatlog textformatter "")
 auto_test(net bsu "${${PROJECT_NAME}_RESOURCES}") # needs nodes list
+auto_test(chatlog chatlinestorage "")
 auto_test(persistence paths "")
 auto_test(persistence dbschema "")
 auto_test(persistence offlinemsgengine "")

--- a/src/chatlog/chatline.cpp
+++ b/src/chatlog/chatline.cpp
@@ -37,14 +37,6 @@ ChatLine::~ChatLine()
     }
 }
 
-void ChatLine::setRow(int idx)
-{
-    row = idx;
-
-    for (int c = 0; c < static_cast<int>(content.size()); ++c)
-        content[c]->setIndex(row, c);
-}
-
 void ChatLine::visibilityChanged(bool visible)
 {
     if (isVisible != visible) {
@@ -53,11 +45,6 @@ void ChatLine::visibilityChanged(bool visible)
     }
 
     isVisible = visible;
-}
-
-int ChatLine::getRow() const
-{
-    return row;
 }
 
 ChatLineContent* ChatLine::getContent(int col) const
@@ -153,6 +140,7 @@ void ChatLine::addColumn(ChatLineContent* item, ColumnFormat fmt)
 
     format.push_back(fmt);
     content.push_back(item);
+    item->setIndex(0, content.size() -1 );
 }
 
 void ChatLine::replaceContent(int col, ChatLineContent* lineContent)
@@ -261,9 +249,4 @@ bool ChatLine::lessThanBSRectTop(const ChatLine::Ptr& lhs, const qreal& rhs)
 bool ChatLine::lessThanBSRectBottom(const ChatLine::Ptr& lhs, const qreal& rhs)
 {
     return lhs->sceneBoundingRect().bottom() < rhs;
-}
-
-bool ChatLine::lessThanRowIndex(const ChatLine::Ptr& lhs, const ChatLine::Ptr& rhs)
-{
-    return lhs->getRow() < rhs->getRow();
 }

--- a/src/chatlog/chatline.h
+++ b/src/chatlog/chatline.h
@@ -24,7 +24,7 @@
 #include <QVector>
 #include <memory>
 
-class ChatLog;
+class ChatWidget;
 class ChatLineContent;
 class QGraphicsScene;
 class QStyleOptionGraphicsItem;
@@ -95,7 +95,7 @@ public:
     static bool lessThanBSRectBottom(const ChatLine::Ptr& lhs, const qreal& rhs);
 
 protected:
-    friend class ChatLog;
+    friend class ChatWidget;
 
     QPointF mapToContent(ChatLineContent* c, QPointF pos);
 

--- a/src/chatlog/chatline.h
+++ b/src/chatlog/chatline.h
@@ -84,7 +84,6 @@ public:
     void reloadTheme();
 
     int getColumnCount();
-    int getRow() const;
 
     ChatLineContent* getContent(int col) const;
     ChatLineContent* getContent(QPointF scenePos) const;
@@ -94,7 +93,6 @@ public:
     // comparators
     static bool lessThanBSRectTop(const ChatLine::Ptr& lhs, const qreal& rhs);
     static bool lessThanBSRectBottom(const ChatLine::Ptr& lhs, const qreal& rhs);
-    static bool lessThanRowIndex(const ChatLine::Ptr& lhs, const ChatLine::Ptr& rhs);
 
 protected:
     friend class ChatLog;
@@ -103,7 +101,6 @@ protected:
 
     void addColumn(ChatLineContent* item, ColumnFormat fmt);
     void updateBBox();
-    void setRow(int idx);
     void visibilityChanged(bool visible);
 
 private:

--- a/src/chatlog/chatlinecontent.cpp
+++ b/src/chatlog/chatlinecontent.cpp
@@ -30,11 +30,6 @@ int ChatLineContent::getColumn() const
     return col;
 }
 
-int ChatLineContent::getRow() const
-{
-    return row;
-}
-
 int ChatLineContent::type() const
 {
     return GraphicsItemType::ChatLineContentType;

--- a/src/chatlog/chatlinecontent.h
+++ b/src/chatlog/chatlinecontent.h
@@ -35,7 +35,6 @@ public:
     };
 
     int getColumn() const;
-    int getRow() const;
 
     virtual void setWidth(qreal width) = 0;
     int type() const final;

--- a/src/chatlog/chatlinestorage.cpp
+++ b/src/chatlog/chatlinestorage.cpp
@@ -1,0 +1,203 @@
+#include "chatlinestorage.h"
+
+#include <QDebug>
+
+ChatLineStorage::iterator ChatLineStorage::insertChatMessage(ChatLogIdx idx, QDateTime timestamp, ChatLine::Ptr line)
+{
+    if (idxInfoMap.find(idx) != idxInfoMap.end()) {
+        qWarning() << "Index is already rendered, not updating";
+        return lines.end();
+    }
+
+    auto linePosIncrementIt = infoIteratorForIdx(idx);
+
+    auto insertionPoint = equivalentLineIterator(linePosIncrementIt);
+    insertionPoint = adjustItForDate(insertionPoint, timestamp);
+
+    insertionPoint = lines.insert(insertionPoint, line);
+
+    // All indexes after the insertion have to be incremented by one
+    incrementLinePosAfter(linePosIncrementIt);
+
+    // Newly inserted index is insertinPoint - start
+    IdxInfo info;
+    info.linePos = std::distance(lines.begin(), insertionPoint);
+    info.timestamp = timestamp;
+    idxInfoMap[idx] = info;
+
+    return insertionPoint;
+}
+
+ChatLineStorage::iterator ChatLineStorage::insertDateLine(QDateTime timestamp, ChatLine::Ptr line)
+{
+    // Assume we only need to render one date line per date. I.e. this does
+    // not handle the case of
+    // * Message inserted Jan 3
+    // * Message inserted Jan 4
+    // * Message inserted Jan 3
+    // In this case the second "Jan 3" message will appear to have been sent
+    // on Jan 4
+    // As of right now this should not be a problem since all items should
+    // be sent/received in order. If we ever implement sender timestamps and
+    // the sender screws us by changing their time we may need to revisit this
+    auto idxMapIt = std::find_if(idxInfoMap.begin(), idxInfoMap.end(), [&] (const IdxInfoMap_t::value_type& v) {
+        return timestamp <= v.second.timestamp;
+    });
+
+    auto insertionPoint = equivalentLineIterator(idxMapIt);
+    insertionPoint = adjustItForDate(insertionPoint, timestamp);
+
+    insertionPoint = lines.insert(insertionPoint, line);
+
+    // All indexes after the insertion have to be incremented by one
+    incrementLinePosAfter(idxMapIt);
+
+    dateMap[line] = timestamp;
+
+    return insertionPoint;
+}
+
+bool ChatLineStorage::contains(QDateTime timestamp) const
+{
+    auto it =  std::find_if(dateMap.begin(), dateMap.end(), [&] (DateLineMap_t::value_type v) {
+        return v.second == timestamp;
+    });
+
+    return it != dateMap.end();
+}
+
+ChatLineStorage::iterator ChatLineStorage::find(ChatLogIdx idx)
+{
+    auto infoIt = infoIteratorForIdx(idx);
+    if (infoIt == idxInfoMap.end()) {
+        return lines.end();
+    }
+
+    return lines.begin() + infoIt->second.linePos;
+
+}
+
+ChatLineStorage::iterator ChatLineStorage::find(ChatLine::Ptr line)
+{
+    return std::find(lines.begin(), lines.end(), line);
+}
+
+void ChatLineStorage::erase(ChatLogIdx idx)
+{
+    auto linePosDecrementIt = infoIteratorForIdx(idx);
+    auto lineIt = equivalentLineIterator(linePosDecrementIt);
+
+    erase(lineIt);
+}
+
+ChatLineStorage::iterator ChatLineStorage::erase(iterator it)
+{
+    iterator prevIt = it;
+
+    do {
+        it = prevIt;
+
+        auto infoIterator = equivalentInfoIterator(it);
+        auto dateMapIt = dateMap.find(*it);
+
+        if (dateMapIt != dateMap.end()) {
+            dateMap.erase(dateMapIt);
+        }
+
+        if (infoIterator != idxInfoMap.end()) {
+            infoIterator = idxInfoMap.erase(infoIterator);
+            decrementLinePosAfter(infoIterator);
+        }
+
+        it = lines.erase(it);
+
+        if (it > lines.begin()) {
+            prevIt = std::prev(it);
+        } else {
+            prevIt = lines.end();
+        }
+    } while (shouldRemovePreviousLine(prevIt, it));
+
+    return it;
+}
+
+ChatLineStorage::iterator ChatLineStorage::equivalentLineIterator(IdxInfoMap_t::iterator it)
+{
+    if (it == idxInfoMap.end()) {
+        return lines.end();
+    }
+
+    return std::next(lines.begin(), it->second.linePos);
+}
+
+ChatLineStorage::IdxInfoMap_t::iterator ChatLineStorage::equivalentInfoIterator(iterator it)
+{
+    auto idx = static_cast<size_t>(std::distance(lines.begin(), it));
+    auto equivalentIt = std::find_if(idxInfoMap.begin(), idxInfoMap.end(), [&](const IdxInfoMap_t::value_type& v) {
+        return v.second.linePos >= idx;
+    });
+
+    return equivalentIt;
+}
+
+ChatLineStorage::IdxInfoMap_t::iterator ChatLineStorage::infoIteratorForIdx(ChatLogIdx idx)
+{
+    // If lower_bound proves to be expensive for appending we can try
+    // special casing when idx > idxToLineMap.rbegin()->first
+
+    // If we find an exact match we return that index, otherwise we return
+    // the first item after it. It's up to the caller to check if there's an
+    // exact match first
+    auto it = std::lower_bound(idxInfoMap.begin(), idxInfoMap.end(), idx, [](const IdxInfoMap_t::value_type& v, ChatLogIdx idx) {
+        return v.first < idx;
+    });
+
+    return it;
+}
+
+ChatLineStorage::iterator ChatLineStorage::adjustItForDate(iterator it, QDateTime timestamp)
+{
+    // Continuously move back until either
+    // 1. The dateline found is earlier than our timestamp
+    // 2. There are no more datelines
+    while (it > lines.begin()) {
+        auto possibleDateIt = it - 1;
+        auto dateIt = dateMap.find(*possibleDateIt);
+        if (dateIt == dateMap.end()) {
+            break;
+        }
+
+        if (dateIt->second > timestamp) {
+            it = possibleDateIt;
+        } else {
+            break;
+        }
+    }
+
+    return it;
+}
+
+void ChatLineStorage::incrementLinePosAfter(IdxInfoMap_t::iterator inputIt)
+{
+    for (auto it = inputIt; it != idxInfoMap.end(); ++it) {
+        it->second.linePos++;
+    }
+}
+
+void ChatLineStorage::decrementLinePosAfter(IdxInfoMap_t::iterator inputIt)
+{
+    // All indexes after the insertion have to be incremented by one
+    for (auto it = inputIt; it != idxInfoMap.end(); ++it) {
+        it->second.linePos--;
+    }
+}
+
+bool ChatLineStorage::shouldRemovePreviousLine(iterator prevIt, iterator it)
+{
+    return prevIt != lines.end() && // Previous iterator is valid
+        dateMap.find(*prevIt) != dateMap.end() && // Previous iterator is a date line
+        (
+            it == lines.end() || // Previous iterator is the last line
+            dateMap.find(*it) != dateMap.end() // Adjacent date lines
+        );
+}

--- a/src/chatlog/chatlinestorage.cpp
+++ b/src/chatlog/chatlinestorage.cpp
@@ -1,3 +1,22 @@
+/*
+    Copyright © 2020-2021 by The qTox Project Contributors
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 #include "chatlinestorage.h"
 
 #include <QDebug>

--- a/src/chatlog/chatlinestorage.h
+++ b/src/chatlog/chatlinestorage.h
@@ -1,0 +1,112 @@
+#pragma once
+
+#include "src/chatlog/chatline.h"
+#include "src/model/ichatlog.h"
+
+#include <QDateTime>
+
+#include <vector>
+#include <map>
+
+/**
+ * Helper class to keep track of what we're currently rendering and in what order
+ * Some constraints that may not be obvious
+ *   * Rendered views are not always contiguous. When we clear the chatlog
+ *   ongoing file transfers are not removed or else we would have no way to stop
+ *   them. If history is loaded after this point then we could actually be
+ *   inserting elements both before and in the middle of our existing rendered
+ *   items
+ *   * We need to be able to go from ChatLogIdx to rendered row index. E.g. if
+ *   an SQL query is made for search, we need to map the result back to the
+ *   displayed row to send it
+ *   * We need to be able to map rows back to ChatLogIdx in order to decide where
+ *   to insert newly added messages
+ *   * Not all rendered lines will have an associated ChatLogIdx, date lines for
+ *   example are not clearly at any ChatLogIdx
+ *   * Need to track date messages to ensure that if messages are inserted above
+ *   the current position the date line is moved appropriately
+ *
+ * The class is designed to be used like a vector over the currently rendered
+ * items, but with some tweaks for ensuring items tied to the current view are
+ * moved correctly (selection indexes, removal of associated date lines,
+ * mappings of ChatLogIdx -> ChatLine::Ptr, etc.)
+ */
+class ChatLineStorage
+{
+
+    struct IdxInfo
+    {
+        size_t linePos;
+        QDateTime timestamp;
+    };
+    using Lines_t = std::vector<ChatLine::Ptr>;
+    using DateLineMap_t = std::map<ChatLine::Ptr, QDateTime>;
+    using IdxInfoMap_t = std::map<ChatLogIdx, IdxInfo>;
+
+public:
+    // Types to conform with other containers
+    using size_type = Lines_t::size_type;
+    using reference = Lines_t::reference;
+    using const_reference = Lines_t::const_reference;
+    using const_iterator = Lines_t::const_iterator;
+    using iterator = Lines_t::iterator;
+
+
+public:
+    iterator insertChatMessage(ChatLogIdx idx, QDateTime timestamp, ChatLine::Ptr line);
+    iterator insertDateLine(QDateTime timestamp, ChatLine::Ptr line);
+
+    ChatLogIdx firstIdx() const { return idxInfoMap.begin()->first; }
+
+    ChatLogIdx lastIdx() const { return idxInfoMap.rbegin()->first; }
+
+    bool contains(ChatLogIdx idx) const { return idxInfoMap.find(idx) != idxInfoMap.end(); }
+
+    bool contains(QDateTime timestamp) const;
+
+    iterator find(ChatLogIdx idx);
+    iterator find(ChatLine::Ptr line);
+
+    const_reference operator[](size_type idx) const { return lines[idx]; }
+
+    const_reference operator[](ChatLogIdx idx) const { return lines[idxInfoMap.at(idx).linePos]; }
+
+    size_type size() const { return lines.size(); }
+
+    iterator begin() { return lines.begin(); }
+    iterator end() { return lines.end(); }
+
+    bool empty() const { return lines.empty(); }
+
+    bool hasIndexedMessage() const { return !idxInfoMap.empty(); }
+
+    void clear()
+    {
+        idxInfoMap.clear();
+        dateMap.clear();
+        return lines.clear();
+    }
+
+    reference front() { return lines.front(); }
+    reference back() { return lines.back(); }
+
+    void erase(ChatLogIdx idx);
+    iterator erase(iterator it);
+
+private:
+    iterator equivalentLineIterator(IdxInfoMap_t::iterator it);
+
+    IdxInfoMap_t::iterator equivalentInfoIterator(iterator it);
+
+    IdxInfoMap_t::iterator infoIteratorForIdx(ChatLogIdx idx);
+
+    iterator adjustItForDate(iterator it, QDateTime timestamp);
+
+    void incrementLinePosAfter(IdxInfoMap_t::iterator it);
+    void decrementLinePosAfter(IdxInfoMap_t::iterator it);
+    bool shouldRemovePreviousLine(iterator prevIt, iterator it);
+
+    std::vector<ChatLine::Ptr> lines;
+    std::map<ChatLine::Ptr, QDateTime> dateMap;
+    IdxInfoMap_t idxInfoMap;
+};

--- a/src/chatlog/chatlinestorage.h
+++ b/src/chatlog/chatlinestorage.h
@@ -1,3 +1,22 @@
+/*
+    Copyright © 2021 by The qTox Project Contributors
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 #pragma once
 
 #include "src/chatlog/chatline.h"

--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -668,7 +668,7 @@ void ChatLog::forceRelayout()
     startResizeWorker();
 }
 
-void ChatLog::checkVisibility(bool causedByScroll)
+void ChatLog::checkVisibility()
 {
     if (lines.empty())
         return;
@@ -712,16 +712,12 @@ void ChatLog::checkVisibility(bool causedByScroll)
     if (!visibleLines.isEmpty()) {
         emit firstVisibleLineChanged(lastLineBeforeVisible, visibleLines.at(0));
     }
-
-    if (causedByScroll && lowerBound != lines.cend() && lowerBound->get()->row == 0) {
-        emit loadHistoryLower();
-    }
 }
 
 void ChatLog::scrollContentsBy(int dx, int dy)
 {
     QGraphicsView::scrollContentsBy(dx, dy);
-    checkVisibility(true);
+    checkVisibility();
 }
 
 void ChatLog::resizeEvent(QResizeEvent* ev)

--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -684,7 +684,7 @@ void ChatLog::forceRelayout()
     startResizeWorker();
 }
 
-void ChatLog::checkVisibility(bool causedWheelEvent)
+void ChatLog::checkVisibility(bool causedByScroll)
 {
     if (lines.empty())
         return;
@@ -729,10 +729,10 @@ void ChatLog::checkVisibility(bool causedWheelEvent)
         emit firstVisibleLineChanged(lastLineBeforeVisible, visibleLines.at(0));
     }
 
-    if (causedWheelEvent) {
+    if (causedByScroll) {
         if (lowerBound != lines.cend() && lowerBound->get()->row == 0) {
             emit loadHistoryLower();
-        } else if (upperBound == lines.cend()) {
+        } else if (upperBound != lines.cend() && upperBound->get()->row >= lines.size() - 10) {
             emit loadHistoryUpper();
         }
     }
@@ -741,7 +741,7 @@ void ChatLog::checkVisibility(bool causedWheelEvent)
 void ChatLog::scrollContentsBy(int dx, int dy)
 {
     QGraphicsView::scrollContentsBy(dx, dy);
-    checkVisibility();
+    checkVisibility(true);
 }
 
 void ChatLog::resizeEvent(QResizeEvent* ev)
@@ -935,12 +935,6 @@ void ChatLog::focusOutEvent(QFocusEvent* ev)
         for (int i = selFirstRow; i <= selLastRow; ++i)
             lines[i]->selectionFocusChanged(false);
     }
-}
-
-void ChatLog::wheelEvent(QWheelEvent *event)
-{
-    QGraphicsView::wheelEvent(event);
-    checkVisibility(true);
 }
 
 void ChatLog::retranslateUi()

--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -932,13 +932,6 @@ void ChatLog::checkVisibility()
 
     visibleLines = newVisibleLines;
 
-    // enforce order
-    std::sort(visibleLines.begin(), visibleLines.end(), ChatLine::lessThanRowIndex);
-
-    // if (!visibleLines.empty())
-    //  qDebug() << "visible from " << visibleLines.first()->getRow() << "to " <<
-    //  visibleLines.last()->getRow() << " total " << visibleLines.size();
-
     if (!visibleLines.isEmpty()) {
         emit firstVisibleLineChanged(lastLineBeforeVisible, visibleLines.at(0));
     }

--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -177,9 +177,8 @@ void ChatLog::updateSceneRect()
 
 void ChatLog::layout(int start, int end, qreal width)
 {
-    if (lines.empty()) {
+    if (lines.empty())
         return;
-    }
 
     qreal h = 0.0;
 
@@ -322,9 +321,8 @@ void ChatLog::mouseMoveEvent(QMouseEvent* ev)
 // Much faster than QGraphicsScene::itemAt()!
 ChatLineContent* ChatLog::getContentFromPos(QPointF scenePos) const
 {
-    if (lines.empty()) {
+    if (lines.empty())
         return nullptr;
-    }
 
     auto itr =
         std::lower_bound(lines.cbegin(), lines.cend(), scenePos.y(), ChatLine::lessThanBSRectBottom);
@@ -467,9 +465,8 @@ void ChatLog::scrollToBottom()
 
 void ChatLog::startResizeWorker()
 {
-    if (lines.empty()) {
+    if (lines.empty())
         return;
-    }
 
     // (re)start the worker
     if (!workerTimer->isActive()) {
@@ -648,9 +645,8 @@ void ChatLog::scrollToLine(ChatLine::Ptr line)
 
 void ChatLog::selectAll()
 {
-    if (lines.empty()) {
+    if (lines.empty())
         return;
-    }
 
     clearSelection();
 
@@ -714,9 +710,8 @@ void ChatLog::forceRelayout()
 
 void ChatLog::checkVisibility(bool causedWheelEvent)
 {
-    if (lines.empty()) {
+    if (lines.empty())
         return;
-    }
 
     // find first visible line
     auto lowerBound = std::lower_bound(lines.cbegin(), lines.cend(), getVisibleRect().top(),
@@ -815,9 +810,8 @@ void ChatLog::updateTypingNotification()
 
     qreal posY = 0.0;
 
-    if (!lines.empty()) {
+    if (!lines.empty())
         posY = lines.last()->sceneBoundingRect().bottom() + lineSpacing;
-    }
 
     notification->layout(useableWidth(), QPointF(0.0, posY));
 }

--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -26,6 +26,7 @@
 #include "src/widget/gui.h"
 #include "src/widget/translator.h"
 #include "src/widget/style.h"
+#include "src/persistence/settings.h"
 
 #include <QAction>
 #include <QApplication>
@@ -39,11 +40,9 @@
 #include <algorithm>
 #include <cassert>
 
-/**
- * @var ChatLog::repNameAfter
- * @brief repetition interval sender name (sec)
- */
 
+namespace
+{
 template <class T>
 T clamp(T x, T min, T max)
 {
@@ -54,14 +53,125 @@ T clamp(T x, T min, T max)
     return x;
 }
 
-ChatLog::ChatLog(QWidget* parent)
+ChatMessage::Ptr getChatMessageForIdx(ChatLogIdx idx,
+                                      const std::map<ChatLogIdx, ChatMessage::Ptr>& messages)
+{
+    auto existingMessageIt = messages.find(idx);
+
+    if (existingMessageIt == messages.end()) {
+        return ChatMessage::Ptr();
+    }
+
+    return existingMessageIt->second;
+}
+
+bool shouldRenderDate(ChatLogIdx idxToRender, const IChatLog& chatLog)
+{
+    if (idxToRender == chatLog.getFirstIdx())
+        return true;
+
+    return chatLog.at(idxToRender - 1).getTimestamp().date()
+           != chatLog.at(idxToRender).getTimestamp().date();
+}
+
+ChatMessage::Ptr dateMessageForItem(const ChatLogItem& item)
+{
+    const auto& s = Settings::getInstance();
+    const auto date = item.getTimestamp().date();
+    auto dateText = date.toString(s.getDateFormat());
+    return ChatMessage::createChatInfoMessage(dateText, ChatMessage::INFO, QDateTime());
+}
+
+ChatMessage::Ptr createMessage(const QString& displayName, bool isSelf, bool colorizeNames,
+                               const ChatLogMessage& chatLogMessage)
+{
+    auto messageType = chatLogMessage.message.isAction ? ChatMessage::MessageType::ACTION
+                                                       : ChatMessage::MessageType::NORMAL;
+
+    const bool bSelfMentioned =
+        std::any_of(chatLogMessage.message.metadata.begin(), chatLogMessage.message.metadata.end(),
+                    [](const MessageMetadata& metadata) {
+                        return metadata.type == MessageMetadataType::selfMention;
+                    });
+
+    if (bSelfMentioned) {
+        messageType = ChatMessage::MessageType::ALERT;
+    }
+
+    const auto timestamp = chatLogMessage.message.timestamp;
+    return ChatMessage::createChatMessage(displayName, chatLogMessage.message.content, messageType,
+                                          isSelf, chatLogMessage.state, timestamp, colorizeNames);
+}
+
+void renderMessageRaw(const QString& displayName, bool isSelf, bool colorizeNames,
+                   const ChatLogMessage& chatLogMessage, ChatMessage::Ptr& chatMessage)
+{
+
+    if (chatMessage) {
+        if (chatLogMessage.state == MessageState::complete) {
+            chatMessage->markAsDelivered(chatLogMessage.message.timestamp);
+        } else if (chatLogMessage.state == MessageState::broken) {
+            chatMessage->markAsBroken();
+        }
+    } else {
+        chatMessage = createMessage(displayName, isSelf, colorizeNames, chatLogMessage);
+    }
+}
+
+/**
+ * @return Chat message message type (info/warning) for the given system message
+ * @param[in] systemMessage
+ */
+ChatMessage::SystemMessageType getChatMessageType(const SystemMessage& systemMessage)
+{
+    switch (systemMessage.messageType)
+    {
+    case SystemMessageType::fileSendFailed:
+    case SystemMessageType::messageSendFailed:
+    case SystemMessageType::unexpectedCallEnd:
+        return ChatMessage::ERROR;
+    case SystemMessageType::userJoinedGroup:
+    case SystemMessageType::userLeftGroup:
+    case SystemMessageType::peerNameChanged:
+    case SystemMessageType::peerStateChange:
+    case SystemMessageType::titleChanged:
+    case SystemMessageType::cleared:
+    case SystemMessageType::outgoingCall:
+    case SystemMessageType::incomingCall:
+    case SystemMessageType::callEnd:
+        return ChatMessage::INFO;
+    }
+
+    return ChatMessage::INFO;
+}
+
+ChatLogIdx firstItemAfterDate(QDate date, const IChatLog& chatLog)
+{
+    auto idxs = chatLog.getDateIdxs(date, 1);
+    if (idxs.size()) {
+        return idxs[0].idx;
+    } else {
+        return chatLog.getNextIdx();
+    }
+}
+
+} // namespace
+
+
+ChatLog::ChatLog(IChatLog& chatLog, const Core& core, QWidget* parent)
     : QGraphicsView(parent)
+    , chatLog(chatLog)
+    , core(core)
 {
     // Create the scene
     busyScene = new QGraphicsScene(this);
     scene = new QGraphicsScene(this);
     scene->setItemIndexMethod(QGraphicsScene::BspTreeIndex);
     setScene(scene);
+
+    busyNotification = ChatMessage::createBusyNotification();
+    busyNotification->addToScene(busyScene);
+    busyNotification->visibilityChanged(true);
 
     // Cfg.
     setInteractive(true);
@@ -128,7 +238,11 @@ ChatLog::ChatLog(QWidget* parent)
     reloadTheme();
     retranslateUi();
     Translator::registerHandler(std::bind(&ChatLog::retranslateUi, this), this);
-    scrollToBottom();
+
+    auto chatLogIdxRange = chatLog.getNextIdx() - chatLog.getFirstIdx();
+    auto firstChatLogIdx = (chatLogIdxRange < 100) ? chatLog.getFirstIdx() : chatLog.getNextIdx() - 100;
+
+    renderMessages(firstChatLogIdx, chatLog.getNextIdx());
 }
 
 ChatLog::~ChatLog()
@@ -576,6 +690,8 @@ void ChatLog::clear()
         insertChatlineAtBottom(l);
 
     updateSceneRect();
+
+    messages.clear();
 }
 
 void ChatLog::copySelectedText(bool toSelectionBuffer) const
@@ -585,16 +701,6 @@ void ChatLog::copySelectedText(bool toSelectionBuffer) const
 
     if (clipboard && !text.isNull())
         clipboard->setText(text, toSelectionBuffer ? QClipboard::Selection : QClipboard::Clipboard);
-}
-
-void ChatLog::setBusyNotification(ChatLine::Ptr notification)
-{
-    if (!notification.get())
-        return;
-
-    busyNotification = notification;
-    busyNotification->addToScene(busyScene);
-    busyNotification->visibilityChanged(true);
 }
 
 void ChatLog::setTypingNotificationVisible(bool visible)
@@ -661,6 +767,80 @@ void ChatLog::reloadTheme()
     for (ChatLine::Ptr l : lines) {
         l->reloadTheme();
     }
+}
+
+void ChatLog::startSearch(const QString& phrase, const ParameterSearch& parameter)
+{
+    disableSearchText();
+
+    bool bForwardSearch = false;
+    switch (parameter.period) {
+    case PeriodSearch::WithTheFirst: {
+        bForwardSearch = true;
+        searchPos.logIdx = chatLog.getFirstIdx();
+        searchPos.numMatches = 0;
+        break;
+    }
+    case PeriodSearch::WithTheEnd:
+    case PeriodSearch::None: {
+        bForwardSearch = false;
+        searchPos.logIdx = chatLog.getNextIdx();
+        searchPos.numMatches = 0;
+        break;
+    }
+    case PeriodSearch::AfterDate: {
+        bForwardSearch = true;
+        searchPos.logIdx = firstItemAfterDate(parameter.date, chatLog);
+        searchPos.numMatches = 0;
+        break;
+    }
+    case PeriodSearch::BeforeDate: {
+        bForwardSearch = false;
+        searchPos.logIdx = firstItemAfterDate(parameter.date, chatLog);
+        searchPos.numMatches = 0;
+        break;
+    }
+    }
+
+    if (bForwardSearch) {
+        onSearchDown(phrase, parameter);
+    } else {
+        onSearchUp(phrase, parameter);
+    }
+}
+
+void ChatLog::onSearchUp(const QString& phrase, const ParameterSearch& parameter)
+{
+    auto result = chatLog.searchBackward(searchPos, phrase, parameter);
+    handleSearchResult(result, SearchDirection::Up);
+}
+
+void ChatLog::onSearchDown(const QString& phrase, const ParameterSearch& parameter)
+{
+    auto result = chatLog.searchForward(searchPos, phrase, parameter);
+    handleSearchResult(result, SearchDirection::Down);
+}
+
+void ChatLog::handleSearchResult(SearchResult result, SearchDirection direction)
+{
+    if (!result.found) {
+        emit messageNotFoundShow(direction);
+        return;
+    }
+
+    disableSearchText();
+
+    searchPos = result.pos;
+
+    auto const firstRenderedIdx = (messages.empty()) ? chatLog.getNextIdx() : messages.begin()->first;
+
+    renderMessages(searchPos.logIdx, firstRenderedIdx, [this, result] {
+        auto msg = messages.at(searchPos.logIdx);
+        scrollToLine(msg);
+
+        auto text = qobject_cast<Text*>(msg->getContent(1));
+        text->selectText(result.exp, std::make_pair(result.start, result.len));
+    });
 }
 
 void ChatLog::forceRelayout()
@@ -770,11 +950,9 @@ void ChatLog::updateTypingNotification()
 
 void ChatLog::updateBusyNotification()
 {
-    if (busyNotification.get()) {
-        // repoisition the busy notification (centered)
-        busyNotification->layout(useableWidth(), getVisibleRect().topLeft()
-                                                     + QPointF(0, getVisibleRect().height() / 2.0));
-    }
+    // repoisition the busy notification (centered)
+    busyNotification->layout(useableWidth(), getVisibleRect().topLeft()
+                                                    + QPointF(0, getVisibleRect().height() / 2.0));
 }
 
 ChatLine::Ptr ChatLog::findLineByPosY(qreal yPos) const
@@ -857,6 +1035,58 @@ void ChatLog::onMultiClickTimeout()
     clickCount = 0;
 }
 
+void ChatLog::renderMessage(ChatLogIdx idx)
+{
+    renderMessages(idx, idx + 1);
+}
+
+void ChatLog::renderMessages(ChatLogIdx begin, ChatLogIdx end,
+                                     std::function<void(void)> onCompletion)
+{
+    QList<ChatLine::Ptr> beforeLines;
+    QList<ChatLine::Ptr> afterLines;
+
+    for (auto i = begin; i < end; ++i) {
+        auto chatMessage = getChatMessageForIdx(i, messages);
+        renderItem(chatLog.at(i), needsToHideName(i), colorizeNames, chatMessage);
+
+        if (messages.find(i) == messages.end()) {
+            QList<ChatLine::Ptr>* lines =
+                (messages.empty() || i > messages.rbegin()->first) ? &afterLines : &beforeLines;
+
+            messages.insert({i, chatMessage});
+
+            if (shouldRenderDate(i, chatLog)) {
+                lines->push_back(dateMessageForItem(chatLog.at(i)));
+            }
+            lines->push_back(chatMessage);
+        }
+    }
+
+    for (auto const& line : afterLines) {
+        insertChatlineAtBottom(line);
+    }
+
+    if (!beforeLines.empty()) {
+        // Rendering upwards is expensive and has async behavior for chatWidget.
+        // Once rendering completes we call our completion callback once and
+        // then disconnect the signal
+        if (onCompletion) {
+            auto connection = std::make_shared<QMetaObject::Connection>();
+            *connection = connect(this, &ChatLog::workerTimeoutFinished,
+                                  [this, onCompletion, connection] {
+                                      onCompletion();
+                                      this->disconnect(*connection);
+                                  });
+        }
+
+        insertChatlinesOnTop(beforeLines);
+    } else if (onCompletion) {
+        onCompletion();
+    }
+}
+
+
 void ChatLog::handleMultiClickEvent()
 {
     // Ignore single or double clicks
@@ -916,7 +1146,7 @@ void ChatLog::focusOutEvent(QFocusEvent* ev)
 void ChatLog::wheelEvent(QWheelEvent *event)
 {
     QGraphicsView::wheelEvent(event);
-    checkVisibility(true);
+    checkVisibility();
 }
 
 void ChatLog::retranslateUi()
@@ -1046,4 +1276,110 @@ void ChatLog::setTypingNotification()
     typingNotification->setVisible(false);
     typingNotification->addToScene(scene);
     updateTypingNotification();
+}
+
+void ChatLog::renderItem(const ChatLogItem& item, bool hideName, bool colorizeNames, ChatMessage::Ptr& chatMessage)
+{
+    const auto& sender = item.getSender();
+
+    bool isSelf = sender == core.getSelfId().getPublicKey();
+
+    switch (item.getContentType()) {
+    case ChatLogItem::ContentType::message: {
+        const auto& chatLogMessage = item.getContentAsMessage();
+
+        renderMessageRaw(item.getDisplayName(), isSelf, colorizeNames, chatLogMessage, chatMessage);
+
+        break;
+    }
+    case ChatLogItem::ContentType::fileTransfer: {
+        const auto& file = item.getContentAsFile();
+        renderFile(item.getDisplayName(), file.file, isSelf, item.getTimestamp(), chatMessage);
+        break;
+    }
+    case ChatLogItem::ContentType::systemMessage: {
+        const auto& systemMessage = item.getContentAsSystemMessage();
+
+        auto chatMessageType = getChatMessageType(systemMessage);
+        chatMessage = ChatMessage::createChatInfoMessage(systemMessage.toString(), chatMessageType, QDateTime::currentDateTime());
+        // Ignore caller's decision to hide the name. We show the icon in the
+        // slot of the sender's name so we always want it visible
+        hideName = false;
+        break;
+    }
+    }
+
+    if (hideName) {
+        chatMessage->hideSender();
+    }
+}
+
+void ChatLog::renderFile(QString displayName, ToxFile file, bool isSelf, QDateTime timestamp,
+                ChatMessage::Ptr& chatMessage)
+{
+    if (!chatMessage) {
+        CoreFile* coreFile = core.getCoreFile();
+        assert(coreFile);
+        chatMessage = ChatMessage::createFileTransferMessage(displayName, *coreFile, file, isSelf, timestamp);
+    } else {
+        auto proxy = static_cast<ChatLineContentProxy*>(chatMessage->getContent(1));
+        assert(proxy->getWidgetType() == ChatLineContentProxy::FileTransferWidgetType);
+        auto ftWidget = static_cast<FileTransferWidget*>(proxy->getWidget());
+        ftWidget->onFileTransferUpdate(file);
+    }
+}
+
+/**
+ * @brief Show, is it needed to hide message author name or not
+ * @param idx ChatLogIdx of the message
+ * @return True if the name should be hidden, false otherwise
+ */
+bool ChatLog::needsToHideName(ChatLogIdx idx) const
+{
+    // If the previous message is not rendered we should show the name
+    // regardless of other constraints
+    auto itemBefore = messages.find(idx - 1);
+    if (itemBefore == messages.end()) {
+        return false;
+    }
+
+    const auto& prevItem = chatLog.at(idx - 1);
+    const auto& currentItem = chatLog.at(idx);
+
+    // Always show the * in the name field for action messages
+    if (currentItem.getContentType() == ChatLogItem::ContentType::message
+        && currentItem.getContentAsMessage().message.isAction) {
+        return false;
+    }
+
+    qint64 messagesTimeDiff = prevItem.getTimestamp().secsTo(currentItem.getTimestamp());
+    return currentItem.getSender() == prevItem.getSender()
+           && messagesTimeDiff < repNameAfter;
+}
+
+void ChatLog::disableSearchText()
+{
+    auto msgIt = messages.find(searchPos.logIdx);
+    if (msgIt != messages.end()) {
+        auto text = qobject_cast<Text*>(msgIt->second->getContent(1));
+        text->deselectText();
+    }
+}
+
+void ChatLog::removeSearchPhrase()
+{
+    disableSearchText();
+}
+
+void ChatLog::jumpToDate(QDate date) {
+    auto idx = firstItemAfterDate(date, chatLog);
+    jumpToIdx(idx);
+}
+
+void ChatLog::jumpToIdx(ChatLogIdx idx) {
+    if (messages.find(idx) == messages.end()) {
+        renderMessages(idx, chatLog.getNextIdx());
+    }
+
+    scrollToLine(messages[idx]);
 }

--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -391,22 +391,6 @@ void ChatLog::insertChatlineAtBottom(ChatLine::Ptr l)
     updateTypingNotification();
 }
 
-void ChatLog::insertChatlineAtBottom(const QList<ChatLine::Ptr>& newLines)
-{
-    if (newLines.isEmpty())
-        return;
-
-    for (ChatLine::Ptr l : newLines) {
-        l->setRow(lines.size());
-        l->addToScene(scene);
-        l->visibilityChanged(false);
-        lines.append(l);
-    }
-
-    layout(lines.last()->getRow(), lines.size(), useableWidth());
-    startResizeWorker();
-}
-
 void ChatLog::insertChatlineOnTop(ChatLine::Ptr l)
 {
     if (!l.get())
@@ -729,12 +713,8 @@ void ChatLog::checkVisibility(bool causedByScroll)
         emit firstVisibleLineChanged(lastLineBeforeVisible, visibleLines.at(0));
     }
 
-    if (causedByScroll) {
-        if (lowerBound != lines.cend() && lowerBound->get()->row == 0) {
-            emit loadHistoryLower();
-        } else if (upperBound != lines.cend() && upperBound->get()->row >= lines.size() - 10) {
-            emit loadHistoryUpper();
-        }
+    if (causedByScroll && lowerBound != lines.cend() && lowerBound->get()->row == 0) {
+        emit loadHistoryLower();
     }
 }
 

--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -679,30 +679,6 @@ void ChatLog::reloadTheme()
     }
 }
 
-void ChatLog::removeFirsts(const int num)
-{
-    if (lines.size() > num) {
-        lines.erase(lines.begin(), lines.begin()+num);
-    } else {
-        lines.clear();
-    }
-
-    for (int i = 0; i < lines.size(); ++i) {
-        lines[i]->setRow(i);
-    }
-
-    moveSelectionRectUpIfSelected(num);
-}
-
-void ChatLog::removeLasts(const int num)
-{
-    if (lines.size() > num) {
-        lines.erase(lines.end()-num, lines.end());
-    } else {
-        lines.clear();
-    }
-}
-
 void ChatLog::forceRelayout()
 {
     startResizeWorker();

--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -27,6 +27,8 @@
 #include "src/widget/translator.h"
 #include "src/widget/style.h"
 #include "src/persistence/settings.h"
+#include "src/chatlog/chatlinestorage.h"
+#include <iostream>
 
 #include <QAction>
 #include <QApplication>
@@ -39,10 +41,17 @@
 
 #include <algorithm>
 #include <cassert>
+#include <set>
 
 
 namespace
 {
+
+// Maximum number of rendered messages at any given time
+static int constexpr maxWindowSize = 300;
+// Amount of messages to purge when removing messages
+static int constexpr windowChunkSize = 100;
+
 template <class T>
 T clamp(T x, T min, T max)
 {
@@ -53,31 +62,10 @@ T clamp(T x, T min, T max)
     return x;
 }
 
-ChatLine::Ptr getChatMessageForIdx(ChatLogIdx idx,
-                                      const std::map<ChatLogIdx, ChatLine::Ptr>& messages)
-{
-    auto existingMessageIt = messages.find(idx);
-
-    if (existingMessageIt == messages.end()) {
-        return ChatMessage::Ptr();
-    }
-
-    return existingMessageIt->second;
-}
-
-bool shouldRenderDate(ChatLogIdx idxToRender, const IChatLog& chatLog)
-{
-    if (idxToRender == chatLog.getFirstIdx())
-        return true;
-
-    return chatLog.at(idxToRender - 1).getTimestamp().date()
-           != chatLog.at(idxToRender).getTimestamp().date();
-}
-
-ChatMessage::Ptr dateMessageForItem(const ChatLogItem& item)
+ChatMessage::Ptr createDateMessage(QDateTime timestamp)
 {
     const auto& s = Settings::getInstance();
-    const auto date = item.getTimestamp().date();
+    const auto date = timestamp.date();
     auto dateText = date.toString(s.getDateFormat());
     return ChatMessage::createChatInfoMessage(dateText, ChatMessage::INFO, QDateTime());
 }
@@ -161,6 +149,56 @@ ChatLogIdx firstItemAfterDate(QDate date, const IChatLog& chatLog)
     }
 }
 
+/**
+ * @brief Applies a function for each line in between first and last in storage.
+ *
+ * @note Undefined behavior if first appears after last
+ * @note If first or last is not seen in storage it is assumed that they point
+ * to elements past the edge of our rendered storage. We will iterate from the
+ * beginning or to the end in these cases
+ */
+template <typename Fn>
+void forEachLineIn(ChatLine::Ptr first, ChatLine::Ptr last, ChatLineStorage& storage, Fn f)
+{
+    auto startIt = storage.find(first);
+
+    if (startIt == storage.end()) {
+        startIt = storage.begin();
+    }
+
+    auto endIt = storage.find(last);
+    if (endIt != storage.end()) {
+        endIt++;
+    }
+
+    for (auto it = startIt; it != endIt; ++it) {
+        f(*it);
+    }
+}
+
+/**
+ * @brief Helper function to add an offset ot a ChatLogIdx without going
+ * outside the bounds of the associated chatlog
+ */
+ChatLogIdx clampedAdd(ChatLogIdx idx, int val, IChatLog& chatLog)
+{
+    if (val < 0) {
+        auto distToEnd = idx - chatLog.getFirstIdx();
+        if (static_cast<size_t>(std::abs(val)) > distToEnd) {
+            return chatLog.getFirstIdx();
+        }
+
+        return idx - std::abs(val);
+    } else {
+        auto distToEnd = chatLog.getNextIdx() - idx;
+        if (static_cast<size_t>(val) > distToEnd) {
+            return chatLog.getNextIdx();
+        }
+
+        return idx + val;
+    }
+}
+
 } // namespace
 
 
@@ -168,6 +206,7 @@ ChatLog::ChatLog(IChatLog& chatLog, const Core& core, QWidget* parent)
     : QGraphicsView(parent)
     , chatLog(chatLog)
     , core(core)
+    , chatLineStorage(new ChatLineStorage())
 {
     // Create the scene
     busyScene = new QGraphicsScene(this);
@@ -245,13 +284,12 @@ ChatLog::ChatLog(IChatLog& chatLog, const Core& core, QWidget* parent)
     retranslateUi();
     Translator::registerHandler(std::bind(&ChatLog::retranslateUi, this), this);
 
-    connect(&chatLog, &IChatLog::itemUpdated, this, &ChatLog::renderMessage);
+    connect(this, &ChatLog::renderFinished, this, &ChatLog::onRenderFinished);
+    connect(&chatLog, &IChatLog::itemUpdated, this, &ChatLog::onMessageUpdated);
+    connect(verticalScrollBar(), &QScrollBar::valueChanged, this, &ChatLog::onScrollValueChanged);
 
-    auto chatLogIdxRange = chatLog.getNextIdx() - chatLog.getFirstIdx();
-    auto firstChatLogIdx = (chatLogIdxRange < 100) ? chatLog.getFirstIdx() : chatLog.getNextIdx() - 100;
-
+    auto firstChatLogIdx = clampedAdd(chatLog.getNextIdx(), -100, chatLog);
     renderMessages(firstChatLogIdx, chatLog.getNextIdx());
-
 }
 
 ChatLog::~ChatLog()
@@ -259,7 +297,7 @@ ChatLog::~ChatLog()
     Translator::unregister(this);
 
     // Remove chatlines from scene
-    for (ChatLine::Ptr l : lines)
+    for (ChatLine::Ptr l : *chatLineStorage)
         l->removeFromScene();
 
     if (busyNotification)
@@ -274,13 +312,14 @@ void ChatLog::clearSelection()
     if (selectionMode == SelectionMode::None)
         return;
 
-    for (int i = selFirstRow; i <= selLastRow; ++i)
-        lines[i]->selectionCleared();
+    forEachLineIn(selFirstRow, selLastRow, *chatLineStorage, [&] (ChatLine::Ptr& line) {
+        line->selectionCleared();
+    });
 
-    selFirstRow = -1;
-    selLastRow = -1;
+    selFirstRow.reset();
+    selLastRow.reset();
     selClickedCol = -1;
-    selClickedRow = -1;
+    selClickedRow.reset();
 
     selectionMode = SelectionMode::None;
     emit selectionChanged();
@@ -300,7 +339,7 @@ void ChatLog::updateSceneRect()
 
 void ChatLog::layout(int start, int end, qreal width)
 {
-    if (lines.empty())
+    if (chatLineStorage->empty())
         return;
 
     qreal h = 0.0;
@@ -308,13 +347,13 @@ void ChatLog::layout(int start, int end, qreal width)
     // Line at start-1 is considered to have the correct position. All following lines are
     // positioned in respect to this line.
     if (start - 1 >= 0)
-        h = lines[start - 1]->sceneBoundingRect().bottom() + lineSpacing;
+        h = (*chatLineStorage)[start - 1]->sceneBoundingRect().bottom() + lineSpacing;
 
-    start = clamp<int>(start, 0, lines.size());
-    end = clamp<int>(end + 1, 0, lines.size());
+    start = clamp<int>(start, 0, chatLineStorage->size());
+    end = clamp<int>(end + 1, 0, chatLineStorage->size());
 
     for (int i = start; i < end; ++i) {
-        ChatLine* l = lines[i].get();
+        ChatLine* l = (*chatLineStorage)[i].get();
 
         l->layout(width, QPointF(0.0, h));
         h += l->sceneBoundingRect().height() + lineSpacing;
@@ -376,10 +415,10 @@ void ChatLog::mouseMoveEvent(QMouseEvent* ev)
 
             ChatLineContent* content = getContentFromPos(sceneClickPos);
             if (content) {
-                selClickedRow = content->getRow();
+                selClickedRow = line;
                 selClickedCol = content->getColumn();
-                selFirstRow = content->getRow();
-                selLastRow = content->getRow();
+                selFirstRow = line;
+                selLastRow = line;
 
                 content->selectionStarted(sceneClickPos);
 
@@ -389,7 +428,7 @@ void ChatLog::mouseMoveEvent(QMouseEvent* ev)
                 if (scene->mouseGrabberItem())
                     scene->mouseGrabberItem()->ungrabMouse();
             } else if (line.get()) {
-                selClickedRow = line->getRow();
+                selClickedRow = line;
                 selFirstRow = selClickedRow;
                 selLastRow = selClickedRow;
 
@@ -401,13 +440,10 @@ void ChatLog::mouseMoveEvent(QMouseEvent* ev)
             ChatLineContent* content = getContentFromPos(scenePos);
             ChatLine::Ptr line = findLineByPosY(scenePos.y());
 
-            int row;
-
             if (content) {
-                row = content->getRow();
                 int col = content->getColumn();
 
-                if (row == selClickedRow && col == selClickedCol) {
+                if (line == selClickedRow && col == selClickedCol) {
                     selectionMode = SelectionMode::Precise;
 
                     content->selectionMouseMove(scenePos);
@@ -415,24 +451,24 @@ void ChatLog::mouseMoveEvent(QMouseEvent* ev)
                 } else if (col != selClickedCol) {
                     selectionMode = SelectionMode::Multi;
 
-                    lines[selClickedRow]->selectionCleared();
+                    line->selectionCleared();
                 }
             } else if (line.get()) {
-                row = line->getRow();
-
-                if (row != selClickedRow) {
+                if (line != selClickedRow) {
                     selectionMode = SelectionMode::Multi;
-                    lines[selClickedRow]->selectionCleared();
+                    line->selectionCleared();
                 }
             } else {
                 return;
             }
 
-            if (row >= selClickedRow)
-                selLastRow = row;
+            auto selClickedIt = chatLineStorage->find(selClickedRow);
+            auto lineIt = chatLineStorage->find(line);
+            if (lineIt > selClickedIt)
+                selLastRow = line;
 
-            if (row <= selClickedRow)
-                selFirstRow = row;
+            if (lineIt <= selClickedIt)
+                selFirstRow = line;
 
             updateMultiSelectionRect();
         }
@@ -444,14 +480,14 @@ void ChatLog::mouseMoveEvent(QMouseEvent* ev)
 // Much faster than QGraphicsScene::itemAt()!
 ChatLineContent* ChatLog::getContentFromPos(QPointF scenePos) const
 {
-    if (lines.empty())
+    if (chatLineStorage->empty())
         return nullptr;
 
     auto itr =
-        std::lower_bound(lines.cbegin(), lines.cend(), scenePos.y(), ChatLine::lessThanBSRectBottom);
+        std::lower_bound(chatLineStorage->begin(), chatLineStorage->end(), scenePos.y(), ChatLine::lessThanBSRectBottom);
 
     // find content
-    if (itr != lines.cend() && (*itr)->sceneBoundingRect().contains(scenePos))
+    if (itr != chatLineStorage->end() && (*itr)->sceneBoundingRect().contains(scenePos))
         return (*itr)->getContent(scenePos);
 
     return nullptr;
@@ -477,86 +513,75 @@ qreal ChatLog::useableWidth() const
     return width() - verticalScrollBar()->sizeHint().width() - margins.right() - margins.left();
 }
 
-void ChatLog::reposition(int start, int end, qreal deltaY)
+void ChatLog::insertChatlines(std::map<ChatLogIdx, ChatLine::Ptr> chatLines)
 {
-    if (lines.isEmpty())
+    if (chatLines.empty())
         return;
 
-    start = clamp<int>(start, 0, lines.size() - 1);
-    end = clamp<int>(end + 1, 0, lines.size());
-
-    for (int i = start; i < end; ++i) {
-        ChatLine* l = lines[i].get();
-        l->moveBy(deltaY);
-    }
-}
-
-void ChatLog::insertChatlineAtBottom(ChatLine::Ptr l)
-{
-    if (!l.get())
-        return;
-
-    bool stickToBtm = stickToBottom();
-
-    // insert
-    l->setRow(lines.size());
-    l->addToScene(scene);
-    lines.append(l);
-
-    // partial refresh
-    layout(lines.last()->getRow(), lines.size(), useableWidth());
-    updateSceneRect();
-
-    if (stickToBtm)
-        scrollToBottom();
-
-    checkVisibility();
-    updateTypingNotification();
-}
-
-void ChatLog::insertChatlineOnTop(ChatLine::Ptr l)
-{
-    if (!l.get())
-        return;
-
-    insertChatlinesOnTop(QList<ChatLine::Ptr>() << l);
-}
-
-void ChatLog::insertChatlinesOnTop(const QList<ChatLine::Ptr>& newLines)
-{
-    if (newLines.isEmpty())
-        return;
+    bool allLinesAtEnd = !chatLineStorage->hasIndexedMessage() || chatLines.begin()->first > chatLineStorage->lastIdx();
+    auto startLineSize = chatLineStorage->size();
 
     QGraphicsScene::ItemIndexMethod oldIndexMeth = scene->itemIndexMethod();
     scene->setItemIndexMethod(QGraphicsScene::NoIndex);
 
-    // alloc space for old and new lines
-    QVector<ChatLine::Ptr> combLines;
-    combLines.reserve(newLines.size() + lines.size());
+    for (auto const& chatLine : chatLines) {
+        auto idx = chatLine.first;
+        auto const& l = chatLine.second;
 
-    // add the new lines
-    int i = 0;
-    for (ChatLine::Ptr l : newLines) {
+        auto insertedMessageIt = chatLineStorage->insertChatMessage(idx, chatLog.at(idx).getTimestamp(), l);
+
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
+        auto date = chatLog.at(idx).getTimestamp().date().startOfDay();
+#else
+        auto date = QDateTime(chatLog.at(idx).getTimestamp().date());
+#endif
+
+        auto insertionIdx = std::distance(chatLineStorage->begin(), insertedMessageIt);
+
+        if (!chatLineStorage->contains(date)) {
+            // If there is no dateline for the given date we need to insert it
+            // above the line we'd like to insert.
+            auto dateLine = createDateMessage(date);
+            chatLineStorage->insertDateLine(date, dateLine);
+            dateLine->addToScene(scene);
+            dateLine->visibilityChanged(false);
+        }
+
         l->addToScene(scene);
+
+        // Optimization copied from previous implementation of upwards
+        // rendering. This will be changed when we call updateVisibility
+        // later
         l->visibilityChanged(false);
-        l->setRow(i++);
-        combLines.push_back(l);
     }
-
-    // add the old lines
-    for (ChatLine::Ptr l : lines) {
-        l->setRow(i++);
-        combLines.push_back(l);
-    }
-
-    lines = combLines;
-
-    moveSelectionRectDownIfSelected(newLines.size());
 
     scene->setItemIndexMethod(oldIndexMeth);
 
-    // redo layout
-    startResizeWorker();
+    // If all insertions are at the bottom we can get away with only rendering
+    // the updated lines, otherwise we need to go through the resize workflow to
+    // re-layout everything asynchronously.
+    //
+    // NOTE: This can make flow from the callers a little frustrating as you
+    // have to rely on the onRenderFinished callback to continue doing any work,
+    // even if all rendering is done synchronously
+    if (allLinesAtEnd) {
+        bool stickToBtm = stickToBottom();
+
+        // partial refresh
+        layout(startLineSize, chatLineStorage->size(), useableWidth());
+        updateSceneRect();
+
+        if (stickToBtm)
+            scrollToBottom();
+
+        checkVisibility();
+        updateTypingNotification();
+        updateMultiSelectionRect();
+
+        emit renderFinished();
+    } else {
+        startResizeWorker();
+    }
 }
 
 bool ChatLog::stickToBottom() const
@@ -572,7 +597,7 @@ void ChatLog::scrollToBottom()
 
 void ChatLog::startResizeWorker()
 {
-    if (lines.empty())
+    if (chatLineStorage->empty())
         return;
 
     // (re)start the worker
@@ -587,7 +612,7 @@ void ChatLog::startResizeWorker()
     // switch to busy scene displaying the busy notification if there is a lot
     // of text to be resized
     int txt = 0;
-    for (ChatLine::Ptr line : lines) {
+    for (ChatLine::Ptr line : *chatLineStorage) {
         if (txt > 500000)
             break;
         for (ChatLineContent* content : line->content)
@@ -606,13 +631,14 @@ void ChatLog::mouseDoubleClickEvent(QMouseEvent* ev)
 {
     QPointF scenePos = mapToScene(ev->pos());
     ChatLineContent* content = getContentFromPos(scenePos);
+    ChatLine::Ptr line = findLineByPosY(scenePos.y());
 
     if (content) {
         content->selectionDoubleClick(scenePos);
         selClickedCol = content->getColumn();
-        selClickedRow = content->getRow();
-        selFirstRow = content->getRow();
-        selLastRow = content->getRow();
+        selClickedRow = line;
+        selFirstRow = line;
+        selLastRow = line;
         selectionMode = SelectionMode::Precise;
 
         emit selectionChanged();
@@ -635,24 +661,24 @@ void ChatLog::mouseDoubleClickEvent(QMouseEvent* ev)
 QString ChatLog::getSelectedText() const
 {
     if (selectionMode == SelectionMode::Precise) {
-        return lines[selClickedRow]->content[selClickedCol]->getSelectedText();
+        return selClickedRow->content[selClickedCol]->getSelectedText();
     } else if (selectionMode == SelectionMode::Multi) {
         // build a nicely formatted message
         QString out;
 
-        for (int i = selFirstRow; i <= selLastRow; ++i) {
-            if (lines[i]->content[1]->getText().isEmpty())
-                continue;
+        forEachLineIn(selFirstRow, selLastRow, *chatLineStorage, [&] (ChatLine::Ptr& line) {
+            if (line->content[1]->getText().isEmpty())
+                return;
 
-            QString timestamp = lines[i]->content[2]->getText().isEmpty()
+            QString timestamp = line->content[2]->getText().isEmpty()
                                     ? tr("pending")
-                                    : lines[i]->content[2]->getText();
-            QString author = lines[i]->content[0]->getText();
-            QString msg = lines[i]->content[1]->getText();
+                                    : line->content[2]->getText();
+            QString author = line->content[0]->getText();
+            QString msg = line->content[1]->getText();
 
             out +=
                 QString(out.isEmpty() ? "[%2] %1: %3" : "\n[%2] %1: %3").arg(author, timestamp, msg);
-        }
+        });
 
         return out;
     }
@@ -662,7 +688,7 @@ QString ChatLog::getSelectedText() const
 
 bool ChatLog::isEmpty() const
 {
-    return lines.isEmpty();
+    return chatLineStorage->empty();
 }
 
 bool ChatLog::hasTextToBeCopied() const
@@ -686,21 +712,19 @@ void ChatLog::clear()
 
     QVector<ChatLine::Ptr> savedLines;
 
-    for (ChatLine::Ptr l : lines) {
-        if (isActiveFileTransfer(l))
-            savedLines.push_back(l);
-        else
-            l->removeFromScene();
+    for (auto it = chatLineStorage->begin(); it != chatLineStorage->end();) {
+        if (!isActiveFileTransfer(*it)) {
+            (*it)->removeFromScene();
+            it = chatLineStorage->erase(it);
+        } else {
+            it++;
+        }
     }
 
-    lines.clear();
     visibleLines.clear();
-    for (ChatLine::Ptr l : savedLines)
-        insertChatlineAtBottom(l);
 
+    checkVisibility();
     updateSceneRect();
-
-    messages.clear();
 }
 
 void ChatLog::copySelectedText(bool toSelectionBuffer) const
@@ -744,14 +768,14 @@ void ChatLog::scrollToLine(ChatLine::Ptr line)
 
 void ChatLog::selectAll()
 {
-    if (lines.empty())
+    if (chatLineStorage->empty())
         return;
 
     clearSelection();
 
     selectionMode = SelectionMode::Multi;
-    selFirstRow = 0;
-    selLastRow = lines.size() - 1;
+    selFirstRow = chatLineStorage->front();;
+    selLastRow = chatLineStorage->back();
 
     emit selectionChanged();
     updateMultiSelectionRect();
@@ -759,7 +783,7 @@ void ChatLog::selectAll()
 
 void ChatLog::fontChanged(const QFont& font)
 {
-    for (ChatLine::Ptr l : lines) {
+    for (ChatLine::Ptr l : *chatLineStorage) {
         l->fontChanged(font);
     }
 }
@@ -773,7 +797,7 @@ void ChatLog::reloadTheme()
     selGraphItem->setPen(QPen(selectionRectColor.darker(120)));
     setTypingNotification();
 
-    for (ChatLine::Ptr l : lines) {
+    for (ChatLine::Ptr l : *chatLineStorage) {
         l->reloadTheme();
     }
 }
@@ -841,15 +865,32 @@ void ChatLog::handleSearchResult(SearchResult result, SearchDirection direction)
 
     searchPos = result.pos;
 
-    auto const firstRenderedIdx = (messages.empty()) ? chatLog.getNextIdx() : messages.begin()->first;
+    auto const firstRenderedIdx = (chatLineStorage->hasIndexedMessage()) ? chatLineStorage->firstIdx() : chatLog.getNextIdx();
 
-    renderMessages(searchPos.logIdx, firstRenderedIdx, [this, result] {
-        auto msg = messages.at(searchPos.logIdx);
+    auto selectText = [this, result] {
+        // With fast changes our callback could become invalid, ensure that the
+        // index we want to view is still actually visible
+        if (!chatLineStorage->contains(searchPos.logIdx))
+            return;
+
+        auto msg = (*chatLineStorage)[searchPos.logIdx];
         scrollToLine(msg);
 
         auto text = qobject_cast<Text*>(msg->getContent(1));
         text->selectText(result.exp, std::make_pair(result.start, result.len));
-    });
+    };
+
+    // If the requested element is visible the render completion callback will
+    // not be called, we need to figure out which path we're going to take
+    // before we take it.
+    if (chatLineStorage->contains(searchPos.logIdx)) {
+        jumpToIdx(searchPos.logIdx);
+        selectText();
+    } else {
+        renderCompletionFns.push_back(selectText);
+        jumpToIdx(searchPos.logIdx);
+    }
+
 }
 
 void ChatLog::forceRelayout()
@@ -859,18 +900,18 @@ void ChatLog::forceRelayout()
 
 void ChatLog::checkVisibility()
 {
-    if (lines.empty())
+    if (chatLineStorage->empty())
         return;
 
     // find first visible line
-    auto lowerBound = std::lower_bound(lines.cbegin(), lines.cend(), getVisibleRect().top(),
+    auto lowerBound = std::lower_bound(chatLineStorage->begin(), chatLineStorage->end(), getVisibleRect().top(),
                                        ChatLine::lessThanBSRectBottom);
 
     // find last visible line
-    auto upperBound = std::lower_bound(lowerBound, lines.cend(), getVisibleRect().bottom(),
+    auto upperBound = std::lower_bound(lowerBound, chatLineStorage->end(), getVisibleRect().bottom(),
                                        ChatLine::lessThanBSRectTop);
 
-    const ChatLine::Ptr lastLineBeforeVisible = lowerBound == lines.cbegin()
+    const ChatLine::Ptr lastLineBeforeVisible = lowerBound == chatLineStorage->begin()
         ? ChatLine::Ptr()
         : *std::prev(lowerBound);
 
@@ -928,10 +969,10 @@ void ChatLog::resizeEvent(QResizeEvent* ev)
 
 void ChatLog::updateMultiSelectionRect()
 {
-    if (selectionMode == SelectionMode::Multi && selFirstRow >= 0 && selLastRow >= 0) {
+    if (selectionMode == SelectionMode::Multi && selFirstRow && selLastRow) {
         QRectF selBBox;
-        selBBox = selBBox.united(lines[selFirstRow]->sceneBoundingRect());
-        selBBox = selBBox.united(lines[selLastRow]->sceneBoundingRect());
+        selBBox = selBBox.united(selFirstRow->sceneBoundingRect());
+        selBBox = selBBox.united(selLastRow->sceneBoundingRect());
 
         if (selGraphItem->rect() != selBBox)
             scene->invalidate(selGraphItem->rect());
@@ -951,8 +992,8 @@ void ChatLog::updateTypingNotification()
 
     qreal posY = 0.0;
 
-    if (!lines.empty())
-        posY = lines.last()->sceneBoundingRect().bottom() + lineSpacing;
+    if (!chatLineStorage->empty())
+        posY = chatLineStorage->back()->sceneBoundingRect().bottom() + lineSpacing;
 
     notification->layout(useableWidth(), QPointF(0.0, posY));
 }
@@ -966,17 +1007,42 @@ void ChatLog::updateBusyNotification()
 
 ChatLine::Ptr ChatLog::findLineByPosY(qreal yPos) const
 {
-    auto itr = std::lower_bound(lines.cbegin(), lines.cend(), yPos, ChatLine::lessThanBSRectBottom);
+    auto itr = std::lower_bound(chatLineStorage->begin(), chatLineStorage->end(), yPos, ChatLine::lessThanBSRectBottom);
 
-    if (itr != lines.cend())
+    if (itr != chatLineStorage->end())
         return *itr;
 
     return ChatLine::Ptr();
 }
 
+void ChatLog::removeLines(ChatLogIdx begin, ChatLogIdx end)
+{
+    if (!chatLineStorage->hasIndexedMessage()) {
+        // No indexed lines to remove
+        return;
+    }
+
+    begin = clamp<ChatLogIdx>(begin, chatLineStorage->firstIdx(), chatLineStorage->lastIdx());
+    end = clamp<ChatLogIdx>(end, chatLineStorage->firstIdx(), chatLineStorage->lastIdx()) + 1;
+
+    // NOTE: Optimization potential if this find proves to be too expensive.
+    // Batching all our erases into one call would be more efficient
+    for (auto it = chatLineStorage->find(begin); it != chatLineStorage->find(end);) {
+        (*it)->removeFromScene();
+        it = chatLineStorage->erase(it);
+    }
+
+    // We need to re-layout anything that is after any line we removed. We could
+    // probably be smarter and try to only re-render anything under what we
+    // removed, but with the sliding window there doesn't seem to be much need
+    if (chatLineStorage->hasIndexedMessage() && begin <= chatLineStorage->lastIdx()) {
+        layout(0, chatLineStorage->size(), useableWidth());
+    }
+}
+
 QRectF ChatLog::calculateSceneRect() const
 {
-    qreal bottom = (lines.empty() ? 0.0 : lines.last()->sceneBoundingRect().bottom());
+    qreal bottom = (chatLineStorage->empty() ? 0.0 : chatLineStorage->back()->sceneBoundingRect().bottom());
 
     if (typingNotification.get() != nullptr)
         bottom += typingNotification->sceneBoundingRect().height() + lineSpacing;
@@ -1011,7 +1077,7 @@ void ChatLog::onWorkerTimeout()
     workerLastIndex += stepSize;
 
     // done?
-    if (workerLastIndex >= lines.size()) {
+    if (workerLastIndex >= chatLineStorage->size()) {
         workerTimer->stop();
 
         // switch back to the scene containing the chat messages
@@ -1035,7 +1101,7 @@ void ChatLog::onWorkerTimeout()
         // hidden during busy screen
         verticalScrollBar()->show();
 
-        emit workerTimeoutFinished();
+        emit renderFinished();
     }
 }
 
@@ -1044,57 +1110,175 @@ void ChatLog::onMultiClickTimeout()
     clickCount = 0;
 }
 
+void ChatLog::onMessageUpdated(ChatLogIdx idx)
+{
+    if (shouldRenderMessage(idx)) {
+        renderMessage(idx);
+    }
+}
+
 void ChatLog::renderMessage(ChatLogIdx idx)
 {
     renderMessages(idx, idx + 1);
 }
 
-void ChatLog::renderMessages(ChatLogIdx begin, ChatLogIdx end,
-                                     std::function<void(void)> onCompletion)
+void ChatLog::renderMessages(ChatLogIdx begin, ChatLogIdx end)
 {
-    QList<ChatLine::Ptr> beforeLines;
-    QList<ChatLine::Ptr> afterLines;
+    auto linesToRender = std::map<ChatLogIdx, ChatLine::Ptr>();
 
     for (auto i = begin; i < end; ++i) {
-        auto chatMessage = getChatMessageForIdx(i, messages);
-        renderItem(chatLog.at(i), needsToHideName(i), colorizeNames, chatMessage);
+        bool alreadyRendered = chatLineStorage->contains(i);
+        bool prevIdxRendered = i != begin || chatLineStorage->contains(i - 1);
 
-        if (messages.find(i) == messages.end()) {
-            QList<ChatLine::Ptr>* lines =
-                (messages.empty() || i > messages.rbegin()->first) ? &afterLines : &beforeLines;
+        auto chatMessage = alreadyRendered ? (*chatLineStorage)[i] : ChatLine::Ptr();
+        renderItem(chatLog.at(i), needsToHideName(i, prevIdxRendered), colorizeNames, chatMessage);
 
-            messages.insert({i, chatMessage});
-
-            if (shouldRenderDate(i, chatLog)) {
-                lines->push_back(dateMessageForItem(chatLog.at(i)));
-            }
-            lines->push_back(chatMessage);
+        if (!alreadyRendered) {
+            linesToRender.insert({i, chatMessage});
         }
     }
 
-    for (auto const& line : afterLines) {
-        insertChatlineAtBottom(line);
+    insertChatlines(linesToRender);
+}
+
+void ChatLog::setRenderedWindowStart(ChatLogIdx begin)
+{
+    // End of the window is pre-determined as a hardcoded window size relative
+    // to the start
+    auto end = clampedAdd(begin, maxWindowSize, chatLog);
+
+    // Use invalid + equal ChatLogIdx to force a full re-render if we do not
+    // have an indexed message to compare to
+    ChatLogIdx currentStart = ChatLogIdx(-1);
+    ChatLogIdx currentEnd = ChatLogIdx(-1);
+
+    if (chatLineStorage->hasIndexedMessage()) {
+        currentStart = chatLineStorage->firstIdx();
+        currentEnd = chatLineStorage->lastIdx() + 1;
     }
 
-    if (!beforeLines.empty()) {
-        // Rendering upwards is expensive and has async behavior for chatWidget.
-        // Once rendering completes we call our completion callback once and
-        // then disconnect the signal
-        if (onCompletion) {
-            auto connection = std::make_shared<QMetaObject::Connection>();
-            *connection = connect(this, &ChatLog::workerTimeoutFinished,
-                                  [this, onCompletion, connection] {
-                                      onCompletion();
-                                      this->disconnect(*connection);
-                                  });
-        }
+    // If the window is already where we have no work to do
+    if (currentStart == begin) {
+        emit renderFinished();
+        return;
+    }
 
-        insertChatlinesOnTop(beforeLines);
-    } else if (onCompletion) {
-        onCompletion();
+    // NOTE: This is more than an optimization, this is important for
+    // selection consistency. If we re-create lines that are already rendered
+    // the selXXXRow members will now be pointing to the wrong ChatLine::Ptr!
+    // Please be sure to test selection logic when scrolling around loading
+    // boundaries if changing this logic.
+    if (begin < currentEnd && begin > currentStart) {
+        // Remove leading lines
+        removeLines(currentStart, begin);
+        renderMessages(currentEnd, end);
+    }
+    else if (end <= currentEnd && end > currentStart) {
+        // Remove trailing lines
+        removeLines(end, currentEnd);
+        renderMessages(begin, currentStart);
+    }
+    else {
+        removeLines(currentStart, currentEnd);
+        renderMessages(begin, end);
     }
 }
 
+void ChatLog::setRenderedWindowEnd(ChatLogIdx end)
+{
+    // Off by 1 since the maxWindowSize is not inclusive
+    auto start = clampedAdd(end, -maxWindowSize + 1, chatLog);
+
+    setRenderedWindowStart(start);
+}
+
+void ChatLog::onRenderFinished()
+{
+    // We have to back these up before we run them, because people might queue
+    // on _more_ items on top of the ones we want. If they do this while we're
+    // iterating we can hit some memory corruption issues
+    auto renderCompletionFnsLocal = renderCompletionFns;
+    renderCompletionFns.clear();
+
+    while (renderCompletionFnsLocal.size()) {
+        renderCompletionFnsLocal.back()();
+        renderCompletionFnsLocal.pop_back();
+    }
+
+    // NOTE: this is a regression from previous behavior. We used to be able to
+    // load an infinite amount of chat and copy paste it out. Now we limit the
+    // user to 300 elements and any time the elements change our selection gets
+    // invalidated. This could be improved in the future but for now I  do not
+    // believe this is a serious usage impediment. Chats can be exported if a
+    // user really needs more than 300 messages to be copied
+    if (chatLineStorage->find(selFirstRow) == chatLineStorage->end() ||
+        chatLineStorage->find(selLastRow) == chatLineStorage->end() ||
+        chatLineStorage->find(selClickedRow) == chatLineStorage->end())
+    {
+        // FIXME: Segfault when selecting while scrolling down
+        clearSelection();
+    }
+}
+
+void ChatLog::onScrollValueChanged(int value)
+{
+    if (!chatLineStorage->hasIndexedMessage()) {
+        // This could be a little better. On a cleared screen we should probably
+        // be able to scroll, but this makes the rest of this function easier
+        return;
+    }
+
+    // When we hit the end of our scroll bar we change the content that's in the
+    // viewport. In this process our scroll value may end up changing again! We
+    // avoid this by changing our scroll position to match where it was before
+    // started our viewport change, but we need to filter out any intermediate
+    // scroll events triggered before we get to that point
+    if (!scrollMonitoringEnabled) {
+        return;
+    }
+
+    if (value == verticalScrollBar()->minimum())
+    {
+        auto idx = clampedAdd(chatLineStorage->firstIdx(), -static_cast<int>(windowChunkSize), chatLog);
+
+        if (idx != chatLineStorage->firstIdx()) {
+            auto currentTop = (*chatLineStorage)[chatLineStorage->firstIdx()];
+
+            renderCompletionFns.push_back([this, currentTop] {
+                scrollToLine(currentTop);
+                scrollMonitoringEnabled = true;
+            });
+
+            scrollMonitoringEnabled = false;
+            setRenderedWindowStart(idx);
+        }
+
+    }
+    else if (value == verticalScrollBar()->maximum())
+    {
+        auto idx = clampedAdd(chatLineStorage->lastIdx(), static_cast<int>(windowChunkSize), chatLog);
+
+        if (idx != chatLineStorage->lastIdx() + 1) {
+            // FIXME: This should be the top line
+            auto currentBottomIdx = chatLineStorage->lastIdx();
+            auto currentTopPx = mapToScene(0, 0).y();
+            auto currentBottomPx = (*chatLineStorage)[currentBottomIdx]->sceneBoundingRect().bottom();
+            auto bottomOffset = currentBottomPx - currentTopPx;
+
+            renderCompletionFns.push_back([this, currentBottomIdx, bottomOffset] {
+                auto it = chatLineStorage->find(currentBottomIdx);
+                if (it != chatLineStorage->end()) {
+                    updateSceneRect();
+                    verticalScrollBar()->setValue((*it)->sceneBoundingRect().bottom() - bottomOffset);
+                    scrollMonitoringEnabled = true;
+                }
+            });
+
+            scrollMonitoringEnabled = false;
+            setRenderedWindowEnd(idx);
+        }
+    }
+}
 
 void ChatLog::handleMultiClickEvent()
 {
@@ -1106,13 +1290,14 @@ void ChatLog::handleMultiClickEvent()
     case 3:
         QPointF scenePos = mapToScene(lastClickPos);
         ChatLineContent* content = getContentFromPos(scenePos);
+        ChatLine::Ptr line = findLineByPosY(scenePos.y());
 
         if (content) {
             content->selectionTripleClick(scenePos);
             selClickedCol = content->getColumn();
-            selClickedRow = content->getRow();
-            selFirstRow = content->getRow();
-            selLastRow = content->getRow();
+            selClickedRow = line;
+            selFirstRow = line;
+            selLastRow = line;
             selectionMode = SelectionMode::Precise;
 
             emit selectionChanged();
@@ -1128,6 +1313,24 @@ void ChatLog::showEvent(QShowEvent*)
     // the scrollbar to move.
 }
 
+void ChatLog::hideEvent(QHideEvent* event)
+{
+    // Purge accumulated lines from the chatlog. We do not purge messages while
+    // the chatlog is open because it causes flickers. When a user leaves the
+    // chat we take the opportunity to remove old messages. If a user only has
+    // one friend this could end up accumulating chat logs until they restart
+    // qTox, but that isn't a regression from previously released behavior.
+
+    auto numLinesToRemove = chatLineStorage->size() > maxWindowSize
+        ? chatLineStorage->size() - maxWindowSize
+        : 0;
+
+    if (numLinesToRemove > 0) {
+        removeLines(chatLineStorage->firstIdx(), chatLineStorage->firstIdx() + numLinesToRemove);
+        startResizeWorker();
+    }
+}
+
 void ChatLog::focusInEvent(QFocusEvent* ev)
 {
     QGraphicsView::focusInEvent(ev);
@@ -1135,8 +1338,15 @@ void ChatLog::focusInEvent(QFocusEvent* ev)
     if (selectionMode != SelectionMode::None) {
         selGraphItem->setBrush(QBrush(selectionRectColor));
 
-        for (int i = selFirstRow; i <= selLastRow; ++i)
-            lines[i]->selectionFocusChanged(true);
+        auto endIt = chatLineStorage->find(selLastRow);
+        // Increase by one since this selLastRow is inclusive, not exclusive
+        // like our loop expects
+        if (endIt != chatLineStorage->end()) {
+            endIt++;
+        }
+
+        for (auto it = chatLineStorage->begin(); it != chatLineStorage->end() && it != endIt; ++it)
+            (*it)->selectionFocusChanged(true);
     }
 }
 
@@ -1147,8 +1357,15 @@ void ChatLog::focusOutEvent(QFocusEvent* ev)
     if (selectionMode != SelectionMode::None) {
         selGraphItem->setBrush(QBrush(selectionRectColor.lighter(120)));
 
-        for (int i = selFirstRow; i <= selLastRow; ++i)
-            lines[i]->selectionFocusChanged(false);
+        auto endIt = chatLineStorage->find(selLastRow);
+        // Increase by one since this selLastRow is inclusive, not exclusive
+        // like our loop expects
+        if (endIt != chatLineStorage->end()) {
+            endIt++;
+        }
+
+        for (auto it = chatLineStorage->begin(); it != chatLineStorage->end() && it != endIt; ++it)
+            (*it)->selectionFocusChanged(false);
     }
 }
 
@@ -1182,102 +1399,6 @@ bool ChatLog::isActiveFileTransfer(ChatLine::Ptr l)
     return false;
 }
 
-/**
- * @brief Adjusts the selection based on chatlog changing lines
- * @param offset Amount to shift selection rect up by. Must be non-negative.
-  */
-void ChatLog::moveSelectionRectUpIfSelected(int offset)
-{
-    assert(offset >= 0);
-    switch (selectionMode)
-    {
-        case SelectionMode::None:
-            return;
-        case SelectionMode::Precise:
-            movePreciseSelectionUp(offset);
-            break;
-        case SelectionMode::Multi:
-            moveMultiSelectionUp(offset);
-            break;
-    }
-}
-
-/**
- * @brief Adjusts the selections based on chatlog changing lines
- * @param offset removed from the lines indexes. Must be non-negative.
-  */
-void ChatLog::moveSelectionRectDownIfSelected(int offset)
-{
-    assert(offset >= 0);
-    switch (selectionMode)
-    {
-        case SelectionMode::None:
-            return;
-        case SelectionMode::Precise:
-            movePreciseSelectionDown(offset);
-            break;
-        case SelectionMode::Multi:
-            moveMultiSelectionDown(offset);
-            break;
-    }
-}
-
-void ChatLog::movePreciseSelectionDown(int offset)
-{
-    assert(selFirstRow == selLastRow && selFirstRow == selClickedRow);
-    const int lastLine = lines.size() - 1;
-    if (selClickedRow + offset > lastLine) {
-        clearSelection();
-    } else {
-        const int newRow = selClickedRow + offset;
-        selClickedRow = newRow;
-        selLastRow = newRow;
-        selFirstRow = newRow;
-        emit selectionChanged();
-    }
-}
-
-void ChatLog::movePreciseSelectionUp(int offset)
-{
-    assert(selFirstRow == selLastRow && selFirstRow == selClickedRow);
-    if (selClickedRow < offset) {
-        clearSelection();
-    } else {
-        const int newRow = selClickedRow - offset;
-        selClickedRow = newRow;
-        selLastRow = newRow;
-        selFirstRow = newRow;
-        emit selectionChanged();
-    }
-}
-
-void ChatLog::moveMultiSelectionUp(int offset)
-{
-    if (selLastRow < offset) { // entire selection now out of bounds
-        clearSelection();
-    } else {
-        selLastRow -= offset;
-        selClickedRow = std::max(0, selClickedRow - offset);
-        selFirstRow = std::max(0, selFirstRow - offset);
-        updateMultiSelectionRect();
-        emit selectionChanged();
-    }
-}
-
-void ChatLog::moveMultiSelectionDown(int offset)
-{
-    const int lastLine = lines.size() - 1;
-    if (selFirstRow + offset > lastLine) { // entire selection now out of bounds
-        clearSelection();
-    } else {
-        selFirstRow += offset;
-        selClickedRow = std::min(lastLine, selClickedRow + offset);
-        selLastRow = std::min(lastLine, selLastRow + offset);
-        updateMultiSelectionRect();
-        emit selectionChanged();
-    }
-}
-
 void ChatLog::setTypingNotification()
 {
     typingNotification = ChatMessage::createTypingNotification();
@@ -1286,6 +1407,7 @@ void ChatLog::setTypingNotification()
     typingNotification->addToScene(scene);
     updateTypingNotification();
 }
+
 
 void ChatLog::renderItem(const ChatLogItem& item, bool hideName, bool colorizeNames, ChatLine::Ptr& chatMessage)
 {
@@ -1339,16 +1461,18 @@ void ChatLog::renderFile(QString displayName, ToxFile file, bool isSelf, QDateTi
 }
 
 /**
- * @brief Show, is it needed to hide message author name or not
+ * @brief Determine if the name at the given idx needs to be hidden
  * @param idx ChatLogIdx of the message
+ * @param prevIdxRendered Hint if the previous index is going to be rendered at
+ * all. If the previous line is not rendered we always show the name
  * @return True if the name should be hidden, false otherwise
  */
-bool ChatLog::needsToHideName(ChatLogIdx idx) const
+bool ChatLog::needsToHideName(ChatLogIdx idx, bool prevIdxRendered) const
 {
     // If the previous message is not rendered we should show the name
     // regardless of other constraints
-    auto itemBefore = messages.find(idx - 1);
-    if (itemBefore == messages.end()) {
+
+    if (!prevIdxRendered) {
         return false;
     }
 
@@ -1364,15 +1488,27 @@ bool ChatLog::needsToHideName(ChatLogIdx idx) const
     qint64 messagesTimeDiff = prevItem.getTimestamp().secsTo(currentItem.getTimestamp());
     return currentItem.getSender() == prevItem.getSender()
            && messagesTimeDiff < repNameAfter;
+
+    return false;
+}
+
+bool ChatLog::shouldRenderMessage(ChatLogIdx idx) const
+{
+    return chatLineStorage->contains(idx) ||
+        (
+            chatLineStorage->contains(idx - 1) && idx + 1 == chatLog.getNextIdx()
+        ) || chatLineStorage->empty();
 }
 
 void ChatLog::disableSearchText()
 {
-    auto msgIt = messages.find(searchPos.logIdx);
-    if (msgIt != messages.end()) {
-        auto text = qobject_cast<Text*>(msgIt->second->getContent(1));
-        text->deselectText();
+    if (!chatLineStorage->contains(searchPos.logIdx)) {
+        return;
     }
+
+    auto line = (*chatLineStorage)[searchPos.logIdx];
+    auto text = qobject_cast<Text*>(line->getContent(1));
+    text->deselectText();
 }
 
 void ChatLog::removeSearchPhrase()
@@ -1385,10 +1521,32 @@ void ChatLog::jumpToDate(QDate date) {
     jumpToIdx(idx);
 }
 
-void ChatLog::jumpToIdx(ChatLogIdx idx) {
-    if (messages.find(idx) == messages.end()) {
-        renderMessages(idx, chatLog.getNextIdx());
+void ChatLog::jumpToIdx(ChatLogIdx idx)
+{
+    if (idx == chatLog.getNextIdx()) {
+        idx = chatLog.getNextIdx() - 1;
     }
 
-    scrollToLine(messages[idx]);
+    if (chatLineStorage->contains(idx)) {
+        scrollToLine((*chatLineStorage)[idx]);
+        return;
+    }
+
+    // If the requested idx is not currently rendered we need to request a
+    // render and jump to the requested line after the render completes
+    renderCompletionFns.push_back([this, idx] {
+        if (chatLineStorage->contains(idx)) {
+            scrollToLine((*chatLineStorage)[idx]);
+        }
+    });
+
+    // If the chatlog is empty it's likely the user has just cleared. In this
+    // case it makes more sense to present the jump as if we're coming from the
+    // bottom
+    if (chatLineStorage->hasIndexedMessage() && idx > chatLineStorage->lastIdx()) {
+        setRenderedWindowEnd(clampedAdd(idx, windowChunkSize, chatLog));
+    }
+    else {
+        setRenderedWindowStart(clampedAdd(idx, -windowChunkSize, chatLog));
+    }
 }

--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -672,7 +672,7 @@ void ChatLog::scrollToLine(ChatLine::Ptr line)
         workerStb = false;
     } else {
         updateSceneRect();
-        verticalScrollBar()->setValue(line->sceneBoundingRect().top());
+        verticalScrollBar()->setValue(line->sceneBoundingRect().top()); // NOTE: start here
     }
 }
 

--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -913,6 +913,12 @@ void ChatLog::focusOutEvent(QFocusEvent* ev)
     }
 }
 
+void ChatLog::wheelEvent(QWheelEvent *event)
+{
+    QGraphicsView::wheelEvent(event);
+    checkVisibility(true);
+}
+
 void ChatLog::retranslateUi()
 {
     copyAction->setText(tr("Copy"));

--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -400,7 +400,7 @@ void ChatLog::insertChatlineAtBottom(const QList<ChatLine::Ptr>& newLines)
     if (newLines.isEmpty())
         return;
 
-    if (lines.size() + static_cast<int>(DEF_NUM_MSG_TO_LOAD) >= maxMessages) {
+    if (lines.size() + DEF_NUM_MSG_TO_LOAD >= maxMessages) {
         removeFirsts(DEF_NUM_MSG_TO_LOAD);
     }
 
@@ -451,7 +451,7 @@ void ChatLog::insertChatlinesOnTop(const QList<ChatLine::Ptr>& newLines)
         combLines.push_back(l);
     }
 
-    if (lines.size() + static_cast<int>(DEF_NUM_MSG_TO_LOAD) >= maxMessages) {
+    if (lines.size() + DEF_NUM_MSG_TO_LOAD >= maxMessages) {
         removeLasts(DEF_NUM_MSG_TO_LOAD);
     }
 
@@ -801,6 +801,7 @@ void ChatLog::checkVisibility(bool causedWheelEvent)
     }
 
     if (causedWheelEvent) {
+        qDebug() << "causedWheelEvent";
         if (lowerBound != lines.cend() && lowerBound->get()->row == 0) {
             emit loadHistoryLower();
         } else if (upperBound == lines.cend()) {

--- a/src/chatlog/chatlog.cpp
+++ b/src/chatlog/chatlog.cpp
@@ -933,12 +933,10 @@ void ChatLog::onWorkerTimeout()
         updateMultiSelectionRect();
 
         // scroll
-        if (workerStb) {
+        if (workerStb)
             scrollToBottom();
-            workerStb = false;
-        } else {
+        else
             scrollToLine(workerAnchorLine);
-        }
 
         // don't keep a Ptr to the anchor line
         workerAnchorLine = ChatLine::Ptr();

--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -43,7 +43,6 @@ public:
     virtual ~ChatLog();
 
     void insertChatlineAtBottom(ChatLine::Ptr l);
-    void insertChatlineAtBottom(const QList<ChatLine::Ptr>& newLines);
     void insertChatlineOnTop(ChatLine::Ptr l);
     void insertChatlinesOnTop(const QList<ChatLine::Ptr>& newLines);
     void clearSelection();
@@ -68,7 +67,6 @@ signals:
     void workerTimeoutFinished();
     void firstVisibleLineChanged(const ChatLine::Ptr& prevLine, const ChatLine::Ptr& firstLine);
     void loadHistoryLower();
-    void loadHistoryUpper();
 
 public slots:
     void forceRelayout();

--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -35,7 +35,6 @@ class ChatLineContent;
 struct ToxFile;
 
 static const size_t DEF_NUM_MSG_TO_LOAD = 100;
-
 class ChatLog : public QGraphicsView
 {
     Q_OBJECT
@@ -58,8 +57,6 @@ public:
     void fontChanged(const QFont& font);
     void removeFirsts(const int num);
     void removeLasts(const int num);
-    void setScroll(const bool scroll);
-    int getNumRemove() const;
 
     QString getSelectedText() const;
 
@@ -99,7 +96,7 @@ protected:
     void updateSceneRect();
     void checkVisibility(bool causedWheelEvent = false);
     void scrollToBottom();
-    void startResizeWorker(ChatLine::Ptr anchorLine = nullptr);
+    void startResizeWorker();
 
     void mouseDoubleClickEvent(QMouseEvent* ev) final;
     void mousePressEvent(QMouseEvent* ev) final;
@@ -170,7 +167,6 @@ private:
     int clickCount = 0;
     QPoint lastClickPos;
     Qt::MouseButton lastClickButton;
-    bool isScroll{true};
 
     // worker vars
     int workerLastIndex = 0;
@@ -180,7 +176,4 @@ private:
     // layout
     QMargins margins = QMargins(10, 10, 10, 10);
     qreal lineSpacing = 5.0f;
-
-    int numRemove{0};
-    const int maxMessages{300};
 };

--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -92,7 +92,7 @@ protected:
 
     void reposition(int start, int end, qreal deltaY);
     void updateSceneRect();
-    void checkVisibility(bool causedWheelEvent = false);
+    void checkVisibility(bool causedByScroll = false);
     void scrollToBottom();
     void startResizeWorker();
 

--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -138,8 +138,8 @@ private:
     void moveMultiSelectionDown(int offset);
     void setTypingNotification();
 
-    void renderItem(const ChatLogItem &item, bool hideName, bool colorizeNames, ChatMessage::Ptr &chatMessage);
-    void renderFile(QString displayName, ToxFile file, bool isSelf, QDateTime timestamp, ChatMessage::Ptr &chatMessage);
+    void renderItem(const ChatLogItem &item, bool hideName, bool colorizeNames, ChatLine::Ptr &chatMessage);
+    void renderFile(QString displayName, ToxFile file, bool isSelf, QDateTime timestamp, ChatLine::Ptr &chatMessage);
     bool needsToHideName(ChatLogIdx idx) const;
     void disableSearchText();
 private:
@@ -193,7 +193,7 @@ private:
     qreal lineSpacing = 5.0f;
 
     IChatLog& chatLog;
-    std::map<ChatLogIdx, ChatMessage::Ptr> messages;
+    std::map<ChatLogIdx, ChatLine::Ptr> messages;
     bool colorizeNames = false;
     SearchPos searchPos;
     const Core& core;

--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -99,7 +99,7 @@ protected:
     void updateSceneRect();
     void checkVisibility(bool causedWheelEvent = false);
     void scrollToBottom();
-    void startResizeWorker(bool stick, ChatLine::Ptr anchorLine = nullptr);
+    void startResizeWorker(ChatLine::Ptr anchorLine = nullptr);
 
     void mouseDoubleClickEvent(QMouseEvent* ev) final;
     void mousePressEvent(QMouseEvent* ev) final;

--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -55,8 +55,6 @@ public:
     void scrollToLine(ChatLine::Ptr line);
     void selectAll();
     void fontChanged(const QFont& font);
-    void removeFirsts(const int num);
-    void removeLasts(const int num);
 
     QString getSelectedText() const;
 

--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -66,7 +66,6 @@ signals:
     void selectionChanged();
     void workerTimeoutFinished();
     void firstVisibleLineChanged(const ChatLine::Ptr& prevLine, const ChatLine::Ptr& firstLine);
-    void loadHistoryLower();
 
 public slots:
     void forceRelayout();
@@ -90,7 +89,7 @@ protected:
 
     void reposition(int start, int end, qreal deltaY);
     void updateSceneRect();
-    void checkVisibility(bool causedByScroll = false);
+    void checkVisibility();
     void scrollToBottom();
     void startResizeWorker();
 

--- a/src/chatlog/chatlog.h
+++ b/src/chatlog/chatlog.h
@@ -35,6 +35,8 @@ class QTimer;
 class ChatLineContent;
 struct ToxFile;
 
+class ChatLineStorage;
+
 static const size_t DEF_NUM_MSG_TO_LOAD = 100;
 class ChatLog : public QGraphicsView
 {
@@ -43,9 +45,7 @@ public:
     explicit ChatLog(IChatLog& chatLog, const Core& core, QWidget* parent = nullptr);
     virtual ~ChatLog();
 
-    void insertChatlineAtBottom(ChatLine::Ptr l);
-    void insertChatlineOnTop(ChatLine::Ptr l);
-    void insertChatlinesOnTop(const QList<ChatLine::Ptr>& newLines);
+    void insertChatlines(std::map<ChatLogIdx, ChatLine::Ptr> chatLines);
     void clearSelection();
     void clear();
     void copySelectedText(bool toSelectionBuffer = false) const;
@@ -68,10 +68,10 @@ public:
 
 signals:
     void selectionChanged();
-    void workerTimeoutFinished();
     void firstVisibleLineChanged(const ChatLine::Ptr& prevLine, const ChatLine::Ptr& firstLine);
 
     void messageNotFoundShow(SearchDirection direction);
+    void renderFinished();
 public slots:
     void forceRelayout();
     void reloadTheme();
@@ -87,11 +87,15 @@ private slots:
     void onWorkerTimeout();
     void onMultiClickTimeout();
 
+    void onMessageUpdated(ChatLogIdx idx);
     void renderMessage(ChatLogIdx idx);
-    void renderMessages(ChatLogIdx begin, ChatLogIdx end,
-                        std::function<void(void)> onCompletion = std::function<void(void)>());
+    void renderMessages(ChatLogIdx begin, ChatLogIdx end);
 
+    void setRenderedWindowStart(ChatLogIdx start);
+    void setRenderedWindowEnd(ChatLogIdx end);
 
+    void onRenderFinished();
+    void onScrollValueChanged(int value);
 protected:
     QRectF calculateSceneRect() const;
     QRect getVisibleRect() const;
@@ -103,7 +107,6 @@ protected:
 
     qreal useableWidth() const;
 
-    void reposition(int start, int end, qreal deltaY);
     void updateSceneRect();
     void checkVisibility();
     void scrollToBottom();
@@ -116,6 +119,7 @@ protected:
     void scrollContentsBy(int dx, int dy) final;
     void resizeEvent(QResizeEvent* ev) final;
     void showEvent(QShowEvent*) final;
+    void hideEvent(QHideEvent* event) final;
     void focusInEvent(QFocusEvent* ev) final;
     void focusOutEvent(QFocusEvent* ev) final;
     void wheelEvent(QWheelEvent *event) final;
@@ -125,6 +129,8 @@ protected:
     void updateBusyNotification();
 
     ChatLine::Ptr findLineByPosY(qreal yPos) const;
+
+    void removeLines(ChatLogIdx being, ChatLogIdx end);
 
 private:
     void retranslateUi();
@@ -140,7 +146,8 @@ private:
 
     void renderItem(const ChatLogItem &item, bool hideName, bool colorizeNames, ChatLine::Ptr &chatMessage);
     void renderFile(QString displayName, ToxFile file, bool isSelf, QDateTime timestamp, ChatLine::Ptr &chatMessage);
-    bool needsToHideName(ChatLogIdx idx) const;
+    bool needsToHideName(ChatLogIdx idx, bool prevIdxRendered) const;
+    bool shouldRenderMessage(ChatLogIdx idx) const;
     void disableSearchText();
 private:
     enum class SelectionMode
@@ -161,16 +168,22 @@ private:
     QAction* selectAllAction = nullptr;
     QGraphicsScene* scene = nullptr;
     QGraphicsScene* busyScene = nullptr;
-    QVector<ChatLine::Ptr> lines;
     QList<ChatLine::Ptr> visibleLines;
     ChatLine::Ptr typingNotification;
     ChatLine::Ptr busyNotification;
 
     // selection
-    int selClickedRow = -1; // These 4 are only valid while selectionMode != None
+
+    // For the time being we store these selection indexes as ChatLine::Ptrs. In
+    // order to do multi-selection we do an O(n) search in the chatline storage
+    // to determine the index. This is inefficient but correct with the moving
+    // window of storage. If this proves to cause performance issues we can move
+    // this responsibility into ChatlineStorage and have it coordinate the
+    // shifting of indexes
+    ChatLine::Ptr selClickedRow; // These 4 are only valid while selectionMode != None
     int selClickedCol = -1;
-    int selFirstRow = -1;
-    int selLastRow = -1;
+    ChatLine::Ptr selFirstRow;
+    ChatLine::Ptr selLastRow;
     QColor selectionRectColor = Style::getColor(Style::SelectText);
     SelectionMode selectionMode = SelectionMode::None;
     QPointF clickPos;
@@ -184,7 +197,7 @@ private:
     Qt::MouseButton lastClickButton;
 
     // worker vars
-    int workerLastIndex = 0;
+    size_t workerLastIndex = 0;
     bool workerStb = false;
     ChatLine::Ptr workerAnchorLine;
 
@@ -193,8 +206,12 @@ private:
     qreal lineSpacing = 5.0f;
 
     IChatLog& chatLog;
-    std::map<ChatLogIdx, ChatLine::Ptr> messages;
     bool colorizeNames = false;
     SearchPos searchPos;
     const Core& core;
+    bool scrollMonitoringEnabled = true;
+
+    std::unique_ptr<ChatLineStorage> chatLineStorage;
+
+    std::vector<std::function<void(void)>> renderCompletionFns;
 };

--- a/src/chatlog/chatwidget.cpp
+++ b/src/chatlog/chatwidget.cpp
@@ -536,8 +536,6 @@ void ChatWidget::insertChatlines(std::map<ChatLogIdx, ChatLine::Ptr> chatLines)
         auto date = QDateTime(chatLog.at(idx).getTimestamp().date());
 #endif
 
-        auto insertionIdx = std::distance(chatLineStorage->begin(), insertedMessageIt);
-
         if (!chatLineStorage->contains(date)) {
             // If there is no dateline for the given date we need to insert it
             // above the line we'd like to insert.

--- a/src/chatlog/chatwidget.cpp
+++ b/src/chatlog/chatwidget.cpp
@@ -17,7 +17,7 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "chatlog.h"
+#include "chatwidget.h"
 #include "chatlinecontent.h"
 #include "chatlinecontentproxy.h"
 #include "chatmessage.h"
@@ -202,7 +202,7 @@ ChatLogIdx clampedAdd(ChatLogIdx idx, int val, IChatLog& chatLog)
 } // namespace
 
 
-ChatLog::ChatLog(IChatLog& chatLog, const Core& core, QWidget* parent)
+ChatWidget::ChatWidget(IChatLog& chatLog, const Core& core, QWidget* parent)
     : QGraphicsView(parent)
     , chatLog(chatLog)
     , core(core)
@@ -257,42 +257,42 @@ ChatLog::ChatLog(IChatLog& chatLog, const Core& core, QWidget* parent)
     selectionTimer->setInterval(1000 / 30);
     selectionTimer->setSingleShot(false);
     selectionTimer->start();
-    connect(selectionTimer, &QTimer::timeout, this, &ChatLog::onSelectionTimerTimeout);
+    connect(selectionTimer, &QTimer::timeout, this, &ChatWidget::onSelectionTimerTimeout);
 
     // Background worker
     // Updates the layout of all chat-lines after a resize
     workerTimer = new QTimer(this);
     workerTimer->setSingleShot(false);
     workerTimer->setInterval(5);
-    connect(workerTimer, &QTimer::timeout, this, &ChatLog::onWorkerTimeout);
+    connect(workerTimer, &QTimer::timeout, this, &ChatWidget::onWorkerTimeout);
 
     // This timer is used to detect multiple clicks
     multiClickTimer = new QTimer(this);
     multiClickTimer->setSingleShot(true);
     multiClickTimer->setInterval(QApplication::doubleClickInterval());
-    connect(multiClickTimer, &QTimer::timeout, this, &ChatLog::onMultiClickTimeout);
+    connect(multiClickTimer, &QTimer::timeout, this, &ChatWidget::onMultiClickTimeout);
 
     // selection
-    connect(this, &ChatLog::selectionChanged, this, [this]() {
+    connect(this, &ChatWidget::selectionChanged, this, [this]() {
         copyAction->setEnabled(hasTextToBeCopied());
         copySelectedText(true);
     });
 
-    connect(&GUI::getInstance(), &GUI::themeReload, this, &ChatLog::reloadTheme);
+    connect(&GUI::getInstance(), &GUI::themeReload, this, &ChatWidget::reloadTheme);
 
     reloadTheme();
     retranslateUi();
-    Translator::registerHandler(std::bind(&ChatLog::retranslateUi, this), this);
+    Translator::registerHandler(std::bind(&ChatWidget::retranslateUi, this), this);
 
-    connect(this, &ChatLog::renderFinished, this, &ChatLog::onRenderFinished);
-    connect(&chatLog, &IChatLog::itemUpdated, this, &ChatLog::onMessageUpdated);
-    connect(verticalScrollBar(), &QScrollBar::valueChanged, this, &ChatLog::onScrollValueChanged);
+    connect(this, &ChatWidget::renderFinished, this, &ChatWidget::onRenderFinished);
+    connect(&chatLog, &IChatLog::itemUpdated, this, &ChatWidget::onMessageUpdated);
+    connect(verticalScrollBar(), &QScrollBar::valueChanged, this, &ChatWidget::onScrollValueChanged);
 
     auto firstChatLogIdx = clampedAdd(chatLog.getNextIdx(), -100, chatLog);
     renderMessages(firstChatLogIdx, chatLog.getNextIdx());
 }
 
-ChatLog::~ChatLog()
+ChatWidget::~ChatWidget()
 {
     Translator::unregister(this);
 
@@ -307,7 +307,7 @@ ChatLog::~ChatLog()
         typingNotification->removeFromScene();
 }
 
-void ChatLog::clearSelection()
+void ChatWidget::clearSelection()
 {
     if (selectionMode == SelectionMode::None)
         return;
@@ -327,17 +327,17 @@ void ChatLog::clearSelection()
     updateMultiSelectionRect();
 }
 
-QRect ChatLog::getVisibleRect() const
+QRect ChatWidget::getVisibleRect() const
 {
     return mapToScene(viewport()->rect()).boundingRect().toRect();
 }
 
-void ChatLog::updateSceneRect()
+void ChatWidget::updateSceneRect()
 {
     setSceneRect(calculateSceneRect());
 }
 
-void ChatLog::layout(int start, int end, qreal width)
+void ChatWidget::layout(int start, int end, qreal width)
 {
     if (chatLineStorage->empty())
         return;
@@ -360,7 +360,7 @@ void ChatLog::layout(int start, int end, qreal width)
     }
 }
 
-void ChatLog::mousePressEvent(QMouseEvent* ev)
+void ChatWidget::mousePressEvent(QMouseEvent* ev)
 {
     QGraphicsView::mousePressEvent(ev);
 
@@ -383,7 +383,7 @@ void ChatLog::mousePressEvent(QMouseEvent* ev)
     handleMultiClickEvent();
 }
 
-void ChatLog::mouseReleaseEvent(QMouseEvent* ev)
+void ChatWidget::mouseReleaseEvent(QMouseEvent* ev)
 {
     QGraphicsView::mouseReleaseEvent(ev);
 
@@ -392,7 +392,7 @@ void ChatLog::mouseReleaseEvent(QMouseEvent* ev)
     multiClickTimer->start();
 }
 
-void ChatLog::mouseMoveEvent(QMouseEvent* ev)
+void ChatWidget::mouseMoveEvent(QMouseEvent* ev)
 {
     QGraphicsView::mouseMoveEvent(ev);
 
@@ -478,7 +478,7 @@ void ChatLog::mouseMoveEvent(QMouseEvent* ev)
 }
 
 // Much faster than QGraphicsScene::itemAt()!
-ChatLineContent* ChatLog::getContentFromPos(QPointF scenePos) const
+ChatLineContent* ChatWidget::getContentFromPos(QPointF scenePos) const
 {
     if (chatLineStorage->empty())
         return nullptr;
@@ -493,7 +493,7 @@ ChatLineContent* ChatLog::getContentFromPos(QPointF scenePos) const
     return nullptr;
 }
 
-bool ChatLog::isOverSelection(QPointF scenePos) const
+bool ChatWidget::isOverSelection(QPointF scenePos) const
 {
     if (selectionMode == SelectionMode::Precise) {
         ChatLineContent* content = getContentFromPos(scenePos);
@@ -508,12 +508,12 @@ bool ChatLog::isOverSelection(QPointF scenePos) const
     return false;
 }
 
-qreal ChatLog::useableWidth() const
+qreal ChatWidget::useableWidth() const
 {
     return width() - verticalScrollBar()->sizeHint().width() - margins.right() - margins.left();
 }
 
-void ChatLog::insertChatlines(std::map<ChatLogIdx, ChatLine::Ptr> chatLines)
+void ChatWidget::insertChatlines(std::map<ChatLogIdx, ChatLine::Ptr> chatLines)
 {
     if (chatLines.empty())
         return;
@@ -584,18 +584,18 @@ void ChatLog::insertChatlines(std::map<ChatLogIdx, ChatLine::Ptr> chatLines)
     }
 }
 
-bool ChatLog::stickToBottom() const
+bool ChatWidget::stickToBottom() const
 {
     return verticalScrollBar()->value() == verticalScrollBar()->maximum();
 }
 
-void ChatLog::scrollToBottom()
+void ChatWidget::scrollToBottom()
 {
     updateSceneRect();
     verticalScrollBar()->setValue(verticalScrollBar()->maximum());
 }
 
-void ChatLog::startResizeWorker()
+void ChatWidget::startResizeWorker()
 {
     if (chatLineStorage->empty())
         return;
@@ -627,7 +627,7 @@ void ChatLog::startResizeWorker()
     verticalScrollBar()->hide();
 }
 
-void ChatLog::mouseDoubleClickEvent(QMouseEvent* ev)
+void ChatWidget::mouseDoubleClickEvent(QMouseEvent* ev)
 {
     QPointF scenePos = mapToScene(ev->pos());
     ChatLineContent* content = getContentFromPos(scenePos);
@@ -658,7 +658,7 @@ void ChatLog::mouseDoubleClickEvent(QMouseEvent* ev)
     handleMultiClickEvent();
 }
 
-QString ChatLog::getSelectedText() const
+QString ChatWidget::getSelectedText() const
 {
     if (selectionMode == SelectionMode::Precise) {
         return selClickedRow->content[selClickedCol]->getSelectedText();
@@ -686,12 +686,12 @@ QString ChatLog::getSelectedText() const
     return QString();
 }
 
-bool ChatLog::isEmpty() const
+bool ChatWidget::isEmpty() const
 {
     return chatLineStorage->empty();
 }
 
-bool ChatLog::hasTextToBeCopied() const
+bool ChatWidget::hasTextToBeCopied() const
 {
     return selectionMode != SelectionMode::None;
 }
@@ -701,12 +701,12 @@ bool ChatLog::hasTextToBeCopied() const
  * @param pos Position on screen in global coordinates
  * @sa getContentFromPos()
  */
-ChatLineContent* ChatLog::getContentFromGlobalPos(QPoint pos) const
+ChatLineContent* ChatWidget::getContentFromGlobalPos(QPoint pos) const
 {
     return getContentFromPos(mapToScene(mapFromGlobal(pos)));
 }
 
-void ChatLog::clear()
+void ChatWidget::clear()
 {
     clearSelection();
 
@@ -727,7 +727,7 @@ void ChatLog::clear()
     updateSceneRect();
 }
 
-void ChatLog::copySelectedText(bool toSelectionBuffer) const
+void ChatWidget::copySelectedText(bool toSelectionBuffer) const
 {
     QString text = getSelectedText();
     QClipboard* clipboard = QApplication::clipboard();
@@ -736,7 +736,7 @@ void ChatLog::copySelectedText(bool toSelectionBuffer) const
         clipboard->setText(text, toSelectionBuffer ? QClipboard::Selection : QClipboard::Clipboard);
 }
 
-void ChatLog::setTypingNotificationVisible(bool visible)
+void ChatWidget::setTypingNotificationVisible(bool visible)
 {
     if (typingNotification.get()) {
         typingNotification->setVisible(visible);
@@ -744,7 +744,7 @@ void ChatLog::setTypingNotificationVisible(bool visible)
     }
 }
 
-void ChatLog::setTypingNotificationName(const QString& displayName)
+void ChatWidget::setTypingNotificationName(const QString& displayName)
 {
     if (!typingNotification.get()) {
         setTypingNotification();
@@ -757,7 +757,7 @@ void ChatLog::setTypingNotificationName(const QString& displayName)
     updateTypingNotification();
 }
 
-void ChatLog::scrollToLine(ChatLine::Ptr line)
+void ChatWidget::scrollToLine(ChatLine::Ptr line)
 {
     if (!line.get())
         return;
@@ -766,7 +766,7 @@ void ChatLog::scrollToLine(ChatLine::Ptr line)
     verticalScrollBar()->setValue(line->sceneBoundingRect().top());
 }
 
-void ChatLog::selectAll()
+void ChatWidget::selectAll()
 {
     if (chatLineStorage->empty())
         return;
@@ -781,14 +781,14 @@ void ChatLog::selectAll()
     updateMultiSelectionRect();
 }
 
-void ChatLog::fontChanged(const QFont& font)
+void ChatWidget::fontChanged(const QFont& font)
 {
     for (ChatLine::Ptr l : *chatLineStorage) {
         l->fontChanged(font);
     }
 }
 
-void ChatLog::reloadTheme()
+void ChatWidget::reloadTheme()
 {
     setStyleSheet(Style::getStylesheet("chatArea/chatArea.css"));
     setBackgroundBrush(QBrush(Style::getColor(Style::GroundBase), Qt::SolidPattern));
@@ -802,7 +802,7 @@ void ChatLog::reloadTheme()
     }
 }
 
-void ChatLog::startSearch(const QString& phrase, const ParameterSearch& parameter)
+void ChatWidget::startSearch(const QString& phrase, const ParameterSearch& parameter)
 {
     disableSearchText();
 
@@ -842,19 +842,19 @@ void ChatLog::startSearch(const QString& phrase, const ParameterSearch& paramete
     }
 }
 
-void ChatLog::onSearchUp(const QString& phrase, const ParameterSearch& parameter)
+void ChatWidget::onSearchUp(const QString& phrase, const ParameterSearch& parameter)
 {
     auto result = chatLog.searchBackward(searchPos, phrase, parameter);
     handleSearchResult(result, SearchDirection::Up);
 }
 
-void ChatLog::onSearchDown(const QString& phrase, const ParameterSearch& parameter)
+void ChatWidget::onSearchDown(const QString& phrase, const ParameterSearch& parameter)
 {
     auto result = chatLog.searchForward(searchPos, phrase, parameter);
     handleSearchResult(result, SearchDirection::Down);
 }
 
-void ChatLog::handleSearchResult(SearchResult result, SearchDirection direction)
+void ChatWidget::handleSearchResult(SearchResult result, SearchDirection direction)
 {
     if (!result.found) {
         emit messageNotFoundShow(direction);
@@ -893,12 +893,12 @@ void ChatLog::handleSearchResult(SearchResult result, SearchDirection direction)
 
 }
 
-void ChatLog::forceRelayout()
+void ChatWidget::forceRelayout()
 {
     startResizeWorker();
 }
 
-void ChatLog::checkVisibility()
+void ChatWidget::checkVisibility()
 {
     if (chatLineStorage->empty())
         return;
@@ -937,13 +937,13 @@ void ChatLog::checkVisibility()
     }
 }
 
-void ChatLog::scrollContentsBy(int dx, int dy)
+void ChatWidget::scrollContentsBy(int dx, int dy)
 {
     QGraphicsView::scrollContentsBy(dx, dy);
     checkVisibility();
 }
 
-void ChatLog::resizeEvent(QResizeEvent* ev)
+void ChatWidget::resizeEvent(QResizeEvent* ev)
 {
     bool stb = stickToBottom();
 
@@ -960,7 +960,7 @@ void ChatLog::resizeEvent(QResizeEvent* ev)
     updateBusyNotification();
 }
 
-void ChatLog::updateMultiSelectionRect()
+void ChatWidget::updateMultiSelectionRect()
 {
     if (selectionMode == SelectionMode::Multi && selFirstRow && selLastRow) {
         QRectF selBBox;
@@ -977,7 +977,7 @@ void ChatLog::updateMultiSelectionRect()
     }
 }
 
-void ChatLog::updateTypingNotification()
+void ChatWidget::updateTypingNotification()
 {
     ChatLine* notification = typingNotification.get();
     if (!notification)
@@ -991,14 +991,14 @@ void ChatLog::updateTypingNotification()
     notification->layout(useableWidth(), QPointF(0.0, posY));
 }
 
-void ChatLog::updateBusyNotification()
+void ChatWidget::updateBusyNotification()
 {
     // repoisition the busy notification (centered)
     busyNotification->layout(useableWidth(), getVisibleRect().topLeft()
                                                     + QPointF(0, getVisibleRect().height() / 2.0));
 }
 
-ChatLine::Ptr ChatLog::findLineByPosY(qreal yPos) const
+ChatLine::Ptr ChatWidget::findLineByPosY(qreal yPos) const
 {
     auto itr = std::lower_bound(chatLineStorage->begin(), chatLineStorage->end(), yPos, ChatLine::lessThanBSRectBottom);
 
@@ -1008,7 +1008,7 @@ ChatLine::Ptr ChatLog::findLineByPosY(qreal yPos) const
     return ChatLine::Ptr();
 }
 
-void ChatLog::removeLines(ChatLogIdx begin, ChatLogIdx end)
+void ChatWidget::removeLines(ChatLogIdx begin, ChatLogIdx end)
 {
     if (!chatLineStorage->hasIndexedMessage()) {
         // No indexed lines to remove
@@ -1033,7 +1033,7 @@ void ChatLog::removeLines(ChatLogIdx begin, ChatLogIdx end)
     }
 }
 
-QRectF ChatLog::calculateSceneRect() const
+QRectF ChatWidget::calculateSceneRect() const
 {
     qreal bottom = (chatLineStorage->empty() ? 0.0 : chatLineStorage->back()->sceneBoundingRect().bottom());
 
@@ -1044,7 +1044,7 @@ QRectF ChatLog::calculateSceneRect() const
                   bottom + margins.bottom() + margins.top());
 }
 
-void ChatLog::onSelectionTimerTimeout()
+void ChatWidget::onSelectionTimerTimeout()
 {
     const int scrollSpeed = 10;
 
@@ -1060,7 +1060,7 @@ void ChatLog::onSelectionTimerTimeout()
     }
 }
 
-void ChatLog::onWorkerTimeout()
+void ChatWidget::onWorkerTimeout()
 {
     // Fairly arbitrary but
     // large values will make the UI unresponsive
@@ -1098,24 +1098,24 @@ void ChatLog::onWorkerTimeout()
     }
 }
 
-void ChatLog::onMultiClickTimeout()
+void ChatWidget::onMultiClickTimeout()
 {
     clickCount = 0;
 }
 
-void ChatLog::onMessageUpdated(ChatLogIdx idx)
+void ChatWidget::onMessageUpdated(ChatLogIdx idx)
 {
     if (shouldRenderMessage(idx)) {
         renderMessage(idx);
     }
 }
 
-void ChatLog::renderMessage(ChatLogIdx idx)
+void ChatWidget::renderMessage(ChatLogIdx idx)
 {
     renderMessages(idx, idx + 1);
 }
 
-void ChatLog::renderMessages(ChatLogIdx begin, ChatLogIdx end)
+void ChatWidget::renderMessages(ChatLogIdx begin, ChatLogIdx end)
 {
     auto linesToRender = std::map<ChatLogIdx, ChatLine::Ptr>();
 
@@ -1134,7 +1134,7 @@ void ChatLog::renderMessages(ChatLogIdx begin, ChatLogIdx end)
     insertChatlines(linesToRender);
 }
 
-void ChatLog::setRenderedWindowStart(ChatLogIdx begin)
+void ChatWidget::setRenderedWindowStart(ChatLogIdx begin)
 {
     // End of the window is pre-determined as a hardcoded window size relative
     // to the start
@@ -1177,7 +1177,7 @@ void ChatLog::setRenderedWindowStart(ChatLogIdx begin)
     }
 }
 
-void ChatLog::setRenderedWindowEnd(ChatLogIdx end)
+void ChatWidget::setRenderedWindowEnd(ChatLogIdx end)
 {
     // Off by 1 since the maxWindowSize is not inclusive
     auto start = clampedAdd(end, -maxWindowSize + 1, chatLog);
@@ -1185,7 +1185,7 @@ void ChatLog::setRenderedWindowEnd(ChatLogIdx end)
     setRenderedWindowStart(start);
 }
 
-void ChatLog::onRenderFinished()
+void ChatWidget::onRenderFinished()
 {
     // We have to back these up before we run them, because people might queue
     // on _more_ items on top of the ones we want. If they do this while we're
@@ -1213,7 +1213,7 @@ void ChatLog::onRenderFinished()
     }
 }
 
-void ChatLog::onScrollValueChanged(int value)
+void ChatWidget::onScrollValueChanged(int value)
 {
     if (!chatLineStorage->hasIndexedMessage()) {
         // This could be a little better. On a cleared screen we should probably
@@ -1273,7 +1273,7 @@ void ChatLog::onScrollValueChanged(int value)
     }
 }
 
-void ChatLog::handleMultiClickEvent()
+void ChatWidget::handleMultiClickEvent()
 {
     // Ignore single or double clicks
     if (clickCount < 2)
@@ -1299,14 +1299,14 @@ void ChatLog::handleMultiClickEvent()
     }
 }
 
-void ChatLog::showEvent(QShowEvent*)
+void ChatWidget::showEvent(QShowEvent*)
 {
     // Empty.
     // The default implementation calls centerOn - for some reason - causing
     // the scrollbar to move.
 }
 
-void ChatLog::hideEvent(QHideEvent* event)
+void ChatWidget::hideEvent(QHideEvent* event)
 {
     // Purge accumulated lines from the chatlog. We do not purge messages while
     // the chatlog is open because it causes flickers. When a user leaves the
@@ -1324,7 +1324,7 @@ void ChatLog::hideEvent(QHideEvent* event)
     }
 }
 
-void ChatLog::focusInEvent(QFocusEvent* ev)
+void ChatWidget::focusInEvent(QFocusEvent* ev)
 {
     QGraphicsView::focusInEvent(ev);
 
@@ -1343,7 +1343,7 @@ void ChatLog::focusInEvent(QFocusEvent* ev)
     }
 }
 
-void ChatLog::focusOutEvent(QFocusEvent* ev)
+void ChatWidget::focusOutEvent(QFocusEvent* ev)
 {
     QGraphicsView::focusOutEvent(ev);
 
@@ -1362,19 +1362,19 @@ void ChatLog::focusOutEvent(QFocusEvent* ev)
     }
 }
 
-void ChatLog::wheelEvent(QWheelEvent *event)
+void ChatWidget::wheelEvent(QWheelEvent *event)
 {
     QGraphicsView::wheelEvent(event);
     checkVisibility();
 }
 
-void ChatLog::retranslateUi()
+void ChatWidget::retranslateUi()
 {
     copyAction->setText(tr("Copy"));
     selectAllAction->setText(tr("Select all"));
 }
 
-bool ChatLog::isActiveFileTransfer(ChatLine::Ptr l)
+bool ChatWidget::isActiveFileTransfer(ChatLine::Ptr l)
 {
     int count = l->getColumnCount();
     for (int i = 0; i < count; ++i) {
@@ -1392,7 +1392,7 @@ bool ChatLog::isActiveFileTransfer(ChatLine::Ptr l)
     return false;
 }
 
-void ChatLog::setTypingNotification()
+void ChatWidget::setTypingNotification()
 {
     typingNotification = ChatMessage::createTypingNotification();
     typingNotification->visibilityChanged(true);
@@ -1402,7 +1402,7 @@ void ChatLog::setTypingNotification()
 }
 
 
-void ChatLog::renderItem(const ChatLogItem& item, bool hideName, bool colorizeNames, ChatLine::Ptr& chatMessage)
+void ChatWidget::renderItem(const ChatLogItem& item, bool hideName, bool colorizeNames, ChatLine::Ptr& chatMessage)
 {
     const auto& sender = item.getSender();
 
@@ -1438,7 +1438,7 @@ void ChatLog::renderItem(const ChatLogItem& item, bool hideName, bool colorizeNa
     }
 }
 
-void ChatLog::renderFile(QString displayName, ToxFile file, bool isSelf, QDateTime timestamp,
+void ChatWidget::renderFile(QString displayName, ToxFile file, bool isSelf, QDateTime timestamp,
                 ChatLine::Ptr& chatMessage)
 {
     if (!chatMessage) {
@@ -1460,7 +1460,7 @@ void ChatLog::renderFile(QString displayName, ToxFile file, bool isSelf, QDateTi
  * all. If the previous line is not rendered we always show the name
  * @return True if the name should be hidden, false otherwise
  */
-bool ChatLog::needsToHideName(ChatLogIdx idx, bool prevIdxRendered) const
+bool ChatWidget::needsToHideName(ChatLogIdx idx, bool prevIdxRendered) const
 {
     // If the previous message is not rendered we should show the name
     // regardless of other constraints
@@ -1485,7 +1485,7 @@ bool ChatLog::needsToHideName(ChatLogIdx idx, bool prevIdxRendered) const
     return false;
 }
 
-bool ChatLog::shouldRenderMessage(ChatLogIdx idx) const
+bool ChatWidget::shouldRenderMessage(ChatLogIdx idx) const
 {
     return chatLineStorage->contains(idx) ||
         (
@@ -1493,7 +1493,7 @@ bool ChatLog::shouldRenderMessage(ChatLogIdx idx) const
         ) || chatLineStorage->empty();
 }
 
-void ChatLog::disableSearchText()
+void ChatWidget::disableSearchText()
 {
     if (!chatLineStorage->contains(searchPos.logIdx)) {
         return;
@@ -1504,17 +1504,17 @@ void ChatLog::disableSearchText()
     text->deselectText();
 }
 
-void ChatLog::removeSearchPhrase()
+void ChatWidget::removeSearchPhrase()
 {
     disableSearchText();
 }
 
-void ChatLog::jumpToDate(QDate date) {
+void ChatWidget::jumpToDate(QDate date) {
     auto idx = firstItemAfterDate(date, chatLog);
     jumpToIdx(idx);
 }
 
-void ChatLog::jumpToIdx(ChatLogIdx idx)
+void ChatWidget::jumpToIdx(ChatLogIdx idx)
 {
     if (idx == chatLog.getNextIdx()) {
         idx = chatLog.getNextIdx() - 1;

--- a/src/chatlog/chatwidget.h
+++ b/src/chatlog/chatwidget.h
@@ -38,12 +38,12 @@ struct ToxFile;
 class ChatLineStorage;
 
 static const size_t DEF_NUM_MSG_TO_LOAD = 100;
-class ChatLog : public QGraphicsView
+class ChatWidget : public QGraphicsView
 {
     Q_OBJECT
 public:
-    explicit ChatLog(IChatLog& chatLog, const Core& core, QWidget* parent = nullptr);
-    virtual ~ChatLog();
+    explicit ChatWidget(IChatLog& chatLog, const Core& core, QWidget* parent = nullptr);
+    virtual ~ChatWidget();
 
     void insertChatlines(std::map<ChatLogIdx, ChatLine::Ptr> chatLines);
     void clearSelection();

--- a/src/chatlog/content/text.cpp
+++ b/src/chatlog/content/text.cpp
@@ -66,11 +66,9 @@ void Text::selectText(const QString& txt, const std::pair<int, int>& point)
         return;
     }
 
-    selectCursor = doc->find(txt, point.first);
-    selectPoint = point;
+    auto cursor = doc->find(txt, point.first);
 
-    regenerate();
-    update();
+    selectText(cursor, point);
 }
 
 void Text::selectText(const QRegularExpression &exp, const std::pair<int, int>& point)
@@ -81,20 +79,14 @@ void Text::selectText(const QRegularExpression &exp, const std::pair<int, int>& 
         return;
     }
 
-    selectCursor = doc->find(exp, point.first);
-    selectPoint = point;
+    auto cursor = doc->find(exp, point.first);
 
-    regenerate();
-    update();
+    selectText(cursor, point);
 }
 
 void Text::deselectText()
 {
     dirty = true;
-
-    selectCursor = QTextCursor();
-    selectPoint = {0, 0};
-
     regenerate();
     update();
 }
@@ -363,10 +355,6 @@ void Text::regenerate()
         dirty = false;
     }
 
-    if (!selectCursor.isNull()) {
-        selectText(selectCursor, selectPoint);
-    }
-
     // if we are not visible -> free mem
     if (!keepInMemory)
         freeResources();
@@ -474,6 +462,9 @@ void Text::selectText(QTextCursor& cursor, const std::pair<int, int>& point)
         QTextCharFormat format;
         format.setBackground(QBrush(Style::getColor(Style::SearchHighlighted)));
         cursor.mergeCharFormat(format);
+
+        regenerate();
+        update();
     }
 }
 

--- a/src/chatlog/content/text.h
+++ b/src/chatlog/content/text.h
@@ -23,7 +23,6 @@
 #include "src/widget/style.h"
 
 #include <QFont>
-#include <QTextCursor>
 
 class QTextDocument;
 
@@ -110,7 +109,4 @@ private:
     TextType textType;
     QColor color;
     QColor customColor;
-
-    QTextCursor selectCursor;
-    std::pair<int, int> selectPoint{0, 0};
 };

--- a/src/model/chathistory.cpp
+++ b/src/model/chathistory.cpp
@@ -96,10 +96,9 @@ ChatHistory::ChatHistory(Friend& f_, History* history_, const ICoreIdHandler& co
 
     // NOTE: this has to be done _after_ sending all sent messages since initial
     // state of the message has to be marked according to our dispatch state
-    constexpr auto defaultNumMessagesToLoad = 100;
-    auto firstChatLogIdx = sessionChatLog.getFirstIdx().get() < defaultNumMessagesToLoad
+    auto firstChatLogIdx = sessionChatLog.getFirstIdx().get() < DEF_NUM_MSG_TO_LOAD
                                ? ChatLogIdx(0)
-                               : sessionChatLog.getFirstIdx() - defaultNumMessagesToLoad;
+                               : sessionChatLog.getFirstIdx() - DEF_NUM_MSG_TO_LOAD;
 
     if (canUseHistory()) {
         loadHistoryIntoSessionChatLog(firstChatLogIdx);

--- a/src/model/chathistory.cpp
+++ b/src/model/chathistory.cpp
@@ -160,19 +160,13 @@ SearchResult ChatHistory::searchBackward(SearchPos startIdx, const QString& phra
         history->getDateWhereFindPhrase(f.getPublicKey(), earliestMessageDate, phrase,
                                         parameter);
 
-    if (dateWherePhraseFound.isValid()) {
-        auto loadIdx = history->getNumMessagesForFriendBeforeDate(f.getPublicKey(), dateWherePhraseFound);
-        loadHistoryIntoSessionChatLog(ChatLogIdx(loadIdx));
+    auto loadIdx = history->getNumMessagesForFriendBeforeDate(f.getPublicKey(), dateWherePhraseFound);
+    loadHistoryIntoSessionChatLog(ChatLogIdx(loadIdx));
 
-        // Reset search pos to the message we just loaded to avoid a double search
-        startIdx.logIdx = ChatLogIdx(loadIdx);
-        startIdx.numMatches = 0;
-        return sessionChatLog.searchBackward(startIdx, phrase, parameter);
-    }
-
-    SearchResult ret;
-    ret.found = false;
-    return ret;
+    // Reset search pos to the message we just loaded to avoid a double search
+    startIdx.logIdx = ChatLogIdx(loadIdx);
+    startIdx.numMatches = 0;
+    return sessionChatLog.searchBackward(startIdx, phrase, parameter);
 }
 
 ChatLogIdx ChatHistory::getFirstIdx() const

--- a/src/model/chathistory.cpp
+++ b/src/model/chathistory.cpp
@@ -96,9 +96,10 @@ ChatHistory::ChatHistory(Friend& f_, History* history_, const ICoreIdHandler& co
 
     // NOTE: this has to be done _after_ sending all sent messages since initial
     // state of the message has to be marked according to our dispatch state
-    auto firstChatLogIdx = sessionChatLog.getFirstIdx().get() < DEF_NUM_MSG_TO_LOAD
+    constexpr auto defaultNumMessagesToLoad = 100;
+    auto firstChatLogIdx = sessionChatLog.getFirstIdx().get() < defaultNumMessagesToLoad
                                ? ChatLogIdx(0)
-                               : sessionChatLog.getFirstIdx() - DEF_NUM_MSG_TO_LOAD;
+                               : sessionChatLog.getFirstIdx() - defaultNumMessagesToLoad;
 
     if (canUseHistory()) {
         loadHistoryIntoSessionChatLog(firstChatLogIdx);

--- a/src/model/contact.h
+++ b/src/model/contact.h
@@ -36,8 +36,6 @@ public:
     virtual void setEventFlag(bool flag) = 0;
     virtual bool getEventFlag() const = 0;
 
-    virtual bool useHistory() const = 0; // TODO: remove after added history in group chat
-
 signals:
     void displayedNameChanged(const QString& newName);
 };

--- a/src/model/friend.cpp
+++ b/src/model/friend.cpp
@@ -192,9 +192,6 @@ Status::Status Friend::getStatus() const
     return isNegotiating ? Status::Status::Negotiating : friendStatus;
 }
 
-bool Friend::useHistory() const
-{
-    return true;
 }
 
 void Friend::setExtendedMessageSupport(bool supported)
@@ -226,4 +223,3 @@ void Friend::onNegotiationComplete() {
     if (Status::isOnline(getStatus())) {
         emit onlineOfflineChanged(friendPk, true);
     }
-}

--- a/src/model/friend.cpp
+++ b/src/model/friend.cpp
@@ -192,8 +192,6 @@ Status::Status Friend::getStatus() const
     return isNegotiating ? Status::Status::Negotiating : friendStatus;
 }
 
-}
-
 void Friend::setExtendedMessageSupport(bool supported)
 {
     supportedExtensions[ExtensionType::messages] = supported;
@@ -223,3 +221,4 @@ void Friend::onNegotiationComplete() {
     if (Status::isOnline(getStatus())) {
         emit onlineOfflineChanged(friendPk, true);
     }
+}

--- a/src/model/friend.h
+++ b/src/model/friend.h
@@ -54,7 +54,6 @@ public:
     void finishNegotiation();
     void setStatus(Status::Status s);
     Status::Status getStatus() const;
-    bool useHistory() const final;
 
     void setExtendedMessageSupport(bool supported);
     ExtensionSet getSupportedExtensions() const;

--- a/src/model/group.cpp
+++ b/src/model/group.cpp
@@ -202,7 +202,4 @@ QString Group::getSelfName() const
     return selfName;
 }
 
-bool Group::useHistory() const
-{
-    return false;
 }

--- a/src/model/group.cpp
+++ b/src/model/group.cpp
@@ -201,5 +201,3 @@ QString Group::getSelfName() const
 {
     return selfName;
 }
-
-}

--- a/src/model/group.h
+++ b/src/model/group.h
@@ -61,7 +61,6 @@ public:
     QString getSelfName() const;
 
     bool useHistory() const final;
-
 signals:
     void titleChangedByUser(const QString& title);
     void titleChanged(const QString& author, const QString& title);

--- a/src/model/group.h
+++ b/src/model/group.h
@@ -60,7 +60,6 @@ public:
     void setSelfName(const QString& name);
     QString getSelfName() const;
 
-    bool useHistory() const final;
 signals:
     void titleChangedByUser(const QString& title);
     void titleChanged(const QString& author, const QString& title);

--- a/src/model/ichatlog.h
+++ b/src/model/ichatlog.h
@@ -34,8 +34,6 @@
 
 #include <cassert>
 
-static const auto DEF_NUM_MSG_TO_LOAD = 100;
-
 using ChatLogIdx =
     NamedType<size_t, struct ChatLogIdxTag, Orderable, UnderlyingAddable, UnitlessDifferencable, Incrementable>;
 Q_DECLARE_METATYPE(ChatLogIdx)

--- a/src/model/ichatlog.h
+++ b/src/model/ichatlog.h
@@ -69,7 +69,7 @@ struct SearchPos
 
 struct SearchResult
 {
-    bool found{false};
+    bool found;
     SearchPos pos;
     size_t start;
     size_t len;

--- a/src/model/ichatlog.h
+++ b/src/model/ichatlog.h
@@ -34,6 +34,8 @@
 
 #include <cassert>
 
+static const auto DEF_NUM_MSG_TO_LOAD = 100;
+
 using ChatLogIdx =
     NamedType<size_t, struct ChatLogIdxTag, Orderable, UnderlyingAddable, UnitlessDifferencable, Incrementable>;
 Q_DECLARE_METATYPE(ChatLogIdx)

--- a/src/persistence/history.cpp
+++ b/src/persistence/history.cpp
@@ -1146,7 +1146,12 @@ QDateTime History::getDateWhereFindPhrase(const ToxPk& friendPk, const QDateTime
     }
 
     if (parameter.period == PeriodSearch::AfterDate || parameter.period == PeriodSearch::BeforeDate) {
+
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
+        date = parameter.date.startOfDay();
+#else
         date = QDateTime(parameter.date);
+#endif
     }
 
     QString period;

--- a/src/persistence/history.cpp
+++ b/src/persistence/history.cpp
@@ -1139,14 +1139,14 @@ QDateTime History::getDateWhereFindPhrase(const ToxPk& friendPk, const QDateTime
         break;
     }
 
-    QDateTime time = from;
+    QDateTime date = from;
 
-    if (!time.isValid()) {
-        time = QDateTime::currentDateTime();
+    if (!date.isValid()) {
+        date = QDateTime::currentDateTime();
     }
 
     if (parameter.period == PeriodSearch::AfterDate || parameter.period == PeriodSearch::BeforeDate) {
-        time = parameter.time;
+        date = QDateTime(parameter.date);
     }
 
     QString period;
@@ -1156,15 +1156,15 @@ QDateTime History::getDateWhereFindPhrase(const ToxPk& friendPk, const QDateTime
         break;
     case PeriodSearch::AfterDate:
         period = QStringLiteral("AND timestamp > '%1' ORDER BY timestamp ASC LIMIT 1;")
-                     .arg(time.toMSecsSinceEpoch());
+                     .arg(date.toMSecsSinceEpoch());
         break;
     case PeriodSearch::BeforeDate:
         period = QStringLiteral("AND timestamp < '%1' ORDER BY timestamp DESC LIMIT 1;")
-                     .arg(time.toMSecsSinceEpoch());
+                     .arg(date.toMSecsSinceEpoch());
         break;
     default:
         period = QStringLiteral("AND timestamp < '%1' ORDER BY timestamp DESC LIMIT 1;")
-                     .arg(time.toMSecsSinceEpoch());
+                     .arg(date.toMSecsSinceEpoch());
         break;
     }
 

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -19,7 +19,7 @@
 
 #include "chatform.h"
 #include "src/chatlog/chatlinecontentproxy.h"
-#include "src/chatlog/chatlog.h"
+#include "src/chatlog/chatwidget.h"
 #include "src/chatlog/chatmessage.h"
 #include "src/chatlog/content/filetransferwidget.h"
 #include "src/chatlog/content/text.h"

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -633,14 +633,6 @@ void ChatForm::sendImageFromPreview()
     }
 }
 
-void ChatForm::insertChatMessage(ChatMessage::Ptr msg)
-{
-    GenericChatForm::insertChatMessage(msg);
-    if (netcam && bodySplitter->sizes()[1] == 0) {
-        netcam->setShowMessages(true, true);
-    }
-}
-
 void ChatForm::onCopyStatusMessage()
 {
     // make sure to copy not truncated text directly from the friend

--- a/src/widget/form/chatform.h
+++ b/src/widget/form/chatform.h
@@ -118,7 +118,6 @@ private:
 
 protected:
     std::unique_ptr<NetCamView> createNetcam();
-    void insertChatMessage(ChatMessage::Ptr msg) final;
     void dragEnterEvent(QDragEnterEvent* ev) final;
     void dropEvent(QDropEvent* ev) final;
     void hideEvent(QHideEvent* event) final;

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -20,7 +20,7 @@
 #include "genericchatform.h"
 
 #include "src/chatlog/chatlinecontentproxy.h"
-#include "src/chatlog/chatlog.h"
+#include "src/chatlog/chatwidget.h"
 #include "src/chatlog/content/filetransferwidget.h"
 #include "src/chatlog/content/timestamp.h"
 #include "src/core/core.h"
@@ -147,14 +147,14 @@ GenericChatForm::GenericChatForm(const Core& _core, const Contact* contact, ICha
     headWidget = new ChatFormHeader();
     searchForm = new SearchForm();
     dateInfo = new QLabel(this);
-    chatWidget = new ChatLog(chatLog, core, this);
+    chatWidget = new ChatWidget(chatLog, core, this);
     searchForm->hide();
     dateInfo->setAlignment(Qt::AlignHCenter);
     dateInfo->setVisible(false);
 
     // settings
     const Settings& s = Settings::getInstance();
-    connect(&s, &Settings::emojiFontPointSizeChanged, chatWidget, &ChatLog::forceRelayout);
+    connect(&s, &Settings::emojiFontPointSizeChanged, chatWidget, &ChatWidget::forceRelayout);
     connect(&s, &Settings::chatMessageFontChanged, this, &GenericChatForm::onChatMessageFontChanged);
 
     msgEdit = new ChatTextEdit();
@@ -243,15 +243,15 @@ GenericChatForm::GenericChatForm(const Core& _core, const Contact* contact, ICha
     exportChatAction =
         menu.addAction(QIcon::fromTheme("document-save"), QString(), this, SLOT(onExportChat()));
 
-    connect(chatWidget, &ChatLog::customContextMenuRequested, this,
+    connect(chatWidget, &ChatWidget::customContextMenuRequested, this,
             &GenericChatForm::onChatContextMenuRequested);
-    connect(chatWidget, &ChatLog::firstVisibleLineChanged, this, &GenericChatForm::updateShowDateInfo);
+    connect(chatWidget, &ChatWidget::firstVisibleLineChanged, this, &GenericChatForm::updateShowDateInfo);
 
-    connect(searchForm, &SearchForm::searchInBegin, chatWidget, &ChatLog::startSearch);
-    connect(searchForm, &SearchForm::searchUp, chatWidget, &ChatLog::onSearchUp);
-    connect(searchForm, &SearchForm::searchDown, chatWidget, &ChatLog::onSearchDown);
-    connect(searchForm, &SearchForm::visibleChanged, chatWidget, &ChatLog::removeSearchPhrase);
-    connect(chatWidget, &ChatLog::messageNotFoundShow, searchForm, &SearchForm::showMessageNotFound);
+    connect(searchForm, &SearchForm::searchInBegin, chatWidget, &ChatWidget::startSearch);
+    connect(searchForm, &SearchForm::searchUp, chatWidget, &ChatWidget::onSearchUp);
+    connect(searchForm, &SearchForm::searchDown, chatWidget, &ChatWidget::onSearchDown);
+    connect(searchForm, &SearchForm::visibleChanged, chatWidget, &ChatWidget::removeSearchPhrase);
+    connect(chatWidget, &ChatWidget::messageNotFoundShow, searchForm, &SearchForm::showMessageNotFound);
 
     connect(msgEdit, &ChatTextEdit::enterPressed, this, &GenericChatForm::onSendTriggered);
 

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -44,6 +44,7 @@
 #include "src/widget/tool/flyoutoverlaywidget.h"
 #include "src/widget/translator.h"
 #include "src/widget/widget.h"
+#include "src/widget/gui.h"
 
 #include <QClipboard>
 #include <QFileDialog>

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -822,22 +822,12 @@ void GenericChatForm::onLoadHistory()
 {
     LoadHistoryDialog dlg(&chatLog);
     if (dlg.exec()) {
+        QDateTime time = dlg.getFromDate();
+        auto idx = firstItemAfterDate(dlg.getFromDate().date(), chatLog);
+        auto end = ChatLogIdx(idx.get() + 100);
         chatWidget->clear();
         messages.clear();
-
-        QDateTime time = dlg.getFromDate();
-        auto type = dlg.getLoadType();
-
-        auto begin = firstItemAfterDate(dlg.getFromDate().date(), chatLog);
-        auto end = ChatLogIdx(begin.get() + 1);
-
-        renderMessages(begin, end);
-
-        if (type == LoadHistoryDialog::from) {
-            loadHistoryUpper();
-        } else {
-            loadHistoryLower();
-        }
+        renderMessages(idx, end);
     }
 }
 
@@ -1044,13 +1034,15 @@ void GenericChatForm::renderMessages(ChatLogIdx begin, ChatLogIdx end,
 
 void GenericChatForm::loadHistoryLower()
 {
-    auto end = messages.begin()->first;
-    auto begin = ChatLogIdx(0);
-    if (end.get() > 100) {
-        begin = ChatLogIdx(end.get() - 100);
+    auto begin = messages.begin()->first;
+
+    if (begin.get() > 100) {
+        begin = ChatLogIdx(begin.get() - 100);
+    } else {
+        begin = ChatLogIdx(0);
     }
 
-    renderMessages(begin, end);
+    renderMessages(begin, chatLog.getNextIdx());
 }
 
 void GenericChatForm::loadHistoryUpper()

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -685,11 +685,6 @@ QDateTime GenericChatForm::getTime(const ChatLine::Ptr &chatLine) const
     return QDateTime();
 }
 
-/**
- * @brief GenericChatForm::loadHistory load history
- * @param time start date
- * @param type indicates the direction of loading history
- */
 void GenericChatForm::loadHistory(const QDateTime &time, const LoadHistoryDialog::LoadType type)
 {
     chatWidget->clear();
@@ -705,10 +700,6 @@ void GenericChatForm::loadHistory(const QDateTime &time, const LoadHistoryDialog
     }
 }
 
-/**
- * @brief GenericChatForm::loadHistoryTo load history before to date "time" or before the first "messages" item
- * @param time start date
- */
 void GenericChatForm::loadHistoryTo(const QDateTime &time)
 {
     chatWidget->setScroll(false);
@@ -735,11 +726,6 @@ void GenericChatForm::loadHistoryTo(const QDateTime &time)
     }
 }
 
-/**
- * @brief GenericChatForm::loadHistoryFrom load history starting from date "time" or from the last "messages" item
- * @param time start date
- * @return true if function loaded history else false
- */
 bool GenericChatForm::loadHistoryFrom(const QDateTime &time)
 {
     chatWidget->setScroll(false);
@@ -750,16 +736,18 @@ bool GenericChatForm::loadHistoryFrom(const QDateTime &time)
         begin = firstItemAfterDate(time.date(), chatLog);
     }
 
-    const auto end = chatLog.getNextIdx() < begin + DEF_NUM_MSG_TO_LOAD
-        ? chatLog.getNextIdx()
-        : begin + DEF_NUM_MSG_TO_LOAD;
+    int add = DEF_NUM_MSG_TO_LOAD;
+    if (begin.get() + DEF_NUM_MSG_TO_LOAD > chatLog.getNextIdx().get()) {
+        auto t = chatLog.getNextIdx();
+        add = chatLog.getNextIdx().get() - begin.get();
+    }
 
-    // The chatLog.getNextIdx() is usually 1 more than the idx on last "messages" item
-    // so if we have nothing to load, "add" is equal 1
-    if (end - begin <= 1) {
+    if (add  <= 1) {
         chatWidget->setScroll(true);
         return false;
     }
+
+    auto end = ChatLogIdx(begin.get() + add);
 
     renderMessages(begin, end);
 
@@ -1219,17 +1207,11 @@ void GenericChatForm::goToCurrentDate()
     renderMessages(begin, end);
 }
 
-/**
- * @brief GenericChatForm::loadHistoryLower load history after scrolling chatlog before first "messages" item
- */
 void GenericChatForm::loadHistoryLower()
 {
     loadHistoryTo(QDateTime());
 }
 
-/**
- * @brief GenericChatForm::loadHistoryUpper load history after scrolling chatlog after last "messages" item
- */
 void GenericChatForm::loadHistoryUpper()
 {
     if (messages.empty()) {

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -132,108 +132,6 @@ QPushButton* createButton(const QString& name, T* self, Fun onClickSlot)
     return btn;
 }
 
-ChatMessage::Ptr getChatMessageForIdx(ChatLogIdx idx,
-                                      const std::map<ChatLogIdx, ChatMessage::Ptr>& messages)
-{
-    auto existingMessageIt = messages.find(idx);
-
-    if (existingMessageIt == messages.end()) {
-        return ChatMessage::Ptr();
-    }
-
-    return existingMessageIt->second;
-}
-
-bool shouldRenderDate(ChatLogIdx idxToRender, const IChatLog& chatLog)
-{
-    if (idxToRender == chatLog.getFirstIdx())
-        return true;
-
-    return chatLog.at(idxToRender - 1).getTimestamp().date()
-           != chatLog.at(idxToRender).getTimestamp().date();
-}
-
-ChatMessage::Ptr dateMessageForItem(const ChatLogItem& item)
-{
-    const auto& s = Settings::getInstance();
-    const auto date = item.getTimestamp().date();
-    auto dateText = date.toString(s.getDateFormat());
-    return ChatMessage::createChatInfoMessage(dateText, ChatMessage::INFO, QDateTime());
-}
-
-ChatMessage::Ptr createMessage(const QString& displayName, bool isSelf, bool colorizeNames,
-                               const ChatLogMessage& chatLogMessage)
-{
-    auto messageType = chatLogMessage.message.isAction ? ChatMessage::MessageType::ACTION
-                                                       : ChatMessage::MessageType::NORMAL;
-
-    const bool bSelfMentioned =
-        std::any_of(chatLogMessage.message.metadata.begin(), chatLogMessage.message.metadata.end(),
-                    [](const MessageMetadata& metadata) {
-                        return metadata.type == MessageMetadataType::selfMention;
-                    });
-
-    if (bSelfMentioned) {
-        messageType = ChatMessage::MessageType::ALERT;
-    }
-
-    const auto timestamp = chatLogMessage.message.timestamp;
-    return ChatMessage::createChatMessage(displayName, chatLogMessage.message.content, messageType,
-                                          isSelf, chatLogMessage.state, timestamp, colorizeNames);
-}
-
-void renderMessageRaw(const QString& displayName, bool isSelf, bool colorizeNames,
-                   const ChatLogMessage& chatLogMessage, ChatMessage::Ptr& chatMessage)
-{
-
-    if (chatMessage) {
-        if (chatLogMessage.state == MessageState::complete) {
-            chatMessage->markAsDelivered(chatLogMessage.message.timestamp);
-        } else if (chatLogMessage.state == MessageState::broken) {
-            chatMessage->markAsBroken();
-        }
-    } else {
-        chatMessage = createMessage(displayName, isSelf, colorizeNames, chatLogMessage);
-    }
-}
-
-
-
-ChatLogIdx firstItemAfterDate(QDate date, const IChatLog& chatLog)
-{
-    auto idxs = chatLog.getDateIdxs(date, 1);
-    if (idxs.size()) {
-        return idxs[0].idx;
-    } else {
-        return chatLog.getNextIdx();
-    }
-}
-
-/**
- * @return Chat message message type (info/warning) for the given system message
- * @param[in] systemMessage
- */
-ChatMessage::SystemMessageType getChatMessageType(const SystemMessage& systemMessage)
-{
-    switch (systemMessage.messageType) {
-    case SystemMessageType::fileSendFailed:
-    case SystemMessageType::messageSendFailed:
-    case SystemMessageType::unexpectedCallEnd:
-        return ChatMessage::ERROR;
-    case SystemMessageType::userJoinedGroup:
-    case SystemMessageType::userLeftGroup:
-    case SystemMessageType::peerNameChanged:
-    case SystemMessageType::peerStateChange:
-    case SystemMessageType::titleChanged:
-    case SystemMessageType::cleared:
-    case SystemMessageType::outgoingCall:
-    case SystemMessageType::incomingCall:
-    case SystemMessageType::callEnd:
-        return ChatMessage::INFO;
-    }
-
-    return ChatMessage::INFO;
-}
 } // namespace
 
 GenericChatForm::GenericChatForm(const Core& _core, const Contact* contact, IChatLog& chatLog,
@@ -249,8 +147,7 @@ GenericChatForm::GenericChatForm(const Core& _core, const Contact* contact, ICha
     headWidget = new ChatFormHeader();
     searchForm = new SearchForm();
     dateInfo = new QLabel(this);
-    chatWidget = new ChatLog(this);
-    chatWidget->setBusyNotification(ChatMessage::createBusyNotification());
+    chatWidget = new ChatLog(chatLog, core, this);
     searchForm->hide();
     dateInfo->setAlignment(Qt::AlignHCenter);
     dateInfo->setVisible(false);
@@ -344,13 +241,11 @@ GenericChatForm::GenericChatForm(const Core& _core, const Contact* contact, ICha
             &GenericChatForm::onChatContextMenuRequested);
     connect(chatWidget, &ChatLog::firstVisibleLineChanged, this, &GenericChatForm::updateShowDateInfo);
 
-    connect(searchForm, &SearchForm::searchInBegin, this, &GenericChatForm::searchInBegin);
-    connect(searchForm, &SearchForm::searchUp, this, &GenericChatForm::onSearchUp);
-    connect(searchForm, &SearchForm::searchDown, this, &GenericChatForm::onSearchDown);
-    connect(searchForm, &SearchForm::visibleChanged, this, &GenericChatForm::onSearchTriggered);
-    connect(this, &GenericChatForm::messageNotFoundShow, searchForm, &SearchForm::showMessageNotFound);
-
-    connect(&chatLog, &IChatLog::itemUpdated, this, &GenericChatForm::renderMessage);
+    connect(searchForm, &SearchForm::searchInBegin, chatWidget, &ChatLog::startSearch);
+    connect(searchForm, &SearchForm::searchUp, chatWidget, &ChatLog::onSearchUp);
+    connect(searchForm, &SearchForm::searchDown, chatWidget, &ChatLog::onSearchDown);
+    connect(searchForm, &SearchForm::visibleChanged, chatWidget, &ChatLog::removeSearchPhrase);
+    connect(chatWidget, &ChatLog::messageNotFoundShow, searchForm, &SearchForm::showMessageNotFound);
 
     connect(msgEdit, &ChatTextEdit::enterPressed, this, &GenericChatForm::onSendTriggered);
 
@@ -369,31 +264,12 @@ GenericChatForm::GenericChatForm(const Core& _core, const Contact* contact, ICha
     // update header on name/title change
     connect(contact, &Contact::displayedNameChanged, this, &GenericChatForm::setName);
 
-    auto chatLogIdxRange = chatLog.getNextIdx() - chatLog.getFirstIdx();
-    auto firstChatLogIdx = (chatLogIdxRange < 100) ? chatLog.getFirstIdx() : chatLog.getNextIdx() - 100;
-
-    renderMessages(firstChatLogIdx, chatLog.getNextIdx());
 }
 
 GenericChatForm::~GenericChatForm()
 {
     Translator::unregister(this);
     delete searchForm;
-}
-
-void GenericChatForm::renderFile(QString displayName, ToxFile file, bool isSelf, QDateTime timestamp,
-                ChatMessage::Ptr& chatMessage)
-{
-    if (!chatMessage) {
-        CoreFile* coreFile = core.getCoreFile();
-        assert(coreFile);
-        chatMessage = ChatMessage::createFileTransferMessage(displayName, *coreFile, file, isSelf, timestamp);
-    } else {
-        auto proxy = static_cast<ChatLineContentProxy*>(chatMessage->getContent(1));
-        assert(proxy->getWidgetType() == ChatLineContentProxy::FileTransferWidgetType);
-        auto ftWidget = static_cast<FileTransferWidget*>(proxy->getWidget());
-        ftWidget->onFileTransferUpdate(file);
-    }
 }
 
 void GenericChatForm::adjustFileMenuPosition()
@@ -561,33 +437,6 @@ void GenericChatForm::onSendTriggered()
     messageDispatcher.sendMessage(isAction, msg);
 }
 
-/**
- * @brief Show, is it needed to hide message author name or not
- * @param idx ChatLogIdx of the message
- * @return True if the name should be hidden, false otherwise
- */
-bool GenericChatForm::needsToHideName(ChatLogIdx idx) const
-{
-    // If the previous message is not rendered we should show the name
-    // regardless of other constraints
-    auto itemBefore = messages.find(idx - 1);
-    if (itemBefore == messages.end()) {
-        return false;
-    }
-
-    const auto& prevItem = chatLog.at(idx - 1);
-    const auto& currentItem = chatLog.at(idx);
-
-    // Always show the * in the name field for action messages
-    if (currentItem.getContentType() == ChatLogItem::ContentType::message
-        && currentItem.getContentAsMessage().message.isAction) {
-        return false;
-    }
-
-    qint64 messagesTimeDiff = prevItem.getTimestamp().secsTo(currentItem.getTimestamp());
-    return currentItem.getSender() == prevItem.getSender()
-           && messagesTimeDiff < chatWidget->repNameAfter;
-}
 
 void GenericChatForm::onEmoteButtonClicked()
 {
@@ -639,7 +488,7 @@ void GenericChatForm::onChatMessageFontChanged(const QFont& font)
 
 void GenericChatForm::setColorizedNames(bool enable)
 {
-    colorizeNames = enable;
+    chatWidget->setColorizedNames(enable);
 }
 
 void GenericChatForm::addSystemInfoMessage(const QDateTime& datetime, SystemMessageType messageType,
@@ -676,15 +525,6 @@ QDateTime GenericChatForm::getTime(const ChatLine::Ptr &chatLine) const
 }
 
 
-void GenericChatForm::disableSearchText()
-{
-    auto msgIt = messages.find(searchPos.logIdx);
-    if (msgIt != messages.end()) {
-        auto text = qobject_cast<Text*>(msgIt->second->getContent(1));
-        text->deselectText();
-    }
-}
-
 void GenericChatForm::clearChatArea()
 {
     clearChatArea(/* confirm = */ true, /* inform = */ true);
@@ -706,8 +546,6 @@ void GenericChatForm::clearChatArea(bool confirm, bool inform)
 
     if (inform)
         addSystemInfoMessage(QDateTime::currentDateTime(), SystemMessageType::cleared, {});
-
-    messages.clear();
 }
 
 void GenericChatForm::onSelectAllClicked()
@@ -821,9 +659,7 @@ void GenericChatForm::onLoadHistory()
 {
     LoadHistoryDialog dlg(&chatLog);
     if (dlg.exec()) {
-        QDateTime time = dlg.getFromDate();
-        auto idx = firstItemAfterDate(dlg.getFromDate().date(), chatLog);
-        renderMessages(idx, chatLog.getNextIdx());
+        chatWidget->jumpToDate(dlg.getFromDate().date());
     }
 }
 
@@ -856,176 +692,6 @@ void GenericChatForm::onExportChat()
     }
     file.write(buffer.toUtf8());
     file.close();
-}
-
-void GenericChatForm::onSearchTriggered()
-{
-    if (searchForm->isHidden()) {
-        searchForm->removeSearchPhrase();
-    }
-    disableSearchText();
-}
-
-void GenericChatForm::searchInBegin(const QString& phrase, const ParameterSearch& parameter)
-{
-    disableSearchText();
-
-    bool bForwardSearch = false;
-    switch (parameter.period) {
-    case PeriodSearch::WithTheFirst: {
-        bForwardSearch = true;
-        searchPos.logIdx = chatLog.getFirstIdx();
-        searchPos.numMatches = 0;
-        break;
-    }
-    case PeriodSearch::WithTheEnd:
-    case PeriodSearch::None: {
-        bForwardSearch = false;
-        searchPos.logIdx = chatLog.getNextIdx();
-        searchPos.numMatches = 0;
-        break;
-    }
-    case PeriodSearch::AfterDate: {
-        bForwardSearch = true;
-        searchPos.logIdx = firstItemAfterDate(parameter.date, chatLog);
-        searchPos.numMatches = 0;
-        break;
-    }
-    case PeriodSearch::BeforeDate: {
-        bForwardSearch = false;
-        searchPos.logIdx = firstItemAfterDate(parameter.date, chatLog);
-        searchPos.numMatches = 0;
-        break;
-    }
-    }
-
-    if (bForwardSearch) {
-        onSearchDown(phrase, parameter);
-    } else {
-        onSearchUp(phrase, parameter);
-    }
-}
-
-void GenericChatForm::onSearchUp(const QString& phrase, const ParameterSearch& parameter)
-{
-    auto result = chatLog.searchBackward(searchPos, phrase, parameter);
-    handleSearchResult(result, SearchDirection::Up);
-}
-
-void GenericChatForm::onSearchDown(const QString& phrase, const ParameterSearch& parameter)
-{
-    auto result = chatLog.searchForward(searchPos, phrase, parameter);
-    handleSearchResult(result, SearchDirection::Down);
-}
-
-void GenericChatForm::handleSearchResult(SearchResult result, SearchDirection direction)
-{
-    if (!result.found) {
-        emit messageNotFoundShow(direction);
-        return;
-    }
-
-    disableSearchText();
-
-    searchPos = result.pos;
-
-    auto const firstRenderedIdx = (messages.empty()) ? chatLog.getNextIdx() : messages.begin()->first;
-
-    renderMessages(searchPos.logIdx, firstRenderedIdx, [this, result] {
-        auto msg = messages.at(searchPos.logIdx);
-        chatWidget->scrollToLine(msg);
-
-        auto text = qobject_cast<Text*>(msg->getContent(1));
-        text->selectText(result.exp, std::make_pair(result.start, result.len));
-    });
-}
-
-void GenericChatForm::renderItem(const ChatLogItem& item, bool hideName, bool colorizeNames, ChatMessage::Ptr& chatMessage)
-{
-    const auto& sender = item.getSender();
-
-    bool isSelf = sender == core.getSelfId().getPublicKey();
-
-    switch (item.getContentType()) {
-    case ChatLogItem::ContentType::message: {
-        const auto& chatLogMessage = item.getContentAsMessage();
-
-        renderMessageRaw(item.getDisplayName(), isSelf, colorizeNames, chatLogMessage, chatMessage);
-
-        break;
-    }
-    case ChatLogItem::ContentType::fileTransfer: {
-        const auto& file = item.getContentAsFile();
-        renderFile(item.getDisplayName(), file.file, isSelf, item.getTimestamp(), chatMessage);
-        break;
-    }
-    case ChatLogItem::ContentType::systemMessage: {
-        const auto& systemMessage = item.getContentAsSystemMessage();
-
-        auto chatMessageType = getChatMessageType(systemMessage);
-        chatMessage = ChatMessage::createChatInfoMessage(systemMessage.toString(), chatMessageType,
-                                                         QDateTime::currentDateTime());
-        // Ignore caller's decision to hide the name. We show the icon in the
-        // slot of the sender's name so we always want it visible
-        hideName = false;
-        break;
-    }
-    }
-
-    if (hideName) {
-        chatMessage->hideSender();
-    }
-}
-
-void GenericChatForm::renderMessage(ChatLogIdx idx)
-{
-    renderMessages(idx, idx + 1);
-}
-
-void GenericChatForm::renderMessages(ChatLogIdx begin, ChatLogIdx end,
-                                     std::function<void(void)> onCompletion)
-{
-    QList<ChatLine::Ptr> beforeLines;
-    QList<ChatLine::Ptr> afterLines;
-
-    for (auto i = begin; i < end; ++i) {
-        auto chatMessage = getChatMessageForIdx(i, messages);
-        renderItem(chatLog.at(i), needsToHideName(i), colorizeNames, chatMessage);
-
-        if (messages.find(i) == messages.end()) {
-            QList<ChatLine::Ptr>* lines =
-                (messages.empty() || i > messages.rbegin()->first) ? &afterLines : &beforeLines;
-
-            messages.insert({i, chatMessage});
-
-            if (shouldRenderDate(i, chatLog)) {
-                lines->push_back(dateMessageForItem(chatLog.at(i)));
-            }
-            lines->push_back(chatMessage);
-        }
-    }
-
-    for (auto const& line : afterLines) {
-        chatWidget->insertChatlineAtBottom(line);
-    }
-
-    if (!beforeLines.empty()) {
-        // Rendering upwards is expensive and has async behavior for chatWidget.
-        // Once rendering completes we call our completion callback once and
-        // then disconnect the signal
-        if (onCompletion) {
-            auto connection = std::make_shared<QMetaObject::Connection>();
-            *connection = connect(chatWidget, &ChatLog::workerTimeoutFinished,
-                                  [this, onCompletion, connection] {
-                                      onCompletion();
-                                      this->disconnect(*connection);
-                                  });
-        }
-
-        chatWidget->insertChatlinesOnTop(beforeLines);
-    } else if (onCompletion) {
-        onCompletion();
-    }
 }
 
 void GenericChatForm::updateShowDateInfo(const ChatLine::Ptr& prevLine, const ChatLine::Ptr& topLine)

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -316,13 +316,6 @@ GenericChatForm::GenericChatForm(const Core& _core, const Contact* contact, ICha
     quoteAction = menu.addAction(QIcon(), QString(), this, SLOT(quoteSelectedText()),
                                  QKeySequence(Qt::ALT + Qt::Key_Q));
     addAction(quoteAction);
-
-    menu.addSeparator();
-
-    goCurrentDateAction = menu.addAction(QIcon(), QString(), this, SLOT(goToCurrentDate()),
-                                  QKeySequence(Qt::CTRL + Qt::Key_G));
-    addAction(goCurrentDateAction);
-
     menu.addSeparator();
 
     searchAction = menu.addAction(QIcon(), QString(), this, SLOT(searchFormShow()),
@@ -1060,17 +1053,6 @@ void GenericChatForm::renderMessages(ChatLogIdx begin, ChatLogIdx end,
     }
 }
 
-void GenericChatForm::goToCurrentDate()
-{
-    chatWidget->clear();
-    messages.clear();
-    auto end = chatLog.getNextIdx();
-    auto numMessages = std::min(DEF_NUM_MSG_TO_LOAD, chatLog.getNextIdx() - chatLog.getFirstIdx());
-    auto begin = end - numMessages;
-
-    renderMessages(begin, end);
-}
-
 void GenericChatForm::loadHistoryLower()
 {
     auto end = messages.begin()->first;
@@ -1122,7 +1104,6 @@ void GenericChatForm::retranslateUi()
     quoteAction->setText(tr("Quote selected text"));
     copyLinkAction->setText(tr("Copy link address"));
     searchAction->setText(tr("Search in text"));
-    goCurrentDateAction->setText(tr("Go to current date"));
     loadHistoryAction->setText(tr("Load chat history..."));
     exportChatAction->setText(tr("Export to file"));
 }

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -716,8 +716,8 @@ void GenericChatForm::loadHistoryTo(const QDateTime &time)
     }
 
     if (begin != end) {
-        if (searchResult.found == true && searchResult.pos.logIdx == end) {
-            renderMessages(begin, end, [this]{enableSearchText();});
+        if (searchResult.found == true) {
+            renderMessages(begin, searchResult.pos.logIdx, [this]{enableSearchText();});
         } else {
             renderMessages(begin, end);
         }
@@ -979,6 +979,12 @@ void GenericChatForm::searchInBegin(const QString& phrase, const ParameterSearch
         goToCurrentDate();
     }
 
+    if (!parameter.time.isNull()) {
+        LoadHistoryDialog::LoadType type = (parameter.period == PeriodSearch::BeforeDate)
+                ? LoadHistoryDialog::to : LoadHistoryDialog::from;
+        loadHistory(parameter.time, type);
+    }
+
     bool bForwardSearch = false;
     switch (parameter.period) {
     case PeriodSearch::WithTheFirst: {
@@ -1024,6 +1030,12 @@ void GenericChatForm::onSearchUp(const QString& phrase, const ParameterSearch& p
 void GenericChatForm::onSearchDown(const QString& phrase, const ParameterSearch& parameter)
 {
     auto result = chatLog.searchForward(searchResult.pos, phrase, parameter);
+
+    if (result.found && result.pos.logIdx.get() > messages.end()->first.get()) {
+        const auto dt = chatLog.at(result.pos.logIdx).getTimestamp();
+        loadHistory(dt, LoadHistoryDialog::from);
+    }
+
     handleSearchResult(result, SearchDirection::Down);
 }
 
@@ -1038,56 +1050,9 @@ void GenericChatForm::handleSearchResult(SearchResult result, SearchDirection di
 
     searchResult = result;
 
-    auto searchIdx = result.pos.logIdx;
+    auto const firstRenderedIdx = (messages.empty()) ? chatLog.getNextIdx() : messages.begin()->first;
 
-    auto firstRenderedIdx = messages.begin()->first;
-    auto endRenderedIdx = messages.rbegin()->first;
-
-    if (direction == SearchDirection::Up) {
-        if (searchIdx < firstRenderedIdx) {
-            if (searchIdx - chatLog.getFirstIdx() > DEF_NUM_MSG_TO_LOAD / 2) {
-                firstRenderedIdx = searchIdx - DEF_NUM_MSG_TO_LOAD / 2;
-            } else {
-                firstRenderedIdx = chatLog.getFirstIdx();
-            }
-        }
-
-        if (endRenderedIdx - firstRenderedIdx > DEF_NUM_MSG_TO_LOAD) {
-            endRenderedIdx = firstRenderedIdx + DEF_NUM_MSG_TO_LOAD;
-        }
-    } else {
-        if (searchIdx < firstRenderedIdx) {
-            firstRenderedIdx = searchIdx;
-        }
-
-        if (firstRenderedIdx == searchIdx || searchIdx > endRenderedIdx) {
-            if (searchIdx + DEF_NUM_MSG_TO_LOAD > chatLog.getNextIdx()) {
-                endRenderedIdx = chatLog.getNextIdx();
-            } else {
-                endRenderedIdx = searchIdx + DEF_NUM_MSG_TO_LOAD;
-            }
-        }
-
-        if (endRenderedIdx - firstRenderedIdx > DEF_NUM_MSG_TO_LOAD) {
-            if (endRenderedIdx - chatLog.getFirstIdx() > DEF_NUM_MSG_TO_LOAD) {
-                firstRenderedIdx = endRenderedIdx - DEF_NUM_MSG_TO_LOAD;
-            } else {
-                firstRenderedIdx = chatLog.getFirstIdx();
-            }
-        }
-    }
-
-    if (!messages.empty() && (firstRenderedIdx < messages.begin()->first
-                              || endRenderedIdx > messages.rbegin()->first)) {
-        chatWidget->clear();
-        messages.clear();
-
-        auto mediator = endRenderedIdx;
-        endRenderedIdx = firstRenderedIdx;
-        firstRenderedIdx = mediator;
-    }
-
-    renderMessages(endRenderedIdx, firstRenderedIdx, [this]{enableSearchText();});
+    renderMessages(searchResult.pos.logIdx, firstRenderedIdx, [this]{enableSearchText();});
 }
 
 void GenericChatForm::renderItem(const ChatLogItem& item, bool hideName, bool colorizeNames, ChatMessage::Ptr& chatMessage)

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -995,10 +995,6 @@ void GenericChatForm::searchInBegin(const QString& phrase, const ParameterSearch
         return;
     }
 
-    if (messages.size() == 0) {
-        return;
-    }
-
     if (chatLog.getNextIdx() == messages.rbegin()->first + 1) {
         disableSearchText();
     } else {

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -343,7 +343,6 @@ GenericChatForm::GenericChatForm(const Core& _core, const Contact* contact, ICha
             &GenericChatForm::onChatContextMenuRequested);
     connect(chatWidget, &ChatLog::firstVisibleLineChanged, this, &GenericChatForm::updateShowDateInfo);
     connect(chatWidget, &ChatLog::loadHistoryLower, this, &GenericChatForm::loadHistoryLower);
-    connect(chatWidget, &ChatLog::loadHistoryUpper, this, &GenericChatForm::loadHistoryUpper);
 
     connect(searchForm, &SearchForm::searchInBegin, this, &GenericChatForm::searchInBegin);
     connect(searchForm, &SearchForm::searchUp, this, &GenericChatForm::onSearchUp);
@@ -824,10 +823,7 @@ void GenericChatForm::onLoadHistory()
     if (dlg.exec()) {
         QDateTime time = dlg.getFromDate();
         auto idx = firstItemAfterDate(dlg.getFromDate().date(), chatLog);
-        auto end = ChatLogIdx(idx.get() + 100);
-        chatWidget->clear();
-        messages.clear();
-        renderMessages(idx, end);
+        renderMessages(idx, chatLog.getNextIdx());
     }
 }
 
@@ -1043,18 +1039,6 @@ void GenericChatForm::loadHistoryLower()
     }
 
     renderMessages(begin, chatLog.getNextIdx());
-}
-
-void GenericChatForm::loadHistoryUpper()
-{
-    auto begin = messages.end()->first;
-
-    int add = 100;
-    if (begin.get() + 100 > chatLog.getNextIdx().get()) {
-        add = chatLog.getNextIdx().get() - (begin.get() + 100);
-    }
-    auto end = ChatLogIdx(begin.get() + add);
-    renderMessages(begin, end);
 }
 
 void GenericChatForm::updateShowDateInfo(const ChatLine::Ptr& prevLine, const ChatLine::Ptr& topLine)

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -716,11 +716,7 @@ void GenericChatForm::loadHistoryTo(const QDateTime &time)
     }
 
     if (begin != end) {
-        if (searchResult.found == true) {
-            renderMessages(begin, searchResult.pos.logIdx, [this]{enableSearchText();});
-        } else {
-            renderMessages(begin, end);
-        }
+        renderMessages(begin, end);
     } else {
         chatWidget->setScroll(true);
     }
@@ -765,21 +761,11 @@ void GenericChatForm::removeLastsMessages(const int num)
 
 void GenericChatForm::disableSearchText()
 {
-    auto msgIt = messages.find(searchResult.pos.logIdx);
+    auto msgIt = messages.find(searchPos.logIdx);
     if (msgIt != messages.end()) {
         auto text = qobject_cast<Text*>(msgIt->second->getContent(1));
         text->deselectText();
     }
-}
-
-void GenericChatForm::enableSearchText()
-{
-    auto msg = messages.at(searchResult.pos.logIdx);
-    chatWidget->scrollToLine(msg);
-
-    auto text = qobject_cast<Text*>(msg->getContent(1));
-    text->visibilityChanged(true);
-    text->selectText(searchResult.exp, std::make_pair(searchResult.start, searchResult.len));
 }
 
 void GenericChatForm::clearChatArea()
@@ -959,7 +945,6 @@ void GenericChatForm::onExportChat()
 void GenericChatForm::onSearchTriggered()
 {
     if (searchForm->isHidden()) {
-        searchResult.found = false;
         searchForm->removeSearchPhrase();
     }
     disableSearchText();
@@ -989,27 +974,27 @@ void GenericChatForm::searchInBegin(const QString& phrase, const ParameterSearch
     switch (parameter.period) {
     case PeriodSearch::WithTheFirst: {
         bForwardSearch = true;
-        searchResult.pos.logIdx = chatLog.getFirstIdx();
-        searchResult.pos.numMatches = 0;
+        searchPos.logIdx = chatLog.getFirstIdx();
+        searchPos.numMatches = 0;
         break;
     }
     case PeriodSearch::WithTheEnd:
     case PeriodSearch::None: {
         bForwardSearch = false;
-        searchResult.pos.logIdx = chatLog.getNextIdx();
-        searchResult.pos.numMatches = 0;
+        searchPos.logIdx = chatLog.getNextIdx();
+        searchPos.numMatches = 0;
         break;
     }
     case PeriodSearch::AfterDate: {
         bForwardSearch = true;
-        searchResult.pos.logIdx = firstItemAfterDate(parameter.time.date(), chatLog);
-        searchResult.pos.numMatches = 0;
+        searchPos.logIdx = firstItemAfterDate(parameter.time.date(), chatLog);
+        searchPos.numMatches = 0;
         break;
     }
     case PeriodSearch::BeforeDate: {
         bForwardSearch = false;
-        searchResult.pos.logIdx = firstItemAfterDate(parameter.time.date(), chatLog);
-        searchResult.pos.numMatches = 0;
+        searchPos.logIdx = firstItemAfterDate(parameter.time.date(), chatLog);
+        searchPos.numMatches = 0;
         break;
     }
     }
@@ -1023,13 +1008,13 @@ void GenericChatForm::searchInBegin(const QString& phrase, const ParameterSearch
 
 void GenericChatForm::onSearchUp(const QString& phrase, const ParameterSearch& parameter)
 {
-    auto result = chatLog.searchBackward(searchResult.pos, phrase, parameter);
+    auto result = chatLog.searchBackward(searchPos, phrase, parameter);
     handleSearchResult(result, SearchDirection::Up);
 }
 
 void GenericChatForm::onSearchDown(const QString& phrase, const ParameterSearch& parameter)
 {
-    auto result = chatLog.searchForward(searchResult.pos, phrase, parameter);
+    auto result = chatLog.searchForward(searchPos, phrase, parameter);
 
     if (result.found && result.pos.logIdx.get() > messages.end()->first.get()) {
         const auto dt = chatLog.at(result.pos.logIdx).getTimestamp();
@@ -1048,11 +1033,18 @@ void GenericChatForm::handleSearchResult(SearchResult result, SearchDirection di
 
     disableSearchText();
 
-    searchResult = result;
+    searchPos = result.pos;
 
     auto const firstRenderedIdx = (messages.empty()) ? chatLog.getNextIdx() : messages.begin()->first;
 
-    renderMessages(searchResult.pos.logIdx, firstRenderedIdx, [this]{enableSearchText();});
+    renderMessages(searchPos.logIdx, firstRenderedIdx, [this, result] {
+        auto msg = messages.at(searchPos.logIdx);
+        chatWidget->scrollToLine(msg);
+
+        auto text = qobject_cast<Text*>(msg->getContent(1));
+        text->visibilityChanged(true);
+        text->selectText(result.exp, std::make_pair(result.start, result.len));
+    });
 }
 
 void GenericChatForm::renderItem(const ChatLogItem& item, bool hideName, bool colorizeNames, ChatMessage::Ptr& chatMessage)

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -378,7 +378,7 @@ GenericChatForm::GenericChatForm(const Core& _core, const Contact* contact, ICha
     connect(contact, &Contact::displayedNameChanged, this, &GenericChatForm::setName);
 
     auto chatLogIdxRange = chatLog.getNextIdx() - chatLog.getFirstIdx();
-    auto firstChatLogIdx = (chatLogIdxRange < DEF_NUM_MSG_TO_LOAD) ? chatLog.getFirstIdx() : chatLog.getNextIdx() - DEF_NUM_MSG_TO_LOAD;
+    auto firstChatLogIdx = (chatLogIdxRange < 100) ? chatLog.getFirstIdx() : chatLog.getNextIdx() - 100;
 
     renderMessages(firstChatLogIdx, chatLog.getNextIdx());
 }
@@ -701,10 +701,10 @@ void GenericChatForm::loadHistoryTo(const QDateTime &time)
 {
     auto end = chatLog.getFirstIdx();
     if (time.isNull()) {
-        if (messages.size() + DEF_NUM_MSG_TO_LOAD >= maxMessages) {
-            end = ChatLogIdx(messages.rbegin()->first.get() - DEF_NUM_MSG_TO_LOAD);
-            chatWidget->removeLasts(DEF_NUM_MSG_TO_LOAD);
-            removeLastsMessages(DEF_NUM_MSG_TO_LOAD);
+        if (messages.size() + 100 >= maxMessages) {
+            end = ChatLogIdx(messages.rbegin()->first.get() - 100);
+            chatWidget->removeLasts(100);
+            removeLastsMessages(100);
         } else {
             end = messages.begin()->first;
         }
@@ -724,10 +724,10 @@ void GenericChatForm::loadHistoryFrom(const QDateTime &time)
 {
     auto begin = chatLog.getFirstIdx();
     if (time.isNull()) {
-        if (messages.size() + DEF_NUM_MSG_TO_LOAD >= maxMessages) {
-            begin = ChatLogIdx(messages.rbegin()->first.get() + DEF_NUM_MSG_TO_LOAD);
-            chatWidget->removeFirsts(DEF_NUM_MSG_TO_LOAD);
-            removeFirstsMessages(DEF_NUM_MSG_TO_LOAD);
+        if (messages.size() + 100 >= maxMessages) {
+            begin = ChatLogIdx(messages.rbegin()->first.get() + 100);
+            chatWidget->removeFirsts(100);
+            removeFirstsMessages(100);
         } else {
             begin = messages.rbegin()->first;
         }
@@ -736,9 +736,9 @@ void GenericChatForm::loadHistoryFrom(const QDateTime &time)
         begin = firstItemAfterDate(time.date(), chatLog);
     }
 
-    int add = DEF_NUM_MSG_TO_LOAD;
-    if (begin.get() + DEF_NUM_MSG_TO_LOAD > chatLog.getNextIdx().get()) {
-        add = chatLog.getNextIdx().get() - (begin.get() + DEF_NUM_MSG_TO_LOAD);
+    int add = 100;
+    if (begin.get() + 100 > chatLog.getNextIdx().get()) {
+        add = chatLog.getNextIdx().get() - (begin.get() + 100);
     }
     auto end = ChatLogIdx(begin.get() + add);
     renderMessages(begin, end);
@@ -756,7 +756,7 @@ void GenericChatForm::removeFirstsMessages(const int num)
 void GenericChatForm::removeLastsMessages(const int num)
 {
     if (static_cast<int>(messages.size()) > num) {
-        messages.erase(std::next(messages.end(), -num), messages.end());
+        messages.erase(std::next(messages.end(), -100), messages.end());
     } else {
         messages.clear();
     }

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -726,7 +726,7 @@ void GenericChatForm::loadHistoryTo(const QDateTime &time)
     }
 }
 
-bool GenericChatForm::loadHistoryFrom(const QDateTime &time)
+void GenericChatForm::loadHistoryFrom(const QDateTime &time)
 {
     chatWidget->setScroll(false);
     auto begin = chatLog.getFirstIdx();
@@ -738,20 +738,10 @@ bool GenericChatForm::loadHistoryFrom(const QDateTime &time)
 
     int add = DEF_NUM_MSG_TO_LOAD;
     if (begin.get() + DEF_NUM_MSG_TO_LOAD > chatLog.getNextIdx().get()) {
-        auto t = chatLog.getNextIdx();
         add = chatLog.getNextIdx().get() - begin.get();
     }
-
-    if (add  <= 1) {
-        chatWidget->setScroll(true);
-        return false;
-    }
-
     auto end = ChatLogIdx(begin.get() + add);
-
     renderMessages(begin, end);
-
-    return true;
 }
 
 void GenericChatForm::removeFirstsMessages(const int num)
@@ -1219,9 +1209,8 @@ void GenericChatForm::loadHistoryUpper()
     }
 
     auto msg = messages.crbegin()->second;
-    if (loadHistoryFrom(QDateTime())) {
-        chatWidget->scrollToLine(msg);
-    }
+    loadHistoryFrom(QDateTime());
+    chatWidget->scrollToLine(msg);
 }
 
 void GenericChatForm::updateShowDateInfo(const ChatLine::Ptr& prevLine, const ChatLine::Ptr& topLine)

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -342,7 +342,6 @@ GenericChatForm::GenericChatForm(const Core& _core, const Contact* contact, ICha
     connect(chatWidget, &ChatLog::customContextMenuRequested, this,
             &GenericChatForm::onChatContextMenuRequested);
     connect(chatWidget, &ChatLog::firstVisibleLineChanged, this, &GenericChatForm::updateShowDateInfo);
-    connect(chatWidget, &ChatLog::loadHistoryLower, this, &GenericChatForm::loadHistoryLower);
 
     connect(searchForm, &SearchForm::searchInBegin, this, &GenericChatForm::searchInBegin);
     connect(searchForm, &SearchForm::searchUp, this, &GenericChatForm::onSearchUp);
@@ -1026,19 +1025,6 @@ void GenericChatForm::renderMessages(ChatLogIdx begin, ChatLogIdx end,
     } else if (onCompletion) {
         onCompletion();
     }
-}
-
-void GenericChatForm::loadHistoryLower()
-{
-    auto begin = messages.begin()->first;
-
-    if (begin.get() > 100) {
-        begin = ChatLogIdx(begin.get() - 100);
-    } else {
-        begin = ChatLogIdx(0);
-    }
-
-    renderMessages(begin, chatLog.getNextIdx());
 }
 
 void GenericChatForm::updateShowDateInfo(const ChatLine::Ptr& prevLine, const ChatLine::Ptr& topLine)

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -688,47 +688,16 @@ void GenericChatForm::loadHistory(const QDateTime &time, const LoadHistoryDialog
     chatWidget->clear();
     messages.clear();
 
+    auto begin = firstItemAfterDate(time.date(), chatLog);
+    auto end = ChatLogIdx(begin.get() + 1);
+
+    renderMessages(begin, end);
+
     if (type == LoadHistoryDialog::from) {
-        loadHistoryFrom(time);
-        auto msg = messages.cbegin()->second;
-        chatWidget->scrollToLine(msg);
+        loadHistoryUpper();
     } else {
-        loadHistoryTo(time);
+        loadHistoryLower();
     }
-}
-
-void GenericChatForm::loadHistoryTo(const QDateTime &time)
-{
-    auto end = chatLog.getFirstIdx();
-    if (time.isNull()) {
-        end = messages.begin()->first;
-    } else {
-        end = firstItemAfterDate(time.date(), chatLog);
-    }
-
-    auto begin = chatLog.getFirstIdx();
-    if (end - begin > DEF_NUM_MSG_TO_LOAD) {
-        begin = end - DEF_NUM_MSG_TO_LOAD;
-    }
-
-    renderMessages(begin, end);
-}
-
-void GenericChatForm::loadHistoryFrom(const QDateTime &time)
-{
-    auto begin = chatLog.getFirstIdx();
-    if (time.isNull()) {
-        begin = messages.rbegin()->first;
-    } else {
-        begin = firstItemAfterDate(time.date(), chatLog);
-    }
-
-    int add = 100;
-    if (begin.get() + 100 > chatLog.getNextIdx().get()) {
-        add = chatLog.getNextIdx().get() - (begin.get() + 100);
-    }
-    auto end = ChatLogIdx(begin.get() + add);
-    renderMessages(begin, end);
 }
 
 
@@ -1104,14 +1073,25 @@ void GenericChatForm::goToCurrentDate()
 
 void GenericChatForm::loadHistoryLower()
 {
-    loadHistoryTo(QDateTime());
+    auto end = messages.begin()->first;
+    auto begin = ChatLogIdx(0);
+    if (end.get() > 100) {
+        begin = ChatLogIdx(end.get() - 100);
+    }
+
+    renderMessages(begin, end);
 }
 
 void GenericChatForm::loadHistoryUpper()
 {
-    auto msg = messages.crbegin()->second;
-    loadHistoryFrom(QDateTime());
-    chatWidget->scrollToLine(msg);
+    auto begin = messages.rbegin()->first;
+
+    int add = 100;
+    if (begin.get() + 100 > chatLog.getNextIdx().get()) {
+        add = chatLog.getNextIdx().get() - (begin.get() + 100);
+    }
+    auto end = ChatLogIdx(begin.get() + add);
+    renderMessages(begin, end);
 }
 
 void GenericChatForm::updateShowDateInfo(const ChatLine::Ptr& prevLine, const ChatLine::Ptr& topLine)

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -216,6 +216,12 @@ GenericChatForm::GenericChatForm(const Core& _core, const Contact* contact, ICha
     addAction(quoteAction);
     menu.addSeparator();
 
+    goToCurrentDateAction = menu.addAction(QIcon(), QString(), this, SLOT(goToCurrentDate()),
+                                  QKeySequence(Qt::CTRL + Qt::Key_G));
+    addAction(goToCurrentDateAction);
+
+    menu.addSeparator();
+
     searchAction = menu.addAction(QIcon(), QString(), this, SLOT(searchFormShow()),
                                   QKeySequence(Qt::CTRL + Qt::Key_F));
     addAction(searchAction);
@@ -501,14 +507,6 @@ void GenericChatForm::addSystemInfoMessage(const QDateTime& datetime, SystemMess
     chatLog.addSystemMessage(systemMessage);
 }
 
-void GenericChatForm::addSystemDateMessage(const QDate& date)
-{
-    const Settings& s = Settings::getInstance();
-    QString dateText = date.toString(s.getDateFormat());
-
-    insertChatMessage(ChatMessage::createChatInfoMessage(dateText, ChatMessage::INFO, QDateTime()));
-}
-
 QDateTime GenericChatForm::getTime(const ChatLine::Ptr &chatLine) const
 {
     if (chatLine) {
@@ -551,12 +549,6 @@ void GenericChatForm::clearChatArea(bool confirm, bool inform)
 void GenericChatForm::onSelectAllClicked()
 {
     chatWidget->selectAll();
-}
-
-void GenericChatForm::insertChatMessage(ChatMessage::Ptr msg)
-{
-    chatWidget->insertChatlineAtBottom(std::static_pointer_cast<ChatLine>(msg));
-    emit messageInserted();
 }
 
 void GenericChatForm::hideEvent(QHideEvent* event)
@@ -694,6 +686,11 @@ void GenericChatForm::onExportChat()
     file.close();
 }
 
+void GenericChatForm::goToCurrentDate()
+{
+    chatWidget->jumpToIdx(chatLog.getNextIdx());
+}
+
 void GenericChatForm::updateShowDateInfo(const ChatLine::Ptr& prevLine, const ChatLine::Ptr& topLine)
 {
     // If the dateInfo is visible we need to pretend the top line is the one
@@ -722,6 +719,7 @@ void GenericChatForm::retranslateUi()
     quoteAction->setText(tr("Quote selected text"));
     copyLinkAction->setText(tr("Copy link address"));
     searchAction->setText(tr("Search in text"));
+    goToCurrentDateAction->setText(tr("Go to current date"));
     loadHistoryAction->setText(tr("Load chat history..."));
     exportChatAction->setText(tr("Export to file"));
 }

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -952,17 +952,7 @@ void GenericChatForm::onSearchTriggered()
 
 void GenericChatForm::searchInBegin(const QString& phrase, const ParameterSearch& parameter)
 {
-    if (phrase.isEmpty()) {
-        disableSearchText();
-
-        return;
-    }
-
-    if (chatLog.getNextIdx() == messages.rbegin()->first + 1) {
-        disableSearchText();
-    } else {
-        goToCurrentDate();
-    }
+    disableSearchText();
 
     if (!parameter.time.isNull()) {
         LoadHistoryDialog::LoadType type = (parameter.period == PeriodSearch::BeforeDate)
@@ -1014,7 +1004,7 @@ void GenericChatForm::onSearchUp(const QString& phrase, const ParameterSearch& p
 
 void GenericChatForm::onSearchDown(const QString& phrase, const ParameterSearch& parameter)
 {
-    auto result = chatLog.searchForward(searchPos, phrase, parameter);
+    auto result = chatLog.searchForward(searchPos, phrase, parameter);    
 
     if (result.found && result.pos.logIdx.get() > messages.end()->first.get()) {
         const auto dt = chatLog.at(result.pos.logIdx).getTimestamp();

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -1004,13 +1004,7 @@ void GenericChatForm::onSearchUp(const QString& phrase, const ParameterSearch& p
 
 void GenericChatForm::onSearchDown(const QString& phrase, const ParameterSearch& parameter)
 {
-    auto result = chatLog.searchForward(searchPos, phrase, parameter);    
-
-    if (result.found && result.pos.logIdx.get() > messages.end()->first.get()) {
-        const auto dt = chatLog.at(result.pos.logIdx).getTimestamp();
-        loadHistory(dt, LoadHistoryDialog::from);
-    }
-
+    auto result = chatLog.searchForward(searchPos, phrase, parameter);
     handleSearchResult(result, SearchDirection::Down);
 }
 
@@ -1032,7 +1026,6 @@ void GenericChatForm::handleSearchResult(SearchResult result, SearchDirection di
         chatWidget->scrollToLine(msg);
 
         auto text = qobject_cast<Text*>(msg->getContent(1));
-        text->visibilityChanged(true);
         text->selectText(result.exp, std::make_pair(result.start, result.len));
     });
 }

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -734,6 +734,7 @@ void GenericChatForm::loadHistoryFrom(const QDateTime &time)
 
     int add = DEF_NUM_MSG_TO_LOAD;
     if (begin.get() + DEF_NUM_MSG_TO_LOAD > chatLog.getNextIdx().get()) {
+        auto aTest = chatLog.getNextIdx().get();
         add = chatLog.getNextIdx().get() - begin.get();
     }
     auto end = ChatLogIdx(begin.get() + add);

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -701,13 +701,7 @@ void GenericChatForm::loadHistoryTo(const QDateTime &time)
 {
     auto end = chatLog.getFirstIdx();
     if (time.isNull()) {
-        if (messages.size() + 100 >= maxMessages) {
-            end = ChatLogIdx(messages.rbegin()->first.get() - 100);
-            chatWidget->removeLasts(100);
-            removeLastsMessages(100);
-        } else {
-            end = messages.begin()->first;
-        }
+        end = messages.begin()->first;
     } else {
         end = firstItemAfterDate(time.date(), chatLog);
     }
@@ -724,14 +718,7 @@ void GenericChatForm::loadHistoryFrom(const QDateTime &time)
 {
     auto begin = chatLog.getFirstIdx();
     if (time.isNull()) {
-        if (messages.size() + 100 >= maxMessages) {
-            begin = ChatLogIdx(messages.rbegin()->first.get() + 100);
-            chatWidget->removeFirsts(100);
-            removeFirstsMessages(100);
-        } else {
-            begin = messages.rbegin()->first;
-        }
-
+        begin = messages.rbegin()->first;
     } else {
         begin = firstItemAfterDate(time.date(), chatLog);
     }
@@ -742,24 +729,6 @@ void GenericChatForm::loadHistoryFrom(const QDateTime &time)
     }
     auto end = ChatLogIdx(begin.get() + add);
     renderMessages(begin, end);
-}
-
-void GenericChatForm::removeFirstsMessages(const int num)
-{
-    if (static_cast<int>(messages.size()) > num) {
-        messages.erase(messages.begin(), std::next(messages.begin(), num));
-    } else {
-        messages.clear();
-    }
-}
-
-void GenericChatForm::removeLastsMessages(const int num)
-{
-    if (static_cast<int>(messages.size()) > num) {
-        messages.erase(std::next(messages.end(), -100), messages.end());
-    } else {
-        messages.clear();
-    }
 }
 
 
@@ -1073,10 +1042,6 @@ void GenericChatForm::renderItem(const ChatLogItem& item, bool hideName, bool co
 
 void GenericChatForm::renderMessage(ChatLogIdx idx)
 {
-    if (chatWidget->getLines().size() >= maxMessages) {
-        chatWidget->removeFirsts(optimalRemove);
-        removeFirstsMessages(optimalRemove);
-    }
     renderMessages(idx, idx + 1);
 }
 

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -53,8 +53,6 @@
 #include <QStringBuilder>
 #include <QtGlobal>
 
-#include <QDebug>
-
 #ifdef SPELL_CHECKING
 #include <KF5/SonnetUi/sonnet/spellcheckdecorator.h>
 #endif
@@ -693,7 +691,6 @@ void GenericChatForm::loadHistory(const QDateTime &time, const LoadHistoryDialog
     if (type == LoadHistoryDialog::from) {
         loadHistoryFrom(time);
         auto msg = messages.cbegin()->second;
-        chatWidget->setScroll(true);
         chatWidget->scrollToLine(msg);
     } else {
         loadHistoryTo(time);
@@ -702,10 +699,15 @@ void GenericChatForm::loadHistory(const QDateTime &time, const LoadHistoryDialog
 
 void GenericChatForm::loadHistoryTo(const QDateTime &time)
 {
-    chatWidget->setScroll(false);
     auto end = chatLog.getFirstIdx();
     if (time.isNull()) {
-        end = messages.begin()->first;
+        if (messages.size() + DEF_NUM_MSG_TO_LOAD >= maxMessages) {
+            end = ChatLogIdx(messages.rbegin()->first.get() - DEF_NUM_MSG_TO_LOAD);
+            chatWidget->removeLasts(DEF_NUM_MSG_TO_LOAD);
+            removeLastsMessages(DEF_NUM_MSG_TO_LOAD);
+        } else {
+            end = messages.begin()->first;
+        }
     } else {
         end = firstItemAfterDate(time.date(), chatLog);
     }
@@ -715,27 +717,28 @@ void GenericChatForm::loadHistoryTo(const QDateTime &time)
         begin = end - DEF_NUM_MSG_TO_LOAD;
     }
 
-    if (begin != end) {
-        renderMessages(begin, end);
-    } else {
-        chatWidget->setScroll(true);
-    }
+    renderMessages(begin, end);
 }
 
 void GenericChatForm::loadHistoryFrom(const QDateTime &time)
 {
-    chatWidget->setScroll(false);
     auto begin = chatLog.getFirstIdx();
     if (time.isNull()) {
-        begin = messages.rbegin()->first;
+        if (messages.size() + DEF_NUM_MSG_TO_LOAD >= maxMessages) {
+            begin = ChatLogIdx(messages.rbegin()->first.get() + DEF_NUM_MSG_TO_LOAD);
+            chatWidget->removeFirsts(DEF_NUM_MSG_TO_LOAD);
+            removeFirstsMessages(DEF_NUM_MSG_TO_LOAD);
+        } else {
+            begin = messages.rbegin()->first;
+        }
+
     } else {
         begin = firstItemAfterDate(time.date(), chatLog);
     }
 
     int add = DEF_NUM_MSG_TO_LOAD;
     if (begin.get() + DEF_NUM_MSG_TO_LOAD > chatLog.getNextIdx().get()) {
-        auto aTest = chatLog.getNextIdx().get();
-        add = chatLog.getNextIdx().get() - begin.get();
+        add = chatLog.getNextIdx().get() - (begin.get() + DEF_NUM_MSG_TO_LOAD);
     }
     auto end = ChatLogIdx(begin.get() + add);
     renderMessages(begin, end);
@@ -1070,6 +1073,10 @@ void GenericChatForm::renderItem(const ChatLogItem& item, bool hideName, bool co
 
 void GenericChatForm::renderMessage(ChatLogIdx idx)
 {
+    if (chatWidget->getLines().size() >= maxMessages) {
+        chatWidget->removeFirsts(optimalRemove);
+        removeFirstsMessages(optimalRemove);
+    }
     renderMessages(idx, idx + 1);
 }
 
@@ -1096,13 +1103,8 @@ void GenericChatForm::renderMessages(ChatLogIdx begin, ChatLogIdx end,
         }
     }
 
-    if (beforeLines.isEmpty() && afterLines.isEmpty()) {
-        chatWidget->setScroll(true);
-    }
-
-    chatWidget->insertChatlineAtBottom(afterLines);
-    if (chatWidget->getNumRemove()) {
-        removeFirstsMessages(chatWidget->getNumRemove());
+    for (auto const& line : afterLines) {
+        chatWidget->insertChatlineAtBottom(line);
     }
 
     if (!beforeLines.empty()) {
@@ -1119,9 +1121,6 @@ void GenericChatForm::renderMessages(ChatLogIdx begin, ChatLogIdx end,
         }
 
         chatWidget->insertChatlinesOnTop(beforeLines);
-        if (chatWidget->getNumRemove()) {
-            removeLastsMessages(chatWidget->getNumRemove());
-        }
     } else if (onCompletion) {
         onCompletion();
     }

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -1144,10 +1144,6 @@ void GenericChatForm::loadHistoryLower()
 
 void GenericChatForm::loadHistoryUpper()
 {
-    if (messages.empty()) {
-        return;
-    }
-
     auto msg = messages.crbegin()->second;
     loadHistoryFrom(QDateTime());
     chatWidget->scrollToLine(msg);

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -130,7 +130,7 @@ private:
     QDateTime getTime(const ChatLine::Ptr& chatLine) const;
     void loadHistory(const QDateTime& time, const LoadHistoryDialog::LoadType type);
     void loadHistoryTo(const QDateTime& time);
-    bool loadHistoryFrom(const QDateTime& time);
+    void loadHistoryFrom(const QDateTime& time);
     void removeFirstsMessages(const int num);
     void removeLastsMessages(const int num);
 

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -129,8 +129,6 @@ private:
     void addSystemDateMessage(const QDate& date);
     QDateTime getTime(const ChatLine::Ptr& chatLine) const;
     void loadHistory(const QDateTime& time, const LoadHistoryDialog::LoadType type);
-    void loadHistoryTo(const QDateTime& time);
-    void loadHistoryFrom(const QDateTime& time);
 
     void renderItem(const ChatLogItem &item, bool hideName, bool colorizeNames, ChatMessage::Ptr &chatMessage);
     void renderFile(QString displayName, ToxFile file, bool isSelf, QDateTime timestamp, ChatMessage::Ptr &chatMessage);

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -120,7 +120,6 @@ protected slots:
                         std::function<void(void)> onCompletion = std::function<void(void)>());
 
     void loadHistoryLower();
-    void loadHistoryUpper();
 
 private:
     void retranslateUi();

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -22,7 +22,6 @@
 #include "src/chatlog/chatmessage.h"
 #include "src/core/toxpk.h"
 #include "src/model/ichatlog.h"
-#include "src/widget/form/loadhistorydialog.h"
 #include "src/widget/searchtypes.h"
 
 #include <QMenu>
@@ -127,7 +126,6 @@ private:
     void retranslateUi();
     void addSystemDateMessage(const QDate& date);
     QDateTime getTime(const ChatLine::Ptr& chatLine) const;
-    void loadHistory(const QDateTime& time, const LoadHistoryDialog::LoadType type);
 
     void renderItem(const ChatLogItem &item, bool hideName, bool colorizeNames, ChatMessage::Ptr &chatMessage);
     void renderFile(QString displayName, ToxFile file, bool isSelf, QDateTime timestamp, ChatMessage::Ptr &chatMessage);

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -119,7 +119,6 @@ protected slots:
     void renderMessage(ChatLogIdx idx);
     void renderMessages(ChatLogIdx begin, ChatLogIdx end,
                         std::function<void(void)> onCompletion = std::function<void(void)>());
-    void goToCurrentDate();
 
     void loadHistoryLower();
     void loadHistoryUpper();
@@ -159,7 +158,6 @@ protected:
     QAction* searchAction;
     QAction* loadHistoryAction;
     QAction* exportChatAction;
-    QAction* goCurrentDateAction;
 
     QMenu menu;
 

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -108,6 +108,7 @@ protected slots:
     void onExportChat();
     void searchFormShow();
     void updateShowDateInfo(const ChatLine::Ptr& prevLine, const ChatLine::Ptr& topLine);
+    void goToCurrentDate();
 
 private:
     void retranslateUi();
@@ -117,7 +118,6 @@ private:
 protected:
     ChatMessage::Ptr createMessage(const ToxPk& author, const QString& message,
                                    const QDateTime& datetime, bool isAction, bool isSent, bool colorizeName = false);
-    virtual void insertChatMessage(ChatMessage::Ptr msg);
     void adjustFileMenuPosition();
     void hideEvent(QHideEvent* event) override;
     void showEvent(QShowEvent*) override;
@@ -137,6 +137,7 @@ protected:
     QAction* quoteAction;
     QAction* copyLinkAction;
     QAction* searchAction;
+    QAction* goToCurrentDateAction;
     QAction* loadHistoryAction;
     QAction* exportChatAction;
 

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -119,8 +119,6 @@ protected slots:
     void renderMessages(ChatLogIdx begin, ChatLogIdx end,
                         std::function<void(void)> onCompletion = std::function<void(void)>());
 
-    void loadHistoryLower();
-
 private:
     void retranslateUi();
     void addSystemDateMessage(const QDate& date);

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -131,8 +131,6 @@ private:
     void loadHistory(const QDateTime& time, const LoadHistoryDialog::LoadType type);
     void loadHistoryTo(const QDateTime& time);
     void loadHistoryFrom(const QDateTime& time);
-    void removeFirstsMessages(const int num);
-    void removeLastsMessages(const int num);
 
     void renderItem(const ChatLogItem &item, bool hideName, bool colorizeNames, ChatMessage::Ptr &chatMessage);
     void renderFile(QString displayName, ToxFile file, bool isSelf, QDateTime timestamp, ChatMessage::Ptr &chatMessage);
@@ -192,8 +190,4 @@ protected:
     SearchPos searchPos;
     std::map<ChatLogIdx, ChatMessage::Ptr> messages;
     bool colorizeNames = false;
-
-private:
-    const int maxMessages{300};
-    const int optimalRemove{50};
 };

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -82,7 +82,6 @@ public:
 
 signals:
     void messageInserted();
-    void messageNotFoundShow(SearchDirection direction);
 
 public slots:
     void focusInput();
@@ -108,28 +107,16 @@ protected slots:
     void onLoadHistory();
     void onExportChat();
     void searchFormShow();
-    void onSearchTriggered();
     void updateShowDateInfo(const ChatLine::Ptr& prevLine, const ChatLine::Ptr& topLine);
-
-    void searchInBegin(const QString& phrase, const ParameterSearch& parameter);
-    void onSearchUp(const QString& phrase, const ParameterSearch& parameter);
-    void onSearchDown(const QString& phrase, const ParameterSearch& parameter);
-    void handleSearchResult(SearchResult result, SearchDirection direction);
-    void renderMessage(ChatLogIdx idx);
-    void renderMessages(ChatLogIdx begin, ChatLogIdx end,
-                        std::function<void(void)> onCompletion = std::function<void(void)>());
 
 private:
     void retranslateUi();
     void addSystemDateMessage(const QDate& date);
     QDateTime getTime(const ChatLine::Ptr& chatLine) const;
 
-    void renderItem(const ChatLogItem &item, bool hideName, bool colorizeNames, ChatMessage::Ptr &chatMessage);
-    void renderFile(QString displayName, ToxFile file, bool isSelf, QDateTime timestamp, ChatMessage::Ptr &chatMessage);
 protected:
     ChatMessage::Ptr createMessage(const ToxPk& author, const QString& message,
                                    const QDateTime& datetime, bool isAction, bool isSent, bool colorizeName = false);
-    bool needsToHideName(ChatLogIdx idx) const;
     virtual void insertChatMessage(ChatMessage::Ptr msg);
     void adjustFileMenuPosition();
     void hideEvent(QHideEvent* event) override;
@@ -137,7 +124,6 @@ protected:
     bool event(QEvent*) final;
     void resizeEvent(QResizeEvent* event) final;
     bool eventFilter(QObject* object, QEvent* event) final;
-    void disableSearchText();
     bool searchInText(const QString& phrase, const ParameterSearch& parameter, SearchDirection direction);
     std::pair<int, int> indexForSearchInLine(const QString& txt, const QString& phrase, const ParameterSearch& parameter, SearchDirection direction);
 
@@ -178,7 +164,4 @@ protected:
 
     IChatLog& chatLog;
     IMessageDispatcher& messageDispatcher;
-    SearchPos searchPos;
-    std::map<ChatLogIdx, ChatMessage::Ptr> messages;
-    bool colorizeNames = false;
 };

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -192,4 +192,8 @@ protected:
     SearchPos searchPos;
     std::map<ChatLogIdx, ChatMessage::Ptr> messages;
     bool colorizeNames = false;
+
+private:
+    const int maxMessages{300};
+    const int optimalRemove{50};
 };

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -148,7 +148,6 @@ protected:
     void resizeEvent(QResizeEvent* event) final;
     bool eventFilter(QObject* object, QEvent* event) final;
     void disableSearchText();
-    void enableSearchText();
     bool searchInText(const QString& phrase, const ParameterSearch& parameter, SearchDirection direction);
     std::pair<int, int> indexForSearchInLine(const QString& txt, const QString& phrase, const ParameterSearch& parameter, SearchDirection direction);
 
@@ -190,7 +189,7 @@ protected:
 
     IChatLog& chatLog;
     IMessageDispatcher& messageDispatcher;
-    SearchResult searchResult;
+    SearchPos searchPos;
     std::map<ChatLogIdx, ChatMessage::Ptr> messages;
     bool colorizeNames = false;
 };

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -34,7 +34,7 @@
  */
 
 class ChatFormHeader;
-class ChatLog;
+class ChatWidget;
 class ChatTextEdit;
 class Contact;
 class ContentLayout;
@@ -155,7 +155,7 @@ protected:
 
     SearchForm *searchForm;
     QLabel *dateInfo;
-    ChatLog* chatWidget;
+    ChatWidget* chatWidget;
     ChatTextEdit* msgEdit;
 #ifdef SPELL_CHECKING
     Sonnet::SpellCheckDecorator* decorator{nullptr};

--- a/src/widget/form/groupchatform.cpp
+++ b/src/widget/form/groupchatform.cpp
@@ -23,7 +23,7 @@
 #include "src/core/core.h"
 #include "src/core/coreav.h"
 #include "src/core/groupid.h"
-#include "src/chatlog/chatlog.h"
+#include "src/chatlog/chatwidget.h"
 #include "src/chatlog/content/text.h"
 #include "src/model/friend.h"
 #include "src/friendlist.h"

--- a/src/widget/form/loadhistorydialog.cpp
+++ b/src/widget/form/loadhistorydialog.cpp
@@ -75,12 +75,14 @@ LoadHistoryDialog::LoadType LoadHistoryDialog::getLoadType()
     return LoadType::to;
 }
 
-void LoadHistoryDialog::turnSearchMode()
+void LoadHistoryDialog::setTitle(const QString& title)
 {
-    setWindowTitle(tr("Select date dialog"));
-    ui->fromLabel->setText(tr("Select a date"));
-    ui->loadTypeComboBox->setVisible(false);
-    ui->infoLabel->setVisible(false);
+    setWindowTitle(title);
+}
+
+void LoadHistoryDialog::setInfoLabel(const QString& info)
+{
+    ui->fromLabel->setText(info);
 }
 
 void LoadHistoryDialog::highlightDates(int year, int month)

--- a/src/widget/form/loadhistorydialog.cpp
+++ b/src/widget/form/loadhistorydialog.cpp
@@ -38,15 +38,11 @@ LoadHistoryDialog::LoadHistoryDialog(const IChatLog* chatLog, QWidget* parent)
             &LoadHistoryDialog::highlightDates);
 }
 
-LoadHistoryDialog::LoadHistoryDialog(Mode mode, QWidget* parent)
+LoadHistoryDialog::LoadHistoryDialog(QWidget* parent)
     : QDialog(parent)
     , ui(new Ui::LoadHistoryDialog)
 {
     ui->setupUi(this);
-
-    if (mode == Mode::search) {
-        enableSearchMode();
-    }
 }
 
 LoadHistoryDialog::~LoadHistoryDialog()
@@ -79,7 +75,7 @@ LoadHistoryDialog::LoadType LoadHistoryDialog::getLoadType()
     return LoadType::to;
 }
 
-void LoadHistoryDialog::enableSearchMode()
+void LoadHistoryDialog::turnSearchMode()
 {
     setWindowTitle(tr("Select date dialog"));
     ui->fromLabel->setText(tr("Select a date"));

--- a/src/widget/form/loadhistorydialog.cpp
+++ b/src/widget/form/loadhistorydialog.cpp
@@ -66,15 +66,6 @@ QDateTime LoadHistoryDialog::getFromDate()
     return res;
 }
 
-LoadHistoryDialog::LoadType LoadHistoryDialog::getLoadType()
-{
-    if (ui->loadTypeComboBox->currentIndex() == 0) {
-        return LoadType::from;
-    }
-
-    return LoadType::to;
-}
-
 void LoadHistoryDialog::setTitle(const QString& title)
 {
     setWindowTitle(title);

--- a/src/widget/form/loadhistorydialog.h
+++ b/src/widget/form/loadhistorydialog.h
@@ -44,7 +44,8 @@ public:
 
     QDateTime getFromDate();
     LoadType getLoadType();
-    void turnSearchMode();
+    void setTitle(const QString& title);
+    void setInfoLabel(const QString& info);
 
 public slots:
     void highlightDates(int year, int month);

--- a/src/widget/form/loadhistorydialog.h
+++ b/src/widget/form/loadhistorydialog.h
@@ -38,24 +38,18 @@ public:
         to
     };
 
-    enum Mode {
-        common,
-        search
-    };
-
     explicit LoadHistoryDialog(const IChatLog* chatLog, QWidget* parent = nullptr);
-    explicit LoadHistoryDialog(Mode mode, QWidget* parent = nullptr);
+    explicit LoadHistoryDialog(QWidget* parent = nullptr);
     ~LoadHistoryDialog();
 
     QDateTime getFromDate();
     LoadType getLoadType();
+    void turnSearchMode();
 
 public slots:
     void highlightDates(int year, int month);
 
 private:
-    void enableSearchMode();
-
     Ui::LoadHistoryDialog* ui;
     const IChatLog* chatLog;
 };

--- a/src/widget/form/loadhistorydialog.h
+++ b/src/widget/form/loadhistorydialog.h
@@ -33,17 +33,11 @@ class LoadHistoryDialog : public QDialog
     Q_OBJECT
 
 public:
-    enum LoadType {
-        from,
-        to
-    };
-
     explicit LoadHistoryDialog(const IChatLog* chatLog, QWidget* parent = nullptr);
     explicit LoadHistoryDialog(QWidget* parent = nullptr);
     ~LoadHistoryDialog();
 
     QDateTime getFromDate();
-    LoadType getLoadType();
     void setTitle(const QString& title);
     void setInfoLabel(const QString& info);
 

--- a/src/widget/form/loadhistorydialog.ui
+++ b/src/widget/form/loadhistorydialog.ui
@@ -41,7 +41,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="infoLabel">
+      <widget class="QLabel" name="label">
        <property name="text">
         <string>(about 100 messages are loaded)</string>
        </property>

--- a/src/widget/form/loadhistorydialog.ui
+++ b/src/widget/form/loadhistorydialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>410</width>
-    <height>332</height>
+    <width>347</width>
+    <height>264</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,60 +16,22 @@
   <property name="modal">
    <bool>true</bool>
   </property>
-  <layout class="QFormLayout" name="formLayout">
-   <item row="0" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QLabel" name="fromLabel">
-       <property name="text">
-        <string>Load history</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="loadTypeComboBox">
-       <item>
-        <property name="text">
-         <string>from</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>to</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>(about 100 messages are loaded)</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>17</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
+  <layout class="QVBoxLayout" name="verticalLayout_3">
+   <item>
+    <widget class="QLabel" name="fromLabel">
+     <property name="text">
+      <string>Load history from:</string>
+     </property>
+    </widget>
    </item>
-   <item row="1" column="0">
+   <item>
     <widget class="QCalendarWidget" name="fromDate">
      <property name="gridVisible">
       <bool>false</bool>
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>

--- a/src/widget/form/searchsettingsform.cpp
+++ b/src/widget/form/searchsettingsform.cpp
@@ -165,7 +165,8 @@ void SearchSettingsForm::onRegularClicked(const bool checked)
 
 void SearchSettingsForm::onChoiceDate()
 {
-    LoadHistoryDialog dlg(LoadHistoryDialog::search);
+    LoadHistoryDialog dlg;
+    dlg.turnSearchMode();
     if (dlg.exec()) {
         startTime = dlg.getFromDate();
         updateStartDateLabel();

--- a/src/widget/form/searchsettingsform.cpp
+++ b/src/widget/form/searchsettingsform.cpp
@@ -90,7 +90,7 @@ ParameterSearch SearchSettingsForm::getParameterSearch()
         break;
     }
 
-    ps.time = startTime;
+    ps.date = startDate;
     ps.isUpdate = isUpdate;
     isUpdate = false;
 
@@ -105,7 +105,7 @@ void SearchSettingsForm::reloadTheme()
 
 void SearchSettingsForm::updateStartDateLabel()
 {
-    ui->startDateLabel->setText(startTime.toString(Settings::getInstance().getDateFormat()));
+    ui->startDateLabel->setText(startDate.toString(Settings::getInstance().getDateFormat()));
 }
 
 void SearchSettingsForm::setUpdate(const bool isUpdate)
@@ -123,8 +123,8 @@ void SearchSettingsForm::onStartSearchSelected(const int index)
         ui->choiceDateButton->setProperty("state", QStringLiteral("green"));
         ui->choiceDateButton->setStyleSheet(Style::getStylesheet(QStringLiteral("chatForm/buttons.css")));
 
-        if (startTime.isNull()) {
-            startTime = QDateTime::currentDateTime();
+        if (startDate.isNull()) {
+            startDate = QDate::currentDate();
             updateStartDateLabel();
         }
 
@@ -166,9 +166,10 @@ void SearchSettingsForm::onRegularClicked(const bool checked)
 void SearchSettingsForm::onChoiceDate()
 {
     LoadHistoryDialog dlg;
-    dlg.turnSearchMode();
+    dlg.setTitle(tr("Select Date Dialog"));
+    dlg.setInfoLabel(tr("Select a date"));
     if (dlg.exec()) {
-        startTime = dlg.getFromDate();
+        startDate = dlg.getFromDate().date();
         updateStartDateLabel();
     }
 

--- a/src/widget/form/searchsettingsform.h
+++ b/src/widget/form/searchsettingsform.h
@@ -39,7 +39,7 @@ public:
 
 private:
     Ui::SearchSettingsForm *ui;
-    QDateTime startTime;
+    QDate startDate;
     bool isUpdate{false};
 
     void updateStartDateLabel();

--- a/src/widget/searchtypes.h
+++ b/src/widget/searchtypes.h
@@ -47,13 +47,13 @@ enum class SearchDirection {
 struct ParameterSearch {
     FilterSearch filter{FilterSearch::None};
     PeriodSearch period{PeriodSearch::None};
-    QDateTime time;
+    QDate date;
     bool isUpdate{false};
 
     bool operator ==(const ParameterSearch& other) {
         return filter == other.filter &&
             period == other.period &&
-            time == other.time;
+            date == other.date;
     }
 
     bool operator !=(const ParameterSearch& other) {

--- a/test/chatlog/chatlinestorage_test.cpp
+++ b/test/chatlog/chatlinestorage_test.cpp
@@ -1,3 +1,21 @@
+/*
+    Copyright © 2021 by The qTox Project Contributors
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
 
 #include "src/chatlog/chatlinestorage.h"
 #include <QTest>

--- a/test/chatlog/chatlinestorage_test.cpp
+++ b/test/chatlog/chatlinestorage_test.cpp
@@ -1,0 +1,335 @@
+
+#include "src/chatlog/chatlinestorage.h"
+#include <QTest>
+
+namespace
+{
+    class IdxChatLine : public ChatLine
+    {
+    public:
+        explicit IdxChatLine(ChatLogIdx idx)
+            : ChatLine()
+            , idx(idx)
+        {}
+
+        ChatLogIdx get() { return idx; }
+    private:
+        ChatLogIdx idx;
+
+    };
+
+    class TimestampChatLine : public ChatLine
+    {
+    public:
+        explicit TimestampChatLine(QDateTime dateTime)
+            : ChatLine()
+            , timestamp(dateTime)
+        {}
+
+        QDateTime get() { return timestamp; }
+    private:
+        QDateTime timestamp;
+    };
+
+    ChatLogIdx idxFromChatLine(ChatLine::Ptr p) {
+        return std::static_pointer_cast<IdxChatLine>(p)->get();
+    }
+
+    QDateTime timestampFromChatLine(ChatLine::Ptr p) {
+        return std::static_pointer_cast<TimestampChatLine>(p)->get();
+    }
+
+} // namespace
+
+
+class TestChatLineStorage : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void init();
+    void testChatLogIdxAccess();
+    void testIndexAccess();
+    void testRangeBasedIteration();
+    void testAppendingItems();
+    void testPrependingItems();
+    void testMiddleInsertion();
+    void testIndexRemoval();
+    void testItRemoval();
+    void testDateLineAddition();
+    void testDateLineRemoval();
+    void testInsertionBeforeDates();
+    void testInsertionAfterDate();
+    void testContainsTimestamp();
+    void testContainsIdx();
+    void testEndOfStorageDateRemoval();
+    void testConsecutiveDateLineRemoval();
+private:
+    ChatLineStorage storage;
+
+    static constexpr size_t initialStartIdx = 10;
+    static constexpr size_t initialEndIdx = 20;
+    static const QDateTime initialTimestamp;
+
+};
+
+constexpr size_t TestChatLineStorage::initialStartIdx;
+constexpr size_t TestChatLineStorage::initialEndIdx;
+
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 15, 0))
+const QDateTime TestChatLineStorage::initialTimestamp = QDate(2021, 01, 01).startOfDay();
+#else
+const QDateTime TestChatLineStorage::initialTimestamp(QDate(2021, 01, 01));
+#endif
+
+void TestChatLineStorage::init()
+{
+    storage = ChatLineStorage();
+
+    for (auto idx = ChatLogIdx(initialStartIdx); idx < ChatLogIdx(initialEndIdx); ++idx) {
+        storage.insertChatMessage(idx, initialTimestamp, std::make_shared<IdxChatLine>(idx));
+    }
+}
+
+void TestChatLineStorage::testChatLogIdxAccess()
+{
+    for (auto idx = ChatLogIdx(initialStartIdx); idx < ChatLogIdx(initialEndIdx); ++idx) {
+        QCOMPARE(idxFromChatLine(storage[idx]).get(), idx.get());
+    }
+}
+
+void TestChatLineStorage::testIndexAccess()
+{
+    for (size_t i = 0; i < initialEndIdx - initialStartIdx; ++i) {
+        QCOMPARE(idxFromChatLine(storage[i]).get(), initialStartIdx + i);
+    }
+}
+
+
+void TestChatLineStorage::testRangeBasedIteration()
+{
+    auto idx = ChatLogIdx(initialStartIdx);
+
+    for (const auto& p : storage) {
+        QCOMPARE(idxFromChatLine(p).get(), idx.get());
+        idx = idx + 1;
+    }
+}
+
+void TestChatLineStorage::testAppendingItems()
+{
+    for (auto idx = ChatLogIdx(initialEndIdx); idx < ChatLogIdx(initialEndIdx + 10); ++idx) {
+        storage.insertChatMessage(idx, initialTimestamp, std::make_shared<IdxChatLine>(idx));
+        QCOMPARE(storage.lastIdx().get(), idx.get());
+    }
+
+    for (auto idx = ChatLogIdx(initialEndIdx); idx < storage.lastIdx(); ++idx) {
+        QCOMPARE(idxFromChatLine(storage[idx]).get(), idx.get());
+        QCOMPARE(idxFromChatLine(storage[idx.get() - initialStartIdx]).get(), idx.get());
+    }
+}
+
+void TestChatLineStorage::testMiddleInsertion()
+{
+    ChatLogIdx newEnd = ChatLogIdx(initialEndIdx + 5);
+    ChatLogIdx insertIdx = ChatLogIdx(initialEndIdx + 3);
+
+    storage.insertChatMessage(newEnd, initialTimestamp, std::make_shared<IdxChatLine>(newEnd));
+    storage.insertChatMessage(insertIdx, initialTimestamp, std::make_shared<IdxChatLine>(insertIdx));
+
+    QCOMPARE(idxFromChatLine(storage[insertIdx]).get(), insertIdx.get());
+    QCOMPARE(idxFromChatLine(storage[initialEndIdx - initialStartIdx]).get(), insertIdx.get());
+    QCOMPARE(idxFromChatLine(storage[initialEndIdx - initialStartIdx + 1]).get(), newEnd.get());
+}
+
+void TestChatLineStorage::testPrependingItems()
+{
+    for (auto idx = ChatLogIdx(initialStartIdx - 1); idx != ChatLogIdx(-1); idx = idx - 1) {
+        storage.insertChatMessage(idx, initialTimestamp, std::make_shared<IdxChatLine>(idx));
+        QCOMPARE(storage.firstIdx().get(), idx.get());
+    }
+
+    for (auto idx = storage.firstIdx(); idx < storage.lastIdx(); ++idx) {
+        QCOMPARE(idxFromChatLine(storage[idx]).get(), idx.get());
+        QCOMPARE(idxFromChatLine(storage[idx.get()]).get(), idx.get());
+    }
+}
+
+void TestChatLineStorage::testIndexRemoval()
+{
+    QCOMPARE(initialStartIdx, static_cast<size_t>(10));
+    QCOMPARE(initialEndIdx, static_cast<size_t>(20));
+    QCOMPARE(storage.size(), static_cast<size_t>(10));
+
+    storage.erase(ChatLogIdx(11));
+
+    QCOMPARE(storage.size(), static_cast<size_t>(9));
+
+    QCOMPARE(idxFromChatLine(storage[0]).get(), static_cast<size_t>(10));
+    QCOMPARE(idxFromChatLine(storage[1]).get(), static_cast<size_t>(12));
+
+    auto idx = static_cast<size_t>(12);
+    for (auto it = std::next(storage.begin()); it != storage.end(); ++it) {
+        QCOMPARE(idxFromChatLine((*it)).get(), idx++);
+    }
+}
+
+void TestChatLineStorage::testItRemoval()
+{
+    auto it = storage.begin();
+    it = it + 2;
+
+    storage.erase(it);
+
+    QCOMPARE(idxFromChatLine(storage[0]).get(), initialStartIdx);
+    QCOMPARE(idxFromChatLine(storage[1]).get(), initialStartIdx + 1);
+    // Item should have been removed
+    QCOMPARE(idxFromChatLine(storage[2]).get(), initialStartIdx + 3);
+}
+
+void TestChatLineStorage::testDateLineAddition()
+{
+    storage.insertDateLine(initialTimestamp, std::make_shared<TimestampChatLine>(initialTimestamp));
+    auto newTimestamp = initialTimestamp.addDays(1);
+    storage.insertDateLine(newTimestamp, std::make_shared<TimestampChatLine>(newTimestamp));
+
+    QCOMPARE(storage.size(), initialEndIdx - initialStartIdx + 2);
+    QCOMPARE(timestampFromChatLine(storage[0]), initialTimestamp);
+    QCOMPARE(timestampFromChatLine(storage[storage.size() - 1]), newTimestamp);
+
+    for (size_t i = 1; i < storage.size() - 2; ++i)
+    {
+        // Ensure that indexed items all stayed in the right order
+        QCOMPARE(idxFromChatLine(storage[i]).get(), idxFromChatLine(storage[ChatLogIdx(initialStartIdx + i - 1)]).get());
+    }
+
+}
+
+void TestChatLineStorage::testDateLineRemoval()
+{
+    // For the time being there is no removal requirement
+    storage.insertDateLine(initialTimestamp, std::make_shared<TimestampChatLine>(initialTimestamp));
+
+    QVERIFY(storage.contains(initialTimestamp));
+    QCOMPARE(timestampFromChatLine(storage[0]), initialTimestamp);
+
+    storage.erase(storage.begin());
+
+    QVERIFY(!storage.contains(initialTimestamp));
+    QCOMPARE(idxFromChatLine(storage[0]).get(), initialStartIdx);
+}
+
+void TestChatLineStorage::testInsertionBeforeDates()
+{
+    storage.insertDateLine(initialTimestamp, std::make_shared<TimestampChatLine>(initialTimestamp));
+
+    auto yesterday = initialTimestamp.addDays(-1);
+    storage.insertDateLine(yesterday, std::make_shared<TimestampChatLine>(yesterday));
+
+    auto firstIdx = ChatLogIdx(initialStartIdx - 2);
+    storage.insertChatMessage(firstIdx, initialTimestamp.addDays(-2), std::make_shared<IdxChatLine>(firstIdx));
+
+    QCOMPARE(idxFromChatLine(storage[0]).get(), firstIdx.get());
+    QCOMPARE(timestampFromChatLine(storage[1]), yesterday);
+    QCOMPARE(timestampFromChatLine(storage[2]), initialTimestamp);
+    QCOMPARE(idxFromChatLine(storage[3]).get(), initialStartIdx);
+
+    auto secondIdx = ChatLogIdx(initialStartIdx - 1);
+    storage.insertChatMessage(secondIdx, initialTimestamp.addDays(-1), std::make_shared<IdxChatLine>(secondIdx));
+
+    QCOMPARE(idxFromChatLine(storage[0]).get(), firstIdx.get());
+    QCOMPARE(timestampFromChatLine(storage[1]), yesterday);
+    QCOMPARE(idxFromChatLine(storage[2]).get(), secondIdx.get());
+    QCOMPARE(timestampFromChatLine(storage[3]), initialTimestamp);
+    QCOMPARE(idxFromChatLine(storage[4]).get(), initialStartIdx);
+}
+
+void TestChatLineStorage::testInsertionAfterDate()
+{
+    auto newTimestamp = initialTimestamp.addDays(1);
+    storage.insertDateLine(newTimestamp, std::make_shared<TimestampChatLine>(newTimestamp));
+
+    QCOMPARE(storage.size(), initialEndIdx - initialStartIdx + 1);
+    QCOMPARE(timestampFromChatLine(storage[initialEndIdx - initialStartIdx]), newTimestamp);
+
+    storage.insertChatMessage(ChatLogIdx(initialEndIdx), newTimestamp, std::make_shared<IdxChatLine>(ChatLogIdx(initialEndIdx)));
+    QCOMPARE(idxFromChatLine(storage[initialEndIdx - initialStartIdx + 1]).get(), initialEndIdx);
+    QCOMPARE(idxFromChatLine(storage[ChatLogIdx(initialEndIdx)]).get(), initialEndIdx);
+}
+
+void TestChatLineStorage::testContainsTimestamp()
+{
+    QCOMPARE(storage.contains(initialTimestamp), false);
+    storage.insertDateLine(initialTimestamp, std::make_shared<TimestampChatLine>(initialTimestamp));
+    QCOMPARE(storage.contains(initialTimestamp), true);
+}
+
+void TestChatLineStorage::testContainsIdx()
+{
+    QCOMPARE(storage.contains(ChatLogIdx(initialEndIdx)), false);
+    QCOMPARE(storage.contains(ChatLogIdx(initialStartIdx)), true);
+}
+
+void TestChatLineStorage::testEndOfStorageDateRemoval()
+{
+    auto tomorrow = initialTimestamp.addDays(1);
+    storage.insertDateLine(tomorrow, std::make_shared<TimestampChatLine>(tomorrow));
+    storage.insertChatMessage(ChatLogIdx(initialEndIdx), tomorrow, std::make_shared<IdxChatLine>(ChatLogIdx(initialEndIdx)));
+
+    QCOMPARE(storage.size(), initialEndIdx - initialStartIdx + 2);
+
+    auto it = storage.begin() + storage.size() - 2;
+    QCOMPARE(timestampFromChatLine(*it++), tomorrow);
+    QCOMPARE(idxFromChatLine(*it).get(), initialEndIdx);
+
+    storage.erase(it);
+
+    QCOMPARE(storage.size(), initialEndIdx - initialStartIdx);
+
+    it = storage.begin() + storage.size() - 1;
+    QCOMPARE(idxFromChatLine(*it++).get(), initialEndIdx - 1);
+}
+
+void TestChatLineStorage::testConsecutiveDateLineRemoval()
+{
+    auto todayPlus1 = initialTimestamp.addDays(1);
+    auto todayPlus2 = initialTimestamp.addDays(2);
+
+    auto todayPlus1Idx = ChatLogIdx(initialEndIdx);
+    auto todayPlus1Idx2 = ChatLogIdx(initialEndIdx + 1);
+    auto todayPlus2Idx = ChatLogIdx(initialEndIdx + 2);
+
+
+    storage.insertDateLine(todayPlus1, std::make_shared<TimestampChatLine>(todayPlus1));
+    storage.insertChatMessage(todayPlus1Idx, todayPlus1, std::make_shared<IdxChatLine>(todayPlus1Idx));
+    storage.insertChatMessage(todayPlus1Idx2, todayPlus1, std::make_shared<IdxChatLine>(todayPlus1Idx2));
+
+    storage.insertDateLine(todayPlus2, std::make_shared<TimestampChatLine>(todayPlus2));
+    storage.insertChatMessage(todayPlus2Idx, todayPlus2, std::make_shared<IdxChatLine>(todayPlus2Idx));
+
+    // 2 date lines and 3 messages were inserted for a total of 5 new lines
+    QCOMPARE(storage.size(), initialEndIdx - initialStartIdx + 5);
+
+    storage.erase(storage.find(todayPlus1Idx2));
+
+    auto newItemIdxStart = initialEndIdx - initialStartIdx;
+
+    // Only the chat message should have been removed
+    QCOMPARE(storage.size(), initialEndIdx - initialStartIdx + 4);
+
+    QCOMPARE(timestampFromChatLine(storage[newItemIdxStart]), todayPlus1);
+    QCOMPARE(idxFromChatLine(storage[newItemIdxStart + 1]).get(), todayPlus1Idx.get());
+    QCOMPARE(timestampFromChatLine(storage[newItemIdxStart + 2]), todayPlus2);
+    QCOMPARE(idxFromChatLine(storage[newItemIdxStart + 3]).get(), todayPlus2Idx.get());
+
+    storage.erase(storage.find(todayPlus1Idx));
+
+    // The chat message + the dateline for it should have been removed as there
+    // were 2 adjacent datelines caused by the removal
+    QCOMPARE(storage.size(), initialEndIdx - initialStartIdx + 2);
+    QCOMPARE(timestampFromChatLine(storage[newItemIdxStart]), todayPlus2);
+    QCOMPARE(idxFromChatLine(storage[newItemIdxStart + 1]).get(), todayPlus2Idx.get());
+}
+
+QTEST_GUILESS_MAIN(TestChatLineStorage);
+#include "chatlinestorage_test.moc"


### PR DESCRIPTION
**NOTE: Based on top of #6311** 

Refactor/fixes for chatlog to resolve #6223 #5878 #5940

This PR has commits that fall under two categories
* Re-apply reverts from 1.17
** Note there's a fix in the middle of the reverts to deal with an updated Qt since the initial patch
* Implement a more architecturally sound sliding window chat log

Quick sample of what the new sliding window looks like in practice. Given the scope of this change I suggest reviewers try it themselves to see how it feels.

![new_chatlog](https://user-images.githubusercontent.com/1069811/133003690-dba435e8-a763-48cc-8eb2-bcb2e00fce23.gif)

The only remaining janky behavior is that selections for messages removed from the chatlog are cleared. This means you have to use the export chat log feature to get long logs. A future improvement would be to not purge messages that are selected.

Implementation commit messages for review context...

refactor(chatlog): Rename ChatLog -> ChatWidget

* Makes the distinction between IChatLog (the model class) and
  ChatWidget (the view class) more clear

refactor(chatlog): Remove unused getRow functions from ChatLine

* The getRow functions would not track correctly since the rows indexes
  cannot be fixed to the view anymore

feat(chatlog): Re-implement sliding window ChatLog view

* Replace lines/messages with helper class to synchronize state between
  IChatLog and ChatLog more easily
* selection indexes have been replaced with ChatLine::Ptrs, this is to
  ensure consistency while the view slides around
	* This has another benefit of removing all the code that has to
	  manually slide the selection boxes around
* Replaced all insertion/removal functions with single "insertAtIdx".
  This helps ensure that mappings between ChatLogIdx and position within
  the view are captured correctly as items in the view slide around
* workerTimeout replaced with more generic name "renderFinished" that is
  used in synchronous and asynchronous paths
* Removed unused function ChatForm::insertChatMessage
* Re-implemented "Go to current date" with new ChatLog APIs
* Removed unused GenericChatForm::addSystemDateMessage. This is handled
  by ChatLog now
* Resolves #6223
* Resolves #5878
* Resolves #5940

refactor(chatlog): Store ChatLine::Ptr in messages instead of ChatMessage

* This simplifies future refactoring since the rest of ChatLog expects
  to be working with the base class

refactor(chatlog): Move rendering of messages from GenericChatForm -> ChatLog

* Simplifies reasoning about who owns what functionality between
  GenericChatForm and ChatLog. GenericChatForm is now just a layout
  class and ChatLog handles all interactions with retrieving and
  displaying messages from the model
* Reasoning for work is described in more detail in #6223


- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6374)
<!-- Reviewable:end -->
