### PR TITLE
chore(CI): Replace CentOS 8 CI with AlmaLinux

### DIFF
--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -45,15 +45,15 @@ jobs:
         name: "Build docker image"
         with:
           docker_image_name: debian_old
-  build-centos-docker:
-    name: Build centos docker image
+  build-almalinux-docker:
+    name: Build almalinux docker image
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/build-docker-image
         name: "Build docker image"
         with:
-          docker_image_name: centos
+          docker_image_name: almalinux
   build-fedora-docker:
     name: Build fedora docker image
     runs-on: ubuntu-latest
@@ -90,10 +90,10 @@ jobs:
         name: "Build docker image"
         with:
           docker_image_name: windows_builder.i686
-  build-centos:
-    name: Centos
+  build-almalinux:
+    name: Almalinux
     runs-on: ubuntu-latest
-    needs: build-centos-docker
+    needs: build-almalinux-docker
     strategy:
       matrix:
         features: [full, minimal]
@@ -103,9 +103,9 @@ jobs:
       - uses: ./.github/actions/load-docker-image
         name: Load docker image
         with:
-          docker_image_name: centos
+          docker_image_name: almalinux
       - name: Run build
-        run: docker compose run --rm centos ./.travis/build-qtox-linux.sh --build-type ${{ matrix.build_type }} --${{ matrix.features }}
+        run: docker compose run --rm almalinux ./.travis/build-qtox-linux.sh --build-type ${{ matrix.build_type }} --${{ matrix.features }}
   build-fedora:
     name: Fedora
     runs-on: ubuntu-latest

--- a/buildscripts/docker/Dockerfile.almalinux
+++ b/buildscripts/docker/Dockerfile.almalinux
@@ -13,12 +13,12 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-FROM centos:latest
+FROM almalinux:latest
 
 RUN dnf --nodocs -y install dnf-plugins-core && \
 	dnf config-manager --set-enabled powertools && \
+	dnf --nodocs -y install https://mirrors.rpmfusion.org/free/el/rpmfusion-free-release-$(rpm -E %almalinux).noarch.rpm && \
 	dnf --nodocs -y install epel-release && \
-	dnf --nodocs -y install --nogpgcheck https://mirrors.rpmfusion.org/free/el/rpmfusion-free-release-8.noarch.rpm https://mirrors.rpmfusion.org/nonfree/el/rpmfusion-nonfree-release-8.noarch.rpm &&  \
 	dnf --nodocs -y install \
 		cmake \
 		make \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,11 +55,11 @@ services:
       context: ./buildscripts
       dockerfile: docker/Dockerfile.flatpak_builder
     <<: *shared_params
-  centos:
-    image: qtox_centos:latest
+  almalinux:
+    image: qtox_almalinux:latest
     build:
       context: ./buildscripts
-      dockerfile: docker/Dockerfile.centos
+      dockerfile: docker/Dockerfile.almalinux
     <<: *shared_params
   fedora:
     image: qtox_fedora:latest


### PR DESCRIPTION
CentOS is EOL, and AlmaLinux seems like the closest successor

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6445)
<!-- Reviewable:end -->
