### PR TITLE
fix(ui): contact list optimization

### DIFF
--- a/src/model/friendlist/friendlistmanager.h
+++ b/src/model/friendlist/friendlistmanager.h
@@ -32,10 +32,12 @@ class FriendListManager : public QObject
 public:
     using IFriendListItemPtr = std::shared_ptr<IFriendListItem>;
 
-    explicit FriendListManager(QObject *parent = nullptr);
+    explicit FriendListManager(int countContacts, QObject *parent = nullptr);
 
     QVector<IFriendListItemPtr> getItems() const;
     bool needHideCircles() const;
+    // If the contact positions have changed, need to redraw view
+    bool getPositionsChanged() const;
 
     void addFriendListItem(IFriendListItem* item);
     void removeFriendListItem(IFriendListItem* item);
@@ -45,7 +47,8 @@ public:
     void setFilter(const QString& searchString, bool hideOnline,
                    bool hideOffline, bool hideGroups);
     void applyFilter();
-    void updatePositions();    
+    void updatePositions();
+    void setSortRequired();
 
     void setGroupsOnTop(bool v);
 
@@ -67,6 +70,10 @@ private:
     bool byName = true;
     bool hideCircles = false;
     bool groupsOnTop;
+    bool positionsChanged;
+    bool needSort;
     QVector<IFriendListItemPtr> items;
+    // At startup, while the size of items is less than countContacts, the view will not be processed to improve performance
+    int countContacts;
 
 };


### PR DESCRIPTION
New changes:

- When the application starts, the contact widgets are drawn after adding the entire list.
- When writing messages, the view will be redrawn if the sort order is changed. 

This should remove flashing during chatting and speed up the launch.

Fix: #6372

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6388)
<!-- Reviewable:end -->
