### PR TITLE
feat(logging): Hide toxcore spam when using IPv4

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,6 +94,11 @@ void logMessageHandler(QtMsgType type, const QMessageLogContext& ctxt, const QSt
         && msg == QString("QFSFileEngine::open: No file name specified"))
         return;
 
+    if (msg == QString("attempted to send message with network family 10 (probably IPv6) on IPv4 socket")) {
+        // non-stop c-toxcore spam for IPv4 users: https://github.com/TokTok/c-toxcore/issues/1432
+        return;
+    }
+
     QRegExp snoreFilter{QStringLiteral("Snore::Notification.*was already closed")};
     if (type == QtWarningMsg
         && msg.contains(snoreFilter))


### PR DESCRIPTION
- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6537)
<!-- Reviewable:end -->
