### PR TITLE
chore(release): Create release on tag push

### DIFF
--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -1,6 +1,14 @@
-name: Test
+name: Build, test, and deploy
 on: [pull_request, push]
 jobs:
+  update-nightly-tag:
+    name: Update nightly release tag
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v2
+      - name: Move nightly tag to head for nightly release
+        run: git tag -f nightly && git push origin nightly -f
   build-flatpak-docker:
     name: Build flatpak docker
     runs-on: ubuntu-latest
@@ -189,7 +197,12 @@ jobs:
   build-appimage:
     name: Appimage
     runs-on: ubuntu-latest
-    needs: build-ubuntu-lts-docker
+    needs: [build-ubuntu-lts-docker, update-nightly-tag]
+    if: |
+      always() &&
+      needs.build-ubuntu-lts-docker.result == 'success' &&
+      (needs.update-nightly-tag.result == 'success' ||
+        needs.update-nightly-tag.result == 'skipped')
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/load-docker-image
@@ -203,10 +216,27 @@ jobs:
         with:
           name: qTox-${{ github.sha }}.x86_64.AppImage
           path: qTox-*.x86_64.AppImage
+      - name: Rename artifact for nightly upload
+        run: cp qTox-*.x86_64.AppImage qTox-nightly.x86_64.AppImage
+      - name: Upload to nightly release
+        uses: ncipollo/release-action@v1
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        with:
+          allowUpdates: true
+          tag: nightly
+          prerelease: true
+          replacesArtifacts: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: "qTox-nightly.x86_64.AppImage"
   build-flatpak:
     name: Flatpak
     runs-on: ubuntu-latest
-    needs: build-flatpak-docker
+    needs: [build-flatpak-docker, update-nightly-tag]
+    if: |
+      always() &&
+      needs.build-flatpak-docker.result == 'success' &&
+      (needs.update-nightly-tag.result == 'success' ||
+        needs.update-nightly-tag.result == 'skipped')
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/load-docker-image
@@ -220,10 +250,27 @@ jobs:
         with:
           name: qTox-${{ github.sha }}.x86_64.flatpak
           path: qtox.flatpak
+      - name: Rename artifact for nightly upload
+        run: cp qtox.flatpak qTox-nightly.flatpak
+      - name: Upload to nightly release
+        uses: ncipollo/release-action@v1
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        with:
+          allowUpdates: true
+          tag: nightly
+          prerelease: true
+          replacesArtifacts: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: "qTox-nightly.flatpak"
   build-windows:
     name: Windows
     runs-on: ubuntu-latest
-    needs: build-windows-docker
+    needs: [build-windows-docker, update-nightly-tag]
+    if: |
+      always() &&
+      needs.build-windows-docker.result == 'success' &&
+      (needs.update-nightly-tag.result == 'success' ||
+        needs.update-nightly-tag.result == 'skipped')
     strategy:
       matrix:
         build_type: [debug, release]
@@ -245,10 +292,42 @@ jobs:
         with:
           name: setup-qtox-x86_64-${{ matrix.build_type }}.zip
           path: install-prefix/qtox-x86_64-${{ matrix.build_type }}.zip
+          if-no-files-found: ignore
+      - name: Rename zip for nightly upload
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        run: cp install-prefix/qtox-x86_64-${{ matrix.build_type }}.zip setup-qtox-nightly-x86_64-${{ matrix.build_type }}.zip
+      - name: Upload zip to nightly release
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          tag: nightly
+          prerelease: true
+          replacesArtifacts: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: "setup-qtox-nightly-x86_64-${{ matrix.build_type }}.zip"
+      - name: Rename exe for nightly upload
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.build_type == 'release'
+        run: cp package-prefix/setup-qtox.exe setup-qtox-nightly-x86_64-release.exe
+      - name: Upload exe to nightly release
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.build_type == 'release'
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          tag: nightly
+          prerelease: true
+          replacesArtifacts: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: "setup-qtox-nightly-x86_64-release.exe"
   build-windows-i686:
     name: Windows i686
     runs-on: ubuntu-latest
