### PR TITLE
perf: reduce repainting in animations

### DIFF
--- a/src/chatlog/content/broken.cpp
+++ b/src/chatlog/content/broken.cpp
@@ -50,11 +50,6 @@ void Broken::setWidth(qreal width)
     Q_UNUSED(width)
 }
 
-void Broken::visibilityChanged(bool visible)
-{
-    Q_UNUSED(visible)
-}
-
 qreal Broken::getAscent() const
 {
     return 0.0;

--- a/src/chatlog/content/broken.h
+++ b/src/chatlog/content/broken.h
@@ -33,7 +33,6 @@ public:
     void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
                        QWidget* widget) override;
     void setWidth(qreal width) override;
-    void visibilityChanged(bool visible) override;
     qreal getAscent() const override;
 
 private:

--- a/src/chatlog/content/notificationicon.h
+++ b/src/chatlog/content/notificationicon.h
@@ -23,8 +23,7 @@
 
 #include <QLinearGradient>
 #include <QPixmap>
-
-class QTimer;
+#include <QTimer>
 
 class NotificationIcon : public ChatLineContent
 {
@@ -42,10 +41,12 @@ private slots:
     void updateGradient();
 
 private:
+    static constexpr int framerate = 30; // 30Hz
+
     QSize size;
     QPixmap pmap;
     QLinearGradient grad;
-    QTimer* updateTimer = nullptr;
+    QTimer updateTimer;
 
     qreal dotWidth = 0.2;
     qreal alpha = 0.0;

--- a/src/chatlog/content/spinner.h
+++ b/src/chatlog/content/spinner.h
@@ -37,16 +37,17 @@ public:
     void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,
                        QWidget* widget) override;
     void setWidth(qreal width) override;
-    void visibilityChanged(bool visible) override;
     qreal getAscent() const override;
 
 private slots:
     void timeout();
 
 private:
+    static constexpr int framerate = 30; // 30Hz
     QSize size;
     QPixmap pmap;
     qreal rotSpeed;
+    qreal curRot;
     QTimer timer;
     qreal alpha = 0.0;
     QVariantAnimation* blendAnimation;


### PR DESCRIPTION
By profiling qTox using perf I discovered, that
NotificationIcon::updateGradient takes significant amount of CPU time
even though qTox is idle and no one is typing.

This commit fixes:

1) correctly determine visibility of NotificationIcon
2) only invalidate boundingRect in fixed intervals
3) apply the same fixes to Spinner since it has the same problem

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6414)
<!-- Reviewable:end -->
