### PR TITLE
feat(history): Add self join/part messages

### DIFF
--- a/src/chatlog/chatwidget.cpp
+++ b/src/chatlog/chatwidget.cpp
@@ -133,6 +133,8 @@ ChatMessage::SystemMessageType getChatMessageType(const SystemMessage& systemMes
     case SystemMessageType::outgoingCall:
     case SystemMessageType::incomingCall:
     case SystemMessageType::callEnd:
+    case SystemMessageType::selfJoinedGroup:
+    case SystemMessageType::selfLeftGroup:
         return ChatMessage::INFO;
     }
 

--- a/src/model/systemmessage.h
+++ b/src/model/systemmessage.h
@@ -42,6 +42,8 @@ enum class SystemMessageType
     incomingCall,
     callEnd,
     messageSendFailed,
+    selfJoinedGroup,
+    selfLeftGroup,
 };
 
 struct SystemMessage
@@ -53,62 +55,36 @@ struct SystemMessage
 
     QString toString() const
     {
-        QString translated;
-        size_t numArgs = 0;
-
         switch (messageType) {
         case SystemMessageType::fileSendFailed:
-            translated = QObject::tr("Failed to send file \"%1\"");
-            numArgs = 1;
-            break;
+            return QObject::tr("Failed to send file \"%1\"").arg(args[0]);
         case SystemMessageType::userJoinedGroup:
-            translated = QObject::tr("%1 has joined the group");
-            numArgs = 1;
-            break;
+            return QObject::tr("%1 has joined the group").arg(args[0]);
         case SystemMessageType::userLeftGroup:
-            translated = QObject::tr("%1 has left the group");
-            numArgs = 1;
-            break;
+            return QObject::tr("%1 has left the group").arg(args[0]);
         case SystemMessageType::peerNameChanged:
-            translated = QObject::tr("%1 is now known as %2");
-            numArgs = 2;
-            break;
+            return QObject::tr("%1 is now known as %2").arg(args[0]).arg(args[1]);
         case SystemMessageType::titleChanged:
-            translated = QObject::tr("%1 has set the title to %2");
-            numArgs = 2;
-            break;
+            return QObject::tr("%1 has set the title to %2").arg(args[0]).arg(args[1]);
         case SystemMessageType::cleared:
-            translated = QObject::tr("Cleared");
-            break;
+            return QObject::tr("Cleared");
         case SystemMessageType::unexpectedCallEnd:
-            translated = QObject::tr("Call with %1 ended unexpectedly. %2");
-            numArgs = 2;
-            break;
+            return QObject::tr("Call with %1 ended unexpectedly. %2").arg(args[0]).arg(args[1]);
         case SystemMessageType::callEnd:
-            translated = QObject::tr("Call with %1 ended. %2");
-            numArgs = 2;
-            break;
+            return QObject::tr("Call with %1 ended. %2").arg(args[0]).arg(args[1]);
         case SystemMessageType::peerStateChange:
-            translated = QObject::tr("%1 is now %2", "e.g. \"Dubslow is now online\"");
-            numArgs = 2;
-            break;
+            return QObject::tr("%1 is now %2", "e.g. \"Dubslow is now online\"").arg(args[0]).arg(args[1]);
         case SystemMessageType::outgoingCall:
-            translated = QObject::tr("Calling %1");
-            numArgs = 1;
-            break;
+            return QObject::tr("Calling %1").arg(args[0]);
         case SystemMessageType::incomingCall:
-            translated = QObject::tr("%1 calling");
-            numArgs = 1;
-            break;
+            return QObject::tr("%1 calling").arg(args[0]);
         case SystemMessageType::messageSendFailed:
-            translated = QObject::tr("Message failed to send");
-            break;
+            return QObject::tr("Message failed to send");
+        case SystemMessageType::selfJoinedGroup:
+            return QObject::tr("You have joined the group");
+        case SystemMessageType::selfLeftGroup:
+            return QObject::tr("You have left the group");
         }
-
-        for (size_t i = 0; i < numArgs; ++i) {
-            translated = translated.arg(args[i]);
-        }
-
-        return translated;
+        return {};
     }
 };

