### PR TITLE
chore(CI): Split Win deps into their own job

### DIFF
--- a/.github/workflows/commit-format.yaml
+++ b/.github/workflows/commit-format.yaml
@@ -1,0 +1,14 @@
+name: Commit Format
+on: pull_request
+jobs:
+  verify-commit-format:
+    name: Verify Commit Format
+    runs-on: ubuntu-18.04
+    env:
+      GITHUB_CONTEXT: ${{ github.event.pull_request.commits_url }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # so that we can see the full commit range
+      - name: Run
+        run: ./.travis/verify-commit-format.sh

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -70,16 +70,14 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run
         run: ./flatpak/build-flatpak.sh
-  win:
-    name: Windows
+  win-deps:
+    name: Windows Deps
     runs-on: ubuntu-latest
     strategy:
       matrix:
         arch: [i686, x86_64]
-        type: [debug, release]
     env:
       BUILD__: ${{ matrix.arch }}
-      BTYPE__: ${{ matrix.type }}
     steps:
       - uses: actions/checkout@v2
       - name: Cache dependencies
@@ -98,6 +96,24 @@ jobs:
         run: |
           ./.travis/build-windows.sh "$BUILD__" "release" "cache/${BUILD__}" stage2
           ls -al cache
+  win:
+    name: Windows
+    runs-on: ubuntu-latest
+    needs: win-deps
+    strategy:
+      matrix:
+        arch: [i686, x86_64]
+        type: [debug, release]
+    env:
+      BUILD__: ${{ matrix.arch }}
+      BTYPE__: ${{ matrix.type }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Fetch cached dependencies
+        uses: actions/cache@v2
+        with:
+          path: cache
+          key: deps-${{ matrix.arch }}-${{ hashFiles('windows/cross-compile/build.sh') }}-${{ hashFiles('.travis/build-windows.sh') }}
       - name: qTox build
         run: |
           ./.travis/build-windows.sh "$BUILD__" "$BTYPE__" "cache/${BUILD__}" stage3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,17 +1,6 @@
-name: test
-on: pull_request
+name: Test
+on: [pull_request, push]
 jobs:
-  verify-commit-format:
-    name: Verify Commit Format
-    runs-on: ubuntu-18.04
-    env:
-      GITHUB_CONTEXT: ${{ github.event.pull_request.commits_url }}
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0 # so that we can see the full commit range
-      - name: Run
-        run: ./.travis/verify-commit-format.sh
   build-docs:
     name: Docs
     runs-on: ubuntu-18.04


### PR DESCRIPTION
Avoids each build type of qTox from building deps in parallel on cache miss, when both debug and release qTox use the same deps

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6383)
<!-- Reviewable:end -->
