### PR TITLE
refactor(model): Rename Contact and ContactId to Chat and ChatId

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,8 +242,8 @@ set(${PROJECT_NAME}_SOURCES
   src/core/toxoptions.h
   src/core/toxpk.cpp
   src/core/toxpk.h
-  src/core/contactid.cpp
-  src/core/contactid.h
+  src/core/chatid.cpp
+  src/core/chatid.h
   src/core/toxstring.cpp
   src/core/toxstring.h
   src/friendlist.cpp
@@ -266,8 +266,8 @@ set(${PROJECT_NAME}_SOURCES
   src/model/chatroom/friendchatroom.h
   src/model/chatroom/groupchatroom.cpp
   src/model/chatroom/groupchatroom.h
-  src/model/contact.cpp
-  src/model/contact.h
+  src/model/chat.cpp
+  src/model/chat.h
   src/model/dialogs/idialogs.cpp
   src/model/dialogs/idialogs.h
   src/model/dialogs/idialogsmanager.h

--- a/cmake/Testing.cmake
+++ b/cmake/Testing.cmake
@@ -38,7 +38,7 @@ endfunction()
 add_subdirectory(test/mock)
 
 auto_test(core core "${${PROJECT_NAME}_RESOURCES}")
-auto_test(core contactid "")
+auto_test(core chatid "")
 auto_test(core toxid "")
 auto_test(core toxstring "")
 auto_test(core fileprogress "")

--- a/src/core/chatid.cpp
+++ b/src/core/chatid.cpp
@@ -21,71 +21,71 @@
 #include <QString>
 #include <cstdint>
 #include <QHash>
-#include "src/core/contactid.h"
+#include "src/core/chatid.h"
 
 /**
  * @brief The default constructor. Creates an empty id.
  */
-ContactId::ContactId()
+ChatId::ChatId()
     : id()
 {
 }
-ContactId::~ContactId() = default;
+ChatId::~ChatId() = default;
 
 /**
- * @brief Constructs a ContactId from bytes.
- * @param rawId The bytes to construct the ContactId from.
+ * @brief Constructs a ChatId from bytes.
+ * @param rawId The bytes to construct the ChatId from.
  */
-ContactId::ContactId(const QByteArray& rawId)
+ChatId::ChatId(const QByteArray& rawId)
 {
     id = QByteArray(rawId);
 }
 
 /**
- * @brief Compares the equality of the ContactId.
- * @param other ContactId to compare.
- * @return True if both ContactId are equal, false otherwise.
+ * @brief Compares the equality of the ChatId.
+ * @param other ChatId to compare.
+ * @return True if both ChatId are equal, false otherwise.
  */
-bool ContactId::operator==(const ContactId& other) const
+bool ChatId::operator==(const ChatId& other) const
 {
     return id == other.id;
 }
 
 /**
- * @brief Compares the inequality of the ContactId.
- * @param other ContactId to compare.
- * @return True if both ContactIds are not equal, false otherwise.
+ * @brief Compares the inequality of the ChatId.
+ * @param other ChatId to compare.
+ * @return True if both ChatIds are not equal, false otherwise.
  */
-bool ContactId::operator!=(const ContactId& other) const
+bool ChatId::operator!=(const ChatId& other) const
 {
     return id != other.id;
 }
 
 /**
- * @brief Compares two ContactIds
- * @param other ContactId to compare.
- * @return True if this ContactIds is less than the other ContactId, false otherwise.
+ * @brief Compares two ChatIds
+ * @param other ChatId to compare.
+ * @return True if this ChatIds is less than the other ChatId, false otherwise.
  */
-bool ContactId::operator<(const ContactId& other) const
+bool ChatId::operator<(const ChatId& other) const
 {
     return id < other.id;
 }
 
 /**
- * @brief Converts the ContactId to a uppercase hex string.
+ * @brief Converts the ChatId to a uppercase hex string.
  * @return QString containing the hex representation of the id
  */
-QString ContactId::toString() const
+QString ChatId::toString() const
 {
     return id.toHex().toUpper();
 }
 
 /**
  * @brief Returns a pointer to the raw id data.
- * @return Pointer to the raw id data, which is exactly `ContactId::getPkSize()`
- *         bytes long. Returns a nullptr if the ContactId is empty.
+ * @return Pointer to the raw id data, which is exactly `ChatId::getPkSize()`
+ *         bytes long. Returns a nullptr if the ChatId is empty.
  */
-const uint8_t* ContactId::getData() const
+const uint8_t* ChatId::getData() const
 {
     if (id.isEmpty()) {
         return nullptr;
@@ -98,16 +98,16 @@ const uint8_t* ContactId::getData() const
  * @brief Get a copy of the id
  * @return Copied id bytes
  */
-QByteArray ContactId::getByteArray() const
+QByteArray ChatId::getByteArray() const
 {
     return QByteArray(id); // TODO: Is a copy really necessary?
 }
 
 /**
- * @brief Checks if the ContactId contains a id.
+ * @brief Checks if the ChatId contains a id.
  * @return True if there is a id, False otherwise.
  */
-bool ContactId::isEmpty() const
+bool ChatId::isEmpty() const
 {
     return id.isEmpty();
 }

--- a/src/core/chatid.h
+++ b/src/core/chatid.h
@@ -25,17 +25,17 @@
 #include <QHash>
 #include <memory>
 
-class ContactId
+class ChatId
 {
 public:
-    virtual ~ContactId();
-    ContactId(const ContactId&) = default;
-    ContactId& operator=(const ContactId&) = default;
-    ContactId(ContactId&&) = default;
-    ContactId& operator=(ContactId&&) = default;
-    bool operator==(const ContactId& other) const;
-    bool operator!=(const ContactId& other) const;
-    bool operator<(const ContactId& other) const;
+    virtual ~ChatId();
+    ChatId(const ChatId&) = default;
+    ChatId& operator=(const ChatId&) = default;
+    ChatId(ChatId&&) = default;
+    ChatId& operator=(ChatId&&) = default;
+    bool operator==(const ChatId& other) const;
+    bool operator!=(const ChatId& other) const;
+    bool operator<(const ChatId& other) const;
     QString toString() const;
     QByteArray getByteArray() const;
     const uint8_t* getData() const;
@@ -43,14 +43,14 @@ public:
     virtual int getSize() const = 0;
 
 protected:
-    ContactId();
-    explicit ContactId(const QByteArray& rawId);
+    ChatId();
+    explicit ChatId(const QByteArray& rawId);
     QByteArray id;
 };
 
-inline uint qHash(const ContactId& id)
+inline uint qHash(const ChatId& id)
 {
     return qHash(id.getByteArray());
 }
 
-using ContactIdPtr = std::shared_ptr<const ContactId>;
+using ChatIdPtr = std::shared_ptr<const ChatId>;

--- a/src/core/groupid.cpp
+++ b/src/core/groupid.cpp
@@ -33,7 +33,7 @@
  * @brief The default constructor. Creates an empty Tox group ID.
  */
 GroupId::GroupId()
-    : ContactId()
+    : ChatId()
 {
 }
 
@@ -43,7 +43,7 @@ GroupId::GroupId()
  *              GroupId::size, else the GroupId will be empty.
  */
 GroupId::GroupId(const QByteArray& rawId)
-    : ContactId([rawId](){
+    : ChatId([rawId](){
         assert(rawId.length() == size);
         return rawId;}())
 {
@@ -55,7 +55,7 @@ GroupId::GroupId(const QByteArray& rawId)
  * GroupId::size from the specified buffer.
  */
 GroupId::GroupId(const uint8_t* rawId)
-    : ContactId(QByteArray(reinterpret_cast<const char*>(rawId), size))
+    : ChatId(QByteArray(reinterpret_cast<const char*>(rawId), size))
 {
 }
 

--- a/src/core/groupid.h
+++ b/src/core/groupid.h
@@ -19,11 +19,11 @@
 
 #pragma once
 
-#include "src/core/contactid.h"
+#include "src/core/chatid.h"
 #include <QByteArray>
 #include <cstdint>
 
-class GroupId : public ContactId
+class GroupId : public ChatId
 {
 public:
     static constexpr int size = 32;

--- a/src/core/toxid.cpp
+++ b/src/core/toxid.cpp
@@ -18,7 +18,7 @@
 */
 
 
-#include "contactid.h"
+#include "chatid.h"
 #include "toxid.h"
 #include "toxpk.h"
 

--- a/src/core/toxpk.cpp
+++ b/src/core/toxpk.cpp
@@ -17,7 +17,7 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "contactid.h"
+#include "chatid.h"
 #include "toxpk.h"
 
 #include <QByteArray>
@@ -34,7 +34,7 @@
  * @brief The default constructor. Creates an empty Tox key.
  */
 ToxPk::ToxPk()
-    : ContactId()
+    : ChatId()
 {
 }
 
@@ -44,7 +44,7 @@ ToxPk::ToxPk()
  *              ToxPk::size, else the ToxPk will be empty.
  */
 ToxPk::ToxPk(const QByteArray& rawId)
-    : ContactId([&rawId](){
+    : ChatId([&rawId](){
         assert(rawId.length() == size);
         return rawId;}())
 {
@@ -56,7 +56,7 @@ ToxPk::ToxPk(const QByteArray& rawId)
  * ToxPk::size from the specified buffer.
  */
 ToxPk::ToxPk(const uint8_t* rawId)
-    : ContactId(QByteArray(reinterpret_cast<const char*>(rawId), size))
+    : ChatId(QByteArray(reinterpret_cast<const char*>(rawId), size))
 {
 }
 
@@ -68,7 +68,7 @@ ToxPk::ToxPk(const uint8_t* rawId)
  * @param pk Tox Pk string to convert to ToxPk object
  */
 ToxPk::ToxPk(const QString& pk)
-    : ContactId([&pk](){
+    : ChatId([&pk](){
     if (pk.length() == numHexChars) {
         return QByteArray::fromHex(pk.toLatin1());
     } else {

--- a/src/core/toxpk.h
+++ b/src/core/toxpk.h
@@ -19,11 +19,11 @@
 
 #pragma once
 
-#include "src/core/contactid.h"
+#include "src/core/chatid.h"
 #include <QByteArray>
 #include <cstdint>
 
-class ToxPk : public ContactId
+class ToxPk : public ChatId
 {
 public:
     static constexpr int size = 32;

--- a/src/friendlist.cpp
+++ b/src/friendlist.cpp
@@ -20,7 +20,7 @@
 #include "friendlist.h"
 #include "src/model/friend.h"
 #include "src/persistence/settings.h"
-#include "src/core/contactid.h"
+#include "src/core/chatid.h"
 #include "src/core/toxpk.h"
 #include <QDebug>
 #include <QHash>

--- a/src/model/chat.cpp
+++ b/src/model/chat.cpp
@@ -18,10 +18,10 @@
 */
 
 
-#include "contact.h"
+#include "chat.h"
 #include <QVariant>
 
-Contact::~Contact()
+Chat::~Chat()
 {
 
 }

--- a/src/model/chat.h
+++ b/src/model/chat.h
@@ -19,20 +19,20 @@
 
 #pragma once
 
-#include "src/core/contactid.h"
+#include "src/core/chatid.h"
 #include <QObject>
 #include <QString>
 
-class Contact : public QObject
+class Chat : public QObject
 {
     Q_OBJECT
 public:
-    virtual ~Contact() = 0;
+    virtual ~Chat() = 0;
 
     virtual void setName(const QString& name) = 0;
     virtual QString getDisplayedName() const = 0;
     virtual uint32_t getId() const = 0;
-    virtual const ContactId& getPersistentId() const = 0;
+    virtual const ChatId& getPersistentId() const = 0;
     virtual void setEventFlag(bool flag) = 0;
     virtual bool getEventFlag() const = 0;
 

--- a/src/model/chatroom/chatroom.h
+++ b/src/model/chatroom/chatroom.h
@@ -19,7 +19,7 @@
 
 #pragma once
 
-#include "src/model/contact.h"
+#include "src/model/chat.h"
 
 class Chatroom
 {
@@ -31,5 +31,5 @@ public:
     Chatroom(Chatroom&&) = default;
     Chatroom& operator=(Chatroom&&) = default;
 
-    virtual Contact* getContact() = 0;
+    virtual Chat* getChat() = 0;
 };

--- a/src/model/chatroom/friendchatroom.cpp
+++ b/src/model/chatroom/friendchatroom.cpp
@@ -55,7 +55,7 @@ Friend* FriendChatroom::getFriend()
     return frnd;
 }
 
-Contact* FriendChatroom::getContact()
+Chat* FriendChatroom::getChat()
 {
     return frnd;
 }
@@ -175,14 +175,14 @@ bool FriendChatroom::canBeRemovedFromWindow() const
 {
     const auto friendPk = frnd->getPublicKey();
     const auto dialogs = dialogsManager->getFriendDialogs(friendPk);
-    return dialogs && dialogs->hasContact(friendPk);
+    return dialogs && dialogs->hasChat(friendPk);
 }
 
 bool FriendChatroom::friendCanBeRemoved() const
 {
     const auto friendPk = frnd->getPublicKey();
     const auto dialogs = dialogsManager->getFriendDialogs(friendPk);
-    return !dialogs || !dialogs->hasContact(friendPk);
+    return !dialogs || !dialogs->hasChat(friendPk);
 }
 
 void FriendChatroom::removeFriendFromDialogs()

--- a/src/model/chatroom/friendchatroom.h
+++ b/src/model/chatroom/friendchatroom.h
@@ -50,7 +50,7 @@ public:
     FriendChatroom(Friend* frnd_, IDialogsManager* dialogsManager_, Core& core_,
         Settings& settings_);
 
-    Contact* getContact() override;
+    Chat* getChat() override;
 
 public slots:
 

--- a/src/model/chatroom/groupchatroom.cpp
+++ b/src/model/chatroom/groupchatroom.cpp
@@ -35,7 +35,7 @@ GroupChatroom::GroupChatroom(Group* group_, IDialogsManager* dialogsManager_, Co
 {
 }
 
-Contact* GroupChatroom::getContact()
+Chat* GroupChatroom::getChat()
 {
     return group;
 }
@@ -84,7 +84,7 @@ bool GroupChatroom::canBeRemovedFromWindow() const
 {
     const auto groupId = group->getPersistentId();
     const auto dialogs = dialogsManager->getGroupDialogs(groupId);
-    return dialogs && dialogs->hasContact(groupId);
+    return dialogs && dialogs->hasChat(groupId);
 }
 
 void GroupChatroom::removeGroupFromDialogs()

--- a/src/model/chatroom/groupchatroom.h
+++ b/src/model/chatroom/groupchatroom.h
@@ -34,7 +34,7 @@ class GroupChatroom : public QObject, public Chatroom
 public:
     GroupChatroom(Group* group_, IDialogsManager* dialogsManager_, Core& core_);
 
-    Contact* getContact() override;
+    Chat* getChat() override;
 
     Group* getGroup();
 

--- a/src/model/dialogs/idialogs.h
+++ b/src/model/dialogs/idialogs.h
@@ -19,7 +19,7 @@
 
 #pragma once
 
-class ContactId;
+class ChatId;
 class GroupId;
 class ToxPk;
 
@@ -33,8 +33,8 @@ public:
     IDialogs(IDialogs&&) = default;
     IDialogs& operator=(IDialogs&&) = default;
 
-    virtual bool hasContact(const ContactId& contactId) const = 0;
-    virtual bool isContactActive(const ContactId& contactId) const = 0;
+    virtual bool hasChat(const ChatId& chatId) const = 0;
+    virtual bool isChatActive(const ChatId& chatId) const = 0;
 
     virtual void removeFriend(const ToxPk& friendPk) = 0;
     virtual void removeGroup(const GroupId& groupId) = 0;

--- a/src/model/friend.cpp
+++ b/src/model/friend.cpp
@@ -138,7 +138,7 @@ uint32_t Friend::getId() const
     return friendId;
 }
 
-const ContactId& Friend::getPersistentId() const
+const ChatId& Friend::getPersistentId() const
 {
     return friendPk;
 }

--- a/src/model/friend.h
+++ b/src/model/friend.h
@@ -19,16 +19,16 @@
 
 #pragma once
 
-#include "contact.h"
+#include "chat.h"
 #include "src/core/core.h"
 #include "src/core/extension.h"
 #include "src/core/toxpk.h"
-#include "src/core/contactid.h"
+#include "src/core/chatid.h"
 #include "src/model/status.h"
 #include <QObject>
 #include <QString>
 
-class Friend : public Contact
+class Friend : public Chat
 {
     Q_OBJECT
 public:
@@ -49,7 +49,7 @@ public:
 
     const ToxPk& getPublicKey() const;
     uint32_t getId() const override;
-    const ContactId& getPersistentId() const override;
+    const ChatId& getPersistentId() const override;
 
     void finishNegotiation();
     void setStatus(Status::Status s);

--- a/src/model/group.cpp
+++ b/src/model/group.cpp
@@ -19,7 +19,7 @@
 
 #include "group.h"
 #include "friend.h"
-#include "src/core/contactid.h"
+#include "src/core/chatid.h"
 #include "src/core/groupid.h"
 #include "src/core/toxpk.h"
 #include "src/friendlist.h"

--- a/src/model/group.h
+++ b/src/model/group.h
@@ -19,9 +19,9 @@
 
 #pragma once
 
-#include "contact.h"
+#include "chat.h"
 
-#include "src/core/contactid.h"
+#include "src/core/chatid.h"
 #include "src/core/groupid.h"
 #include "src/core/icoregroupquery.h"
 #include "src/core/icoreidhandler.h"
@@ -31,7 +31,7 @@
 #include <QObject>
 #include <QStringList>
 
-class Group : public Contact
+class Group : public Chat
 {
     Q_OBJECT
 public:

--- a/src/nexus.cpp
+++ b/src/nexus.cpp
@@ -107,7 +107,7 @@ void Nexus::start()
     qRegisterMetaType<ToxPk>("ToxPk");
     qRegisterMetaType<ToxId>("ToxId");
     qRegisterMetaType<ToxPk>("GroupId");
-    qRegisterMetaType<ToxPk>("ContactId");
+    qRegisterMetaType<ToxPk>("ChatId");
     qRegisterMetaType<GroupInvite>("GroupInvite");
     qRegisterMetaType<ReceiptNum>("ReceiptNum");
     qRegisterMetaType<RowId>("RowId");

--- a/src/widget/categorywidget.cpp
+++ b/src/widget/categorywidget.cpp
@@ -165,7 +165,7 @@ void CategoryWidget::search(const QString& searchString, bool updateAll, bool hi
     setVisible(inCategory || listLayout->hasChatrooms());
 }
 
-bool CategoryWidget::cycleContacts(bool forward)
+bool CategoryWidget::cycleChats(bool forward)
 {
     if (listLayout->friendTotalCount() == 0) {
         return false;
@@ -196,7 +196,7 @@ bool CategoryWidget::cycleContacts(bool forward)
     return false;
 }
 
-bool CategoryWidget::cycleContacts(FriendWidget* activeChatroomWidget, bool forward)
+bool CategoryWidget::cycleChats(FriendWidget* activeChatroomWidget, bool forward)
 {
     int index = -1;
     QLayout* currentLayout = nullptr;

--- a/src/widget/categorywidget.h
+++ b/src/widget/categorywidget.h
@@ -45,8 +45,8 @@ public:
     void updateStatus();
 
     bool hasChatrooms() const;
-    bool cycleContacts(bool forward);
-    bool cycleContacts(FriendWidget* activeChatroomWidget, bool forward);
+    bool cycleChats(bool forward);
+    bool cycleChats(FriendWidget* activeChatroomWidget, bool forward);
     void search(const QString& searchString, bool updateAll = false, bool hideOnline = false,
                 bool hideOffline = false);
 

--- a/src/widget/contentdialog.h
+++ b/src/widget/contentdialog.h
@@ -62,19 +62,19 @@ public:
     void ensureSplitterVisible();
     void updateTitleAndStatusIcon();
 
-    void cycleContacts(bool forward, bool loop = true);
+    void cycleChats(bool forward, bool loop = true);
     void onVideoShow(QSize size);
     void onVideoHide();
 
     void addFriendWidget(FriendWidget* widget, Status::Status status);
     bool isActiveWidget(GenericChatroomWidget* widget);
 
-    bool hasContact(const ContactId& contactId) const override;
-    bool isContactActive(const ContactId& contactId) const override;
+    bool hasChat(const ChatId& chatId) const override;
+    bool isChatActive(const ChatId& chatId) const override;
 
-    void focusContact(const ContactId& friendPk);
+    void focusChat(const ChatId& friendPk);
     void updateFriendStatus(const ToxPk& friendPk, Status::Status status);
-    void updateContactStatusLight(const ContactId& contactId);
+    void updateChatStatusLight(const ChatId& chatId);
 
     void setStatusMessage(const ToxPk& friendPk, const QString& message);
 
@@ -89,8 +89,8 @@ signals:
 
 public slots:
     void reorderLayouts(bool newGroupOnTop);
-    void previousContact();
-    void nextContact();
+    void previousChat();
+    void nextChat();
     void setUsername(const QString& newName);
     void reloadTheme() override;
 
@@ -119,7 +119,7 @@ private:
     void saveSplitterState();
     QLayout* nextLayout(QLayout* layout, bool forward) const;
     int getCurrentLayout(QLayout*& layout);
-    void focusCommon(const ContactId& id, QHash<const ContactId&, GenericChatroomWidget*> list);
+    void focusCommon(const ChatId& id, QHash<const ChatId&, GenericChatroomWidget*> list);
 
 private:
     QList<QLayout*> layouts;
@@ -132,8 +132,8 @@ private:
     QSize videoSurfaceSize;
     int videoCount;
 
-    QHash<const ContactId&, GenericChatroomWidget*> contactWidgets;
-    QHash<const ContactId&, GenericChatForm*> contactChatForms;
+    QHash<const ChatId&, GenericChatroomWidget*> chatWidgets;
+    QHash<const ChatId&, GenericChatForm*> chatForms;
 
     QString username;
     Settings& settings;

--- a/src/widget/contentdialogmanager.cpp
+++ b/src/widget/contentdialogmanager.cpp
@@ -29,7 +29,7 @@
 #include <tuple>
 
 namespace {
-void removeDialog(ContentDialog* dialog, QHash<const ContactId&, ContentDialog*>& dialogs)
+void removeDialog(ContentDialog* dialog, QHash<const ChatId&, ContentDialog*>& dialogs)
 {
     for (auto it = dialogs.begin(); it != dialogs.end();) {
         if (*it == dialog) {
@@ -48,14 +48,14 @@ ContentDialog* ContentDialogManager::current()
     return currentDialog;
 }
 
-bool ContentDialogManager::contactWidgetExists(const ContactId& contactId)
+bool ContentDialogManager::chatWidgetExists(const ChatId& chatId)
 {
-    const auto dialog = contactDialogs.value(contactId, nullptr);
+    const auto dialog = chatDialogs.value(chatId, nullptr);
     if (dialog == nullptr) {
         return false;
     }
 
-    return dialog->hasContact(contactId);
+    return dialog->hasChat(chatId);
 }
 
 FriendWidget* ContentDialogManager::addFriendToDialog(ContentDialog* dialog,
@@ -70,7 +70,7 @@ FriendWidget* ContentDialogManager::addFriendToDialog(ContentDialog* dialog,
         lastDialog->removeFriend(friendPk);
     }
 
-    contactDialogs[friendPk] = dialog;
+    chatDialogs[friendPk] = dialog;
     return friendWidget;
 }
 
@@ -86,15 +86,15 @@ GroupWidget* ContentDialogManager::addGroupToDialog(ContentDialog* dialog,
         lastDialog->removeGroup(groupId);
     }
 
-    contactDialogs[groupId] = dialog;
+    chatDialogs[groupId] = dialog;
     return groupWidget;
 }
 
-void ContentDialogManager::focusContact(const ContactId& contactId)
+void ContentDialogManager::focusChat(const ChatId& chatId)
 {
-    auto dialog = focusDialog(contactId, contactDialogs);
+    auto dialog = focusDialog(chatId, chatDialogs);
     if (dialog != nullptr) {
-        dialog->focusContact(contactId);
+        dialog->focusChat(chatId);
     }
 }
 
@@ -104,8 +104,8 @@ void ContentDialogManager::focusContact(const ContactId& contactId)
  * @param list List with dialogs
  * @return ContentDialog if found, nullptr otherwise
  */
-ContentDialog* ContentDialogManager::focusDialog(const ContactId& id,
-                                                 const QHash<const ContactId&, ContentDialog*>& list)
+ContentDialog* ContentDialogManager::focusDialog(const ChatId& id,
+                                                 const QHash<const ChatId&, ContentDialog*>& list)
 {
     auto iter = list.find(id);
     if (iter == list.end()) {
@@ -124,13 +124,13 @@ ContentDialog* ContentDialogManager::focusDialog(const ContactId& id,
 
 void ContentDialogManager::updateFriendStatus(const ToxPk& friendPk)
 {
-    auto dialog = contactDialogs.value(friendPk);
+    auto dialog = chatDialogs.value(friendPk);
     if (dialog == nullptr) {
         return;
     }
 
-    dialog->updateContactStatusLight(friendPk);
-    if (dialog->isContactActive(friendPk)) {
+    dialog->updateChatStatusLight(friendPk);
+    if (dialog->isChatActive(friendPk)) {
         dialog->updateTitleAndStatusIcon();
     }
 
@@ -140,35 +140,35 @@ void ContentDialogManager::updateFriendStatus(const ToxPk& friendPk)
 
 void ContentDialogManager::updateGroupStatus(const GroupId& groupId)
 {
-    auto dialog = contactDialogs.value(groupId);
+    auto dialog = chatDialogs.value(groupId);
     if (dialog == nullptr) {
         return;
     }
 
-    dialog->updateContactStatusLight(groupId);
-    if (dialog->isContactActive(groupId)) {
+    dialog->updateChatStatusLight(groupId);
+    if (dialog->isChatActive(groupId)) {
         dialog->updateTitleAndStatusIcon();
     }
 }
 
-bool ContentDialogManager::isContactActive(const ContactId& contactId)
+bool ContentDialogManager::isChatActive(const ChatId& chatId)
 {
-    const auto dialog = contactDialogs.value(contactId);
+    const auto dialog = chatDialogs.value(chatId);
     if (dialog == nullptr) {
         return false;
     }
 
-    return dialog->isContactActive(contactId);
+    return dialog->isChatActive(chatId);
 }
 
 ContentDialog* ContentDialogManager::getFriendDialog(const ToxPk& friendPk) const
 {
-    return contactDialogs.value(friendPk);
+    return chatDialogs.value(friendPk);
 }
 
 ContentDialog* ContentDialogManager::getGroupDialog(const GroupId& groupId) const
 {
-    return contactDialogs.value(groupId);
+    return chatDialogs.value(groupId);
 }
 
 ContentDialogManager* ContentDialogManager::getInstance()
@@ -200,7 +200,7 @@ void ContentDialogManager::onDialogClose()
         currentDialog = nullptr;
     }
 
-    removeDialog(dialog, contactDialogs);
+    removeDialog(dialog, chatDialogs);
 }
 
 IDialogs* ContentDialogManager::getFriendDialogs(const ToxPk& friendPk) const

--- a/src/widget/contentdialogmanager.h
+++ b/src/widget/contentdialogmanager.h
@@ -20,7 +20,7 @@
 #pragma once
 
 #include "contentdialog.h"
-#include "src/core/contactid.h"
+#include "src/core/chatid.h"
 #include "src/core/groupid.h"
 #include "src/core/toxpk.h"
 #include "src/model/dialogs/idialogsmanager.h"
@@ -35,11 +35,11 @@ class ContentDialogManager : public QObject, public IDialogsManager
     Q_OBJECT
 public:
     ContentDialog* current();
-    bool contactWidgetExists(const ContactId& groupId);
-    void focusContact(const ContactId& contactId);
+    bool chatWidgetExists(const ChatId& groupId);
+    void focusChat(const ChatId& chatId);
     void updateFriendStatus(const ToxPk& friendPk);
     void updateGroupStatus(const GroupId& friendPk);
-    bool isContactActive(const ContactId& contactId);
+    bool isChatActive(const ChatId& chatId);
     ContentDialog* getFriendDialog(const ToxPk& friendPk) const;
     ContentDialog* getGroupDialog(const GroupId& friendPk) const;
 
@@ -60,12 +60,12 @@ private slots:
     void onDialogActivate();
 
 private:
-    ContentDialog* focusDialog(const ContactId& id,
-                               const QHash<const ContactId&, ContentDialog*>& list);
+    ContentDialog* focusDialog(const ChatId& id,
+                               const QHash<const ChatId&, ContentDialog*>& list);
 
     ContentDialog* currentDialog = nullptr;
 
-    QHash<const ContactId&, ContentDialog*> contactDialogs;
+    QHash<const ChatId&, ContentDialog*> chatDialogs;
 
     static ContentDialogManager* instance;
 };

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -136,7 +136,7 @@ QPushButton* createButton(const QString& name, T* self, Fun onClickSlot, Setting
 
 } // namespace
 
-GenericChatForm::GenericChatForm(const Core& core_, const Contact* contact, IChatLog& chatLog_,
+GenericChatForm::GenericChatForm(const Core& core_, const Chat* chat, IChatLog& chatLog_,
                                  IMessageDispatcher& messageDispatcher_, DocumentCache& documentCache,
                                  SmileyPack& smileyPack_, Settings& settings_, QWidget* parent_)
     : QWidget(parent_, Qt::Window)
@@ -273,7 +273,7 @@ GenericChatForm::GenericChatForm(const Core& core_, const Contact* contact, ICha
     Translator::registerHandler(std::bind(&GenericChatForm::retranslateUi, this), this);
 
     // update header on name/title change
-    connect(contact, &Contact::displayedNameChanged, this, &GenericChatForm::setName);
+    connect(chat, &Chat::displayedNameChanged, this, &GenericChatForm::setName);
 
 }
 

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -36,7 +36,7 @@
 class ChatFormHeader;
 class ChatWidget;
 class ChatTextEdit;
-class Contact;
+class Chat;
 class ContentLayout;
 class CroppingLabel;
 class FlyoutOverlayWidget;
@@ -71,7 +71,7 @@ class GenericChatForm : public QWidget
 {
     Q_OBJECT
 public:
-    GenericChatForm(const Core& core_, const Contact* contact, IChatLog& chatLog_,
+    GenericChatForm(const Core& core_, const Chat* chat, IChatLog& chatLog_,
                     IMessageDispatcher& messageDispatcher_, DocumentCache&,
                     SmileyPack&, Settings&, QWidget* parent_ = nullptr);
     ~GenericChatForm() override;

--- a/src/widget/friendlistwidget.cpp
+++ b/src/widget/friendlistwidget.cpp
@@ -442,7 +442,7 @@ void FriendListWidget::onGroupchatPositionChanged(bool top)
     itemsChanged();
 }
 
-void FriendListWidget::cycleContacts(GenericChatroomWidget* activeChatroomWidget, bool forward)
+void FriendListWidget::cycleChats(GenericChatroomWidget* activeChatroomWidget, bool forward)
 {
     if (!activeChatroomWidget) {
         return;
@@ -461,7 +461,7 @@ void FriendListWidget::cycleContacts(GenericChatroomWidget* activeChatroomWidget
         QWidget* widget_ = activityLayout->itemAt(index)->widget();
         CategoryWidget* categoryWidget = qobject_cast<CategoryWidget*>(widget_);
 
-        if (categoryWidget == nullptr || categoryWidget->cycleContacts(friendWidget, forward)) {
+        if (categoryWidget == nullptr || categoryWidget->cycleChats(friendWidget, forward)) {
             return;
         }
 
@@ -481,7 +481,7 @@ void FriendListWidget::cycleContacts(GenericChatroomWidget* activeChatroomWidget
             categoryWidget = qobject_cast<CategoryWidget*>(widget);
 
             if (categoryWidget != nullptr) {
-                if (!categoryWidget->cycleContacts(forward)) {
+                if (!categoryWidget->cycleChats(forward)) {
                     // Skip empty or finished categories.
                     index += forward ? 1 : -1;
                     continue;

--- a/src/widget/friendlistwidget.h
+++ b/src/widget/friendlistwidget.h
@@ -60,7 +60,7 @@ public:
     void searchChatrooms(const QString& searchString, bool hideOnline = false,
                          bool hideOffline = false, bool hideGroups = false);
 
-    void cycleContacts(GenericChatroomWidget* activeChatroomWidget, bool forward);
+    void cycleChats(GenericChatroomWidget* activeChatroomWidget, bool forward);
 
     void updateActivityTime(const QDateTime& date);
 

--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -351,7 +351,7 @@ const Friend* FriendWidget::getFriend() const
     return chatroom->getFriend();
 }
 
-const Contact* FriendWidget::getContact() const
+const Chat* FriendWidget::getChat() const
 {
     return getFriend();
 }

--- a/src/widget/friendwidget.h
+++ b/src/widget/friendwidget.h
@@ -44,7 +44,7 @@ public:
     void resetEventFlags() final;
     QString getStatusString() const final;
     const Friend* getFriend() const final;
-    const Contact* getContact() const final;
+    const Chat* getChat() const final;
 
     bool isFriend() const final;
     bool isGroup() const final;

--- a/src/widget/genericchatroomwidget.h
+++ b/src/widget/genericchatroomwidget.h
@@ -30,6 +30,7 @@ class Friend;
 class Group;
 class Contact;
 class Settings;
+class Chat;
 
 class GenericChatroomWidget : public GenericChatItemWidget
 {
@@ -43,7 +44,7 @@ public slots:
     virtual void updateStatusLight() = 0;
     virtual void resetEventFlags() = 0;
     virtual QString getStatusString() const = 0;
-    virtual const Contact* getContact() const = 0;
+    virtual const Chat* getChat() const = 0;
     virtual const Friend* getFriend() const
     {
         return nullptr;

--- a/src/widget/groupwidget.cpp
+++ b/src/widget/groupwidget.cpp
@@ -235,7 +235,7 @@ Group* GroupWidget::getGroup() const
     return chatroom->getGroup();
 }
 
-const Contact* GroupWidget::getContact() const
+const Chat* GroupWidget::getChat() const
 {
     return getGroup();
 }

--- a/src/widget/groupwidget.h
+++ b/src/widget/groupwidget.h
@@ -41,7 +41,7 @@ public:
     void resetEventFlags() final;
     QString getStatusString() const final;
     Group* getGroup() const final;
-    const Contact* getContact() const final;
+    const Chat* getChat() const final;
     void setName(const QString& name);
     void editName();
 

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -192,8 +192,8 @@ public slots:
     void onGroupPeerAudioPlaying(int groupnumber, ToxPk peerPk);
     void onGroupSendFailed(uint32_t groupnumber);
     void onFriendTypingChanged(uint32_t friendnumber, bool isTyping);
-    void nextContact();
-    void previousContact();
+    void nextChat();
+    void previousChat();
     void onFriendDialogShown(const Friend* f);
     void onGroupDialogShown(Group* g);
     void toggleFullscreen();
@@ -268,8 +268,8 @@ private:
     void removeGroup(Group* g, bool fake = false);
     void saveWindowGeometry();
     void saveSplitterGeometry();
-    void cycleContacts(bool forward);
-    void searchContacts();
+    void cycleChats(bool forward);
+    void searchChats();
     void changeDisplayMode();
     void updateFilterText();
     FilterCriteria getFilterCriteria() const;
@@ -322,7 +322,7 @@ private:
     FilesForm* filesForm;
     static Widget* instance;
     GenericChatroomWidget* activeChatroomWidget;
-    FriendListWidget* contactListWidget;
+    FriendListWidget* chatListWidget;
     MaskablePixmapWidget* profilePicture;
     bool notify(QObject* receiver, QEvent* event);
     bool autoAwayActive = false;

--- a/test/core/chatid_test.cpp
+++ b/test/core/chatid_test.cpp
@@ -17,7 +17,7 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "src/core/contactid.h"
+#include "src/core/chatid.h"
 #include "src/core/toxpk.h"
 #include "src/core/toxid.h"
 #include "src/core/groupid.h"
@@ -38,7 +38,7 @@ const QString echoStr =
     QStringLiteral("76518406F6A9F2217E8DC487CC783C25CC16A15EB36FF32E335A235342C48A39");
 const QByteArray echoPk = QByteArray::fromHex(echoStr.toLatin1());
 
-class TestContactId : public QObject
+class TestChatId : public QObject
 {
     Q_OBJECT
 private slots:
@@ -51,13 +51,13 @@ private slots:
     void hashableTest();
 };
 
-void TestContactId::toStringTest()
+void TestChatId::toStringTest()
 {
     ToxPk pk(testPk);
     QVERIFY(testStr == pk.toString());
 }
 
-void TestContactId::equalTest()
+void TestChatId::equalTest()
 {
     ToxPk pk1(testPk);
     ToxPk pk2(testPk);
@@ -67,7 +67,7 @@ void TestContactId::equalTest()
     QVERIFY(!(pk1 != pk2));
 }
 
-void TestContactId::clearTest()
+void TestChatId::clearTest()
 {
     ToxPk empty;
     ToxPk pk(testPk);
@@ -75,14 +75,14 @@ void TestContactId::clearTest()
     QVERIFY(!pk.isEmpty());
 }
 
-void TestContactId::copyTest()
+void TestChatId::copyTest()
 {
     ToxPk src(testPk);
     ToxPk copy = src;
     QVERIFY(copy == src);
 }
 
-void TestContactId::dataTest()
+void TestChatId::dataTest()
 {
     ToxPk pk(testPk);
     QVERIFY(testPk == pk.getByteArray());
@@ -91,7 +91,7 @@ void TestContactId::dataTest()
     }
 }
 
-void TestContactId::sizeTest()
+void TestChatId::sizeTest()
 {
     ToxPk pk;
     GroupId id;
@@ -99,7 +99,7 @@ void TestContactId::sizeTest()
     QVERIFY(id.getSize() == GroupId::size);
 }
 
-void TestContactId::hashableTest()
+void TestChatId::hashableTest()
 {
     ToxPk pk1{testPkArray};
     ToxPk pk2{testPk};
@@ -108,5 +108,5 @@ void TestContactId::hashableTest()
     QVERIFY(qHash(pk1) != qHash(pk3));
 }
 
-QTEST_GUILESS_MAIN(TestContactId)
-#include "contactid_test.moc"
+QTEST_GUILESS_MAIN(TestChatId)
+#include "chatid_test.moc"


### PR DESCRIPTION
* Referring to groups generically as contacts is confusing.
* Friends are referred to as contacts in many places either as more
  neutral wording, or to avoid using the keyword friend as a variable
  name. Calling Contact Chat allows contact to be used for Friends.

- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6538)
<!-- Reviewable:end -->
