### PR TITLE
Backport: fix: Update video API usage for newer libavcodec

### DIFF
--- a/src/video/cameradevice.cpp
+++ b/src/video/cameradevice.cpp
@@ -28,6 +28,9 @@ extern "C" {
 #include "cameradevice.h"
 #include "src/persistence/settings.h"
 
+// no longer needed when avformat version < 59 is no longer supported
+using AvFindInputFormatRet = decltype(av_find_input_format(""));
+
 #if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
 #define USING_V4L 1
 #else
@@ -68,8 +71,8 @@ extern "C" {
 
 QHash<QString, CameraDevice*> CameraDevice::openDevices;
 QMutex CameraDevice::openDeviceLock, CameraDevice::iformatLock;
-AVInputFormat* CameraDevice::iformat{nullptr};
-AVInputFormat* CameraDevice::idesktopFormat{nullptr};
+static AvFindInputFormatRet idesktopFormat{nullptr};
+static AvFindInputFormatRet iformat{nullptr};
 
 CameraDevice::CameraDevice(const QString& devName, AVFormatContext* context)
     : devName{devName}
@@ -89,7 +92,7 @@ CameraDevice* CameraDevice::open(QString devName, AVDictionary** options)
         goto out;
     }
 
-    AVInputFormat* format;
+    AvFindInputFormatRet format;
     if (devName.startsWith("x11grab#")) {
         devName = devName.mid(8);
         format = idesktopFormat;

--- a/src/video/cameradevice.h
+++ b/src/video/cameradevice.h
@@ -65,7 +65,6 @@ private:
     std::atomic_int refcount;
     static QHash<QString, CameraDevice*> openDevices;
     static QMutex openDeviceLock, iformatLock;
-    static AVInputFormat *iformat, *idesktopFormat;
 };
 
 #endif // CAMERADEVICE_H

--- a/src/video/camerasource.cpp
+++ b/src/video/camerasource.cpp
@@ -277,7 +277,6 @@ void CameraSource::openDevice()
     }
 
     // We need to create a new CameraDevice
-    AVCodec* codec;
     device = CameraDevice::open(deviceName, mode);
 
     if (!device) {
@@ -321,7 +320,7 @@ void CameraSource::openDevice()
     AVCodecParameters* cparams = device->context->streams[videoStreamIndex]->codecpar;
     codecId = cparams->codec_id;
 #endif
-    codec = avcodec_find_decoder(codecId);
+    const AVCodec* codec = avcodec_find_decoder(codecId);
     if (!codec) {
         qWarning() << "Codec not found";
         emit openFailed();


### PR DESCRIPTION
Newer version of avformat_open_input, av_find_input_format,
avcodec_find_decoder previously used non-const pointers that are now
const. Support both version for compatibiltiy with other platforms.

Backported from 15673a52b6b4805d482b69281e21947fb7096e05

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6510)
<!-- Reviewable:end -->
