### PR TITLE
chore(CI): apt-get update in gitstats runner

### DIFF
--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -562,7 +562,7 @@ jobs:
           fetch-depth: 0
       - name: Install gitstats
         run: |
-          sudo apt-get install gnuplot
+          sudo apt-get update && sudo apt-get install --no-install-recommends gnuplot
           git clone git://github.com/hoxu/gitstats.git
           cd gitstats
           sudo make install


### PR DESCRIPTION
Package cache is stale and causing a failure to install.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6552)
<!-- Reviewable:end -->
