### PR TITLE
fix(doxygen): Re-enable deploying of doxygen to qtox.github.io

### DIFF
--- a/.ci-scripts/deploy-docs.sh
+++ b/.ci-scripts/deploy-docs.sh
@@ -45,4 +45,6 @@ git add .
 git commit --quiet -m "Deploy to GH pages from commit: $GIT_CHASH"
 
 echo "Pushing to GH pages..."
-git push --force --quiet "https://${GH_TOKEN}@github.com/qTox/doxygen.git" master:gh-pages &> /dev/null
+chmod 600 /tmp/access_key
+echo "$access_key" > /tmp/access_key
+GIT_SSH_COMMAND="ssh -i /tmp/access_key" git push --force --quiet "git@github.com:qTox/doxygen.git" master:gh-pages

--- a/.ci-scripts/deploy-gitstats.sh
+++ b/.ci-scripts/deploy-gitstats.sh
@@ -16,7 +16,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 cd "$GITSTATS_DIR"
-COMMIT=$(cd qTox && git describe)
+COMMIT=$(git describe)
 
 git init --quiet
 git config user.name "qTox bot"
@@ -29,4 +29,4 @@ echo "Pushing to GH pages..."
 touch /tmp/access_key
 chmod 600 /tmp/access_key
 echo "$access_key" > /tmp/access_key
-GIT_SSH_COMMAND="ssh -i /tmp/access_key" git push --force --quiet "git@github.com/qTox/gitstats.git" master:gh-pages
+GIT_SSH_COMMAND="ssh -i /tmp/access_key" git push --force --quiet "git@github.com:qTox/gitstats.git" master:gh-pages

--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -490,6 +490,11 @@ jobs:
           fetch-depth: 0
       - name: Run
         run: ./.ci-scripts/build-docs.sh
+      - name: Deploy
+        if: github.ref == 'refs/heads/master'
+        env:
+          access_key: ${{ secrets.GITSTATS_DEPLOY_KEY }}
+        run: ./.ci-scripts/deploy-docs.sh
   build-gitstats:
     name: Gitstats
     runs-on: ubuntu-latest

--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -481,7 +481,7 @@ jobs:
           artifacts: "qTox-nightly.dmg"
   build-docs:
     name: Docs
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     env:
       DOXYGEN_CONFIG_FILE: doxygen.conf
     steps:
@@ -492,7 +492,7 @@ jobs:
         run: ./.ci-scripts/build-docs.sh
   build-gitstats:
     name: Gitstats
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     env:
       GITSTATS_DIR: gitstats
     steps:
@@ -500,7 +500,11 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install gitstats
-        run: sudo apt-get install gitstats
+        run: |
+          sudo apt-get install gnuplot
+          git clone git://github.com/hoxu/gitstats.git
+          cd gitstats
+          sudo make install
       - name: Run
         run: ./.ci-scripts/build-gitstats.sh
       - name: Deploy


### PR DESCRIPTION
Hasn't been run since the travis days.

Now managed through a deploy key rather than an access token to limit scope to
a single repo. Private key is stored in qTox/qTox as a repository secret, and
the public portion is saved to qTox/doxygen as a deploy key.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6493)
<!-- Reviewable:end -->
