### PR TITLE
chore(build): Use mingw POSIX threading model for pthreads support

### DIFF
--- a/windows/cross-compile/build.sh
+++ b/windows/cross-compile/build.sh
@@ -152,11 +152,15 @@ then
   apt-get install -y --no-install-recommends \
                     g++-mingw-w64-i686 \
                     gcc-mingw-w64-i686
+  update-alternatives --set i686-w64-mingw32-gcc /usr/bin/i686-w64-mingw32-gcc-posix
+  update-alternatives --set i686-w64-mingw32-g++ /usr/bin/i686-w64-mingw32-g++-posix
 elif [[ "$ARCH" == "x86_64" ]]
 then
   apt-get install -y --no-install-recommends \
                     g++-mingw-w64-x86-64 \
                     gcc-mingw-w64-x86-64
+  update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix
+  update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
 fi
 
 


### PR DESCRIPTION
Fix build failure saying that std::mutex was not declared

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6399)
<!-- Reviewable:end -->
