### PR TITLE
chore(CI): Re-remove GH action if-no-files found conditions

### DIFF
--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -348,7 +348,6 @@ jobs:
         with:
           name: setup-qtox-x86_64-${{ matrix.build_type }}.zip
           path: install-prefix/qtox-x86_64-${{ matrix.build_type }}.zip
-          if-no-files-found: ignore
       - name: Rename exe for release upload
         if: contains(github.ref, 'refs/tags/v') && matrix.build_type == 'release'
         run: |
@@ -420,7 +419,6 @@ jobs:
         with:
           name: setup-qtox-i686-${{ matrix.build_type }}.zip
           path: install-prefix/qtox-i686-${{ matrix.build_type }}.zip
-          if-no-files-found: ignore
       - name: Rename exe for release upload
         if: contains(github.ref, 'refs/tags/v') && matrix.build_type == 'release'
         run: |


### PR DESCRIPTION
Was accidentally reintroduced in after c85e24e7dbdea71010df0aa102b82ae5af4174ca
being removed in 5fcf86b5212b1c36686eaacf9c844ceb0e15adb1

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6440)
<!-- Reviewable:end -->
