### PR TITLE
fix(core): Don't apply Windows file transfer rename on other platforms

### DIFF
--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -172,6 +172,15 @@ jobs:
           docker_image_name: debian_old
       - name: Run build
         run: docker-compose run --rm debian_old ./.ci-scripts/build-qtox-linux.sh --build-type ${{ matrix.build_type }} --${{ matrix.features }}
+  translation-check:
+    name: Check for translatable strings
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install deps
+        run: sudo apt-get update && sudo apt-get install qttools5-dev
+      - name: Test for modified translatable strings
+        run: ./tools/update-translation-files.sh ALL && git diff --exit-code
   build-ubuntu:
     name: Ubuntu LTS
     runs-on: ubuntu-latest

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -161,6 +161,9 @@ require a bit more attention & regular checking whether there are new
 translations, on the other, it lessened problems that were happening with
 "manual" way of providing translations.
 
+New translable strings need to be generated into a form Weblate can consume
+using `./tools/update-translation-files.sh ALL` and commiting the result.
+
 To get translations into qTox:
 
 1. Go to `https://hosted.weblate.org/projects/tox/qtox/#repository` and lock
@@ -174,11 +177,7 @@ To get translations into qTox:
     - `translations/README.md`
     - `translations/i18n.pri`
     - `translations/translations.qrc`
-5. To update translatable strings from qTox for Weblate, run
-    `./tools/update-translation-files.sh ALL`
-6. Checkout a new branch with e.g. `git checkout -b update_weblate` and open
-   a Pull Request for it on Github.
-7. After the Pull Request has been merged, `reset` Weblate to master and
+5. After the Pull Request has been merged, `reset` Weblate to master and
    unlock it.
 
 # Releases

--- a/tools/update-translation-files.sh
+++ b/tools/update-translation-files.sh
@@ -27,7 +27,6 @@
 
 set -eu -o pipefail
 
-readonly COMMIT_MSG="chore(i18n): update translation files for Weblate"
 readonly LUPDATE_CMD="lupdate src -no-obsolete -locations none -ts"
 
 if [[ "$@" = "ALL" ]]
@@ -36,9 +35,6 @@ then
     do
         $LUPDATE_CMD "$translation"
     done
-
-    git add translations/*.ts
-    git commit -m "$COMMIT_MSG"
 else
     $LUPDATE_CMD "$@"
 fi

--- a/translations/ar.ts
+++ b/translations/ar.ts
@@ -725,7 +725,7 @@ so you can save the file on Windows.</source>
     </message>
     <message>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">نسخ</translation>
     </message>
     <message>
         <source>Select all</source>

--- a/translations/sr.ts
+++ b/translations/sr.ts
@@ -723,7 +723,7 @@ so you can save the file on Windows.</source>
     </message>
     <message>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Уможи</translation>
     </message>
     <message>
         <source>Select all</source>

--- a/translations/sr_Latn.ts
+++ b/translations/sr_Latn.ts
@@ -723,7 +723,7 @@ so you can save the file on Windows.</source>
     </message>
     <message>
         <source>Copy</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Umoži</translation>
     </message>
     <message>
         <source>Select all</source>


### PR DESCRIPTION
Filename cleaning was originally introduced for Windows
https://github.com/qTox/qTox/issues/1304. It's unneeded on other platforms, so
leave file names as they're sent there.

Fix #5242

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6482)
<!-- Reviewable:end -->