-    needs: build-windows-i686-docker
+    needs: [build-windows-i686-docker, update-nightly-tag]
+    if: |
+      always() &&
+      needs.build-windows-i686-docker.result == 'success' &&
+      (needs.update-nightly-tag.result == 'success' ||
+        needs.update-nightly-tag.result == 'skipped')
     strategy:
       matrix:
         build_type: [debug, release]
@@ -270,9 +349,44 @@ jobs:
         with:
           name: setup-qtox-i686-${{ matrix.build_type }}.zip
           path: install-prefix/qtox-i686-${{ matrix.build_type }}.zip
+          if-no-files-found: ignore
+      - name: Rename zip for nightly upload
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        run: cp install-prefix/qtox-i686-${{ matrix.build_type }}.zip setup-qtox-nightly-i686-${{ matrix.build_type }}.zip
+      - name: Upload zip to nightly release
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          tag: nightly
+          prerelease: true
+          replacesArtifacts: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: "setup-qtox-nightly-i686-${{ matrix.build_type }}.zip"
+      - name: Rename exe for nightly upload
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.build_type == 'release'
+        run: cp package-prefix/setup-qtox.exe setup-qtox-nightly-i686-release.exe
+      - name: Upload exe to nightly release
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.build_type == 'release'
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          tag: nightly
+          prerelease: true
+          replacesArtifacts: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: "setup-qtox-nightly-i686-release.exe"
   build-osx:
     name: macOS
     runs-on: macos-10.15
+    needs: update-nightly-tag
+    if: |
+      always() &&
+      (needs.update-nightly-tag.result == 'success' ||
+        needs.update-nightly-tag.result == 'skipped')
+    env:
+      TRAVIS: true
+      TRAVIS_BUILD_DIR: ${{ github.workspace }}
     steps:
       - uses: actions/checkout@v2
       - name: homebrew
@@ -286,6 +400,18 @@ jobs:
         with:
           name: qTox-${{ github.sha }}.dmg
           path: qTox.dmg
+      - name: Rename artifact for nightly upload
+        run: cp qTox.dmg qTox-nightly.dmg
+      - name: Upload to nightly release
+        uses: ncipollo/release-action@v1
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        with:
+          allowUpdates: true
+          tag: nightly
+          prerelease: true
+          replacesArtifacts: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: "qTox-nightly.dmg"
   build-docs:
     name: Docs
     runs-on: ubuntu-18.04

--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -216,7 +216,26 @@ jobs:
         with:
           name: qTox-${{ github.sha }}.x86_64.AppImage
           path: qTox-*.x86_64.AppImage
+      - name: Get tag name for appimage release file name
+        if: contains(github.ref, 'refs/tags/v')
+        id: get_version
+        run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+      - name: Rename appimage for release upload
+        if: contains(github.ref, 'refs/tags/v')
+        run: |
+          cp qTox-*.x86_64.AppImage qTox-${{ steps.get_version.outputs.VERSION }}.x86_64.AppImage
+          sha256sum qTox-${{ steps.get_version.outputs.VERSION }}.x86_64.AppImage > qTox-${{ steps.get_version.outputs.VERSION }}.x86_64.AppImage.sha256
+          cp qTox-*.x86_64.AppImage.zsync qTox-${{ steps.get_version.outputs.VERSION }}.x86_64.AppImage.zsync
+      - name: Upload to versioned release
+        if: contains(github.ref, 'refs/tags/v')
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          draft: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: "qTox-${{ steps.get_version.outputs.VERSION }}.x86_64.AppImage,qTox-${{ steps.get_version.outputs.VERSION }}.x86_64.AppImage.sha256,qTox-${{ steps.get_version.outputs.VERSION }}.x86_64.AppImage.zsync"
       - name: Rename artifact for nightly upload
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: cp qTox-*.x86_64.AppImage qTox-nightly.x86_64.AppImage
       - name: Upload to nightly release
         uses: ncipollo/release-action@v1
@@ -250,7 +269,25 @@ jobs:
         with:
           name: qTox-${{ github.sha }}.x86_64.flatpak
           path: qtox.flatpak
