### PR TITLE
refactor(history): Remove unused friendPk from FileDbInsertionData

### DIFF
--- a/src/persistence/history.cpp
+++ b/src/persistence/history.cpp
@@ -942,7 +942,6 @@ void History::addNewFileMessage(const ToxPk& friendPk, const QString& fileId,
 
     std::weak_ptr<History> weakThis = shared_from_this();
     FileDbInsertionData insertionData;
-    insertionData.friendPk = friendPk;
     insertionData.fileId = fileId;
     insertionData.fileName = fileName;
     insertionData.filePath = filePath;

--- a/src/persistence/history.h
+++ b/src/persistence/history.h
@@ -116,7 +116,6 @@ struct FileDbInsertionData
     FileDbInsertionData();
 
     RowId historyId;
-    ToxPk friendPk;
     QString fileId;
     QString fileName;
     QString filePath;


### PR DESCRIPTION
- [x] Commits follow our [git commit guidelines](https://github.com/qTox/qTox/blob/master/CONTRIBUTING.md#git-commit-guidelines)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6539)
<!-- Reviewable:end -->
