### PR TITLE
chore(meta): Remove commit format PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,1 +1,0 @@
-- [ ] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

--- a/windows/qtox.nsi
+++ b/windows/qtox.nsi
@@ -215,8 +215,6 @@ FunctionEnd
       FileReadUTF16LE $0 $1 1024
       FileReadUTF16LE $0 $2 1024
     FileClose $0
-    DetailPrint "First read line is: $1"
-    DetailPrint "Second read line is: $2"
     FileOpen $0 "$TEMP\qTox-install-file-permissions.txt" w
       FileWriteUTF16LE  $0 "$INSTDIR"
       FileWriteUTF16LE  $0 "$\r$\n"

--- a/windows/qtox64.nsi
+++ b/windows/qtox64.nsi
@@ -215,8 +215,6 @@ FunctionEnd
       FileReadUTF16LE $0 $1 1024
       FileReadUTF16LE $0 $2 1024
     FileClose $0
-    DetailPrint "First read line is: $1"
-    DetailPrint "Second read line is: $2"
     FileOpen $0 "$TEMP\qTox-install-file-permissions.txt" w
       FileWriteUTF16LE  $0 "$INSTDIR"
       FileWriteUTF16LE  $0 "$\r$\n"


### PR DESCRIPTION
Commit format is already checked in CI, unlike this template which doesn't
actually enforce anything. Each PR showing "1 task done" clutters the PR list
view.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6534)
<!-- Reviewable:end -->
