### PR TITLE
chore(CI): Fix appimage missing rename for nightly zsync upload

### DIFF
--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -251,7 +251,9 @@ jobs:
           artifacts: "qTox-${{ steps.get_version.outputs.VERSION }}.x86_64.AppImage,qTox-${{ steps.get_version.outputs.VERSION }}.x86_64.AppImage.sha256,qTox-${{ steps.get_version.outputs.VERSION }}.x86_64.AppImage.zsync"
       - name: Rename artifact for nightly upload
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        run: cp qTox-*.x86_64.AppImage qTox-nightly.x86_64.AppImage
+        run: |
+          cp qTox-*.x86_64.AppImage qTox-nightly.x86_64.AppImage
+          cp qTox-*.x86_64.AppImage.zsync qTox-nightly.x86_64.AppImage.zsync
       - name: Upload to nightly release
         uses: ncipollo/release-action@v1
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'


### PR DESCRIPTION
- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6498)
<!-- Reviewable:end -->
