### PR TITLE
chore(CI): Include "win" in Windows arch for build scripts

### DIFF
--- a/buildscripts/build_ffmpeg_windows.sh
+++ b/buildscripts/build_ffmpeg_windows.sh
@@ -7,7 +7,7 @@
 usage()
 {
     echo "Download and build ffmpeg for the windows cross compiling environment"
-    echo "Usage: $0 --arch {x86_64|i686}"
+    echo "Usage: $0 --arch {win64|win32}"
 }
 
 ARCH=""
@@ -20,7 +20,7 @@ while (( $# > 0 )); do
     esac
 done
 
-if [ "$ARCH" != "i686" ] && [ "$ARCH" != "x86_64" ]; then
+if [ "$ARCH" != "win32" ] && [ "$ARCH" != "win64" ]; then
     echo "Unexpected arch $ARCH"
     usage
     exit 1
@@ -28,10 +28,12 @@ fi
 
 "$(dirname "$0")"/download/download_ffmpeg.sh
 
-if [ "${ARCH}" == "x86_64" ]; then
+if [ "${ARCH}" == "win64" ]; then
     FFMPEG_ARCH="x86_64"
+    CROSS_PREFIX="x86_64-w64-mingw32-"
 else
     FFMPEG_ARCH="x86"
+    CROSS_PREFIX="i686-w64-mingw32-"
 fi
 
 ./configure --arch=${FFMPEG_ARCH} \
@@ -40,7 +42,7 @@ fi
           --disable-static \
           --prefix=/windows/ \
           --target-os="mingw32" \
-          --cross-prefix="${ARCH}-w64-mingw32-" \
+          --cross-prefix="${CROSS_PREFIX}" \
           --pkg-config="pkg-config" \
           --extra-cflags="-O2 -g0" \
           --disable-debug \

--- a/buildscripts/build_gdb_windows.sh
+++ b/buildscripts/build_gdb_windows.sh
@@ -7,30 +7,36 @@
 usage()
 {
     echo "Download and build gmp for windows"
-    echo "Usage: $0 --arch {x86_64|i686}"
+    echo "Usage: $0 --arch {win64|win32}"
 }
 
 set -euo pipefail
 
 while (( $# > 0 )); do
     case $1 in
-        --arch) ARCH=$2; shift 2 ;;
+        --arch) SCRIPT_ARCH=$2; shift 2 ;;
         -h|--help) usage; exit 1 ;;
         *) echo "Unexpected argument $1"; usage; exit 1;;
     esac
 done
 
-if [ "${ARCH-x}" != "i686" ] && [ "${ARCH-x}" != "x86_64" ]; then
+if [ "${SCRIPT_ARCH-x}" != "win32" ] && [ "${SCRIPT_ARCH-x}" != "win64" ]; then
     echo "Unexpected arch $ARCH"
     usage
     exit 1
+fi
+
+if [ "${SCRIPT_ARCH}" == "win64" ]; then
+    HOST="x86_64-w64-mingw32"
+else
+    HOST="i686-w64-mingw32"
 fi
 
 set -euo pipefail
 
 "$(dirname $0)"/download/download_gdb.sh
 
-CFLAGS="-O2 -g0" ./configure --host="$ARCH-w64-mingw32" \
+CFLAGS="-O2 -g0" ./configure --host="${HOST}" \
                                 --prefix="/windows" \
                                 --enable-static \
                                 --disable-shared

--- a/buildscripts/build_gmp_windows.sh
+++ b/buildscripts/build_gmp_windows.sh
@@ -7,23 +7,29 @@
 usage()
 {
     echo "Download and build gmp for windows"
-    echo "Usage: $0 --arch {x86_64|i686}"
+    echo "Usage: $0 --arch {win64|win32}"
 }
 
 set -euo pipefail
 
 while (( $# > 0 )); do
     case $1 in
-        --arch) ARCH=$2; shift 2 ;;
+        --arch) SCRIPT_ARCH=$2; shift 2 ;;
         -h|--help) usage; exit 1 ;;
         *) echo "Unexpected argument $1"; usage; exit 1;;
     esac
 done
 