--- a/src/widget/form/genericchatform.cpp
+++ b/src/widget/form/genericchatform.cpp
@@ -325,6 +325,8 @@ QDateTime GenericChatForm::getLatestTime() const
             case SystemMessageType::userJoinedGroup:
             case SystemMessageType::fileSendFailed:
             case SystemMessageType::messageSendFailed:
+            case SystemMessageType::selfJoinedGroup:
+            case SystemMessageType::selfLeftGroup:
                 return false;
         }
 

--- a/src/widget/form/groupchatform.cpp
+++ b/src/widget/form/groupchatform.cpp
@@ -133,6 +133,10 @@ GroupChatForm::GroupChatForm(Core& _core, Group* chatGroup, IChatLog& chatLog, I
     connect(group, &Group::numPeersChanged, this, &GroupChatForm::updateUserCount);
     settings.connectTo_blackListChanged(this, [this](QStringList const&) { this->updateUserNames(); });
 
+    if (settings.getShowGroupJoinLeaveMessages()) {
+        addSystemInfoMessage(QDateTime::currentDateTime(), SystemMessageType::selfJoinedGroup, {});
+    }
+
     updateUserNames();
     setAcceptDrops(true);
     Translator::registerHandler(std::bind(&GroupChatForm::retranslateUi, this), this);
@@ -140,6 +144,9 @@ GroupChatForm::GroupChatForm(Core& _core, Group* chatGroup, IChatLog& chatLog, I
 
 GroupChatForm::~GroupChatForm()
 {
+    if (settings.getShowGroupJoinLeaveMessages()) {
+        addSystemInfoMessage(QDateTime::currentDateTime(), SystemMessageType::selfLeftGroup, {});
+    }
     Translator::unregister(this);
 }
 

--- a/translations/ar.ts
+++ b/translations/ar.ts
@@ -2476,6 +2476,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/be.ts
+++ b/translations/be.ts
@@ -2472,6 +2472,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/bg.ts
+++ b/translations/bg.ts
@@ -2473,6 +2473,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/cs.ts
+++ b/translations/cs.ts
@@ -2476,6 +2476,14 @@ ID zahrnuje kód NoSpam (modře) a kontrolní součet (šedě).</translation>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/da.ts
+++ b/translations/da.ts
@@ -2456,6 +2456,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/de.ts
+++ b/translations/de.ts
@@ -2481,6 +2481,14 @@ Diese ID enthält den NoSpam-Code (in blau) und die Prüfsumme (in grau).</trans
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/el.ts
+++ b/translations/el.ts
@@ -2460,6 +2460,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/eo.ts
+++ b/translations/eo.ts
@@ -2448,6 +2448,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/es.ts
+++ b/translations/es.ts
@@ -2473,6 +2473,14 @@ Este ID incluye el código NoSpam (en azul), y la suma de comprobación (en gris
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/et.ts
+++ b/translations/et.ts
@@ -2475,6 +2475,14 @@ See ID sisaldab NoSpam koodi (sinine) ja kontrollsumma (hall).</translation>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/fa.ts
+++ b/translations/fa.ts
@@ -2464,6 +2464,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/fi.ts
+++ b/translations/fi.ts
@@ -2472,6 +2472,14 @@ Tämä ID sisältää spammin estävän koodin(joka on sinisellä), ja tarkistus
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/fr.ts
+++ b/translations/fr.ts
@@ -2472,6 +2472,14 @@ Cet identifiant comprend le code NoSpam (en bleu) et la somme de contrôle (en g
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/gl.ts
+++ b/translations/gl.ts
@@ -2468,6 +2468,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/he.ts
+++ b/translations/he.ts
@@ -2456,6 +2456,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/hr.ts
+++ b/translations/hr.ts
@@ -2464,6 +2464,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/hu.ts
+++ b/translations/hu.ts
@@ -2456,6 +2456,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/is.ts
+++ b/translations/is.ts
@@ -2456,6 +2456,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/it.ts
+++ b/translations/it.ts
@@ -2469,6 +2469,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/ja.ts
+++ b/translations/ja.ts
@@ -2455,6 +2455,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/kn.ts
+++ b/translations/kn.ts
@@ -2456,6 +2456,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/ko.ts
+++ b/translations/ko.ts
@@ -2454,6 +2454,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/lt.ts
+++ b/translations/lt.ts
@@ -2478,6 +2478,14 @@ Pasidalinkite ja su draugais, kad pradėtumėte kalbėtis.
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/lv.ts
+++ b/translations/lv.ts
@@ -2479,6 +2479,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/mk.ts
+++ b/translations/mk.ts
@@ -2472,6 +2472,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/nl.ts
+++ b/translations/nl.ts
@@ -2460,6 +2460,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/nl_BE.ts
+++ b/translations/nl_BE.ts
@@ -2468,6 +2468,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/no_nb.ts
+++ b/translations/no_nb.ts
@@ -2462,6 +2462,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/pl.ts
+++ b/translations/pl.ts
@@ -2498,6 +2498,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/pt.ts
+++ b/translations/pt.ts
@@ -2472,6 +2472,14 @@ Este ID inclui o código NoSpam (em azul) e o checkum (em cinzento).</translatio
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/pt_BR.ts
+++ b/translations/pt_BR.ts
@@ -2480,6 +2480,14 @@ Este ID inclui o código NoSpam (em azul) e o checkum (em cinza).</translation>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/ro.ts
+++ b/translations/ro.ts
@@ -2484,6 +2484,14 @@ Acest ID include codul NoSpam (în albastru) și suma de control (în gri).</tra
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/ru.ts
+++ b/translations/ru.ts
@@ -2482,6 +2482,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/si.ts
+++ b/translations/si.ts
@@ -2456,6 +2456,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/sk.ts
+++ b/translations/sk.ts
@@ -2484,6 +2484,14 @@ Toto ID obsahuje kód NoSpam (modrou) a kontrolný súčet (šedou).</translatio
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/sl.ts
+++ b/translations/sl.ts
@@ -2466,6 +2466,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/sq.ts
+++ b/translations/sq.ts
@@ -2456,6 +2456,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/sr.ts
+++ b/translations/sr.ts
@@ -2472,6 +2472,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/sr_Latn.ts
+++ b/translations/sr_Latn.ts
@@ -2473,6 +2473,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/sv.ts
+++ b/translations/sv.ts
@@ -2472,6 +2472,14 @@ ID:t innehåller NoSpam-koden (i blått) och kontrollsumman (i grått).</transla
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/sw.ts
+++ b/translations/sw.ts
@@ -2456,6 +2456,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/ta.ts
+++ b/translations/ta.ts
@@ -2462,6 +2462,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/tr.ts
+++ b/translations/tr.ts
@@ -2472,6 +2472,14 @@ Bu kimlik NoSpam kodunu (mavi) ve sağlama toplamını (gri) içerir.</translati
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/ug.ts
+++ b/translations/ug.ts
@@ -2468,6 +2468,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/uk.ts
+++ b/translations/uk.ts
@@ -2472,6 +2472,14 @@ It&apos;s difficult to translate &quot;Tox me maybe&quot; because in Ukrainian n
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/ur.ts
+++ b/translations/ur.ts
@@ -2464,6 +2464,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -2468,6 +2468,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>

--- a/translations/zh_TW.ts
+++ b/translations/zh_TW.ts
@@ -2456,6 +2456,14 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Control</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You have joined the group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You have left the group</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>RemoveFriendDialog</name>


### PR DESCRIPTION
Makes it so that looking back in chat history, you can see which users you were
connected to for any message. Otherwise self client restarts are unseen.
Follows showGroupJoinLeaveMessages setting which defaults to false, so only
users who opt in will see the messages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6548)
<!-- Reviewable:end -->
