### PR TITLE
chore(deps): Add msgpack to archlinux dockerfile

### DIFF
--- a/buildscripts/docker/Dockerfile.archlinux
+++ b/buildscripts/docker/Dockerfile.archlinux
@@ -30,6 +30,7 @@ RUN pacman -Syu --noconfirm --needed \
     sqlcipher \
     openal \
     sonnet \
+    msgpack-c \
     snorenotify \
     git \
     && \


### PR DESCRIPTION
Missed in last update since it's not covered in CI.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6486)
<!-- Reviewable:end -->
