### PR TITLE
chore: Add Q_OBJECT macro to NotificationGenerator

### DIFF
--- a/src/model/notificationgenerator.h
+++ b/src/model/notificationgenerator.h
@@ -32,6 +32,8 @@
 
 class NotificationGenerator : public QObject
 {
+    Q_OBJECT
+
 public:
     NotificationGenerator(
         INotificationSettings const& notificationSettings,


### PR DESCRIPTION
Qt requires it for QObject-derived classes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6556)
<!-- Reviewable:end -->