-if [ "${ARCH-x}" != "i686" ] && [ "${ARCH-x}" != "x86_64" ]; then
-    echo "Unexpected arch $ARCH"
+if [ "${SCRIPT_ARCH-x}" != "win32" ] && [ "${SCRIPT_ARCH-x}" != "win64" ]; then
+    echo "Unexpected arch $SCRIPT_ARCH"
     usage
     exit 1
+fi
+
+if [ "${SCRIPT_ARCH}" == "win64" ]; then
+    HOST="x86_64-w64-mingw32"
+else
+    HOST="i686-w64-mingw32"
 fi
 
 set -euo pipefail
@@ -31,7 +37,7 @@ set -euo pipefail
 "$(dirname $0)"/download/download_gmp.sh
 
 # https://gmplib.org/list-archives/gmp-discuss/2020-July/006519.html
-CC_FOR_BUILD=gcc CFLAGS="-O2 -g0" ./configure --host="$ARCH-w64-mingw32" \
+CC_FOR_BUILD=gcc CFLAGS="-O2 -g0" ./configure --host="${HOST}" \
                                 --prefix="/windows" \
                                 --enable-static \
                                 --disable-shared

--- a/buildscripts/build_libexif_windows.sh
+++ b/buildscripts/build_libexif_windows.sh
@@ -7,7 +7,7 @@
 usage()
 {
     echo "Download and build libexif for the windows cross compiling environment"
-    echo "Usage: $0 --arch {x86_64|i686}"
+    echo "Usage: $0 --arch {win64|win32}"
 }
 
 ARCH=""
@@ -20,7 +20,7 @@ while (( $# > 0 )); do
     esac
 done
 
-if [ "$ARCH" != "i686" ] && [ "$ARCH" != "x86_64" ]; then
+if [ "$ARCH" != "win32" ] && [ "$ARCH" != "win64" ]; then
     echo "Unexpected arch $ARCH"
     usage
     exit 1
@@ -31,7 +31,13 @@ set -euo pipefail
 
 "$(dirname $0)"/download/download_libexif.sh
 
-CFLAGS="-O2 -g0" ./configure --host="${ARCH}-w64-mingw32" \
+if [ "${ARCH}" == "win64" ]; then
+    HOST="x86_64-w64-mingw32"
+else
+    HOST="i686-w64-mingw32"
+fi
+
+CFLAGS="-O2 -g0" ./configure --host="${HOST}" \
                          --prefix=/windows/ \
                          --enable-shared \
                          --disable-static \

--- a/buildscripts/build_libexpat_windows.sh
+++ b/buildscripts/build_libexpat_windows.sh
@@ -7,28 +7,34 @@
 usage()
 {
     echo "Download and build libexpat for windows"
-    echo "Usage: $0 --arch {x86_64|i686}"
+    echo "Usage: $0 --arch {win64|win32}"
 }
 
 set -euo pipefail
 
 while (( $# > 0 )); do
     case $1 in
-        --arch) ARCH=$2; shift 2 ;;
+        --arch) SCRIPT_ARCH=$2; shift 2 ;;
         -h|--help) usage; exit 1 ;;
         *) echo "Unexpected argument $1"; usage; exit 1;;
     esac
 done
 
-if [ "${ARCH-x}" != "i686" ] && [ "${ARCH-x}" != "x86_64" ]; then
-    echo "Unexpected arch $ARCH"
+if [ "${SCRIPT_ARCH-x}" != "win32" ] && [ "${SCRIPT_ARCH-x}" != "win64" ]; then
+    echo "Unexpected arch $SCRIPT_ARCH"
     usage
     exit 1
 fi
 
 "$(dirname $0)"/download/download_libexpat.sh
 
