### PR TITLE
refactor(history): Move APIs from Friend-based to Contact-based

### DIFF
--- a/src/model/about/aboutfriend.cpp
+++ b/src/model/about/aboutfriend.cpp
@@ -127,7 +127,7 @@ bool AboutFriend::clearHistory()
     const ToxPk pk = f->getPublicKey();
     History* const history = Nexus::getProfile()->getHistory();
     if (history) {
-        history->removeFriendHistory(pk);
+        history->removeChatHistory(pk);
         return true;
     }
 

--- a/src/model/chathistory.cpp
+++ b/src/model/chathistory.cpp
@@ -160,7 +160,7 @@ SearchResult ChatHistory::searchBackward(SearchPos startIdx, const QString& phra
         history->getDateWhereFindPhrase(f.getPublicKey(), earliestMessageDate, phrase,
                                         parameter);
 
-    auto loadIdx = history->getNumMessagesForFriendBeforeDate(f.getPublicKey(), dateWherePhraseFound);
+    auto loadIdx = history->getNumMessagesForChatBeforeDate(f.getPublicKey(), dateWherePhraseFound);
     loadHistoryIntoSessionChatLog(ChatLogIdx(loadIdx));
 
     // Reset search pos to the message we just loaded to avoid a double search
@@ -187,7 +187,7 @@ std::vector<IChatLog::DateChatLogIdxPair> ChatHistory::getDateIdxs(const QDate& 
                                                                    size_t maxDates) const
 {
     if (canUseHistory()) {
-        auto counts = history->getNumMessagesForFriendBeforeDateBoundaries(f.getPublicKey(),
+        auto counts = history->getNumMessagesForChatBeforeDateBoundaries(f.getPublicKey(),
                                                                            startDate, maxDates);
 
         std::vector<IChatLog::DateChatLogIdxPair> ret;
@@ -352,7 +352,7 @@ void ChatHistory::loadHistoryIntoSessionChatLog(ChatLogIdx start) const
     // We know that both history and us have a start index of 0 so the type
     // conversion should be safe
     assert(getFirstIdx() == ChatLogIdx(0));
-    auto messages = history->getMessagesForFriend(f.getPublicKey(), start.get(), end.get());
+    auto messages = history->getMessagesForChat(f.getPublicKey(), start.get(), end.get());
 
     assert(messages.size() == static_cast<int>(end.get() - start.get()));
     ChatLogIdx nextIdx = start;
@@ -425,7 +425,7 @@ void ChatHistory::loadHistoryIntoSessionChatLog(ChatLogIdx start) const
  */
 void ChatHistory::dispatchUnsentMessages(IMessageDispatcher& messageDispatcher)
 {
-    auto unsentMessages = history->getUndeliveredMessagesForFriend(f.getPublicKey());
+    auto unsentMessages = history->getUndeliveredMessagesForChat(f.getPublicKey());
 
     auto requiredExtensions = std::accumulate(
         unsentMessages.begin(), unsentMessages.end(),
@@ -521,7 +521,7 @@ bool ChatHistory::canUseHistory() const
 ChatLogIdx ChatHistory::getInitialChatLogIdx() const
 {
     if (canUseHistory()) {
-        return ChatLogIdx(history->getNumMessagesForFriend(f.getPublicKey()));
+        return ChatLogIdx(history->getNumMessagesForChat(f.getPublicKey()));
     }
     return ChatLogIdx(0);
 }

--- a/src/persistence/history.h
+++ b/src/persistence/history.h
@@ -30,7 +30,6 @@
 
 #include "src/core/extension.h"
 #include "src/core/toxfile.h"
-#include "src/core/toxpk.h"
 #include "src/model/brokenmessagereason.h"
 #include "src/model/systemmessage.h"
 #include "src/persistence/db/rawdatabase.h"
@@ -38,6 +37,8 @@
 
 class Profile;
 class HistoryKeeper;
+class ContactId;
+class ToxPk;
 
 enum class HistMessageContentType
 {
@@ -190,28 +191,28 @@ public:
 
     bool isValid();
 
-    bool historyExists(const ToxPk& friendPk);
+    bool historyExists(const ContactId& chatId);
 
     void eraseHistory();
-    void removeFriendHistory(const ToxPk& friendPk);
-    void addNewMessage(const ToxPk& friendPk, const QString& message, const ToxPk& sender,
+    void removeChatHistory(const ContactId& chatId);
+    void addNewMessage(const ContactId& chatId, const QString& message, const ToxPk& sender,
                        const QDateTime& time, bool isDelivered, ExtensionSet extensions,
                        QString dispName, const std::function<void(RowId)>& insertIdCallback = {});
 
-    void addNewFileMessage(const ToxPk& friendPk, const QString& fileId,
+    void addNewFileMessage(const ContactId& chatId, const QString& fileId,
                            const QString& fileName, const QString& filePath, int64_t size,
                            const ToxPk& sender, const QDateTime& time, QString const& dispName);
 
-    void addNewSystemMessage(const ToxPk& friendPk, const SystemMessage& systemMessage);
+    void addNewSystemMessage(const ContactId& chatId, const SystemMessage& systemMessage);
 
     void setFileFinished(const QString& fileId, bool success, const QString& filePath, const QByteArray& fileHash);
-    size_t getNumMessagesForFriend(const ToxPk& friendPk);
-    size_t getNumMessagesForFriendBeforeDate(const ToxPk& friendPk, const QDateTime& date);
-    QList<HistMessage> getMessagesForFriend(const ToxPk& friendPk, size_t firstIdx, size_t lastIdx);
-    QList<HistMessage> getUndeliveredMessagesForFriend(const ToxPk& friendPk);
-    QDateTime getDateWhereFindPhrase(const ToxPk& friendPk, const QDateTime& from, QString phrase,
+    size_t getNumMessagesForChat(const ContactId& chatId);
+    size_t getNumMessagesForChatBeforeDate(const ContactId& chatId, const QDateTime& date);
+    QList<HistMessage> getMessagesForChat(const ContactId& chatId, size_t firstIdx, size_t lastIdx);
+    QList<HistMessage> getUndeliveredMessagesForChat(const ContactId& chatId);
+    QDateTime getDateWhereFindPhrase(const ContactId& chatId, const QDateTime& from, QString phrase,
                                      const ParameterSearch& parameter);
-    QList<DateIdx> getNumMessagesForFriendBeforeDateBoundaries(const ToxPk& friendPk,
+    QList<DateIdx> getNumMessagesForChatBeforeDateBoundaries(const ContactId& chatId,
                                                                const QDate& from, size_t maxNum);
 
     void markAsDelivered(RowId messageId);
@@ -225,7 +226,7 @@ private slots:
 
 private:
     QVector<RawDatabase::Query>
-    generateNewFileTransferQueries(const ToxPk& friendPk, const ToxPk& sender, const QDateTime& time,
+    generateNewFileTransferQueries(const ContactId& chatId, const ToxPk& sender, const QDateTime& time,
                                    const QString& dispName, const FileDbInsertionData& insertionData);
     bool historyAccessBlocked();
     static RawDatabase::Query generateFileFinished(RowId fileId, bool success,

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1761,7 +1761,7 @@ void Widget::removeFriend(Friend* f, bool fake)
         }
 
         if (ask.removeHistory()) {
-            profile.getHistory()->removeFriendHistory(f->getPublicKey());
+            profile.getHistory()->removeChatHistory(f->getPublicKey());
         }
     }
 


### PR DESCRIPTION
Makes it more clear when we're talking about an author (ToxPK) or a chat
(ContactId). Prepares for group chat history which will use the same APIs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6546)
<!-- Reviewable:end -->
