### PR TITLE
feat(CI): Run AddressSanitizer on Fedora build

### DIFF
--- a/.ci-scripts/build-qtox-linux.sh
+++ b/.ci-scripts/build-qtox-linux.sh
@@ -27,6 +27,7 @@ while (( $# > 0 )); do
     case $1 in
     --minimal) MINIMAL=1 ; shift ;;
     --full) MINIMAL=0; shift ;;
+    --sanitize) SANITIZE=1; shift ;;
     --build-type) BUILD_TYPE=$2; shift 2 ;;
     --help|-h) usage; exit 1 ;;
     *) echo "Unexpected argument $1"; usage; exit 1 ;;
@@ -45,6 +46,11 @@ if [ -z "${BUILD_TYPE+x}" ]; then
     exit 1
 fi
 
+SANITIZE_ARGS=""
+if [ ! -z ${SANITIZE+x} ]; then
+    SANITIZE_ARGS="-DASAN=ON"
+fi
+
 SRCDIR=/qtox
 export CTEST_OUTPUT_ON_FAILURE=1
 
@@ -53,14 +59,16 @@ if [ $MINIMAL -eq 1 ]; then
         -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
         -DSMILEYS=DISABLED \
         -DSTRICT_OPTIONS=ON \
-        -DSPELL_CHECK=OFF
+        -DSPELL_CHECK=OFF \
+        $SANITIZE_ARGS
 else
     cmake "$SRCDIR" \
         -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
         -DUPDATE_CHECK=ON \
         -DSTRICT_OPTIONS=ON \
         -DCODE_COVERAGE=ON \
-        -DDESKTOP_NOTIFICATIONS=ON
+        -DDESKTOP_NOTIFICATIONS=ON \
+        $SANITIZE_ARGS
 fi
 
 cmake --build . -- -j $(nproc)

--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -109,7 +109,7 @@ jobs:
       - name: Run build
         run: docker-compose run --rm almalinux ./.ci-scripts/build-qtox-linux.sh --build-type ${{ matrix.build_type }} --${{ matrix.features }}
   build-fedora:
-    name: Fedora
+    name: Fedora with ASAN
     runs-on: ubuntu-latest
     needs: build-fedora-docker
     strategy:
@@ -123,7 +123,7 @@ jobs:
         with:
           docker_image_name: fedora
       - name: Run build
-        run: docker-compose run --rm fedora ./.ci-scripts/build-qtox-linux.sh --build-type ${{ matrix.build_type }} --${{ matrix.features }}
+        run: docker-compose run --rm fedora ./.ci-scripts/build-qtox-linux.sh --build-type ${{ matrix.build_type }} --${{ matrix.features }} --sanitize
   build-opensuse:
     name: Opensuse
     runs-on: ubuntu-latest


### PR DESCRIPTION
Keep disabled for jobs that produce artifacts to not effect user performance.
Platforms that do produce artifacts could be tested as well by doubling the
build jobs and using one to test and the other to produce artifacts.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6459)
<!-- Reviewable:end -->
