### PR TITLE
fix(core): Track avatar offer file size to avoid cancelling transfers

### DIFF
--- a/src/core/core.h
+++ b/src/core/core.h
@@ -165,7 +165,7 @@ signals:
      * @deprecated prefer signals using ToxPk
      */
 
-    void fileAvatarOfferReceived(uint32_t friendId, uint32_t fileId, const QByteArray& avatarHash);
+    void fileAvatarOfferReceived(uint32_t friendId, uint32_t fileId, const QByteArray& avatarHash, uint64_t filesize);
 
     void friendMessageReceived(uint32_t friendId, const QString& message, bool isAction);
     void friendAdded(uint32_t friendId, const ToxPk& friendPk);

--- a/src/core/corefile.cpp
+++ b/src/core/corefile.cpp
@@ -344,7 +344,7 @@ void CoreFile::onFileReceiveCallback(Tox* tox, uint32_t friendId, uint32_t fileI
             tox_file_get_file_id(tox, friendId, fileId, avatarHash, nullptr);
             QByteArray avatarBytes{static_cast<const char*>(static_cast<const void*>(avatarHash)),
                                    TOX_HASH_LENGTH};
-            emit core->fileAvatarOfferReceived(friendId, fileId, avatarBytes);
+            emit core->fileAvatarOfferReceived(friendId, fileId, avatarBytes, filesize);
             return;
         }
     } else {
@@ -371,7 +371,7 @@ void CoreFile::onFileReceiveCallback(Tox* tox, uint32_t friendId, uint32_t fileI
 }
 
 // TODO(sudden6): This whole method is a mess but needed to get stuff working for now
-void CoreFile::handleAvatarOffer(uint32_t friendId, uint32_t fileId, bool accept)
+void CoreFile::handleAvatarOffer(uint32_t friendId, uint32_t fileId, bool accept, uint64_t filesize)
 {
     if (!accept) {
         // If it's an avatar but we already have it cached, cancel
@@ -388,7 +388,7 @@ void CoreFile::handleAvatarOffer(uint32_t friendId, uint32_t fileId, bool accept
                     .arg(fileId);
     tox_file_control(tox, friendId, fileId, TOX_FILE_CONTROL_RESUME, nullptr);
 
-    ToxFile file{fileId, friendId, "<avatar>", "", 0, ToxFile::RECEIVING};
+    ToxFile file{fileId, friendId, "<avatar>", "", filesize, ToxFile::RECEIVING};
     file.fileKind = TOX_FILE_KIND_AVATAR;
     file.resumeFileId.resize(TOX_FILE_ID_LENGTH);
     tox_file_get_file_id(tox, friendId, fileId, reinterpret_cast<uint8_t*>(file.resumeFileId.data()),

--- a/src/core/corefile.h
+++ b/src/core/corefile.h
@@ -48,7 +48,7 @@ class CoreFile : public QObject
     Q_OBJECT
 
 public:
-    void handleAvatarOffer(uint32_t friendId, uint32_t fileId, bool accept);
+    void handleAvatarOffer(uint32_t friendId, uint32_t fileId, bool accept, uint64_t filesize);
     static CoreFilePtr makeCoreFile(Core* core, Tox* tox, CompatibleRecursiveMutex& coreLoopLock);
 
     void sendFile(uint32_t friendId, QString filename, QString filePath,

--- a/src/persistence/profile.cpp
+++ b/src/persistence/profile.cpp
@@ -472,11 +472,11 @@ void Profile::onSaveToxSave()
 }
 
 // TODO(sudden6): handle this better maybe?
-void Profile::onAvatarOfferReceived(uint32_t friendId, uint32_t fileId, const QByteArray& avatarHash)
+void Profile::onAvatarOfferReceived(uint32_t friendId, uint32_t fileId, const QByteArray& avatarHash, uint64_t filesize)
 {
     // accept if we don't have it already
     const bool accept = getAvatarHash(core->getFriendPublicKey(friendId)) != avatarHash;
-    core->getCoreFile()->handleAvatarOffer(friendId, fileId, accept);
+    core->getCoreFile()->handleAvatarOffer(friendId, fileId, accept, filesize);
 }
 
 /**

--- a/src/persistence/profile.h
+++ b/src/persistence/profile.h
@@ -101,7 +101,7 @@ private slots:
     void removeAvatar(const ToxPk& owner);
     void onSaveToxSave();
     // TODO(sudden6): use ToxPk instead of friendId
-    void onAvatarOfferReceived(uint32_t friendId, uint32_t fileId, const QByteArray& avatarHash);
+    void onAvatarOfferReceived(uint32_t friendId, uint32_t fileId, const QByteArray& avatarHash, uint64_t filesize);
 
 private:
     Profile(const QString& name, std::unique_ptr<ToxEncrypt> passkey, Paths& paths, Settings &settings_);


### PR DESCRIPTION
When ToxFile is constructed with a file size of 0, it cancels the transfer as
soon as the first chunk is received due to the received size being
larger than expected.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6461)
<!-- Reviewable:end -->
