### PR TITLE
chore(CI): Don't try to upload installer on debug builds

### DIFF
--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -345,6 +345,7 @@ jobs:
       - name: Run build
         run: docker-compose run --rm windows_builder ./windows/cross-compile/build.sh --arch x86_64 --build-type ${{ matrix.build_type }} --run-tests --src-dir /qtox
       - name: Upload installer
+        if: matrix.build_type == 'release'
         uses: actions/upload-artifact@v2
         with:
           name: setup-qtox-x86_64-${{ matrix.build_type }}.exe
@@ -405,6 +406,7 @@ jobs:
       - name: Run build
         run: docker-compose run --rm windows_builder.i686 ./windows/cross-compile/build.sh --arch i686 --build-type ${{ matrix.build_type }} --run-tests --src-dir /qtox
       - name: Upload installer
+        if: matrix.build_type == 'release'
         uses: actions/upload-artifact@v2
         with:
           name: setup-qtox-i686-${{ matrix.build_type }}.exe


### PR DESCRIPTION
The installer is only built on release builds. We used to ignore failure to
upload prior to 5fcf86b5212b1c36686eaacf9c844ceb0e15adb1. We stopped ignoring
because a07ab89cc84bcab3a75277dd4efd1608535127bb tried to make our upload
targetted, but it only resolved the issue for the zip, not the installer.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6501)
<!-- Reviewable:end -->
