### PR TITLE
chore(CI): Run tests on pushed commits

### DIFF
--- a/.github/workflows/commit-format.yaml
+++ b/.github/workflows/commit-format.yaml
@@ -1,0 +1,14 @@
+name: Commit Format
+on: pull_request
+jobs:
+  verify-commit-format:
+    name: Verify Commit Format
+    runs-on: ubuntu-18.04
+    env:
+      GITHUB_CONTEXT: ${{ github.event.pull_request.commits_url }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # so that we can see the full commit range
+      - name: Run
+        run: ./.travis/verify-commit-format.sh

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,17 +1,6 @@
-name: test
-on: pull_request
+name: Test
+on: [pull_request, push]
 jobs:
-  verify-commit-format:
-    name: Verify Commit Format
-    runs-on: ubuntu-18.04
-    env:
-      GITHUB_CONTEXT: ${{ github.event.pull_request.commits_url }}
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0 # so that we can see the full commit range
-      - name: Run
-        run: ./.travis/verify-commit-format.sh
   build-docs:
     name: Docs
     runs-on: ubuntu-18.04


### PR DESCRIPTION
Split commit format check into its own workflow that only runs on PR.

Can be built off for nightly or per-commit releases.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6384)
<!-- Reviewable:end -->