-CFLAGS="-O2 -g0" ./configure --host="$ARCH-w64-mingw32" \
+if [ "${SCRIPT_ARCH}" == "win64" ]; then
+    HOST="x86_64-w64-mingw32"
+else
+    HOST="i686-w64-mingw32"
+fi
+
+CFLAGS="-O2 -g0" ./configure --host="${HOST}" \
                                 --prefix="/windows" \
                                 --enable-static \
                                 --disable-shared

--- a/buildscripts/build_openal_windows.sh
+++ b/buildscripts/build_openal_windows.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 usage()
 {
     echo "Download and build openal for the windows cross compiling environment"
-    echo "Usage: $0 --arch {x86_64|i686}"
+    echo "Usage: $0 --arch {win64|win32}"
 }
 
 ARCH=""
@@ -22,7 +22,7 @@ while (( $# > 0 )); do
     esac
 done
 
-if [ "$ARCH" != "i686" ] && [ "$ARCH" != "x86_64" ]; then
+if [ "$ARCH" != "win32" ] && [ "$ARCH" != "win64" ]; then
     echo "Unexpected arch $ARCH"
     usage
     exit 1
@@ -32,14 +32,20 @@ fi
 
 patch -p1 < "$(dirname "$0")"/patches/openal-cmake-3-11.patch
 
+if [ "${ARCH}" == "win64" ]; then
+    MINGW_DIR="x86_64-w64-mingw32"
+else
+    MINGW_DIR="x86-w64-mingw32"
+fi
+
 export CFLAGS="-fPIC"
 cmake -DCMAKE_INSTALL_PREFIX=/windows/ \
     -DCMAKE_BUILD_TYPE=Release \
     -DALSOFT_UTILS=OFF \
     -DALSOFT_EXAMPLES=OFF \
     -DCMAKE_TOOLCHAIN_FILE=/build/windows-toolchain.cmake \
-    -DDSOUND_INCLUDE_DIR=/usr/${ARCH}-w64-mingw32/include \
-    -DDSOUND_LIBRARY=/usr/${ARCH}-w64-mingw32/lib/libdsound.a \
+    -DDSOUND_INCLUDE_DIR="/usr/${MINGW_DIR}/include" \
+    -DDSOUND_LIBRARY="/usr/${MINGW_DIR}/lib/libdsound.a" \
     .
 
 make -j $(nproc)

--- a/buildscripts/build_openssl_windows.sh
+++ b/buildscripts/build_openssl_windows.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 usage()
 {
     echo "Download and build openssl for the windows cross compiling environment"
-    echo "Usage: $0 --arch {x86_64|i686}"
+    echo "Usage: $0 --arch {win64|win32}"
 }
 
 ARCH=""
@@ -22,28 +22,25 @@ while (( $# > 0 )); do
     esac
 done
 
-if [ "$ARCH" != "i686" ] && [ "$ARCH" != "x86_64" ]; then
-    echo "Unexpected arch $ARCH"
+if [[ "$ARCH" == "win64" ]]; then
+    OPENSSL_ARCH="mingw64"
+    PREFIX="x86_64-w64-mingw32-"
+elif [[ "$ARCH" == "win32" ]]; then
+    OPENSSL_ARCH="mingw"
+    PREFIX="i686-w64-mingw32-"
+else
+    echo "Invalid architecture"
     usage
     exit 1
 fi
 
 "$(dirname "$0")"/download/download_openssl.sh
 
-if [[ "$ARCH" == "x86_64" ]]; then
-    OPENSSL_ARCH="mingw64"
-elif [[ "$ARCH" == "i686" ]]; then
-    OPENSSL_ARCH="mingw"
-else
-    echo "Invalid architecture"
-    exit 1
-fi
-
 ./Configure --prefix=/windows/ \
     --openssldir=/windows/ssl \
     shared \
     $OPENSSL_ARCH \
-    --cross-compile-prefix=${ARCH}-w64-mingw32-
+    --cross-compile-prefix=${PREFIX}
 
 make -j $(nproc)
 make install

--- a/buildscripts/build_opus_windows.sh
+++ b/buildscripts/build_opus_windows.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 usage()
 {
     echo "Download and build opus for the windows cross compiling environment"
-    echo "Usage: $0 --arch {x86_64|i686}"
+    echo "Usage: $0 --arch {win64|win32}"
 }
 
 ARCH=""
@@ -22,7 +22,11 @@ while (( $# > 0 )); do
     esac
 done
 
-if [ "$ARCH" != "i686" ] && [ "$ARCH" != "x86_64" ]; then
+if [[ "$ARCH" == "win64" ]]; then
+    HOST="x86_64-w64-mingw32"
+elif [[ "$ARCH" == "win32" ]]; then
+    HOST="i686-w64-mingw32"
+else
     echo "Unexpected arch $ARCH"
     usage
     exit 1
@@ -31,7 +35,7 @@ fi
 "$(dirname "$0")"/download/download_opus.sh
 
 LDFLAGS="-fstack-protector" CFLAGS="-O2 -g0" \
-    ./configure --host="${ARCH}-w64-mingw32" \
+    ./configure --host="${HOST}" \
                              --prefix=/windows/ \
                              --enable-shared \
                              --disable-static \

--- a/buildscripts/build_qrencode_windows.sh
+++ b/buildscripts/build_qrencode_windows.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 usage()
 {
     echo "Download and build qrencode for the windows cross compiling environment"
-    echo "Usage: $0 --arch {x86_64|i686}"
+    echo "Usage: $0 --arch {win64|win32}"
 }
 
 ARCH=""
@@ -22,7 +22,11 @@ while (( $# > 0 )); do
     esac
 done
 
-if [ "$ARCH" != "i686" ] && [ "$ARCH" != "x86_64" ]; then
+if [[ "$ARCH" == "win64" ]]; then
+    HOST="x86_64-w64-mingw32"
+elif [[ "$ARCH" == "win32" ]]; then
+    HOST="i686-w64-mingw32"
+else
     echo "Unexpected arch $ARCH"
     usage
     exit 1
@@ -30,7 +34,7 @@ fi
 
 "$(dirname "$0")"/download/download_qrencode.sh
 
-CFLAGS="-O2 -g0" ./configure --host="${ARCH}-w64-mingw32" \
+CFLAGS="-O2 -g0" ./configure --host="${HOST}" \
                             --prefix=/windows \
                             --enable-shared \
                             --disable-static \

--- a/buildscripts/build_qt_windows.sh
+++ b/buildscripts/build_qt_windows.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 usage()
 {
     echo "Download and build qt for the windows cross compiling environment"
-    echo "Usage: $0 --arch {x86_64|i686}"
+    echo "Usage: $0 --arch {win64|win32}"
 }
 
 ARCH=""
@@ -22,7 +22,11 @@ while (( $# > 0 )); do
     esac
 done
 
-if [ "$ARCH" != "i686" ] && [ "$ARCH" != "x86_64" ]; then
+if [[ "$ARCH" == "win64" ]]; then
+    CROSS="x86_64-w64-mingw32-"
+elif [[ "$ARCH" == "win32" ]]; then
+    CROSS="i686-w64-mingw32-"
+else
     echo "Unexpected arch $ARCH"
     usage
     exit 1
@@ -36,7 +40,7 @@ export OPENSSL_LIBS
 ./configure -prefix /windows/ \
     -release \
     -shared \
-    -device-option CROSS_COMPILE=${ARCH}-w64-mingw32- \
+    -device-option CROSS_COMPILE=${CROSS} \
     -xplatform win32-g++ \
     -openssl \
     "$(pkg-config --cflags openssl)" \

--- a/buildscripts/build_sodium_windows.sh
+++ b/buildscripts/build_sodium_windows.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 usage()
 {
     echo "Download and build sodium for the windows cross compiling environment"
-    echo "Usage: $0 --arch {x86_64|i686}"
+    echo "Usage: $0 --arch {win64|win32}"
 }
 
 ARCH=""
@@ -22,7 +22,11 @@ while (( $# > 0 )); do
     esac
 done
 
-if [ "$ARCH" != "i686" ] && [ "$ARCH" != "x86_64" ]; then
+if [[ "$ARCH" == "win64" ]]; then
+    HOST="x86_64-w64-mingw32"
+elif [[ "$ARCH" == "win32" ]]; then
+    HOST="i686-w64-mingw32"
+else
     echo "Unexpected arch $ARCH"
     usage
     exit 1
@@ -31,7 +35,7 @@ fi
 "$(dirname "$0")"/download/download_sodium.sh
 
 LDFLAGS="-fstack-protector" \
-  ./configure --host="${ARCH}-w64-mingw32" \
+  ./configure --host="${HOST}" \
               --prefix=/windows \
               --enable-shared \
               --disable-static

--- a/buildscripts/build_sqlcipher_windows.sh
+++ b/buildscripts/build_sqlcipher_windows.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 usage()
 {
     echo "Download and build sqlcipher for the windows cross compiling environment"
-    echo "Usage: $0 --arch {x86_64|i686}"
+    echo "Usage: $0 --arch {win64|win32}"
 }
 
 ARCH=""
@@ -22,7 +22,11 @@ while (( $# > 0 )); do
     esac
 done
 
-if [ "$ARCH" != "i686" ] && [ "$ARCH" != "x86_64" ]; then
+if [[ "$ARCH" == "win64" ]]; then
+    HOST="x86_64-w64-mingw32"
+elif [[ "$ARCH" == "win32" ]]; then
+    HOST="i686-w64-mingw32"
+else
     echo "Unexpected arch $ARCH"
     usage
     exit 1
@@ -33,7 +37,7 @@ fi
 sed -i s/'if test "$TARGET_EXEEXT" = ".exe"'/'if test ".exe" = ".exe"'/g configure
 sed -i 's|exec $PWD/mksourceid manifest|exec $PWD/mksourceid.exe manifest|g' tool/mksqlite3h.tcl
 
-./configure --host="${ARCH}-w64-mingw32" \
+./configure --host="${HOST}" \
             --prefix=/windows/ \
             --enable-shared \
             --disable-static \

--- a/buildscripts/docker/Dockerfile.windows_builder
+++ b/buildscripts/docker/Dockerfile.windows_builder
@@ -22,6 +22,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ARG ARCH
 ARG WINEARCH
 ENV WINEARCH=${WINEARCH}
+ARG SCRIPT_ARCH=${WINEARCH}
 
 RUN dpkg --add-architecture i386 && \
     apt-get update && apt-get install -y --no-install-recommends \
@@ -62,7 +63,7 @@ COPY build_openssl_windows.sh /build/build_openssl_windows.sh
 
 RUN mkdir -p /src/openssl && \
   cd /src/openssl && \
-  /build/build_openssl_windows.sh --arch ${ARCH} && \
+  /build/build_openssl_windows.sh --arch ${SCRIPT_ARCH} && \
   rm -fr /src/openssl
 
 env PKG_CONFIG_PATH=/windows/lib/pkgconfig
@@ -72,7 +73,7 @@ COPY build_qt_windows.sh /build/build_qt_windows.sh
 
 RUN mkdir -p /src/qt && \
   cd /src/qt && \
-  /build/build_qt_windows.sh --arch ${ARCH} && \
+  /build/build_qt_windows.sh --arch ${SCRIPT_ARCH} && \
   rm -fr /src/qt
 
 COPY download/download_sqlcipher.sh /build/download/download_sqlcipher.sh
@@ -80,14 +81,14 @@ COPY build_sqlcipher_windows.sh /build/build_sqlcipher_windows.sh
 
 RUN mkdir -p /src/sqlcipher && \
   cd /src/sqlcipher && \
-  /build/build_sqlcipher_windows.sh  --arch ${ARCH} && \
+  /build/build_sqlcipher_windows.sh  --arch ${SCRIPT_ARCH} && \
   rm -fr /src/sqlcipher
 
 COPY download/download_ffmpeg.sh /build/download/download_ffmpeg.sh
 COPY build_ffmpeg_windows.sh /build/build_ffmpeg_windows.sh
 RUN mkdir -p /src/ffmpeg && \
   cd /src/ffmpeg && \
-  /build/build_ffmpeg_windows.sh --arch ${ARCH} && \
+  /build/build_ffmpeg_windows.sh --arch ${SCRIPT_ARCH} && \
   rm -fr /src/ffmpeg
 
 COPY toolchain/windows-${ARCH}-toolchain.cmake /build/windows-toolchain.cmake
@@ -98,21 +99,21 @@ COPY patches/openal-cmake-3-11.patch /build/patches/openal-cmake-3-11.patch
 
 RUN mkdir -p /src/openal && \
   cd /src/openal && \
-  /build/build_openal_windows.sh --arch ${ARCH} && \
+  /build/build_openal_windows.sh --arch ${SCRIPT_ARCH} && \
   rm -fr /src/openal
 
 COPY download/download_qrencode.sh /build/download/download_qrencode.sh
 COPY build_qrencode_windows.sh /build/build_qrencode_windows.sh
 RUN mkdir -p /src/qrencode && \
   cd /src/qrencode && \
-  /build/build_qrencode_windows.sh  --arch ${ARCH} && \
+  /build/build_qrencode_windows.sh  --arch ${SCRIPT_ARCH} && \
   rm -fr /src/qrencode
 
 COPY download/download_libexif.sh /build/download/download_libexif.sh
 COPY build_libexif_windows.sh /build/build_libexif_windows.sh
 RUN mkdir -p /src/exif && \
   cd /src/exif && \
-  /build/build_libexif_windows.sh --arch ${ARCH} && \
+  /build/build_libexif_windows.sh --arch ${SCRIPT_ARCH} && \
   rm -fr /src/exif
 
 COPY download/download_snore.sh /build/download/download_snore.sh
@@ -126,14 +127,14 @@ COPY download/download_opus.sh /build/download/download_opus.sh
 COPY build_opus_windows.sh /build/build_opus_windows.sh
 RUN mkdir -p /src/opus && \
   cd /src/opus && \
-  /build/build_opus_windows.sh --arch ${ARCH} && \
+  /build/build_opus_windows.sh --arch ${SCRIPT_ARCH} && \
   rm -fr /src/opus
 
 COPY download/download_sodium.sh /build/download/download_sodium.sh
 COPY build_sodium_windows.sh /build/build_sodium_windows.sh
 RUN mkdir -p /src/sodium && \
   cd /src/sodium && \
-  /build/build_sodium_windows.sh --arch ${ARCH} && \
+  /build/build_sodium_windows.sh --arch ${SCRIPT_ARCH} && \
   rm -fr /src/sodium
 
 COPY download/download_vpx.sh /build/download/download_vpx.sh
@@ -141,7 +142,7 @@ COPY build_vpx_windows.sh /build/build_vpx_windows.sh
 COPY patches/vpx.patch /build/patches/vpx.patch
 RUN mkdir -p /src/vpx && \
   cd /src/vpx && \
-  /build/build_vpx_windows.sh --arch ${ARCH} && \
+  /build/build_vpx_windows.sh --arch ${SCRIPT_ARCH} && \
   rm -fr /src/vpx
 
 COPY download/download_mingw_ldd.sh /build/download/download_mingw_ldd.sh


### PR DESCRIPTION
To help disambiguate Windows arches with other platforms that will be used.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6529)
<!-- Reviewable:end -->
