### PR TITLE
Fix(docs): Correct Windows cross compile example command

### DIFF
--- a/windows/cross-compile/README.md
+++ b/windows/cross-compile/README.md
@@ -10,5 +10,5 @@ $ docker compose run windows_builder
 # mkdir build-windows
 # cd build-windows
 # # Example is using --arch x86_64, --arch i686 should be used if you are in the i686 docker image
-# /qtox/windows/cross-compile/build.sh --src-dir /qtox --arch x86_64 --build-type Release
+# /qtox/windows/cross-compile/build.sh --src-dir /qtox --arch x86_64 --build-type release
 ```


### PR DESCRIPTION
release/debug is case sensitive, so "Release" causes an error

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6456)
<!-- Reviewable:end -->
