### PR TITLE
fix(Windows): Correct Program Files directory for 32-bit Windows

### DIFF
--- a/windows/qtox.nsi
+++ b/windows/qtox.nsi
@@ -208,7 +208,7 @@ FunctionEnd
 
   Section "Create install directory"
     CreateDirectory "$INSTDIR"
-    nsExec::ExecToStack 'icacls "$PROGRAMFILES64" /save "$TEMP\program-files-permissions.txt"'
+    nsExec::ExecToStack 'icacls "$PROGRAMFILES" /save "$TEMP\program-files-permissions.txt"'
     Pop $0 # return value/error/timeout
     Pop $1 # printed text, up to ${NSIS_MAX_STRLEN}
     FileOpen $0 "$TEMP\program-files-permissions.txt" r


### PR DESCRIPTION
Both installers accidentally try to get permissions from the 64-bit Program
Files, introduced in 553bd47e8171fd4f15e062e4faf734e32002f6fb.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6517)
<!-- Reviewable:end -->
