### PR TITLE
fix(Windows): Add missed openal dll since CI refactor

### DIFF
--- a/buildscripts/docker/Dockerfile.windows_builder
+++ b/buildscripts/docker/Dockerfile.windows_builder
@@ -191,6 +191,7 @@ RUN mkdir /export && \
   cp /windows/bin/libtoxcore.dll /export && \
   cp /windows/bin/libopus-*.dll /export && \
   cp /windows/lib/libvpx.dll /export && \
+  cp /windows/bin/OpenAL32.dll /export && \
   cp /windows/bin/libssl-*.dll /export && \
   cp /windows/bin/libsnore-qt5.dll /export && \
   mkdir -p /export/libsnore-qt5/ && \

--- a/windows/cross-compile/build.sh
+++ b/windows/cross-compile/build.sh
@@ -219,3 +219,11 @@ then
   echo "Error: Missing some dlls."
   exit 1
 fi
+
+# Check that OpenAL is bundled. It is availabe from WINE, but not on Windows systems
+if grep -q '/root/.wine/drive_c/windows/system32/openal32.dll' dlls-required
+then
+  cat dlls-required
+  echo "Error: Missing OpenAL."
+  exit 1
+fi


### PR DESCRIPTION
Old windows/cross-compile/build.sh copied OPENAL_PREFIX_DIR/bin/*.dll to be
included, but the current Dockerfile.windows_builder copies libs one by one
and misses OpenAL. qTox fails to start on launch with due to missing
OpenAL32.dll on Windows because of this.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6448)
<!-- Reviewable:end -->
