### PR TITLE
chore(CI): Revert reversal of 64-bit and 32-bit DLL search paths

### DIFF
--- a/windows/cross-compile/build.sh
+++ b/windows/cross-compile/build.sh
@@ -197,7 +197,7 @@ do
     WINE_DLL_DIR="/opt/wine-stable/lib/wine/i386-windows"
   elif [[ "$ARCH" == "x86_64" ]]
   then
-    WINE_DLL_DIR="/opt/wine-stable/lib/wine/i386-windows /opt/wine-stable/lib64/wine/x86_64-windows"
+    WINE_DLL_DIR="/opt/wine-stable/lib64/wine/x86_64-windows /opt/wine-stable/lib/wine/i386-windows"
   fi
   python3 /usr/local/bin/mingw-ldd.py $line --dll-lookup-dirs $QTOX_PREFIX_DIR $WINE_DLL_DIR --output-format tree >> dlls-required
 done < <(cat exes runtime-dlls)


### PR DESCRIPTION
Instroduced in 80a0a4ae620d299d2379c28613d3298643f3fd19, caught in post-merge
review here: https://github.com/qTox/qTox/pull/6483/files#r815294041

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6497)
<!-- Reviewable:end -->
