### PR TITLE
chore(release): Remove support for macOS 10.14

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -566,7 +566,7 @@ See [AppArmor] to enable confinement for increased security.
 
 ## OS X
 
-Supported OS X versions: >=10.8. (NOTE: only 10.13 is tested during CI)
+Supported OS X versions: >=10.15.
 
 Compiling qTox on OS X for development requires 2 tools:
 [Xcode](https://developer.apple.com/xcode/) and [homebrew](https://brew.sh).


### PR DESCRIPTION
macOS 10.14 is EOL by Apple, and brew no longer supports it. We can no longer
build qTox on 10.14 using our brew-based release process. Instead we will
release from 10.15, which loses compatibility with 10.14 with our current build
process.

- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6520)
<!-- Reviewable:end -->
