### PR TITLE
fix: don't link emoji resources into targets that don't need them

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,17 +181,15 @@ if(NOT SMILEYS)
   set(SMILEYS "")
 endif()
 
+set(SMILEY_RESOURCES "")
 if(NOT "${SMILEYS}" STREQUAL "DISABLED")
-  set(${PROJECT_NAME}_RESOURCES
-        ${${PROJECT_NAME}_RESOURCES}
-        smileys/emojione.qrc)
+  set(SMILEY_RESOURCES smileys/emojione.qrc)
 
   if(NOT "${SMILEYS}" STREQUAL "MIN")
-      set(${PROJECT_NAME}_RESOURCES
-            ${${PROJECT_NAME}_RESOURCES}
+      set(SMILEY_RESOURCES
+            ${SMILEY_RESOURCES}
             smileys/smileys.qrc)
   endif()
-
 endif()
 
 set(${PROJECT_NAME}_SOURCES
@@ -662,6 +660,7 @@ add_executable(${PROJECT_NAME}
   WIN32
   MACOSX_BUNDLE
   ${${PROJECT_NAME}_RESOURCES}
+  ${SMILEY_RESOURCES}
   src/main.cpp)
 target_link_libraries(${PROJECT_NAME}
   ${PROJECT_NAME}_static

--- a/cmake/Testing.cmake
+++ b/cmake/Testing.cmake
@@ -51,7 +51,7 @@ auto_test(persistence paths "")
 auto_test(persistence dbschema "")
 auto_test(persistence offlinemsgengine "")
 if(NOT "${SMILEYS}" STREQUAL "DISABLED")
-  auto_test(persistence smileypack "${${PROJECT_NAME}_RESOURCES}") # needs emojione
+  auto_test(persistence smileypack "${SMILEY_RESOURCES}") # needs emojione
 endif()
 auto_test(model friendlistmanager "")
 auto_test(model friendmessagedispatcher "")


### PR DESCRIPTION
The emoji resouce file is quite big, so link it only when really needed.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6494)
<!-- Reviewable:end -->