+      - name: Get tag name for flatpak release file name
+        if: contains(github.ref, 'refs/tags/v')
+        id: get_version
+        run: echo ::set-output name=VERSION::$(echo $GITHUB_REF | cut -d / -f 3)
+      - name: Rename flatpak for release upload
+        if: contains(github.ref, 'refs/tags/v')
+        run: |
+          cp qtox.flatpak qTox-${{ steps.get_version.outputs.VERSION }}.x86_64.flatpak
+          sha256sum qTox-${{ steps.get_version.outputs.VERSION }}.x86_64.flatpak > qTox-${{ steps.get_version.outputs.VERSION }}.x86_64.flatpak.sha256
+      - name: Upload to versioned release
+        if: contains(github.ref, 'refs/tags/v')
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          draft: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: "qTox-${{ steps.get_version.outputs.VERSION }}.x86_64.flatpak,qTox-${{ steps.get_version.outputs.VERSION }}.x86_64.flatpak.sha256"
       - name: Rename artifact for nightly upload
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: cp qtox.flatpak qTox-nightly.flatpak
       - name: Upload to nightly release
         uses: ncipollo/release-action@v1
@@ -293,6 +330,19 @@ jobs:
           name: setup-qtox-x86_64-${{ matrix.build_type }}.zip
           path: install-prefix/qtox-x86_64-${{ matrix.build_type }}.zip
           if-no-files-found: ignore
+      - name: Rename exe for release upload
+        if: contains(github.ref, 'refs/tags/v') && matrix.build_type == 'release'
+        run: |
+          cp package-prefix/setup-qtox.exe setup-qtox-x86_64-release.exe
+          sha256sum setup-qtox-x86_64-release.exe > setup-qtox-x86_64-release.exe.sha256
+      - name: Upload to versioned release
+        if: contains(github.ref, 'refs/tags/v') && matrix.build_type == 'release'
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          draft: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: "setup-qtox-x86_64-release.exe,setup-qtox-x86_64-release.exe.sha256"
       - name: Rename zip for nightly upload
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: cp install-prefix/qtox-x86_64-${{ matrix.build_type }}.zip setup-qtox-nightly-x86_64-${{ matrix.build_type }}.zip
@@ -350,6 +400,19 @@ jobs:
           name: setup-qtox-i686-${{ matrix.build_type }}.zip
           path: install-prefix/qtox-i686-${{ matrix.build_type }}.zip
           if-no-files-found: ignore
+      - name: Rename exe for release upload
+        if: contains(github.ref, 'refs/tags/v') && matrix.build_type == 'release'
+        run: |
+          cp package-prefix/setup-qtox.exe setup-qtox-i686-release.exe
+          sha256sum setup-qtox-i686-release.exe > setup-qtox-i686-release.exe.sha256
+      - name: Upload to versioned release
+        if: contains(github.ref, 'refs/tags/v') && matrix.build_type == 'release'
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          draft: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: "setup-qtox-i686-release.exe,setup-qtox-i686-release.exe.sha256"
       - name: Rename zip for nightly upload
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: cp install-prefix/qtox-i686-${{ matrix.build_type }}.zip setup-qtox-nightly-i686-${{ matrix.build_type }}.zip
@@ -400,7 +463,19 @@ jobs:
         with:
           name: qTox-${{ github.sha }}.dmg
           path: qTox.dmg
+      - name: Create shasum for versioned release
+        if: contains(github.ref, 'refs/tags/v')
+        run: sha256sum qTox.dmg > qTox.dmg.sha256
+      - name: Upload to versioned release
+        if: contains(github.ref, 'refs/tags/v')
+        uses: ncipollo/release-action@v1
+        with:
+          allowUpdates: true
+          draft: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: "qTox.dmg,qTox.dmg.sha256"
       - name: Rename artifact for nightly upload
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: cp qTox.dmg qTox-nightly.dmg
       - name: Upload to nightly release
         uses: ncipollo/release-action@v1


### PR DESCRIPTION
Release will be created as a draft, remaining private until manually published.
All generated artifacts will be uploaded, but will still need to be signed, and
the code archives still need to be created following
MAINTAINING.md#after-tagging

Based on https://github.com/qTox/qTox/pull/6435.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6436)
<!-- Reviewable:end -->
