### PR TITLE
Backport: fix(CI): Fix memory leak in core_test

### DIFF
--- a/test/core/core_test.cpp
+++ b/test/core/core_test.cpp
@@ -28,6 +28,7 @@
 #include <QSignalSpy>
 #include <src/persistence/settings.h>
 #include <iostream>
+#include <memory>
 
 Q_DECLARE_METATYPE(QList<DhtServer>);
 
@@ -85,7 +86,7 @@ private slots:
 private:
     /* Test Variables */
     Core::ToxCoreErrors* err = nullptr;
-    MockSettings* settings;
+    std::unique_ptr<MockSettings> settings;
     QByteArray savedata{};
     ToxCorePtr test_core;
 };
@@ -97,7 +98,7 @@ namespace {
 
 void TestCore::startup_without_proxy()
 {
-    settings = new MockSettings();
+    settings = std::unique_ptr<MockSettings>(new MockSettings());
 
     // No proxy
     settings->setProxyAddr("");
@@ -122,8 +123,7 @@ void TestCore::startup_without_proxy()
 
 void TestCore::startup_with_invalid_proxy()
 {
-    settings = new MockSettings();
-
+    settings = std::unique_ptr<MockSettings>(new MockSettings());
 
     // Test invalid proxy SOCKS5
     settings->setProxyAddr("Test");


### PR DESCRIPTION
Causes false positives when running tests with ASAN

Backported from 9cd9da4a5360028bab32bb7f04d95e67e895cc0d

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6511)
<!-- Reviewable:end -->
