### PR TITLE
chore(Windows): Remove debug prints from installer

### DIFF
--- a/windows/qtox.nsi
+++ b/windows/qtox.nsi
@@ -215,8 +215,6 @@ FunctionEnd
       FileReadUTF16LE $0 $1 1024
       FileReadUTF16LE $0 $2 1024
     FileClose $0
-    DetailPrint "First read line is: $1"
-    DetailPrint "Second read line is: $2"
     FileOpen $0 "$TEMP\qTox-install-file-permissions.txt" w
       FileWriteUTF16LE  $0 "$INSTDIR"
       FileWriteUTF16LE  $0 "$\r$\n"

--- a/windows/qtox64.nsi
+++ b/windows/qtox64.nsi
@@ -215,8 +215,6 @@ FunctionEnd
       FileReadUTF16LE $0 $1 1024
       FileReadUTF16LE $0 $2 1024
     FileClose $0
-    DetailPrint "First read line is: $1"
-    DetailPrint "Second read line is: $2"
     FileOpen $0 "$TEMP\qTox-install-file-permissions.txt" w
       FileWriteUTF16LE  $0 "$INSTDIR"
       FileWriteUTF16LE  $0 "$\r$\n"


### PR DESCRIPTION
Accidentally left in from development for 553bd47e8171fd4f15e062e4faf734e32002f6fb

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6536)
<!-- Reviewable:end -->
