### PR TITLE
fix(CI): Grant action content write permission for release upload

### DIFF
--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -5,6 +5,8 @@ jobs:
     name: Update nightly release tag
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    permissions:
+        contents: write
     steps:
       - uses: actions/checkout@v2
       - name: Move nightly tag to head for nightly release
@@ -203,6 +205,8 @@ jobs:
       needs.build-ubuntu-lts-docker.result == 'success' &&
       (needs.update-nightly-tag.result == 'success' ||
         needs.update-nightly-tag.result == 'skipped')
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/load-docker-image
@@ -256,6 +260,8 @@ jobs:
       needs.build-flatpak-docker.result == 'success' &&
       (needs.update-nightly-tag.result == 'success' ||
         needs.update-nightly-tag.result == 'skipped')
+    permissions:
+        contents: write
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/load-docker-image
@@ -308,6 +314,8 @@ jobs:
       needs.build-windows-docker.result == 'success' &&
       (needs.update-nightly-tag.result == 'success' ||
         needs.update-nightly-tag.result == 'skipped')
+    permissions:
+        contents: write
     strategy:
       matrix:
         build_type: [debug, release]
@@ -378,6 +386,8 @@ jobs:
       needs.build-windows-i686-docker.result == 'success' &&
       (needs.update-nightly-tag.result == 'success' ||
         needs.update-nightly-tag.result == 'skipped')
+    permissions:
+      contents: write
     strategy:
       matrix:
         build_type: [debug, release]
@@ -447,6 +457,8 @@ jobs:
       always() &&
       (needs.update-nightly-tag.result == 'success' ||
         needs.update-nightly-tag.result == 'skipped')
+    permissions:
+      contents: write
     env:
       TRAVIS: true
       TRAVIS_BUILD_DIR: ${{ github.workspace }}

--- a/buildscripts/download/download_toxcore.sh
+++ b/buildscripts/download/download_toxcore.sh
@@ -17,8 +17,8 @@
 
 set -euo pipefail
 
-TOXCORE_VERSION=0.2.13
-TOXCORE_HASH=67114fa57504c58b695f5dce8ef85124d555f2c3c353d0d2615e6d4845114ab8
+TOXCORE_VERSION=0.2.15
+TOXCORE_HASH=577e23fe52f8be6739a9fffb2b16bfefd3a0ef4994d0714cb28a1ecca3669ca6
 
 source "$(dirname "$0")"/common.sh
 

--- a/windows/cross-compile/README.md
+++ b/windows/cross-compile/README.md
@@ -10,5 +10,5 @@ $ docker compose run windows_builder
 # mkdir build-windows
 # cd build-windows
 # # Example is using --arch x86_64, --arch i686 should be used if you are in the i686 docker image
-# /qtox/windows/cross-compile/build.sh --src-dir /qtox --arch x86_64 --build-type Release
+# /qtox/windows/cross-compile/build.sh --src-dir /qtox --arch x86_64 --build-type release
 ```


### PR DESCRIPTION
By default our organization on GH only grants a more restricted read
permission to actions.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6439)
<!-- Reviewable:end -->
