### PR TITLE
chore(build): Remove check for QtVer

### DIFF
--- a/osx/qTox-Mac-Deployer-ULTIMATE.sh
+++ b/osx/qTox-Mac-Deployer-ULTIMATE.sh
@@ -35,10 +35,6 @@ else
     MAIN_DIR="$(dirname $(readlink -f $0))/../.."
     QTOX_DIR="${MAIN_DIR}/qTox${SUBGIT}"
 fi
-QT_DIR="/usr/local/Cellar/qt5" # Folder name of QT install
-# Figure out latest version
-QT_VER=($(ls ${QT_DIR} | sed -n -e 's/^\([0-9]*\.([0-9]*\.([0-9]*\).*/\1/' -e '1p;$p'))
-QT_DIR_VER="${QT_DIR}/${QT_VER[1]}"
 
 TOXCORE_DIR="${MAIN_DIR}/toxcore" # Change to Git location
 


### PR DESCRIPTION
It is unused, and brew now installs to Cella/qt@5 so this check causes an error.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6522)
<!-- Reviewable:end -->
