### PR TITLE
fix(CI): Grant tag update action workflow permissions

### DIFF
--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -6,7 +6,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     permissions:
-        contents: write
+      contents: write
+      actions: write # due to possibly updating this file
     steps:
       - uses: actions/checkout@v2
       - name: Move nightly tag to head for nightly release


### PR DESCRIPTION
Moving a tag between commits with workflows counts as changing the workflow,
so workflow write permission can be required.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6484)
<!-- Reviewable:end -->
