### PR TITLE
chore(macOS): Remove support for old AvFoundation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -552,17 +552,6 @@ endif()
 add_definitions(-DQT_MESSAGELOGCONTEXT=1)
 
 if(AVFOUNDATION_FOUND)
-  # used for AVFoundation compile time deprecation check
-  execute_process(
-    COMMAND sw_vers -productVersion
-    OUTPUT_VARIABLE MACOS_VER
-  )
-  string(REPLACE "." ";" VERSION_LIST ${MACOS_VER})
-  list(GET VERSION_LIST 0 MACOS_VERSION_MAJOR)
-  list(GET VERSION_LIST 1 MACOS_VERSION_MINOR)
-  add_definitions(-DMACOS_VERSION_MAJOR=${MACOS_VERSION_MAJOR})
-  add_definitions(-DMACOS_VERSION_MINOR=${MACOS_VERSION_MINOR})
-
   set(${PROJECT_NAME}_SOURCES ${${PROJECT_NAME}_SOURCES}
     src/platform/camera/avfoundation.mm
     src/platform/camera/avfoundation.h)

--- a/src/platform/camera/avfoundation.mm
+++ b/src/platform/camera/avfoundation.mm
@@ -27,14 +27,10 @@ QVector<QPair<QString, QString> > avfoundation::getDeviceList()
 {
     QVector<QPair<QString, QString> > result;
 
-#if MACOS_VERSION_MAJOR > 10 || (MACOS_VERSION_MAJOR == 10 && MACOS_VERSION_MINOR > 14)
     AVCaptureDevice* device = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeVideo];
     id objects[] = {device};
     NSUInteger count = sizeof(objects) / sizeof(id);
     NSArray* devices = [NSArray arrayWithObjects:objects count:count];
-#else
-    NSArray* devices = [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo];
-#endif
 
     for (AVCaptureDevice* device in devices) {
         result.append({ QString::fromNSString([device uniqueID]), QString::fromNSString([device localizedName]) });


### PR DESCRIPTION
We no longer need conditional support for the older API since our minimum supported version is now 10.15.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6545)
<!-- Reviewable:end -->
