### PR TITLE
fix(gitstats): Re-enable deploying of gitstats to qtox.github.io

### DIFF
--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -519,3 +519,8 @@ jobs:
         run: sudo apt-get install gitstats
       - name: Run
         run: ./.travis/build-gitstats.sh
+      - name: Deploy
+        if: github.ref == 'refs/heads/master'
+        env:
+          access_key: ${{ secrets.GITSTATS_DEPLOY_KEY }}
+        run: ./.travis/deploy-gitstats.sh

--- a/.travis/deploy-gitstats.sh
+++ b/.travis/deploy-gitstats.sh
@@ -26,4 +26,7 @@ git add .
 git commit --quiet -m "Deploy to GH pages from commit: $COMMIT"
 
 echo "Pushing to GH pages..."
-git push --force --quiet "https://${GH_TOKEN_GITSTATS}@github.com/qTox/gitstats.git" master:gh-pages &> /dev/null
+touch /tmp/access_key
+chmod 600 /tmp/access_key
+echo "$access_key" > /tmp/access_key
+GIT_SSH_COMMAND="ssh -i /tmp/access_key" git push --force --quiet "git@github.com/qTox/gitstats.git" master:gh-pages


### PR DESCRIPTION
Hasn't been run since the travis days.

Now managed through a deploy key rather than an access token to limit scope to
a single repo. Private key is stored in qTox/qTox as a repository secret, and
the public portion is saved to qTox/gitstats as a deploy key.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6467)
<!-- Reviewable:end -->
