### PR TITLE
fix(history): Replace invalid Tox ID saved in peers table with Tox public key

### DIFF
--- a/src/model/chathistory.cpp
+++ b/src/model/chathistory.cpp
@@ -361,9 +361,9 @@ void ChatHistory::loadHistoryIntoSessionChatLog(ChatLogIdx start) const
         // Note that message.id is _not_ a valid conversion here since it is a
         // global id not a per-chat id like the ChatLogIdx
         auto currentIdx = nextIdx++;
-        auto sender = ToxPk(message.sender);
         switch (message.content.getType()) {
         case HistMessageContentType::file: {
+            auto sender = ToxPk(message.sender);
             const auto date = message.timestamp;
             const auto file = message.content.asFile();
             const auto chatLogFile = ChatLogFile{date, file};
@@ -371,6 +371,7 @@ void ChatHistory::loadHistoryIntoSessionChatLog(ChatLogIdx start) const
             break;
         }
         case HistMessageContentType::message: {
+            auto sender = ToxPk(message.sender);
             auto messageContent = message.content.asMessage();
 
             auto isAction = handleActionPrefix(messageContent);

--- a/test/persistence/dbschema_test.cpp
+++ b/test/persistence/dbschema_test.cpp
@@ -54,6 +54,7 @@ private slots:
     void test5to6();
     void test6to7();
     // test7to8 omitted, version only upgrade, versions are not verified in this
+    // test8to9 omitted, data corruption correction upgrade with no schema change
     // test suite
     void cleanupTestCase() const;
 

--- a/windows/cross-compile/build.sh
+++ b/windows/cross-compile/build.sh
@@ -194,10 +194,10 @@ while IFS= read -r line
 do
   if [[ "$ARCH" == "i686" ]]
   then
-    WINE_DLL_DIR="/root/.wine/drive_c/windows/system32"
+    WINE_DLL_DIR="/opt/wine-stable/lib/wine/i386-windows"
   elif [[ "$ARCH" == "x86_64" ]]
   then
-    WINE_DLL_DIR="/root/.wine/drive_c/windows/system32 /root/.wine/drive_c/windows/syswow64"
+    WINE_DLL_DIR="/opt/wine-stable/lib/wine/i386-windows /opt/wine-stable/lib64/wine/x86_64-windows"
   fi
   python3 /usr/local/bin/mingw-ldd.py $line --dll-lookup-dirs $QTOX_PREFIX_DIR $WINE_DLL_DIR --output-format tree >> dlls-required
 done < <(cat exes runtime-dlls)
@@ -221,7 +221,7 @@ then
 fi
 
 # Check that OpenAL is bundled. It is availabe from WINE, but not on Windows systems
-if grep -q '/root/.wine/drive_c/windows/system32/openal32.dll' dlls-required
+if grep -q '/opt/wine-stable/lib/wine/i386-windows/openal32.dll' dlls-required
 then
   cat dlls-required
   echo "Error: Missing OpenAL."


### PR DESCRIPTION
Due to an old bug that has since be fixed, old history dbs can contain both a
Tox ID version and Tox public key version of the same friend, and always
themselves. They could have n more duplicates if they've updated their nospam.

Tox ID is an invalid length to be stored in strongly typed ToxPk, and in
general having multiple entries belonging to the same user effectively violates
our UNIQUE constraint on public_key.

Introduced in 7168d2b8589a3670f9b5c5d88d5a5d20f1bf5966

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6474)
<!-- Reviewable:end -->
