### PR TITLE
fix(toxext): Protect use of toxext modifying functions

### DIFF
--- a/src/core/coreext.h
+++ b/src/core/coreext.h
@@ -27,6 +27,7 @@
 
 #include <bitset>
 #include <memory>
+#include <mutex>
 #include <unordered_map>
 
 struct Tox;
@@ -86,6 +87,7 @@ public:
             ToxExtPacketList* packetList,
             ToxExtensionMessages* toxExtMessages,
             uint32_t friendId,
+            std::mutex* toxext_mutex,
             PacketPassKey);
 
         // Delete copy constructor, we shouldn't be able to copy
@@ -97,16 +99,19 @@ public:
             packetList = other.packetList;
             friendId = other.friendId;
             hasBeenSent = other.hasBeenSent;
+            toxext_mutex = other.toxext_mutex;
             other.toxExtMessages = nullptr;
             other.packetList = nullptr;
             other.friendId = 0;
             other.hasBeenSent = false;
+            other.toxext_mutex = nullptr;
         }
 
         uint64_t addExtendedMessage(QString message) override;
 
         bool send() override;
     private:
+        std::mutex* toxext_mutex;
         bool hasBeenSent = false;
         // Note: non-owning pointer
         ToxExtensionMessages* toxExtMessages;
@@ -141,6 +146,7 @@ private:
 
     CoreExt(ExtensionPtr<ToxExt> toxExt);
 
+    std::mutex toxext_mutex;
     std::unordered_map<uint32_t, Status::Status> currentStatuses;
     ExtensionPtr<ToxExt> toxExt;
     ExtensionPtr<ToxExtensionMessages> toxExtMessages;


### PR DESCRIPTION
When running with -DASAN on and a mod to send 10k messages in quick
succession I was seeing memory corruption within toxext. This was caused
by a race between toxext_iterate and toxext_send being called from
different threads.

Protect the use of functions coming from different threads with a mutex

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6391)
<!-- Reviewable:end -->
