### PR TITLE
Set DEBIAN_FRONTEND=noninteractive in docker builds for apt-get, and disable bootstrap daemon building

### DIFF
--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -53,7 +53,7 @@ RUN apt-get update && \
 RUN git clone https://github.com/toktok/c-toxcore.git /toxcore
 WORKDIR /toxcore
 RUN git checkout v0.2.12 && \
-        cmake . && \
+        cmake . -DBOOTSTRAP_DAEMON=OFF && \
         cmake --build . && \
         make install && \
         echo '/usr/local/lib/' >> /etc/ld.so.conf.d/locallib.conf && \

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -16,6 +16,8 @@
 
 FROM debian:stretch
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update && \
     apt-get -y --force-yes install \
     automake \

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -16,6 +16,8 @@
 
 FROM ubuntu:16.04
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update && \
     apt-get -y --force-yes install \
     build-essential \

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -50,7 +50,7 @@ RUN apt-get update && \
 RUN git clone https://github.com/toktok/c-toxcore.git /toxcore
 WORKDIR /toxcore
 RUN git checkout v0.2.12 && \
-        cmake . && \
+        cmake . -DBOOTSTRAP_DAEMON=OFF && \
         cmake --build . && \
         make install && \
         echo '/usr/local/lib/' >> /etc/ld.so.conf.d/locallib.conf && \


### PR DESCRIPTION
- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6398)
<!-- Reviewable:end -->
