### PR TITLE
fix(appimage): Use external binary path when enabling autorun from appimage

### DIFF
--- a/src/platform/autorun_xdg.cpp
+++ b/src/platform/autorun_xdg.cpp
@@ -38,9 +38,21 @@ QString getAutostartFilePath(QString dir)
     return dir + "/qTox - " + Settings::getInstance().getCurrentProfile() + ".desktop";
 }
 
-inline QString currentCommandLine()
+QString currentBinPath()
 {
-    return "\"" + QApplication::applicationFilePath() + "\" -p \""
+    const auto env = QProcessEnvironment::systemEnvironment();
+    const auto appImageEnvKey = QStringLiteral("APPIMAGE");
+
+    if (env.contains(appImageEnvKey)) {
+        return env.value(appImageEnvKey);
+    } else {
+        return QApplication::applicationFilePath();
+    }
+}
+
+inline QString profileRunCommand()
+{
+    return "\"" + currentBinPath() + "\" -p \""
            + Settings::getInstance().getCurrentProfile() + "\"";
 }
 }
@@ -56,7 +68,7 @@ bool Platform::setAutorun(bool on)
         desktop.write("Type=Application\n");
         desktop.write("Name=qTox\n");
         desktop.write("Exec=");
-        desktop.write(currentCommandLine().toUtf8());
+        desktop.write(profileRunCommand().toUtf8());
         desktop.write("\n");
         desktop.close();
         return true;


### PR DESCRIPTION
Fix #6241

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6382)
<!-- Reviewable:end -->
