### PR TITLE
chore(CI): Fix commit message check range

### DIFF
--- a/.ci-scripts/verify-commit-format.sh
+++ b/.ci-scripts/verify-commit-format.sh
@@ -21,5 +21,5 @@ set -eu -o pipefail
 
 # Verify commit messages
 readarray -t COMMITS <<<$(curl -s ${GITHUB_CONTEXT} | jq -r '.[0,-1].sha')
-COMMIT_RANGE="${COMMITS[0]}..${COMMITS[1]}"
+COMMIT_RANGE="${COMMITS[1]}..${COMMITS[0]}"
 bash ./verify-commit-messages.sh "$COMMIT_RANGE"


### PR DESCRIPTION
It was reversed before which works on normal PRs, but checks commits on
the destination branch when merging two upstream branches.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6516)
<!-- Reviewable:end -->
