### PR TITLE
refactor: Provide a Virtual Method Anchor for Classes in Headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,13 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
 
 # Hardening flags (ASLR, warnings, etc)
 set(POSITION_INDEPENDENT_CODE True)
+
+include(CheckCXXCompilerFlag)
+CHECK_CXX_COMPILER_FLAG(-Wweak-vtables COMPILER_SUPPORTS_WARNING_WEAK_VTABLES)
+if(COMPILER_SUPPORTS_WARNING_WEAK_VTABLES)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wweak-vtables")
+endif()
+
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wstrict-overflow")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wstrict-aliasing")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wold-style-cast")
@@ -232,7 +239,18 @@ set(${PROJECT_NAME}_SOURCES
   src/core/core.h
   src/core/dhtserver.cpp
   src/core/dhtserver.h
+  src/core/icoreextpacket.cpp
+  src/core/icoreextpacket.h
+  src/core/icoresettings.cpp
   src/core/icoresettings.h
+  src/core/icorefriendmessagesender.cpp
+  src/core/icorefriendmessagesender.h
+  src/core/icoregroupmessagesender.cpp
+  src/core/icoregroupmessagesender.h
+  src/core/icoregroupquery.cpp
+  src/core/icoregroupquery.h
+  src/core/icoreidhandler.cpp
+  src/core/icoreidhandler.h
   src/core/toxcall.cpp
   src/core/toxcall.h
   src/core/toxencrypt.cpp
@@ -262,11 +280,13 @@ set(${PROJECT_NAME}_SOURCES
   src/ipc.h
   src/model/about/aboutfriend.cpp
   src/model/about/aboutfriend.h
+  src/model/about/iaboutfriend.cpp
   src/model/about/iaboutfriend.h
   src/model/chathistory.cpp
   src/model/chathistory.h
   src/model/chatlogitem.cpp
   src/model/chatlogitem.h
+  src/model/chatroom/chatroom.cpp
   src/model/chatroom/chatroom.h
   src/model/chatroom/friendchatroom.cpp
   src/model/chatroom/friendchatroom.h
@@ -274,11 +294,15 @@ set(${PROJECT_NAME}_SOURCES
   src/model/chatroom/groupchatroom.h
   src/model/contact.cpp
   src/model/contact.h
+  src/model/dialogs/idialogs.cpp
   src/model/dialogs/idialogs.h
+  src/model/dialogs/idialogsmanager.h
+  src/model/dialogs/idialogsmanager.cpp
   src/model/exiftransform.cpp
   src/model/exiftransform.h
   src/model/friendlist/friendlistmanager.cpp
   src/model/friendlist/friendlistmanager.h
+  src/model/friendlist/ifriendlistitem.cpp
   src/model/friendlist/ifriendlistitem.h
   src/model/friendmessagedispatcher.cpp
   src/model/friendmessagedispatcher.h
@@ -290,6 +314,7 @@ set(${PROJECT_NAME}_SOURCES
   src/model/groupmessagedispatcher.h
   src/model/group.cpp
   src/model/group.h
+  src/model/ibootstraplistgenerator.cpp
   src/model/ibootstraplistgenerator.h
   src/model/ichatlog.h
   src/model/imessagedispatcher.h
@@ -297,6 +322,7 @@ set(${PROJECT_NAME}_SOURCES
   src/model/message.h
   src/model/notificationgenerator.cpp
   src/model/notificationgenerator.h
+  src/model/profile/iprofileinfo.cpp
   src/model/profile/iprofileinfo.h
   src/model/profile/profileinfo.cpp
   src/model/profile/profileinfo.h
@@ -317,7 +343,12 @@ set(${PROJECT_NAME}_SOURCES
   src/persistence/db/rawdatabase.h
   src/persistence/history.cpp
   src/persistence/history.h
+  src/persistence/ifriendsettings.cpp
   src/persistence/ifriendsettings.h
+  src/persistence/igroupsettings.cpp
+  src/persistence/igroupsettings.h
+  src/persistence/inotificationsettings.cpp
+  src/persistence/inotificationsettings.h
   src/persistence/offlinemsgengine.cpp
   src/persistence/offlinemsgengine.h
   src/persistence/paths.cpp
@@ -342,6 +373,7 @@ set(${PROJECT_NAME}_SOURCES
   src/video/camerasource.h
   src/video/corevideosource.cpp
   src/video/corevideosource.h
+  src/video/ivideosettings.cpp
   src/video/ivideosettings.h
   src/video/netcamview.cpp
   src/video/netcamview.h

--- a/audio/CMakeLists.txt
+++ b/audio/CMakeLists.txt
@@ -20,6 +20,8 @@ set(SOURCE_FILES
     "include/audio/iaudiosettings.h"
     "include/audio/iaudiosink.h"
     "include/audio/iaudiosource.h"
+    "src/iaudiosettings.cpp"
+    "src/iaudiosink.cpp"
     "src/audio.cpp"
     "src/backend/alsink.cpp"
     "src/backend/alsink.h"

--- a/audio/include/audio/iaudiosettings.h
+++ b/audio/include/audio/iaudiosettings.h
@@ -25,7 +25,12 @@
 
 class IAudioSettings {
 public:
-    virtual ~IAudioSettings() = default;
+    IAudioSettings() = default;
+    virtual ~IAudioSettings();
+    IAudioSettings(const IAudioSettings&) = default;
+    IAudioSettings& operator=(const IAudioSettings&) = default;
+    IAudioSettings(IAudioSettings&&) = default;
+    IAudioSettings& operator=(IAudioSettings&&) = default;
 
     virtual QString getInDev() const = 0;
     virtual void setInDev(const QString& deviceSpecifier) = 0;

--- a/audio/include/audio/iaudiosink.h
+++ b/audio/include/audio/iaudiosink.h
@@ -96,7 +96,13 @@ public:
         return {};
     }
 
-    virtual ~IAudioSink() = default;
+    IAudioSink() = default;
+    virtual ~IAudioSink();
+    IAudioSink(const IAudioSink&) = default;
+    IAudioSink& operator=(const IAudioSink&) = default;
+    IAudioSink(IAudioSink&&) = default;
+    IAudioSink& operator=(IAudioSink&&) = default;
+
     virtual void playAudioBuffer(const int16_t* data, int samples, unsigned channels,
                                  int sampleRate) const = 0;
     virtual void playMono16Sound(const Sound& sound) = 0;

--- a/audio/src/iaudiosettings.cpp
+++ b/audio/src/iaudiosettings.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2020 by The qTox Project Contributors
+    Copyright © 2021 by The qTox Project Contributors
 
     This file is part of qTox, a Qt-based graphical interface for Tox.
 
@@ -17,20 +17,6 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#pragma once
+#include "audio/iaudiosettings.h"
 
-#include <QList>
-class DhtServer;
-
-class IBootstrapListGenerator
-{
-public:
-    IBootstrapListGenerator() = default;
-    virtual ~IBootstrapListGenerator();
-    IBootstrapListGenerator(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator& operator=(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator(IBootstrapListGenerator&&) = default;
-    IBootstrapListGenerator& operator=(IBootstrapListGenerator&&) = default;
-
-    virtual QList<DhtServer> getBootstrapnodes() = 0;
-};
+IAudioSettings::~IAudioSettings() = default;

--- a/audio/src/iaudiosink.cpp
+++ b/audio/src/iaudiosink.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2020 by The qTox Project Contributors
+    Copyright © 2021 by The qTox Project Contributors
 
     This file is part of qTox, a Qt-based graphical interface for Tox.
 
@@ -17,20 +17,6 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#pragma once
+#include "audio/iaudiosink.h"
 
-#include <QList>
-class DhtServer;
-
-class IBootstrapListGenerator
-{
-public:
-    IBootstrapListGenerator() = default;
-    virtual ~IBootstrapListGenerator();
-    IBootstrapListGenerator(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator& operator=(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator(IBootstrapListGenerator&&) = default;
-    IBootstrapListGenerator& operator=(IBootstrapListGenerator&&) = default;
-
-    virtual QList<DhtServer> getBootstrapnodes() = 0;
-};
+IAudioSink::~IAudioSink() = default;

--- a/cmake/Testing.cmake
+++ b/cmake/Testing.cmake
@@ -34,6 +34,11 @@ function(auto_test subsystem module extra_deps)
     COMMAND ${TEST_CROSSCOMPILING_EMULATOR} test_${module})
 endfunction()
 
+set(MOCK_SOURCES
+  test/mock/mockcoreidhandler.cpp
+  test/mock/mockgroupquery.cpp
+)
+
 auto_test(core core "${${PROJECT_NAME}_RESOURCES}")
 auto_test(core contactid "")
 auto_test(core toxid "")
@@ -45,11 +50,11 @@ auto_test(persistence dbschema "")
 auto_test(persistence offlinemsgengine "")
 auto_test(persistence smileypack "${${PROJECT_NAME}_RESOURCES}") # needs emojione
 auto_test(model friendmessagedispatcher "")
-auto_test(model groupmessagedispatcher "")
+auto_test(model groupmessagedispatcher "${MOCK_SOURCES}")
 auto_test(model messageprocessor "")
 auto_test(model sessionchatlog "")
 auto_test(model exiftransform "")
-auto_test(model notificationgenerator "")
+auto_test(model notificationgenerator "${MOCK_SOURCES}")
 
 if (UNIX)
   auto_test(platform posixsignalnotifier "")

--- a/src/chatlog/chatmessage.cpp
+++ b/src/chatlog/chatmessage.cpp
@@ -45,6 +45,8 @@ ChatMessage::ChatMessage()
 {
 }
 
+ChatMessage::~ChatMessage() = default;
+
 ChatMessage::Ptr ChatMessage::createChatMessage(const QString& sender, const QString& rawMessage,
                                                 MessageType type, bool isMe, MessageState state,
                                                 const QDateTime& date, bool colorizeName)

--- a/src/chatlog/chatmessage.h
+++ b/src/chatlog/chatmessage.h
@@ -48,6 +48,10 @@ public:
     };
 
     ChatMessage();
+    ~ChatMessage();
+    ChatMessage(const ChatMessage&) = default;
+    ChatMessage& operator=(const ChatMessage&) = default;
+    ChatMessage(ChatMessage&&) = default;
 
     static ChatMessage::Ptr createChatMessage(const QString& sender, const QString& rawMessage,
                                               MessageType type, bool isMe, MessageState state,

--- a/src/core/contactid.cpp
+++ b/src/core/contactid.cpp
@@ -30,6 +30,7 @@ ContactId::ContactId()
     : id()
 {
 }
+ContactId::~ContactId() = default;
 
 /**
  * @brief Constructs a ContactId from bytes.

--- a/src/core/contactid.h
+++ b/src/core/contactid.h
@@ -28,9 +28,11 @@
 class ContactId
 {
 public:
-    virtual ~ContactId() = default;
-    ContactId& operator=(const ContactId& other) = default;
-    ContactId& operator=(ContactId&& other) = default;
+    virtual ~ContactId();
+    ContactId(const ContactId&) = default;
+    ContactId& operator=(const ContactId&) = default;
+    ContactId(ContactId&&) = default;
+    ContactId& operator=(ContactId&&) = default;
     bool operator==(const ContactId& other) const;
     bool operator!=(const ContactId& other) const;
     bool operator<(const ContactId& other) const;

--- a/src/core/icoreextpacket.cpp
+++ b/src/core/icoreextpacket.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2020 by The qTox Project Contributors
+    Copyright © 2021 by The qTox Project Contributors
 
     This file is part of qTox, a Qt-based graphical interface for Tox.
 
@@ -17,20 +17,9 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#pragma once
+#include "icoreextpacket.h"
 
-#include <QList>
-class DhtServer;
 
-class IBootstrapListGenerator
-{
-public:
-    IBootstrapListGenerator() = default;
-    virtual ~IBootstrapListGenerator();
-    IBootstrapListGenerator(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator& operator=(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator(IBootstrapListGenerator&&) = default;
-    IBootstrapListGenerator& operator=(IBootstrapListGenerator&&) = default;
+ICoreExtPacket::~ICoreExtPacket() = default;
 
-    virtual QList<DhtServer> getBootstrapnodes() = 0;
-};
+ICoreExtPacketAllocator::~ICoreExtPacketAllocator() = default;

--- a/src/core/icoreextpacket.h
+++ b/src/core/icoreextpacket.h
@@ -36,8 +36,12 @@
 class ICoreExtPacket
 {
 public:
-    virtual ~ICoreExtPacket() = default;
-
+    ICoreExtPacket() = default;
+    virtual ~ICoreExtPacket();
+    ICoreExtPacket(const ICoreExtPacket&) = default;
+    ICoreExtPacket& operator=(const ICoreExtPacket&) = default;
+    ICoreExtPacket(ICoreExtPacket&&) = default;
+    ICoreExtPacket& operator=(ICoreExtPacket&&) = default;
     /**
      * @brief Adds message to packet
      * @return Extended message receipt, UINT64_MAX on failure
@@ -59,7 +63,7 @@ public:
 class ICoreExtPacketAllocator
 {
 public:
-    virtual ~ICoreExtPacketAllocator() = default;
+    virtual ~ICoreExtPacketAllocator();
 
     /**
      * @brief Gets a new packet builder for friend with core friend id friendId

--- a/src/core/icorefriendmessagesender.cpp
+++ b/src/core/icorefriendmessagesender.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2020 by The qTox Project Contributors
+    Copyright © 2021 by The qTox Project Contributors
 
     This file is part of qTox, a Qt-based graphical interface for Tox.
 
@@ -17,20 +17,6 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#pragma once
+#include "icorefriendmessagesender.h"
 
-#include <QList>
-class DhtServer;
-
-class IBootstrapListGenerator
-{
-public:
-    IBootstrapListGenerator() = default;
-    virtual ~IBootstrapListGenerator();
-    IBootstrapListGenerator(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator& operator=(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator(IBootstrapListGenerator&&) = default;
-    IBootstrapListGenerator& operator=(IBootstrapListGenerator&&) = default;
-
-    virtual QList<DhtServer> getBootstrapnodes() = 0;
-};
+ICoreFriendMessageSender::~ICoreFriendMessageSender() = default;

--- a/src/core/icorefriendmessagesender.h
+++ b/src/core/icorefriendmessagesender.h
@@ -27,7 +27,12 @@
 class ICoreFriendMessageSender
 {
 public:
-    virtual ~ICoreFriendMessageSender() = default;
+    ICoreFriendMessageSender() = default;
+    virtual ~ICoreFriendMessageSender();
+    ICoreFriendMessageSender(const ICoreFriendMessageSender&) = default;
+    ICoreFriendMessageSender& operator=(const ICoreFriendMessageSender&) = default;
+    ICoreFriendMessageSender(ICoreFriendMessageSender&&) = default;
+    ICoreFriendMessageSender& operator=(ICoreFriendMessageSender&&) = default;
     virtual bool sendAction(uint32_t friendId, const QString& action, ReceiptNum& receipt) = 0;
     virtual bool sendMessage(uint32_t friendId, const QString& message, ReceiptNum& receipt) = 0;
 };

--- a/src/core/icoregroupmessagesender.cpp
+++ b/src/core/icoregroupmessagesender.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2020 by The qTox Project Contributors
+    Copyright © 2021 by The qTox Project Contributors
 
     This file is part of qTox, a Qt-based graphical interface for Tox.
 
@@ -17,20 +17,6 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#pragma once
+#include "icoregroupmessagesender.h"
 
-#include <QList>
-class DhtServer;
-
-class IBootstrapListGenerator
-{
-public:
-    IBootstrapListGenerator() = default;
-    virtual ~IBootstrapListGenerator();
-    IBootstrapListGenerator(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator& operator=(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator(IBootstrapListGenerator&&) = default;
-    IBootstrapListGenerator& operator=(IBootstrapListGenerator&&) = default;
-
-    virtual QList<DhtServer> getBootstrapnodes() = 0;
-};
+ICoreGroupMessageSender::~ICoreGroupMessageSender() = default;

--- a/src/core/icoregroupmessagesender.h
+++ b/src/core/icoregroupmessagesender.h
@@ -24,7 +24,13 @@
 class ICoreGroupMessageSender
 {
 public:
-    virtual ~ICoreGroupMessageSender() = default;
+    ICoreGroupMessageSender() = default;
+    virtual ~ICoreGroupMessageSender();
+    ICoreGroupMessageSender(const ICoreGroupMessageSender&) = default;
+    ICoreGroupMessageSender& operator=(const ICoreGroupMessageSender&) = default;
+    ICoreGroupMessageSender(ICoreGroupMessageSender&&) = default;
+    ICoreGroupMessageSender& operator=(ICoreGroupMessageSender&&) = default;
+
     virtual void sendGroupAction(int groupId, const QString& message) = 0;
     virtual void sendGroupMessage(int groupId, const QString& message) = 0;
 };

--- a/src/core/icoregroupquery.cpp
+++ b/src/core/icoregroupquery.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2020 by The qTox Project Contributors
+    Copyright © 2021 by The qTox Project Contributors
 
     This file is part of qTox, a Qt-based graphical interface for Tox.
 
@@ -17,20 +17,6 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#pragma once
+#include "icoregroupquery.h"
 
-#include <QList>
-class DhtServer;
-
-class IBootstrapListGenerator
-{
-public:
-    IBootstrapListGenerator() = default;
-    virtual ~IBootstrapListGenerator();
-    IBootstrapListGenerator(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator& operator=(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator(IBootstrapListGenerator&&) = default;
-    IBootstrapListGenerator& operator=(IBootstrapListGenerator&&) = default;
-
-    virtual QList<DhtServer> getBootstrapnodes() = 0;
-};
+ICoreGroupQuery::~ICoreGroupQuery() = default;

--- a/src/core/icoregroupquery.h
+++ b/src/core/icoregroupquery.h
@@ -31,7 +31,13 @@
 class ICoreGroupQuery
 {
 public:
-    virtual ~ICoreGroupQuery() = default;
+    ICoreGroupQuery() = default;
+    virtual ~ICoreGroupQuery();
+    ICoreGroupQuery(const ICoreGroupQuery&) = default;
+    ICoreGroupQuery& operator=(const ICoreGroupQuery&) = default;
+    ICoreGroupQuery(ICoreGroupQuery&&) = default;
+    ICoreGroupQuery& operator=(ICoreGroupQuery&&) = default;
+
     virtual GroupId getGroupPersistentId(uint32_t groupNumber) const = 0;
     virtual uint32_t getGroupNumberPeers(int groupId) const = 0;
     virtual QString getGroupPeerName(int groupId, int peerId) const = 0;

--- a/src/core/icoreidhandler.cpp
+++ b/src/core/icoreidhandler.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2020 by The qTox Project Contributors
+    Copyright © 2021 by The qTox Project Contributors
 
     This file is part of qTox, a Qt-based graphical interface for Tox.
 
@@ -17,20 +17,6 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#pragma once
+#include "icoreidhandler.h"
 
-#include <QList>
-class DhtServer;
-
-class IBootstrapListGenerator
-{
-public:
-    IBootstrapListGenerator() = default;
-    virtual ~IBootstrapListGenerator();
-    IBootstrapListGenerator(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator& operator=(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator(IBootstrapListGenerator&&) = default;
-    IBootstrapListGenerator& operator=(IBootstrapListGenerator&&) = default;
-
-    virtual QList<DhtServer> getBootstrapnodes() = 0;
-};
+ICoreIdHandler::~ICoreIdHandler() = default;

--- a/src/core/icoreidhandler.h
+++ b/src/core/icoreidhandler.h
@@ -26,7 +26,13 @@ class ICoreIdHandler
 {
 
 public:
-    virtual ~ICoreIdHandler() = default;
+    ICoreIdHandler() = default;
+    virtual ~ICoreIdHandler();
+    ICoreIdHandler(const ICoreIdHandler&) = default;
+    ICoreIdHandler& operator=(const ICoreIdHandler&) = default;
+    ICoreIdHandler(ICoreIdHandler&&) = default;
+    ICoreIdHandler& operator=(ICoreIdHandler&&) = default;
+
     virtual ToxId getSelfId() const = 0;
     virtual ToxPk getSelfPublicKey() const = 0;
     virtual QString getUsername() const = 0;

--- a/src/core/icoresettings.cpp
+++ b/src/core/icoresettings.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2020 by The qTox Project Contributors
+    Copyright © 2021 by The qTox Project Contributors
 
     This file is part of qTox, a Qt-based graphical interface for Tox.
 
@@ -17,20 +17,6 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#pragma once
+#include "icoresettings.h"
 
-#include <QList>
-class DhtServer;
-
-class IBootstrapListGenerator
-{
-public:
-    IBootstrapListGenerator() = default;
-    virtual ~IBootstrapListGenerator();
-    IBootstrapListGenerator(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator& operator=(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator(IBootstrapListGenerator&&) = default;
-    IBootstrapListGenerator& operator=(IBootstrapListGenerator&&) = default;
-
-    virtual QList<DhtServer> getBootstrapnodes() = 0;
-};
+ICoreSettings::~ICoreSettings() = default;

--- a/src/core/icoresettings.h
+++ b/src/core/icoresettings.h
@@ -34,7 +34,12 @@ public:
         ptSOCKS5 = 1,
         ptHTTP = 2
     };
-    virtual ~ICoreSettings() = default;
+    ICoreSettings() = default;
+    virtual ~ICoreSettings();
+    ICoreSettings(const ICoreSettings&) = default;
+    ICoreSettings& operator=(const ICoreSettings&) = default;
+    ICoreSettings(ICoreSettings&&) = default;
+    ICoreSettings& operator=(ICoreSettings&&) = default;
 
     virtual bool getEnableIPv6() const = 0;
     virtual void setEnableIPv6(bool enable) = 0;

--- a/src/model/about/iaboutfriend.cpp
+++ b/src/model/about/iaboutfriend.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2020 by The qTox Project Contributors
+    Copyright © 2021 by The qTox Project Contributors
 
     This file is part of qTox, a Qt-based graphical interface for Tox.
 
@@ -17,20 +17,6 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#pragma once
+#include "iaboutfriend.h"
 
-#include <QList>
-class DhtServer;
-
-class IBootstrapListGenerator
-{
-public:
-    IBootstrapListGenerator() = default;
-    virtual ~IBootstrapListGenerator();
-    IBootstrapListGenerator(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator& operator=(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator(IBootstrapListGenerator&&) = default;
-    IBootstrapListGenerator& operator=(IBootstrapListGenerator&&) = default;
-
-    virtual QList<DhtServer> getBootstrapnodes() = 0;
-};
+IAboutFriend::~IAboutFriend() = default;

--- a/src/model/about/iaboutfriend.h
+++ b/src/model/about/iaboutfriend.h
@@ -27,7 +27,13 @@
 class IAboutFriend
 {
 public:
-    virtual ~IAboutFriend() = default;
+    IAboutFriend() = default;
+    virtual ~IAboutFriend();
+    IAboutFriend(const IAboutFriend&) = default;
+    IAboutFriend& operator=(const IAboutFriend&) = default;
+    IAboutFriend(IAboutFriend&&) = default;
+    IAboutFriend& operator=(IAboutFriend&&) = default;
+
     virtual QString getName() const = 0;
     virtual QString getStatusMessage() const = 0;
     virtual ToxPk getPublicKey() const = 0;

--- a/src/model/chatroom/chatroom.cpp
+++ b/src/model/chatroom/chatroom.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2020 by The qTox Project Contributors
+    Copyright © 2021 by The qTox Project Contributors
 
     This file is part of qTox, a Qt-based graphical interface for Tox.
 
@@ -17,20 +17,6 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#pragma once
+#include "chatroom.h"
 
-#include <QList>
-class DhtServer;
-
-class IBootstrapListGenerator
-{
-public:
-    IBootstrapListGenerator() = default;
-    virtual ~IBootstrapListGenerator();
-    IBootstrapListGenerator(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator& operator=(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator(IBootstrapListGenerator&&) = default;
-    IBootstrapListGenerator& operator=(IBootstrapListGenerator&&) = default;
-
-    virtual QList<DhtServer> getBootstrapnodes() = 0;
-};
+Chatroom::~Chatroom() = default;

--- a/src/model/chatroom/chatroom.h
+++ b/src/model/chatroom/chatroom.h
@@ -24,5 +24,12 @@
 class Chatroom
 {
 public:
+    Chatroom() = default;
+    virtual ~Chatroom();
+    Chatroom(const Chatroom&) = default;
+    Chatroom& operator=(const Chatroom&) = default;
+    Chatroom(Chatroom&&) = default;
+    Chatroom& operator=(Chatroom&&) = default;
+
     virtual Contact* getContact() = 0;
 };

--- a/src/model/dialogs/idialogs.cpp
+++ b/src/model/dialogs/idialogs.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2020 by The qTox Project Contributors
+    Copyright © 2021 by The qTox Project Contributors
 
     This file is part of qTox, a Qt-based graphical interface for Tox.
 
@@ -17,20 +17,6 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#pragma once
+#include "idialogs.h"
 
-#include <QList>
-class DhtServer;
-
-class IBootstrapListGenerator
-{
-public:
-    IBootstrapListGenerator() = default;
-    virtual ~IBootstrapListGenerator();
-    IBootstrapListGenerator(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator& operator=(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator(IBootstrapListGenerator&&) = default;
-    IBootstrapListGenerator& operator=(IBootstrapListGenerator&&) = default;
-
-    virtual QList<DhtServer> getBootstrapnodes() = 0;
-};
+IDialogs::~IDialogs() = default;

--- a/src/model/dialogs/idialogs.h
+++ b/src/model/dialogs/idialogs.h
@@ -26,7 +26,13 @@ class ToxPk;
 class IDialogs
 {
 public:
-    virtual ~IDialogs() = default;
+    IDialogs() = default;
+    virtual ~IDialogs();
+    IDialogs(const IDialogs&) = default;
+    IDialogs& operator=(const IDialogs&) = default;
+    IDialogs(IDialogs&&) = default;
+    IDialogs& operator=(IDialogs&&) = default;
+
     virtual bool hasContact(const ContactId& contactId) const = 0;
     virtual bool isContactActive(const ContactId& contactId) const = 0;
 

--- a/src/model/dialogs/idialogsmanager.cpp
+++ b/src/model/dialogs/idialogsmanager.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2020 by The qTox Project Contributors
+    Copyright © 2021 by The qTox Project Contributors
 
     This file is part of qTox, a Qt-based graphical interface for Tox.
 
@@ -17,20 +17,6 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#pragma once
+#include "idialogsmanager.h"
 
-#include <QList>
-class DhtServer;
-
-class IBootstrapListGenerator
-{
-public:
-    IBootstrapListGenerator() = default;
-    virtual ~IBootstrapListGenerator();
-    IBootstrapListGenerator(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator& operator=(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator(IBootstrapListGenerator&&) = default;
-    IBootstrapListGenerator& operator=(IBootstrapListGenerator&&) = default;
-
-    virtual QList<DhtServer> getBootstrapnodes() = 0;
-};
+IDialogsManager::~IDialogsManager() = default;

--- a/src/model/dialogs/idialogsmanager.h
+++ b/src/model/dialogs/idialogsmanager.h
@@ -27,7 +27,13 @@ class ToxPk;
 class IDialogsManager
 {
 public:
-    virtual ~IDialogsManager() = default;
+    IDialogsManager() = default;
+    virtual ~IDialogsManager();
+    IDialogsManager(const IDialogsManager&) = default;
+    IDialogsManager& operator=(const IDialogsManager&) = default;
+    IDialogsManager(IDialogsManager&&) = default;
+    IDialogsManager& operator=(IDialogsManager&&) = default;
+
     virtual IDialogs* getFriendDialogs(const ToxPk& friendPk) const = 0;
     virtual IDialogs* getGroupDialogs(const GroupId& groupId) const = 0;
 };

--- a/src/model/friendlist/ifriendlistitem.cpp
+++ b/src/model/friendlist/ifriendlistitem.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2020 by The qTox Project Contributors
+    Copyright © 2021 by The qTox Project Contributors
 
     This file is part of qTox, a Qt-based graphical interface for Tox.
 
@@ -17,20 +17,6 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#pragma once
+#include "ifriendlistitem.h"
 
-#include <QList>
-class DhtServer;
-
-class IBootstrapListGenerator
-{
-public:
-    IBootstrapListGenerator() = default;
-    virtual ~IBootstrapListGenerator();
-    IBootstrapListGenerator(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator& operator=(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator(IBootstrapListGenerator&&) = default;
-    IBootstrapListGenerator& operator=(IBootstrapListGenerator&&) = default;
-
-    virtual QList<DhtServer> getBootstrapnodes() = 0;
-};
+IFriendListItem::~IFriendListItem() = default;

--- a/src/model/friendlist/ifriendlistitem.h
+++ b/src/model/friendlist/ifriendlistitem.h
@@ -26,8 +26,12 @@ class QWidget;
 class IFriendListItem
 {
 public:
-
-    virtual ~IFriendListItem() = default;
+    IFriendListItem() = default;
+    virtual ~IFriendListItem();
+    IFriendListItem(const IFriendListItem&) = default;
+    IFriendListItem& operator=(const IFriendListItem&) = default;
+    IFriendListItem(IFriendListItem&&) = default;
+    IFriendListItem& operator=(IFriendListItem&&) = default;
 
     virtual bool isFriend() const = 0;
     virtual bool isGroup() const = 0;

--- a/src/model/ibootstraplistgenerator.cpp
+++ b/src/model/ibootstraplistgenerator.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2020 by The qTox Project Contributors
+    Copyright © 2021 by The qTox Project Contributors
 
     This file is part of qTox, a Qt-based graphical interface for Tox.
 
@@ -17,20 +17,6 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#pragma once
+#include "ibootstraplistgenerator.h"
 
-#include <QList>
-class DhtServer;
-
-class IBootstrapListGenerator
-{
-public:
-    IBootstrapListGenerator() = default;
-    virtual ~IBootstrapListGenerator();
-    IBootstrapListGenerator(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator& operator=(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator(IBootstrapListGenerator&&) = default;
-    IBootstrapListGenerator& operator=(IBootstrapListGenerator&&) = default;
-
-    virtual QList<DhtServer> getBootstrapnodes() = 0;
-};
+IBootstrapListGenerator::~IBootstrapListGenerator() = default;

--- a/src/model/notificationgenerator.cpp
+++ b/src/model/notificationgenerator.cpp
@@ -162,6 +162,8 @@ NotificationGenerator::NotificationGenerator(
     , profile(profile)
 {}
 
+NotificationGenerator::~NotificationGenerator() = default;
+
 NotificationData NotificationGenerator::friendMessageNotification(const Friend* f, const QString& message)
 {
     friendNotifications[f]++;

--- a/src/model/notificationgenerator.h
+++ b/src/model/notificationgenerator.h
@@ -39,6 +39,11 @@ public:
         // currently mockable so we allow profile to be nullptr for unit
         // testing
         Profile* profile);
+    virtual ~NotificationGenerator();
+    NotificationGenerator(const NotificationGenerator&) = delete;
+    NotificationGenerator& operator=(const NotificationGenerator&) = delete;
+    NotificationGenerator(NotificationGenerator&&) = delete;
+    NotificationGenerator& operator=(NotificationGenerator&&) = delete;
 
     NotificationData friendMessageNotification(const Friend* f, const QString& message);
     NotificationData groupMessageNotification(const Group* g, const ToxPk& sender, const QString& message);

--- a/src/model/profile/iprofileinfo.cpp
+++ b/src/model/profile/iprofileinfo.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2020 by The qTox Project Contributors
+    Copyright © 2021 by The qTox Project Contributors
 
     This file is part of qTox, a Qt-based graphical interface for Tox.
 
@@ -17,20 +17,6 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#pragma once
+#include "iprofileinfo.h"
 
-#include <QList>
-class DhtServer;
-
-class IBootstrapListGenerator
-{
-public:
-    IBootstrapListGenerator() = default;
-    virtual ~IBootstrapListGenerator();
-    IBootstrapListGenerator(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator& operator=(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator(IBootstrapListGenerator&&) = default;
-    IBootstrapListGenerator& operator=(IBootstrapListGenerator&&) = default;
-
-    virtual QList<DhtServer> getBootstrapnodes() = 0;
-};
+IProfileInfo::~IProfileInfo() = default;

--- a/src/model/profile/iprofileinfo.h
+++ b/src/model/profile/iprofileinfo.h
@@ -39,7 +39,13 @@ public:
     enum class SetAvatarResult {
         OK, EmptyPath, CanNotOpen, CanNotRead, TooLarge
     };
-    virtual ~IProfileInfo() = default;
+
+    IProfileInfo() = default;
+    virtual ~IProfileInfo();
+    IProfileInfo(const IProfileInfo&) = default;
+    IProfileInfo& operator=(const IProfileInfo&) = default;
+    IProfileInfo(IProfileInfo&&) = default;
+    IProfileInfo& operator=(IProfileInfo&&) = default;
 
     virtual bool setPassword(const QString& password) = 0;
     virtual bool deletePassword() = 0;

--- a/src/persistence/ifriendsettings.cpp
+++ b/src/persistence/ifriendsettings.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2020 by The qTox Project Contributors
+    Copyright © 2021 by The qTox Project Contributors
 
     This file is part of qTox, a Qt-based graphical interface for Tox.
 
@@ -17,20 +17,6 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#pragma once
+#include "ifriendsettings.h"
 
-#include <QList>
-class DhtServer;
-
-class IBootstrapListGenerator
-{
-public:
-    IBootstrapListGenerator() = default;
-    virtual ~IBootstrapListGenerator();
-    IBootstrapListGenerator(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator& operator=(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator(IBootstrapListGenerator&&) = default;
-    IBootstrapListGenerator& operator=(IBootstrapListGenerator&&) = default;
-
-    virtual QList<DhtServer> getBootstrapnodes() = 0;
-};
+IFriendSettings::~IFriendSettings() = default;

--- a/src/persistence/ifriendsettings.h
+++ b/src/persistence/ifriendsettings.h
@@ -38,7 +38,12 @@ public:
     };
     Q_DECLARE_FLAGS(AutoAcceptCallFlags, AutoAcceptCall)
 
-    virtual ~IFriendSettings() = default;
+    IFriendSettings() = default;
+    virtual ~IFriendSettings();
+    IFriendSettings(const IFriendSettings&) = default;
+    IFriendSettings& operator=(const IFriendSettings&) = default;
+    IFriendSettings(IFriendSettings&&) = default;
+    IFriendSettings& operator=(IFriendSettings&&) = default;
 
     virtual QString getContactNote(const ToxPk& pk) const = 0;
     virtual void setContactNote(const ToxPk& pk, const QString& note) = 0;

--- a/src/persistence/igroupsettings.cpp
+++ b/src/persistence/igroupsettings.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2020 by The qTox Project Contributors
+    Copyright © 2021 by The qTox Project Contributors
 
     This file is part of qTox, a Qt-based graphical interface for Tox.
 
@@ -17,20 +17,6 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#pragma once
+#include "igroupsettings.h"
 
-#include <QList>
-class DhtServer;
-
-class IBootstrapListGenerator
-{
-public:
-    IBootstrapListGenerator() = default;
-    virtual ~IBootstrapListGenerator();
-    IBootstrapListGenerator(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator& operator=(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator(IBootstrapListGenerator&&) = default;
-    IBootstrapListGenerator& operator=(IBootstrapListGenerator&&) = default;
-
-    virtual QList<DhtServer> getBootstrapnodes() = 0;
-};
+IGroupSettings::~IGroupSettings() = default;

--- a/src/persistence/igroupsettings.h
+++ b/src/persistence/igroupsettings.h
@@ -24,7 +24,13 @@
 class IGroupSettings
 {
 public:
-    virtual ~IGroupSettings() = default;
+    IGroupSettings() = default;
+    virtual ~IGroupSettings();
+    IGroupSettings(const IGroupSettings&) = default;
+    IGroupSettings& operator=(const IGroupSettings&) = default;
+    IGroupSettings(IGroupSettings&&) = default;
+    IGroupSettings& operator=(IGroupSettings&&) = default;
+
     virtual QStringList getBlackList() const = 0;
     virtual void setBlackList(const QStringList& blist) = 0;
 };

--- a/src/persistence/inotificationsettings.cpp
+++ b/src/persistence/inotificationsettings.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2020 by The qTox Project Contributors
+    Copyright © 2021 by The qTox Project Contributors
 
     This file is part of qTox, a Qt-based graphical interface for Tox.
 
@@ -17,20 +17,6 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#pragma once
+#include "inotificationsettings.h"
 
-#include <QList>
-class DhtServer;
-
-class IBootstrapListGenerator
-{
-public:
-    IBootstrapListGenerator() = default;
-    virtual ~IBootstrapListGenerator();
-    IBootstrapListGenerator(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator& operator=(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator(IBootstrapListGenerator&&) = default;
-    IBootstrapListGenerator& operator=(IBootstrapListGenerator&&) = default;
-
-    virtual QList<DhtServer> getBootstrapnodes() = 0;
-};
+INotificationSettings::~INotificationSettings() = default;

--- a/src/persistence/inotificationsettings.h
+++ b/src/persistence/inotificationsettings.h
@@ -24,7 +24,12 @@
 class INotificationSettings
 {
 public:
-    virtual ~INotificationSettings() = default;
+    INotificationSettings() = default;
+    virtual ~INotificationSettings();
+    INotificationSettings(const INotificationSettings&) = default;
+    INotificationSettings& operator=(const INotificationSettings&) = default;
+    INotificationSettings(INotificationSettings&&) = default;
+    INotificationSettings& operator=(INotificationSettings&&) = default;
 
     virtual bool getNotify() const = 0;
     virtual void setNotify(bool newValue) = 0;

--- a/src/video/ivideosettings.cpp
+++ b/src/video/ivideosettings.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2020 by The qTox Project Contributors
+    Copyright © 2021 by The qTox Project Contributors
 
     This file is part of qTox, a Qt-based graphical interface for Tox.
 
@@ -17,20 +17,6 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#pragma once
+#include "ivideosettings.h"
 
-#include <QList>
-class DhtServer;
-
-class IBootstrapListGenerator
-{
-public:
-    IBootstrapListGenerator() = default;
-    virtual ~IBootstrapListGenerator();
-    IBootstrapListGenerator(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator& operator=(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator(IBootstrapListGenerator&&) = default;
-    IBootstrapListGenerator& operator=(IBootstrapListGenerator&&) = default;
-
-    virtual QList<DhtServer> getBootstrapnodes() = 0;
-};
+IVideoSettings::~IVideoSettings() = default;

--- a/src/video/ivideosettings.h
+++ b/src/video/ivideosettings.h
@@ -26,7 +26,12 @@
 
 class IVideoSettings {
 public:
-    virtual ~IVideoSettings() = default;
+    IVideoSettings() = default;
+    virtual ~IVideoSettings();
+    IVideoSettings(const IVideoSettings&) = default;
+    IVideoSettings& operator=(const IVideoSettings&) = default;
+    IVideoSettings(IVideoSettings&&) = default;
+    IVideoSettings& operator=(IVideoSettings&&) = default;
 
     virtual QString getVideoDev() const = 0;
     virtual void setVideoDev(const QString& deviceSpecifier) = 0;

--- a/src/widget/imagepreviewwidget.cpp
+++ b/src/widget/imagepreviewwidget.cpp
@@ -103,6 +103,8 @@ QString getToolTipDisplayingImage(const QPixmap& image)
 
 } // namespace
 
+ImagePreviewButton::~ImagePreviewButton() = default;
+
 void ImagePreviewButton::initialize(const QPixmap& image)
 {
     auto desiredSize = qMin(width(), height()); // Assume widget is a square

--- a/src/widget/imagepreviewwidget.h
+++ b/src/widget/imagepreviewwidget.h
@@ -29,6 +29,11 @@ public:
     ImagePreviewButton(QWidget* parent = nullptr)
         : QPushButton(parent)
     {}
+    ~ImagePreviewButton();
+    ImagePreviewButton(const ImagePreviewButton&) = delete;
+    ImagePreviewButton& operator=(const ImagePreviewButton&) = delete;
+    ImagePreviewButton(ImagePreviewButton&&) = delete;
+    ImagePreviewButton& operator=(ImagePreviewButton&&) = delete;
 
     void setIconFromFile(const QString& filename);
     void setIconFromPixmap(const QPixmap& image);

--- a/test/core/core_test.cpp
+++ b/test/core/core_test.cpp
@@ -77,10 +77,12 @@ private:
 
 class MockNodeListGenerator : public IBootstrapListGenerator
 {
-    QList<DhtServer> getBootstrapnodes() {
-        return BootstrapNodeUpdater::loadDefaultBootstrapNodes();
-    }
+    QList<DhtServer> getBootstrapnodes();
 };
+
+QList<DhtServer> MockNodeListGenerator::getBootstrapnodes() {
+    return BootstrapNodeUpdater::loadDefaultBootstrapNodes();
+}
 
 class TestCore : public QObject
 {

--- a/test/mock/mockcoreidhandler.cpp
+++ b/test/mock/mockcoreidhandler.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2020 by The qTox Project Contributors
+    Copyright © 2021 by The qTox Project Contributors
 
     This file is part of qTox, a Qt-based graphical interface for Tox.
 
@@ -17,20 +17,6 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#pragma once
+#include "mockcoreidhandler.h"
 
-#include <QList>
-class DhtServer;
-
-class IBootstrapListGenerator
-{
-public:
-    IBootstrapListGenerator() = default;
-    virtual ~IBootstrapListGenerator();
-    IBootstrapListGenerator(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator& operator=(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator(IBootstrapListGenerator&&) = default;
-    IBootstrapListGenerator& operator=(IBootstrapListGenerator&&) = default;
-
-    virtual QList<DhtServer> getBootstrapnodes() = 0;
-};
+MockCoreIdHandler::~MockCoreIdHandler() = default;

--- a/test/mock/mockcoreidhandler.h
+++ b/test/mock/mockcoreidhandler.h
@@ -26,6 +26,13 @@
 class MockCoreIdHandler : public ICoreIdHandler
 {
 public:
+    MockCoreIdHandler() = default;
+    virtual ~MockCoreIdHandler();
+    MockCoreIdHandler(const MockCoreIdHandler&) = default;
+    MockCoreIdHandler& operator=(const MockCoreIdHandler&) = default;
+    MockCoreIdHandler(MockCoreIdHandler&&) = default;
+    MockCoreIdHandler& operator=(MockCoreIdHandler&&) = default;
+
     ToxId getSelfId() const override
     {
         std::terminate();

--- a/test/mock/mockgroupquery.cpp
+++ b/test/mock/mockgroupquery.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2020 by The qTox Project Contributors
+    Copyright © 2021 by The qTox Project Contributors
 
     This file is part of qTox, a Qt-based graphical interface for Tox.
 
@@ -17,20 +17,6 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#pragma once
+#include "mockgroupquery.h"
 
-#include <QList>
-class DhtServer;
-
-class IBootstrapListGenerator
-{
-public:
-    IBootstrapListGenerator() = default;
-    virtual ~IBootstrapListGenerator();
-    IBootstrapListGenerator(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator& operator=(const IBootstrapListGenerator&) = default;
-    IBootstrapListGenerator(IBootstrapListGenerator&&) = default;
-    IBootstrapListGenerator& operator=(IBootstrapListGenerator&&) = default;
-
-    virtual QList<DhtServer> getBootstrapnodes() = 0;
-};
+MockGroupQuery::~MockGroupQuery() = default;

--- a/test/mock/mockgroupquery.h
+++ b/test/mock/mockgroupquery.h
@@ -29,6 +29,13 @@
 class MockGroupQuery : public ICoreGroupQuery
 {
 public:
+    MockGroupQuery() = default;
+    virtual ~MockGroupQuery();
+    MockGroupQuery(const MockGroupQuery&) = default;
+    MockGroupQuery& operator=(const MockGroupQuery&) = default;
+    MockGroupQuery(MockGroupQuery&&) = default;
+    MockGroupQuery& operator=(MockGroupQuery&&) = default;
+
     GroupId getGroupPersistentId(uint32_t groupNumber) const override
     {
         return GroupId(0);

--- a/test/model/friendmessagedispatcher_test.cpp
+++ b/test/model/friendmessagedispatcher_test.cpp
@@ -40,17 +40,9 @@ public:
         , currentReceiptId(currentReceiptId)
     {}
 
-    uint64_t addExtendedMessage(QString message) override
-    {
-        this->message = message;
-        return currentReceiptId++;
-    }
+    uint64_t addExtendedMessage(QString message) override;
 
-    bool send() override
-    {
-        numSentMessages++;
-        return true;
-    }
+    bool send() override;
 
     uint64_t& numSentMessages;
     uint64_t& currentReceiptId;
@@ -58,46 +50,65 @@ public:
     QString message;
 };
 
+uint64_t MockCoreExtPacket::addExtendedMessage(QString message)
+{
+    this->message = message;
+    return currentReceiptId++;
+}
+
+bool MockCoreExtPacket::send()
+{
+    numSentMessages++;
+    return true;
+}
+
 class MockCoreExtPacketAllocator : public ICoreExtPacketAllocator
 {
 public:
-    std::unique_ptr<ICoreExtPacket> getPacket(uint32_t friendId) override
-    {
-        return std::unique_ptr<MockCoreExtPacket>(new MockCoreExtPacket(numSentMessages, currentReceiptId));
-    }
+    std::unique_ptr<ICoreExtPacket> getPacket(uint32_t friendId) override;
 
     uint64_t numSentMessages;
     uint64_t currentReceiptId;
 };
 
+std::unique_ptr<ICoreExtPacket> MockCoreExtPacketAllocator::getPacket(uint32_t friendId)
+{
+    return std::unique_ptr<MockCoreExtPacket>(new MockCoreExtPacket(numSentMessages, currentReceiptId));
+}
+
 class MockFriendMessageSender : public ICoreFriendMessageSender
 {
 public:
-    bool sendAction(uint32_t friendId, const QString& action, ReceiptNum& receipt) override
-    {
-        if (canSend) {
-            numSentActions++;
-            receipt = receiptNum;
-            receiptNum.get() += 1;
-        }
-        return canSend;
-    }
+    bool sendAction(uint32_t friendId, const QString& action, ReceiptNum& receipt) override;
 
-    bool sendMessage(uint32_t friendId, const QString& message, ReceiptNum& receipt) override
-    {
-        if (canSend) {
-            numSentMessages++;
-            receipt = receiptNum;
-            receiptNum.get() += 1;
-        }
-        return canSend;
-    }
+    bool sendMessage(uint32_t friendId, const QString& message, ReceiptNum& receipt) override;
 
     bool canSend = true;
     ReceiptNum receiptNum{0};
     size_t numSentActions = 0;
     size_t numSentMessages = 0;
 };
+
+bool MockFriendMessageSender::sendAction(uint32_t friendId, const QString& action, ReceiptNum& receipt)
+{
+    if (canSend) {
+        numSentActions++;
+        receipt = receiptNum;
+        receiptNum.get() += 1;
+    }
+    return canSend;
+}
+
+bool MockFriendMessageSender::sendMessage(uint32_t friendId, const QString& message, ReceiptNum& receipt)
+{
+    if (canSend) {
+        numSentMessages++;
+        receipt = receiptNum;
+        receiptNum.get() += 1;
+    }
+    return canSend;
+}
+
 class TestFriendMessageDispatcher : public QObject
 {
     Q_OBJECT

--- a/test/model/groupmessagedispatcher_test.cpp
+++ b/test/model/groupmessagedispatcher_test.cpp
@@ -36,36 +36,44 @@
 class MockGroupMessageSender : public ICoreGroupMessageSender
 {
 public:
-    void sendGroupAction(int groupId, const QString& action) override
-    {
-        numSentActions++;
-    }
+    void sendGroupAction(int groupId, const QString& action) override;
 
-    void sendGroupMessage(int groupId, const QString& message) override
-    {
-        numSentMessages++;
-    }
+    void sendGroupMessage(int groupId, const QString& message) override;
 
     size_t numSentActions = 0;
     size_t numSentMessages = 0;
 };
 
+void MockGroupMessageSender::sendGroupAction(int groupId, const QString& action)
+{
+    numSentActions++;
+}
+
+void MockGroupMessageSender::sendGroupMessage(int groupId, const QString& message)
+{
+    numSentMessages++;
+}
+
 class MockGroupSettings : public IGroupSettings
 {
 public:
-    QStringList getBlackList() const override
-    {
-        return blacklist;
-    }
+    QStringList getBlackList() const override;
 
-    void setBlackList(const QStringList& blist) override
-    {
-        blacklist = blist;
-    }
+    void setBlackList(const QStringList& blist) override;
 
 private:
     QStringList blacklist;
 };
+
+QStringList MockGroupSettings::getBlackList() const
+{
+    return blacklist;
+}
+
+void MockGroupSettings::setBlackList(const QStringList& blist)
+{
+    blacklist = blist;
+}
 
 class TestGroupMessageDispatcher : public QObject
 {


### PR DESCRIPTION
Define at least one virtual method in cpp files for classes with
vtables to improve link time. This is done by defining a defaulted
destructor in the cpp file, or moving an overridden method from the
header to the cpp file. Where neccessary, create new cpp files and
add them to CMakeLists.

See http://llvm.org/docs/CodingStandards.html#provide-a-virtual-method-anchor-for-classes-in-headers.

Fixes #6036.

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6394)
<!-- Reviewable:end -->
