### PR TITLE
fix build with -DUPDATE_CHECK=OFF and hide related UI elements

### DIFF
--- a/src/widget/form/settings/aboutform.cpp
+++ b/src/widget/form/settings/aboutform.cpp
@@ -62,6 +62,9 @@ AboutForm::AboutForm(UpdateCheck* updateCheck)
 {
     bodyUI->setupUi(this);
 
+#if !UPDATE_CHECK_ENABLED
+    bodyUI->updateStack->setVisible(false);
+#endif
     bodyUI->unstableVersion->setVisible(false);
 #if UPDATE_CHECK_ENABLED
     connect(updateCheck, &UpdateCheck::versionIsUnstable, this, &AboutForm::onUnstableVersion);

--- a/src/widget/form/settings/aboutform.cpp
+++ b/src/widget/form/settings/aboutform.cpp
@@ -63,7 +63,9 @@ AboutForm::AboutForm(UpdateCheck* updateCheck)
     bodyUI->setupUi(this);
 
     bodyUI->unstableVersion->setVisible(false);
+#if UPDATE_CHECK_ENABLED
     connect(updateCheck, &UpdateCheck::versionIsUnstable, this, &AboutForm::onUnstableVersion);
+#endif
 
     // block all child signals during initialization
     const RecursiveSignalBlocker signalBlocker(this);


### PR DESCRIPTION
- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6387)
<!-- Reviewable:end -->
