### PR TITLE
chore(CI): Remove wget as brew and docker dependency

### DIFF
--- a/osx/Brewfile
+++ b/osx/Brewfile
@@ -1,6 +1,5 @@
 brew "coreutils"
 brew "git"
-brew "wget"
 brew "libtool"
 brew "cmake"
 brew "pkgconfig"


### PR DESCRIPTION
All project downloads are done through curl now

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6470)
<!-- Reviewable:end -->
