### PR TITLE
chore(CI): Correct doxygen deploy access

### DIFF
--- a/.ci-scripts/deploy-docs.sh
+++ b/.ci-scripts/deploy-docs.sh
@@ -45,6 +45,7 @@ git add .
 git commit --quiet -m "Deploy to GH pages from commit: $GIT_CHASH"
 
 echo "Pushing to GH pages..."
+touch /tmp/access_key
 chmod 600 /tmp/access_key
 echo "$access_key" > /tmp/access_key
 GIT_SSH_COMMAND="ssh -i /tmp/access_key" git push --force --quiet "git@github.com:qTox/doxygen.git" master:gh-pages

--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -503,7 +503,7 @@ jobs:
       - name: Deploy
         if: github.ref == 'refs/heads/master'
         env:
-          access_key: ${{ secrets.GITSTATS_DEPLOY_KEY }}
+          access_key: ${{ secrets.DOXYGEN_DEPLOY_KEY }}
         run: ./.ci-scripts/deploy-docs.sh
   build-gitstats:
     name: Gitstats


### PR DESCRIPTION
- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6495)
<!-- Reviewable:end -->
