### PR TITLE
chore(CI): Use consistent passing of ARCH to scripts

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,1 +1,0 @@
-- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

--- a/buildscripts/build_gdb_windows.sh
+++ b/buildscripts/build_gdb_windows.sh
@@ -14,19 +14,19 @@ set -euo pipefail
 
 while (( $# > 0 )); do
     case $1 in
-        --arch) SCRIPT_ARCH=$2; shift 2 ;;
+        --arch) ARCH=$2; shift 2 ;;
         -h|--help) usage; exit 1 ;;
         *) echo "Unexpected argument $1"; usage; exit 1;;
     esac
 done
 
-if [ "${SCRIPT_ARCH-x}" != "win32" ] && [ "${SCRIPT_ARCH-x}" != "win64" ]; then
+if [ "$ARCH" != "win32" ] && [ "$ARCH" != "win64" ]; then
     echo "Unexpected arch $ARCH"
     usage
     exit 1
 fi
 
-if [ "${SCRIPT_ARCH}" == "win64" ]; then
+if [ "${ARCH}" == "win64" ]; then
     HOST="x86_64-w64-mingw32"
 else
     HOST="i686-w64-mingw32"

--- a/buildscripts/build_gmp_windows.sh
+++ b/buildscripts/build_gmp_windows.sh
@@ -14,19 +14,19 @@ set -euo pipefail
 
 while (( $# > 0 )); do
     case $1 in
-        --arch) SCRIPT_ARCH=$2; shift 2 ;;
+        --arch) ARCH=$2; shift 2 ;;
         -h|--help) usage; exit 1 ;;
         *) echo "Unexpected argument $1"; usage; exit 1;;
     esac
 done
 
-if [ "${SCRIPT_ARCH-x}" != "win32" ] && [ "${SCRIPT_ARCH-x}" != "win64" ]; then
-    echo "Unexpected arch $SCRIPT_ARCH"
+if [ "$ARCH" != "win32" ] && [ "$ARCH" != "win64" ]; then
+    echo "Unexpected arch $ARCH"
     usage
     exit 1
 fi
 
-if [ "${SCRIPT_ARCH}" == "win64" ]; then
+if [ "${ARCH}" == "win64" ]; then
     HOST="x86_64-w64-mingw32"
 else
     HOST="i686-w64-mingw32"

--- a/buildscripts/build_libexpat_windows.sh
+++ b/buildscripts/build_libexpat_windows.sh
@@ -14,21 +14,21 @@ set -euo pipefail
 
 while (( $# > 0 )); do
     case $1 in
-        --arch) SCRIPT_ARCH=$2; shift 2 ;;
+        --arch) ARCH=$2; shift 2 ;;
         -h|--help) usage; exit 1 ;;
         *) echo "Unexpected argument $1"; usage; exit 1;;
     esac
 done
 
-if [ "${SCRIPT_ARCH-x}" != "win32" ] && [ "${SCRIPT_ARCH-x}" != "win64" ]; then
-    echo "Unexpected arch $SCRIPT_ARCH"
+if [ "$ARCH" != "win32" ] && [ "$ARCH" != "win64" ]; then
+    echo "Unexpected arch $ARCH"
     usage
     exit 1
 fi
 
 "$(dirname $0)"/download/download_libexpat.sh
 
-if [ "${SCRIPT_ARCH}" == "win64" ]; then
+if [ "${ARCH}" == "win64" ]; then
     HOST="x86_64-w64-mingw32"
 else
     HOST="i686-w64-mingw32"

--- a/buildscripts/docker/Dockerfile.windows_builder
+++ b/buildscripts/docker/Dockerfile.windows_builder
@@ -224,21 +224,21 @@ COPY download/download_gmp.sh /build/download/download_gmp.sh
 COPY build_gmp_windows.sh /build/build_gmp_windows.sh
 RUN  mkdir -p /src/gmp && \
   cd /src/gmp && \
-  /build/build_gmp_windows.sh && \
+  /build/build_gmp_windows.sh --arch ${SCRIPT_ARCH} && \
   rm -fr /src/gmp
 
 COPY download/download_libexpat.sh /build/download/download_libexpat.sh
 COPY build_libexpat_windows.sh /build/build_libexpat_windows.sh
 RUN mkdir -p /src/libexpat && \
   cd /src/libexpat && \
-  /build/build_libexpat_windows.sh && \
+  /build/build_libexpat_windows.sh --arch ${SCRIPT_ARCH} && \
   rm -fr /src/libexpat
 
 COPY download/download_gdb.sh /build/download/download_gdb.sh
 COPY build_gdb_windows.sh /build/build_gdb_windows.sh
 RUN mkdir -p /src/gdb && \
   cd /src/gdb && \
-  /build/build_gdb_windows.sh && \
+  /build/build_gdb_windows.sh --arch ${SCRIPT_ARCH} && \
   rm -fr /src/gdb && \
   cp /windows/bin/gdb.exe /debug_export/gdb.exe
 

--- a/windows/qtox.nsi
+++ b/windows/qtox.nsi
@@ -215,8 +215,6 @@ FunctionEnd
       FileReadUTF16LE $0 $1 1024
       FileReadUTF16LE $0 $2 1024
     FileClose $0
-    DetailPrint "First read line is: $1"
-    DetailPrint "Second read line is: $2"
     FileOpen $0 "$TEMP\qTox-install-file-permissions.txt" w
       FileWriteUTF16LE  $0 "$INSTDIR"
       FileWriteUTF16LE  $0 "$\r$\n"

--- a/windows/qtox64.nsi
+++ b/windows/qtox64.nsi
@@ -215,8 +215,6 @@ FunctionEnd
       FileReadUTF16LE $0 $1 1024
       FileReadUTF16LE $0 $2 1024
     FileClose $0
-    DetailPrint "First read line is: $1"
-    DetailPrint "Second read line is: $2"
     FileOpen $0 "$TEMP\qTox-install-file-permissions.txt" w
       FileWriteUTF16LE  $0 "$INSTDIR"
       FileWriteUTF16LE  $0 "$\r$\n"


### PR DESCRIPTION
It's exported as an environment variable that the scripts handle already, and
some of the calls already rely on that. Make all calls rely on that for
consistency.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6527)
<!-- Reviewable:end -->
