### PR TITLE
refactor: Remove Settings singleton

### DIFF
--- a/src/chatlog/chatmessage.h
+++ b/src/chatlog/chatmessage.h
@@ -29,6 +29,7 @@ class CoreFile;
 class QGraphicsScene;
 class DocumentCache;
 class SmileyPack;
+class Settings;
 
 class ChatMessage : public ChatLine
 {
@@ -49,7 +50,7 @@ public:
         ALERT,
     };
 
-    explicit ChatMessage(DocumentCache& documentCache);
+    ChatMessage(DocumentCache&, Settings&);
     ~ChatMessage();
     ChatMessage(const ChatMessage&) = default;
     ChatMessage(ChatMessage&&) = default;
@@ -57,14 +58,14 @@ public:
     static ChatMessage::Ptr createChatMessage(const QString& sender, const QString& rawMessage,
                                               MessageType type, bool isMe, MessageState state,
                                               const QDateTime& date, DocumentCache&,
-                                              SmileyPack& smileyPack, bool colorizeName = false);
+                                              SmileyPack&, Settings&, bool colorizeName = false);
     static ChatMessage::Ptr createChatInfoMessage(const QString& rawMessage, SystemMessageType type,
-                                                  const QDateTime& date, DocumentCache&);
+                                                  const QDateTime& date, DocumentCache&, Settings&);
     static ChatMessage::Ptr createFileTransferMessage(const QString& sender, CoreFile& coreFile,
                                                       ToxFile file, bool isMe, const QDateTime& date,
-                                                      DocumentCache&);
-    static ChatMessage::Ptr createTypingNotification(DocumentCache&);
-    static ChatMessage::Ptr createBusyNotification(DocumentCache&);
+                                                      DocumentCache&, Settings&);
+    static ChatMessage::Ptr createTypingNotification(DocumentCache&, Settings&);
+    static ChatMessage::Ptr createBusyNotification(DocumentCache&, Settings&);
 
     void markAsDelivered(const QDateTime& time);
     void markAsBroken();
@@ -81,4 +82,5 @@ protected:
 private:
     bool action = false;
     DocumentCache& documentCache;
+    Settings& settings;
 };

--- a/src/chatlog/chatwidget.h
+++ b/src/chatlog/chatwidget.h
@@ -35,6 +35,7 @@ class QTimer;
 class ChatLineContent;
 struct ToxFile;
 class SmileyPack;
+class Settings;
 
 class ChatLineStorage;
 
@@ -44,7 +45,7 @@ class ChatWidget : public QGraphicsView
     Q_OBJECT
 public:
     ChatWidget(IChatLog& chatLog_, const Core& core_, DocumentCache&, SmileyPack&,
-        QWidget* parent = nullptr);
+        Settings&, QWidget* parent = nullptr);
     virtual ~ChatWidget();
 
     void insertChatlines(std::map<ChatLogIdx, ChatLine::Ptr> chatLines);
@@ -218,4 +219,5 @@ private:
     std::vector<std::function<void(void)>> renderCompletionFns;
     DocumentCache& documentCache;
     SmileyPack& smileyPack;
+    Settings& settings;
 };

--- a/src/chatlog/content/filetransferwidget.cpp
+++ b/src/chatlog/content/filetransferwidget.cpp
@@ -48,7 +48,8 @@
 // The rightButton is used to cancel a file transfer, or to open the directory a file was
 // downloaded to.
 
-FileTransferWidget::FileTransferWidget(QWidget* parent, CoreFile& _coreFile, ToxFile file)
+FileTransferWidget::FileTransferWidget(QWidget* parent, CoreFile& _coreFile,
+    ToxFile file, Settings& settings_)
     : QWidget(parent)
     , coreFile{_coreFile}
     , ui(new Ui::FileTransferWidget)
@@ -57,6 +58,7 @@ FileTransferWidget::FileTransferWidget(QWidget* parent, CoreFile& _coreFile, Tox
     , buttonColor(Style::getColor(Style::TransferWait))
     , buttonBackgroundColor(Style::getColor(Style::GroundBase))
     , active(true)
+    , settings(settings_)
 {
     ui->setupUi(this);
 
@@ -158,7 +160,7 @@ void FileTransferWidget::setBackgroundColor(const QColor& c, bool whiteFont)
 
     setProperty("fontColor", whiteFont ? "white" : "black");
 
-    setStyleSheet(Style::getStylesheet("fileTransferInstance/filetransferWidget.css"));
+    setStyleSheet(Style::getStylesheet("fileTransferInstance/filetransferWidget.css", settings));
     Style::repolish(this);
 
     update();
@@ -377,11 +379,11 @@ void FileTransferWidget::setupButtons(ToxFile const& file)
 
     switch (file.status) {
     case ToxFile::TRANSMITTING:
-        ui->leftButton->setIcon(QIcon(Style::getImagePath("fileTransferInstance/pause.svg")));
+        ui->leftButton->setIcon(QIcon(Style::getImagePath("fileTransferInstance/pause.svg", settings)));
         ui->leftButton->setObjectName("pause");
         ui->leftButton->setToolTip(tr("Pause transfer"));
 
-        ui->rightButton->setIcon(QIcon(Style::getImagePath("fileTransferInstance/no.svg")));
+        ui->rightButton->setIcon(QIcon(Style::getImagePath("fileTransferInstance/no.svg", settings)));
         ui->rightButton->setObjectName("cancel");
         ui->rightButton->setToolTip(tr("Cancel transfer"));
 
@@ -390,16 +392,16 @@ void FileTransferWidget::setupButtons(ToxFile const& file)
 
     case ToxFile::PAUSED:
         if (file.pauseStatus.localPaused()) {
-            ui->leftButton->setIcon(QIcon(Style::getImagePath("fileTransferInstance/arrow_white.svg")));
+            ui->leftButton->setIcon(QIcon(Style::getImagePath("fileTransferInstance/arrow_white.svg", settings)));
             ui->leftButton->setObjectName("resume");
             ui->leftButton->setToolTip(tr("Resume transfer"));
         } else {
-            ui->leftButton->setIcon(QIcon(Style::getImagePath("fileTransferInstance/pause.svg")));
+            ui->leftButton->setIcon(QIcon(Style::getImagePath("fileTransferInstance/pause.svg", settings)));
             ui->leftButton->setObjectName("pause");
             ui->leftButton->setToolTip(tr("Pause transfer"));
         }
 
-        ui->rightButton->setIcon(QIcon(Style::getImagePath("fileTransferInstance/no.svg")));
+        ui->rightButton->setIcon(QIcon(Style::getImagePath("fileTransferInstance/no.svg", settings)));
         ui->rightButton->setObjectName("cancel");
         ui->rightButton->setToolTip(tr("Cancel transfer"));
 
@@ -407,16 +409,16 @@ void FileTransferWidget::setupButtons(ToxFile const& file)
         break;
 
     case ToxFile::INITIALIZING:
-        ui->rightButton->setIcon(QIcon(Style::getImagePath("fileTransferInstance/no.svg")));
+        ui->rightButton->setIcon(QIcon(Style::getImagePath("fileTransferInstance/no.svg", settings)));
         ui->rightButton->setObjectName("cancel");
         ui->rightButton->setToolTip(tr("Cancel transfer"));
 
         if (file.direction == ToxFile::SENDING) {
-            ui->leftButton->setIcon(QIcon(Style::getImagePath("fileTransferInstance/pause.svg")));
+            ui->leftButton->setIcon(QIcon(Style::getImagePath("fileTransferInstance/pause.svg", settings)));
             ui->leftButton->setObjectName("pause");
             ui->leftButton->setToolTip(tr("Pause transfer"));
         } else {
-            ui->leftButton->setIcon(QIcon(Style::getImagePath("fileTransferInstance/yes.svg")));
+            ui->leftButton->setIcon(QIcon(Style::getImagePath("fileTransferInstance/yes.svg", settings)));
             ui->leftButton->setObjectName("accept");
             ui->leftButton->setToolTip(tr("Accept transfer"));
         }
@@ -427,12 +429,12 @@ void FileTransferWidget::setupButtons(ToxFile const& file)
         ui->rightButton->hide();
         break;
     case ToxFile::FINISHED:
-        ui->leftButton->setIcon(QIcon(Style::getImagePath("fileTransferInstance/yes.svg")));
+        ui->leftButton->setIcon(QIcon(Style::getImagePath("fileTransferInstance/yes.svg", settings)));
         ui->leftButton->setObjectName("ok");
         ui->leftButton->setToolTip(tr("Open file"));
         ui->leftButton->show();
 
-        ui->rightButton->setIcon(QIcon(Style::getImagePath("fileTransferInstance/dir.svg")));
+        ui->rightButton->setIcon(QIcon(Style::getImagePath("fileTransferInstance/dir.svg", settings)));
         ui->rightButton->setObjectName("dir");
         ui->rightButton->setToolTip(tr("Open file directory"));
         ui->rightButton->show();
@@ -466,7 +468,7 @@ void FileTransferWidget::handleButton(QPushButton* btn)
             QString path =
                 QFileDialog::getSaveFileName(Q_NULLPTR,
                                              tr("Save a file", "Title of the file saving dialog"),
-                                             Settings::getInstance().getGlobalAutoAcceptDir() + "/"
+                                             settings.getGlobalAutoAcceptDir() + "/"
                                                  + fileInfo.fileName);
             acceptTransfer(path);
         }

--- a/src/chatlog/content/filetransferwidget.h
+++ b/src/chatlog/content/filetransferwidget.h
@@ -33,13 +33,14 @@ class FileTransferWidget;
 
 class QVariantAnimation;
 class QPushButton;
+class Settings;
 
 class FileTransferWidget : public QWidget
 {
     Q_OBJECT
 
 public:
-    explicit FileTransferWidget(QWidget* parent, CoreFile& _coreFile, ToxFile file);
+    FileTransferWidget(QWidget* parent, CoreFile& _coreFile, ToxFile file, Settings&);
     virtual ~FileTransferWidget();
     bool isActive() const;
     void onFileTransferUpdate(ToxFile file);
@@ -88,5 +89,6 @@ private:
     bool active;
     QTime lastTransmissionUpdate;
     ToxFile::FileStatus lastStatus = ToxFile::INITIALIZING;
+    Settings& settings;
 
 };

--- a/src/chatlog/content/notificationicon.cpp
+++ b/src/chatlog/content/notificationicon.cpp
@@ -25,10 +25,10 @@
 #include <QPainter>
 #include <QTimer>
 
-NotificationIcon::NotificationIcon(QSize Size)
+NotificationIcon::NotificationIcon(Settings& settings, QSize Size)
     : size(Size)
 {
-    pmap = PixmapCache::getInstance().get(Style::getImagePath("chatArea/typing.svg"), size);
+    pmap = PixmapCache::getInstance().get(Style::getImagePath("chatArea/typing.svg", settings), size);
 
     // Timer for the animation, if the Widget is not redrawn, no paint events will
     // arrive and the timer will not be restarted, so this stops automatically

--- a/src/chatlog/content/notificationicon.h
+++ b/src/chatlog/content/notificationicon.h
@@ -25,11 +25,13 @@
 #include <QPixmap>
 #include <QTimer>
 
+class Settings;
+
 class NotificationIcon : public ChatLineContent
 {
     Q_OBJECT
 public:
-    explicit NotificationIcon(QSize size);
+    explicit NotificationIcon(Settings&, QSize size);
 
     QRectF boundingRect() const override;
     void paint(QPainter* painter, const QStyleOptionGraphicsItem* option,

--- a/src/chatlog/content/text.cpp
+++ b/src/chatlog/content/text.cpp
@@ -31,16 +31,17 @@
 #include <QTextBlock>
 #include <QTextFragment>
 
-Text::Text(DocumentCache& documentCache_, const QString& txt, const QFont& font,
-    bool enableElide, const QString& rwText, const TextType& type,
+Text::Text(DocumentCache& documentCache_, Settings& settings_, const QString& txt,
+    const QFont& font, bool enableElide, const QString& rwText, const TextType& type,
     const QColor& custom)
     : rawText(rwText)
     , elide(enableElide)
     , defFont(font)
-    , defStyleSheet(Style::getStylesheet(QStringLiteral("chatArea/innerStyle.css"), font))
+    , defStyleSheet(Style::getStylesheet(QStringLiteral("chatArea/innerStyle.css"), settings_, font))
     , textType(type)
     , customColor(custom)
     , documentCache(documentCache_)
+    , settings{settings_}
 {
     color = textColor();
     setText(txt);
@@ -251,7 +252,7 @@ void Text::visibilityChanged(bool visible)
 
 void Text::reloadTheme()
 {
-    defStyleSheet = Style::getStylesheet(QStringLiteral("chatArea/innerStyle.css"), defFont);
+    defStyleSheet = Style::getStylesheet(QStringLiteral("chatArea/innerStyle.css"), settings, defFont);
     color = textColor();
     dirty = true;
     regenerate();

--- a/src/chatlog/content/text.h
+++ b/src/chatlog/content/text.h
@@ -26,6 +26,7 @@
 
 class QTextDocument;
 class DocumentCache;
+class Settings;
 
 class Text : public ChatLineContent
 {
@@ -39,7 +40,7 @@ public:
         CUSTOM
     };
 
-    Text(DocumentCache&, const QString& txt = "", const QFont& font = QFont(),
+    Text(DocumentCache&, Settings&, const QString& txt = "", const QFont& font = QFont(),
         bool enableElide = false, const QString& rawText = QString(),
         const TextType& type = NORMAL,
         const QColor& custom = Style::getColor(Style::MainText));
@@ -113,4 +114,5 @@ private:
     QColor color;
     QColor customColor;
     DocumentCache& documentCache;
+    Settings& settings;
 };

--- a/src/chatlog/content/timestamp.cpp
+++ b/src/chatlog/content/timestamp.cpp
@@ -19,8 +19,10 @@
 
 #include "timestamp.h"
 
-Timestamp::Timestamp(const QDateTime& time_, const QString& format, const QFont& font, DocumentCache& documentCache_)
-    : Text(documentCache_, time_.toString(format), font, false, time_.toString(format))
+Timestamp::Timestamp(const QDateTime& time_, const QString& format,
+    const QFont& font, DocumentCache& documentCache_, Settings& settings_)
+    : Text(documentCache_, settings_, time_.toString(format), font, false,
+        time_.toString(format))
 {
     time = time_;
 }

--- a/src/chatlog/content/timestamp.h
+++ b/src/chatlog/content/timestamp.h
@@ -25,13 +25,14 @@
 
 class QTextDocument;
 class DocumentCache;
+class Settings;
 
 class Timestamp : public Text
 {
     Q_OBJECT
 public:
     Timestamp(const QDateTime& time_, const QString& format, const QFont& font,
-        DocumentCache&);
+        DocumentCache&, Settings&);
     QDateTime getTime();
 
 protected:

--- a/src/chatlog/customtextdocument.cpp
+++ b/src/chatlog/customtextdocument.cpp
@@ -26,9 +26,11 @@
 #include <QIcon>
 #include <QUrl>
 
-CustomTextDocument::CustomTextDocument(SmileyPack& smileyPack_, QObject* parent)
+CustomTextDocument::CustomTextDocument(SmileyPack& smileyPack_,
+    Settings& settings_, QObject* parent)
     : QTextDocument(parent)
     , smileyPack(smileyPack_)
+    , settings(settings_)
 {
     setUndoRedoEnabled(false);
     setUseDesignMetrics(false);
@@ -37,8 +39,8 @@ CustomTextDocument::CustomTextDocument(SmileyPack& smileyPack_, QObject* parent)
 QVariant CustomTextDocument::loadResource(int type, const QUrl& name)
 {
     if (type == QTextDocument::ImageResource && name.scheme() == "key") {
-        QSize size = QSize(Settings::getInstance().getEmojiFontPointSize(),
-                           Settings::getInstance().getEmojiFontPointSize());
+        QSize size = QSize(settings.getEmojiFontPointSize(),
+                           settings.getEmojiFontPointSize());
         QString fileName = QUrl::fromPercentEncoding(name.toEncoded()).mid(4).toHtmlEscaped();
 
         std::shared_ptr<QIcon> icon = smileyPack.getAsIcon(fileName);

--- a/src/chatlog/customtextdocument.h
+++ b/src/chatlog/customtextdocument.h
@@ -26,12 +26,13 @@
 
 class QIcon;
 class SmileyPack;
+class Settings;
 
 class CustomTextDocument : public QTextDocument
 {
     Q_OBJECT
 public:
-    explicit CustomTextDocument(SmileyPack&, QObject* parent = nullptr);
+    CustomTextDocument(SmileyPack&, Settings&, QObject* parent = nullptr);
 
 protected:
     virtual QVariant loadResource(int type, const QUrl& name);
@@ -39,4 +40,5 @@ protected:
 private:
     QList<std::shared_ptr<QIcon>> emoticonIcons;
     SmileyPack& smileyPack;
+    Settings& settings;
 };

--- a/src/chatlog/documentcache.cpp
+++ b/src/chatlog/documentcache.cpp
@@ -20,8 +20,9 @@
 #include "documentcache.h"
 #include "customtextdocument.h"
 
-DocumentCache::DocumentCache(SmileyPack& smileyPack_)
+DocumentCache::DocumentCache(SmileyPack& smileyPack_, Settings& settings_)
     : smileyPack{smileyPack_}
+    , settings{settings_}
 {
 }
 DocumentCache::~DocumentCache()
@@ -33,7 +34,7 @@ DocumentCache::~DocumentCache()
 QTextDocument* DocumentCache::pop()
 {
     if (documents.empty())
-        documents.push(new CustomTextDocument(smileyPack));
+        documents.push(new CustomTextDocument(smileyPack, settings));
 
     return documents.pop();
 }

--- a/src/chatlog/documentcache.h
+++ b/src/chatlog/documentcache.h
@@ -23,11 +23,12 @@
 
 class QTextDocument;
 class SmileyPack;
+class Settings;
 
 class DocumentCache
 {
 public:
-    explicit DocumentCache(SmileyPack& smileyPack);
+    DocumentCache(SmileyPack&, Settings&);
     ~DocumentCache();
     DocumentCache(DocumentCache&) = delete;
     DocumentCache& operator=(const DocumentCache&) = delete;
@@ -37,4 +38,5 @@ public:
 private:
     QStack<QTextDocument*> documents;
     SmileyPack& smileyPack;
+    Settings& settings;
 };

--- a/src/core/coreav.h
+++ b/src/core/coreav.h
@@ -51,7 +51,8 @@ class CoreAV : public QObject
 public:
     using CoreAVPtr = std::unique_ptr<CoreAV>;
     static CoreAVPtr makeCoreAV(Tox* core, CompatibleRecursiveMutex& toxCoreLock,
-                                IAudioSettings& audioSettings, IGroupSettings& groupSettings);
+                                IAudioSettings& audioSettings, IGroupSettings& groupSettings,
+                                CameraSource&);
 
     void setAudio(IAudioControl& newAudio);
     IAudioControl* getAudio();
@@ -118,7 +119,7 @@ private:
     };
 
     CoreAV(std::unique_ptr<ToxAV, ToxAVDeleter> tox_, CompatibleRecursiveMutex &toxCoreLock,
-           IAudioSettings& audioSettings_, IGroupSettings& groupSettings_);
+           IAudioSettings& audioSettings_, IGroupSettings& groupSettings_, CameraSource&);
     void connectCallbacks();
 
     void process();
@@ -165,4 +166,5 @@ private:
 
     IAudioSettings& audioSettings;
     IGroupSettings& groupSettings;
+    CameraSource& cameraSource;
 };

--- a/src/core/toxcall.h
+++ b/src/core/toxcall.h
@@ -37,6 +37,7 @@ class AudioFilterer;
 class CoreVideoSource;
 class CoreAV;
 class Group;
+class CameraSource;
 
 class ToxCall : public QObject
 {
@@ -91,7 +92,7 @@ class ToxFriendCall : public ToxCall
     Q_OBJECT
 public:
     ToxFriendCall() = delete;
-    ToxFriendCall(uint32_t friendId, bool VideoEnabled, CoreAV& av_, IAudioControl& audio_);
+    ToxFriendCall(uint32_t friendId, bool VideoEnabled, CoreAV& av_, IAudioControl& audio_, CameraSource&);
     ToxFriendCall(ToxFriendCall&& other) = delete;
     ToxFriendCall& operator=(ToxFriendCall&& other) = delete;
     ~ToxFriendCall();
@@ -110,6 +111,7 @@ private:
     TOXAV_FRIEND_CALL_STATE state{TOXAV_FRIEND_CALL_STATE_NONE};
     std::unique_ptr<IAudioSink> sink;
     uint32_t friendId;
+    CameraSource& cameraSource;
 };
 
 class ToxGroupCall : public ToxCall

--- a/src/friendlist.cpp
+++ b/src/friendlist.cpp
@@ -29,14 +29,14 @@
 QHash<ToxPk, Friend*> FriendList::friendList;
 QHash<uint32_t, ToxPk> FriendList::id2key;
 
-Friend* FriendList::addFriend(uint32_t friendId, const ToxPk& friendPk)
+Friend* FriendList::addFriend(uint32_t friendId, const ToxPk& friendPk, Settings& settings)
 {
     auto friendChecker = friendList.find(friendPk);
     if (friendChecker != friendList.end()) {
         qWarning() << "addFriend: friendPk already taken";
     }
 
-    QString alias = Settings::getInstance().getFriendAlias(friendPk);
+    QString alias = settings.getFriendAlias(friendPk);
     Friend* newfriend = new Friend(friendId, friendPk, alias);
     friendList[friendPk] = newfriend;
     id2key[friendId] = friendPk;
@@ -59,12 +59,12 @@ const ToxPk& FriendList::id2Key(uint32_t friendId)
     return id2key[friendId];
 }
 
-void FriendList::removeFriend(const ToxPk& friendPk, bool fake)
+void FriendList::removeFriend(const ToxPk& friendPk, Settings& settings, bool fake)
 {
     auto f_it = friendList.find(friendPk);
     if (f_it != friendList.end()) {
         if (!fake)
-            Settings::getInstance().removeFriendSettings(f_it.value()->getPublicKey());
+            settings.removeFriendSettings(f_it.value()->getPublicKey());
         friendList.erase(f_it);
     }
 }

--- a/src/friendlist.h
+++ b/src/friendlist.h
@@ -29,15 +29,16 @@ class Friend;
 class QByteArray;
 class QString;
 class ToxPk;
+class Settings;
 
 class FriendList
 {
 public:
-    static Friend* addFriend(uint32_t friendId, const ToxPk& friendPk);
+    static Friend* addFriend(uint32_t friendId, const ToxPk& friendPk, Settings&);
     static Friend* findFriend(const ToxPk& friendPk);
     static const ToxPk& id2Key(uint32_t friendId);
     static QList<Friend*> getAllFriends();
-    static void removeFriend(const ToxPk& friendPk, bool fake = false);
+    static void removeFriend(const ToxPk& friendPk, Settings&, bool fake = false);
     static void clear();
     static QString decideNickname(const ToxPk& friendPk, const QString& origName);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -67,7 +67,6 @@ void cleanup()
     s.sync();
 
     Nexus::destroyInstance();
-    CameraSource::destroyInstance();
     Settings::destroyInstance();
     qDebug() << "Cleanup success";
 
@@ -400,13 +399,13 @@ int main(int argc, char* argv[])
     //  note: Because Settings is shouldering global settings as well as model specific ones it
     //  cannot be integrated into a central model object yet
     nexus.setSettings(&settings);
-
+    auto& cameraSource = Nexus::getCameraSource();
     // Autologin
     // TODO (kriby): Shift responsibility of linking views to model objects from nexus
     // Further: generate view instances separately (loginScreen, mainGUI, audio)
     Profile* profile = nullptr;
     if (autoLogin && Profile::exists(profileName) && !Profile::isEncrypted(profileName)) {
-        profile = Profile::loadProfile(profileName, QString(), settings, &parser);
+        profile = Profile::loadProfile(profileName, QString(), settings, &parser, cameraSource);
         if (!profile) {
             QMessageBox::information(nullptr, QObject::tr("Error"),
                                      QObject::tr("Failed to load profile automatically."));

--- a/src/model/chatroom/friendchatroom.cpp
+++ b/src/model/chatroom/friendchatroom.cpp
@@ -42,10 +42,11 @@ QString getShortName(const QString& name)
 
 }
 
-FriendChatroom::FriendChatroom(Friend* frnd_, IDialogsManager* dialogsManager_, Core& core_)
+FriendChatroom::FriendChatroom(Friend* frnd_, IDialogsManager* dialogsManager_, Core& core_, Settings& settings_)
     : frnd{frnd_}
     , dialogsManager{dialogsManager_}
     , core{core_}
+    , settings{settings_}
 {
 }
 
@@ -74,13 +75,13 @@ bool FriendChatroom::canBeInvited() const
 
 int FriendChatroom::getCircleId() const
 {
-    return Settings::getInstance().getFriendCircleID(frnd->getPublicKey());
+    return settings.getFriendCircleID(frnd->getPublicKey());
 }
 
 QString FriendChatroom::getCircleName() const
 {
     const auto circleId = getCircleId();
-    return Settings::getInstance().getCircleName(circleId);
+    return settings.getCircleName(circleId);
 }
 
 void FriendChatroom::inviteToNewGroup()
@@ -93,13 +94,13 @@ void FriendChatroom::inviteToNewGroup()
 QString FriendChatroom::getAutoAcceptDir() const
 {
     const auto pk = frnd->getPublicKey();
-    return Settings::getInstance().getAutoAcceptDir(pk);
+    return settings.getAutoAcceptDir(pk);
 }
 
 void FriendChatroom::setAutoAcceptDir(const QString& dir)
 {
     const auto pk = frnd->getPublicKey();
-    Settings::getInstance().setAutoAcceptDir(pk, dir);
+    settings.setAutoAcceptDir(pk, dir);
 }
 
 void FriendChatroom::disableAutoAccept()
@@ -138,13 +139,12 @@ QVector<CircleToDisplay> FriendChatroom::getOtherCircles() const
 {
     QVector<CircleToDisplay> circles;
     const auto currentCircleId = getCircleId();
-    const auto& s = Settings::getInstance();
-    for (int i = 0; i < s.getCircleCount(); ++i) {
+    for (int i = 0; i < settings.getCircleCount(); ++i) {
         if (i == currentCircleId) {
             continue;
         }
 
-        const auto name = getShortName(s.getCircleName(i));
+        const auto name = getShortName(settings.getCircleName(i));
         const CircleToDisplay circle = { name, i };
         circles.push_back(circle);
     }

--- a/src/model/chatroom/friendchatroom.h
+++ b/src/model/chatroom/friendchatroom.h
@@ -29,6 +29,7 @@ class Core;
 class IDialogsManager;
 class Friend;
 class Group;
+class Settings;
 
 struct GroupToDisplay
 {
@@ -46,7 +47,8 @@ class FriendChatroom : public QObject, public Chatroom
 {
     Q_OBJECT
 public:
-    FriendChatroom(Friend* frnd_, IDialogsManager* dialogsManager_, Core& core_);
+    FriendChatroom(Friend* frnd_, IDialogsManager* dialogsManager_, Core& core_,
+        Settings& settings_);
 
     Contact* getContact() override;
 
@@ -87,4 +89,5 @@ private:
     Friend* frnd{nullptr};
     IDialogsManager* dialogsManager{nullptr};
     Core& core;
+    Settings& settings;
 };

--- a/src/model/profile/profileinfo.cpp
+++ b/src/model/profile/profileinfo.cpp
@@ -99,9 +99,10 @@ bool tryRemoveFile(const QString& filepath)
  * @param profile Pointer to Profile.
  * @note All pointers parameters shouldn't be null.
  */
-ProfileInfo::ProfileInfo(Core* core_, Profile* profile_)
+ProfileInfo::ProfileInfo(Core* core_, Profile* profile_, Settings& settings_)
     : profile{profile_}
     , core{core_}
+    , settings{settings_}
 {
     connect(core_, &Core::idSet, this, &ProfileInfo::idChanged);
     connect(core_, &Core::usernameSet, this, &ProfileInfo::usernameChanged);
@@ -193,7 +194,7 @@ IProfileInfo::RenameResult ProfileInfo::renameProfile(const QString& name)
 
     QString newName = sanitize(name);
 
-    if (Profile::exists(newName)) {
+    if (Profile::exists(newName, settings.getPaths())) {
         return RenameResult::ProfileAlreadyExists;
     }
 
@@ -220,7 +221,7 @@ IProfileInfo::SaveResult ProfileInfo::exportProfile(const QString& path) const
         return SaveResult::NoWritePermission;
     }
 
-    if (!QFile::copy(Settings::getInstance().getPaths().getSettingsDirPath() + current, path)) {
+    if (!QFile::copy(settings.getPaths().getSettingsDirPath() + current, path)) {
         return SaveResult::Error;
     }
 
@@ -244,9 +245,9 @@ QStringList ProfileInfo::removeProfile()
 void ProfileInfo::logout()
 {
     // TODO(kriby): Refactor all of these invokeMethod calls with connect() properly when possible
-    Settings::getInstance().saveGlobal();
+    settings.saveGlobal();
     QMetaObject::invokeMethod(&Nexus::getInstance(), "showLogin",
-                              Q_ARG(QString, Settings::getInstance().getCurrentProfile()));
+                              Q_ARG(QString, settings.getCurrentProfile()));
 }
 
 /**

--- a/src/model/profile/profileinfo.h
+++ b/src/model/profile/profileinfo.h
@@ -28,12 +28,13 @@ class Core;
 class QFile;
 class QPoint;
 class Profile;
+class Settings;
 
 class ProfileInfo : public QObject, public IProfileInfo
 {
     Q_OBJECT
 public:
-    ProfileInfo(Core* core_, Profile* profile_);
+    ProfileInfo(Core* core_, Profile* profile_, Settings&);
 
     bool setPassword(const QString& password) override;
     bool deletePassword() override;
@@ -66,4 +67,5 @@ private:
     IProfileInfo::SetAvatarResult scalePngToAvatar(QByteArray& avatar);
     Profile* const profile;
     Core* const core;
+    Settings& settings;
 };

--- a/src/nexus.cpp
+++ b/src/nexus.cpp
@@ -63,9 +63,7 @@ Nexus::Nexus(QObject* parent)
     : QObject(parent)
     , profile{nullptr}
     , widget{nullptr}
-    , cameraSource(new CameraSource())
 {
-    assert(cameraSource);
 }
 
 Nexus::~Nexus()
@@ -163,7 +161,7 @@ int Nexus::showLogin(const QString& profileName)
     delete profile;
     profile = nullptr;
 
-    LoginScreen loginScreen{profileName};
+    LoginScreen loginScreen{*settings, profileName};
     connectLoginScreen(loginScreen);
 
     QCoreApplication::sendPostedEvents(nullptr, QEvent::DeferredDelete);
@@ -198,6 +196,7 @@ void Nexus::bootstrapWithProfile(Profile* p)
 
 void Nexus::setSettings(Settings* settings_)
 {
+    cameraSource = std::unique_ptr<CameraSource>(new CameraSource{*settings_});
     if (settings) {
         QObject::disconnect(this, &Nexus::saveGlobal, settings, &Settings::saveGlobal);
     }
@@ -231,7 +230,7 @@ void Nexus::showMainGUI()
     assert(profile);
 
     // Create GUI
-    widget = new Widget(*profile, *audioControl, *cameraSource);
+    widget = new Widget(*profile, *audioControl, *cameraSource, *settings);
 
     // Start GUI
     widget->init();

--- a/src/nexus.cpp
+++ b/src/nexus.cpp
@@ -63,7 +63,10 @@ Nexus::Nexus(QObject* parent)
     : QObject(parent)
     , profile{nullptr}
     , widget{nullptr}
-{}
+    , cameraSource(new CameraSource())
+{
+    assert(cameraSource);
+}
 
 Nexus::~Nexus()
 {
@@ -228,7 +231,7 @@ void Nexus::showMainGUI()
     assert(profile);
 
     // Create GUI
-    widget = new Widget(*profile, *audioControl);
+    widget = new Widget(*profile, *audioControl, *cameraSource);
 
     // Start GUI
     widget->init();
@@ -301,7 +304,7 @@ Profile* Nexus::getProfile()
  */
 void Nexus::onCreateNewProfile(const QString& name, const QString& pass)
 {
-    setProfile(Profile::createProfile(name, pass, *settings, parser));
+    setProfile(Profile::createProfile(name, pass, *settings, parser, *cameraSource));
     parser = nullptr; // only apply cmdline proxy settings once
 }
 
@@ -310,7 +313,7 @@ void Nexus::onCreateNewProfile(const QString& name, const QString& pass)
  */
 void Nexus::onLoadProfile(const QString& name, const QString& pass)
 {
-    setProfile(Profile::loadProfile(name, pass, *settings, parser));
+    setProfile(Profile::loadProfile(name, pass, *settings, parser, *cameraSource));
     parser = nullptr; // only apply cmdline proxy settings once
 }
 /**
@@ -342,6 +345,11 @@ void Nexus::setParser(QCommandLineParser* parser_)
 Widget* Nexus::getDesktopGUI()
 {
     return getInstance().widget;
+}
+
+CameraSource& Nexus::getCameraSource()
+{
+    return *getInstance().cameraSource;
 }
 
 #ifdef Q_OS_MAC

--- a/src/nexus.h
+++ b/src/nexus.h
@@ -20,9 +20,11 @@
 
 #pragma once
 
+#include "audio/iaudiocontrol.h"
+
 #include <QObject>
 
-#include "audio/iaudiocontrol.h"
+#include <memory>
 
 class Widget;
 class Profile;
@@ -30,6 +32,7 @@ class Settings;
 class LoginScreen;
 class Core;
 class QCommandLineParser;
+class CameraSource;
 
 #ifdef Q_OS_MAC
 class QMenuBar;
@@ -53,6 +56,7 @@ public:
     static Core* getCore();
     static Profile* getProfile();
     static Widget* getDesktopGUI();
+    static CameraSource& getCameraSource();
 
 
 #ifdef Q_OS_MAC
@@ -104,4 +108,5 @@ private:
     Widget* widget;
     std::unique_ptr<IAudioControl> audioControl;
     QCommandLineParser* parser = nullptr;
+    std::unique_ptr<CameraSource> cameraSource;
 };

--- a/src/persistence/history.cpp
+++ b/src/persistence/history.cpp
@@ -707,8 +707,9 @@ FileDbInsertionData::FileDbInsertionData()
  * @brief Prepares the database to work with the history.
  * @param db This database will be prepared for use with the history.
  */
-History::History(std::shared_ptr<RawDatabase> db_)
+History::History(std::shared_ptr<RawDatabase> db_, Settings& settings_)
     : db(db_)
+    , settings(settings_)
 {
     if (!isValid()) {
         qWarning() << "Database not open, init failed";
@@ -1385,7 +1386,7 @@ void History::markAsDelivered(RowId messageId)
 */
 bool History::historyAccessBlocked()
 {
-    if (!Settings::getInstance().getEnableLogging()) {
+    if (!settings.getEnableLogging()) {
         assert(false);
         qCritical() << "Blocked history access while history is disabled";
         return true;

--- a/src/persistence/history.h
+++ b/src/persistence/history.h
@@ -38,6 +38,7 @@
 
 class Profile;
 class HistoryKeeper;
+class Settings;
 
 enum class HistMessageContentType
 {
@@ -185,7 +186,7 @@ public:
     };
 
 public:
-    explicit History(std::shared_ptr<RawDatabase> db);
+    History(std::shared_ptr<RawDatabase> db, Settings&);
     ~History();
 
     bool isValid();
@@ -245,4 +246,5 @@ private:
 
     // This needs to be a shared pointer to avoid callback lifetime issues
     QHash<QString, FileInfo> fileInfos;
+    Settings& settings;
 };

--- a/src/persistence/profile.cpp
+++ b/src/persistence/profile.cpp
@@ -232,7 +232,7 @@ bool logCreateToxDataError(const CreateToxDataError& error, const QString& userN
 
 QStringList Profile::profiles;
 
-void Profile::initCore(const QByteArray& toxsave, Settings& s, bool isNewProfile)
+void Profile::initCore(const QByteArray& toxsave, Settings& s, bool isNewProfile, CameraSource& cameraSource)
 {
     if (toxsave.isEmpty() && !isNewProfile) {
         qCritical() << "Existing toxsave is empty";
@@ -265,7 +265,7 @@ void Profile::initCore(const QByteArray& toxsave, Settings& s, bool isNewProfile
         return;
     }
 
-    coreAv = CoreAV::makeCoreAV(core->getTox(), core->getCoreLoopLock(), s, s);
+    coreAv = CoreAV::makeCoreAV(core->getTox(), core->getCoreLoopLock(), s, s, cameraSource);
     if (!coreAv) {
         qDebug() << "Failed to start ToxAV";
         emit failedToStart();
@@ -311,7 +311,7 @@ Profile::Profile(const QString& name_, std::unique_ptr<ToxEncrypt> passkey_, Pat
  * @note If the profile is already in use return nullptr.
  */
 Profile* Profile::loadProfile(const QString& name, const QString& password, Settings& settings,
-                              const QCommandLineParser* parser)
+                              const QCommandLineParser* parser, CameraSource& cameraSource)
 {
     if (ProfileLocker::hasLock()) {
         qCritical() << "Tried to load profile " << name << ", but another profile is already locked!";
@@ -339,7 +339,7 @@ Profile* Profile::loadProfile(const QString& name, const QString& password, Sett
     constexpr bool isNewProfile = false;
     settings.updateProfileData(p, parser, isNewProfile);
 
-    p->initCore(toxsave, settings, isNewProfile);
+    p->initCore(toxsave, settings, isNewProfile, cameraSource);
     p->loadDatabase(password);
 
     return p;
@@ -354,7 +354,7 @@ Profile* Profile::loadProfile(const QString& name, const QString& password, Sett
  * @note If the profile is already in use return nullptr.
  */
 Profile* Profile::createProfile(const QString& name, const QString& password, Settings& settings,
-                                const QCommandLineParser* parser)
+                                const QCommandLineParser* parser, CameraSource& cameraSource)
 {
     CreateToxDataError error;
     Paths& paths = settings.getPaths();
@@ -371,7 +371,7 @@ Profile* Profile::createProfile(const QString& name, const QString& password, Se
     constexpr bool isNewProfile = true;
     settings.updateProfileData(p, parser, isNewProfile);
 
-    p->initCore(QByteArray(), settings, isNewProfile);
+    p->initCore(QByteArray(), settings, isNewProfile, cameraSource);
     p->loadDatabase(password);
     return p;
 }

--- a/src/persistence/profile.cpp
+++ b/src/persistence/profile.cpp
@@ -132,7 +132,8 @@ fail:
  * @return Pointer to the tox encryption key.
  */
 std::unique_ptr<ToxEncrypt> createToxData(const QString& name, const QString& password,
-                                          const QString& filePath, CreateToxDataError& error)
+                                          const QString& filePath, CreateToxDataError& error,
+                                          Paths& paths)
 {
     std::unique_ptr<ToxEncrypt> newKey;
     if (!password.isEmpty()) {
@@ -153,7 +154,7 @@ std::unique_ptr<ToxEncrypt> createToxData(const QString& name, const QString& pa
         return nullptr;
     }
 
-    if (!ProfileLocker::lock(name)) {
+    if (!ProfileLocker::lock(name, paths)) {
         error = CreateToxDataError::LOCK_FAILED;
         return nullptr;
     }
@@ -318,14 +319,14 @@ Profile* Profile::loadProfile(const QString& name, const QString& password, Sett
         return nullptr;
     }
 
-    if (!ProfileLocker::lock(name)) {
+    Paths& paths = settings.getPaths();
+    if (!ProfileLocker::lock(name, paths)) {
         qWarning() << "Failed to lock profile " << name;
         return nullptr;
     }
 
     LoadToxDataError error;
     QByteArray toxsave = QByteArray();
-    Paths& paths = settings.getPaths();
     QString path = paths.getSettingsDirPath() + name + ".tox";
     std::unique_ptr<ToxEncrypt> tmpKey = loadToxData(password, path, toxsave, error);
     if (logLoadToxDataError(error, path)) {
@@ -359,7 +360,7 @@ Profile* Profile::createProfile(const QString& name, const QString& password, Se
     CreateToxDataError error;
     Paths& paths = settings.getPaths();
     QString path = paths.getSettingsDirPath() + name + ".tox";
-    std::unique_ptr<ToxEncrypt> tmpKey = createToxData(name, password, path, error);
+    std::unique_ptr<ToxEncrypt> tmpKey = createToxData(name, password, path, error, paths);
 
     if (logCreateToxDataError(error, name)) {
         return nullptr;
@@ -385,7 +386,7 @@ Profile::~Profile()
     onSaveToxSave();
     settings.savePersonal(this);
     settings.sync();
-    ProfileLocker::assertLock();
+    ProfileLocker::assertLock(paths);
     assert(ProfileLocker::getCurLockName() == name);
     ProfileLocker::unlock();
 }
@@ -395,9 +396,9 @@ Profile::~Profile()
  * @param extension Raw extension, e.g. "jpeg" not ".jpeg".
  * @return Vector of filenames.
  */
-QStringList Profile::getFilesByExt(QString extension)
+QStringList Profile::getFilesByExt(QString extension, Settings& settings)
 {
-    QDir dir(Settings::getInstance().getPaths().getSettingsDirPath());
+    QDir dir(settings.getPaths().getSettingsDirPath());
     QStringList out;
     dir.setFilter(QDir::Files | QDir::NoDotAndDotDot);
     dir.setNameFilters(QStringList("*." + extension));
@@ -414,13 +415,13 @@ QStringList Profile::getFilesByExt(QString extension)
  * @brief Scan for profile, automatically importing them if needed.
  * @warning NOT thread-safe.
  */
-const QStringList Profile::getAllProfileNames()
+const QStringList Profile::getAllProfileNames(Settings& settings)
 {
     profiles.clear();
-    QStringList toxfiles = getFilesByExt("tox"), inifiles = getFilesByExt("ini");
+    QStringList toxfiles = getFilesByExt("tox", settings), inifiles = getFilesByExt("ini", settings);
     for (const QString& toxfile : toxfiles) {
         if (!inifiles.contains(toxfile)) {
-            Settings::getInstance().createPersonal(toxfile);
+            settings.createPersonal(toxfile);
         }
 
         profiles.append(toxfile);
@@ -490,7 +491,7 @@ void Profile::onAvatarOfferReceived(uint32_t friendId, uint32_t fileId, const QB
 bool Profile::saveToxSave(QByteArray data)
 {
     assert(!isRemoved);
-    ProfileLocker::assertLock();
+    ProfileLocker::assertLock(paths);
     assert(ProfileLocker::getCurLockName() == name);
 
     QString path = paths.getSettingsDirPath() + name + ".tox";
@@ -634,9 +635,10 @@ void Profile::loadDatabase(QString password)
     // At this point it's too early to load the personal settings (Nexus will do it), so we always
     // load
     // the history, and if it fails we can't change the setting now, but we keep a nullptr
-    database = std::make_shared<RawDatabase>(getDbPath(name), password, salt);
+    database = std::make_shared<RawDatabase>(getDbPath(name, settings.getPaths()),
+        password, salt);
     if (database && database->isOpen()) {
-        history.reset(new History(database));
+        history.reset(new History(database, settings));
     } else {
         qWarning() << "Failed to open database for profile" << name;
         GUI::showError(QObject::tr("Error"),
@@ -804,9 +806,9 @@ void Profile::removeAvatar(const ToxPk& owner)
     }
 }
 
-bool Profile::exists(QString name)
+bool Profile::exists(QString name, Paths& paths)
 {
-    QString path = Settings::getInstance().getPaths().getSettingsDirPath() + name;
+    QString path = paths.getSettingsDirPath() + name;
     return QFile::exists(path + ".tox");
 }
 
@@ -825,10 +827,10 @@ bool Profile::isEncrypted() const
  * @param name Profile name.
  * @return True if profile is encrypted, false otherwise.
  */
-bool Profile::isEncrypted(QString name)
+bool Profile::isEncrypted(QString name, Paths& paths)
 {
     uint8_t data[TOX_PASS_ENCRYPTION_EXTRA_LENGTH] = {0};
-    QString path = Settings::getInstance().getPaths().getSettingsDirPath() + name + ".tox";
+    QString path = paths.getSettingsDirPath() + name + ".tox";
     QFile saveFile(path);
     if (!saveFile.open(QIODevice::ReadOnly)) {
         qWarning() << "Couldn't open tox save " << path;
@@ -879,7 +881,7 @@ QStringList Profile::remove()
         qWarning() << "Could not remove file " << profileConfig.fileName();
     }
 
-    QString dbPath = getDbPath(name);
+    QString dbPath = getDbPath(name, settings.getPaths());
     if (database && database->isOpen() && !database->remove() && QFile::exists(dbPath)) {
         ret.push_back(dbPath);
         qWarning() << "Could not remove file " << dbPath;
@@ -901,7 +903,7 @@ bool Profile::rename(QString newName)
     QString path = paths.getSettingsDirPath() + name,
             newPath = paths.getSettingsDirPath() + newName;
 
-    if (!ProfileLocker::lock(newName)) {
+    if (!ProfileLocker::lock(newName, paths)) {
         return false;
     }
 
@@ -985,7 +987,7 @@ QString Profile::setPassword(const QString& newPassword)
  * @param profileName Profile name.
  * @return Path to database.
  */
-QString Profile::getDbPath(const QString& profileName)
+QString Profile::getDbPath(const QString& profileName, Paths& paths)
 {
-    return Settings::getInstance().getPaths().getSettingsDirPath() + profileName + ".db";
+    return paths.getSettingsDirPath() + profileName + ".db";
 }

--- a/src/persistence/profile.h
+++ b/src/persistence/profile.h
@@ -74,11 +74,11 @@ public:
 
     bool rename(QString newName);
 
-    static const QStringList getAllProfileNames();
+    static const QStringList getAllProfileNames(Settings&);
 
-    static bool exists(QString name);
-    static bool isEncrypted(QString name);
-    static QString getDbPath(const QString& profileName);
+    static bool exists(QString name, Paths&);
+    static bool isEncrypted(QString name, Paths&);
+    static QString getDbPath(const QString& profileName, Paths&);
 
 signals:
     void selfAvatarChanged(const QPixmap& pixmap);
@@ -106,7 +106,7 @@ private slots:
 
 private:
     Profile(const QString& name_, std::unique_ptr<ToxEncrypt> passkey_, Paths& paths_, Settings &settings_);
-    static QStringList getFilesByExt(QString extension);
+    static QStringList getFilesByExt(QString extension, Settings& settings);
     QString avatarPath(const ToxPk& owner, bool forceUnencrypted = false);
     bool saveToxSave(QByteArray data);
     void initCore(const QByteArray& toxsave, Settings &s, bool isNewProfile, CameraSource&);

--- a/src/persistence/profile.h
+++ b/src/persistence/profile.h
@@ -38,6 +38,7 @@
 class Settings;
 class QCommandLineParser;
 class ToxPk;
+class CameraSource;
 
 class Profile : public QObject
 {
@@ -45,9 +46,9 @@ class Profile : public QObject
 
 public:
     static Profile* loadProfile(const QString& name, const QString& password, Settings& settings,
-                                const QCommandLineParser* parser);
+                                const QCommandLineParser* parser, CameraSource&);
     static Profile* createProfile(const QString& name, const QString& password, Settings& settings,
-                                  const QCommandLineParser* parser);
+                                  const QCommandLineParser* parser, CameraSource&);
     ~Profile();
 
     Core& getCore() const;
@@ -108,7 +109,7 @@ private:
     static QStringList getFilesByExt(QString extension);
     QString avatarPath(const ToxPk& owner, bool forceUnencrypted = false);
     bool saveToxSave(QByteArray data);
-    void initCore(const QByteArray& toxsave, Settings &s, bool isNewProfile);
+    void initCore(const QByteArray& toxsave, Settings &s, bool isNewProfile, CameraSource&);
 
 private:
     std::unique_ptr<AvatarBroadcaster> avatarBroadcaster;

--- a/src/persistence/profilelocker.h
+++ b/src/persistence/profilelocker.h
@@ -23,21 +23,23 @@
 #include <QLockFile>
 #include <memory>
 
+class Paths;
+
 class ProfileLocker
 {
 private:
     ProfileLocker() = delete;
 
 public:
-    static bool isLockable(QString profile);
-    static bool lock(QString profile);
+    static bool isLockable(QString profile, Paths&);
+    static bool lock(QString profile, Paths&);
     static void unlock();
     static bool hasLock();
     static QString getCurLockName();
-    static void assertLock();
+    static void assertLock(Paths&);
 
 private:
-    static QString lockPathFromName(const QString& name);
+    static QString lockPathFromName(const QString& name, const Paths&);
     static void deathByBrokenLock();
 
 private:

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -145,8 +145,10 @@ public:
     };
 
 public:
-    static Settings& getInstance();
-    static void destroyInstance();
+    Settings();
+    ~Settings();
+    Settings(Settings& settings) = delete;
+    Settings& operator=(const Settings&) = delete;
 
     Paths& getPaths();
     void createSettingsDir();
@@ -568,11 +570,6 @@ public:
 
 private:
     struct friendProp;
-
-    Settings();
-    ~Settings();
-    Settings(Settings& settings) = delete;
-    Settings& operator=(const Settings&) = delete;
     void savePersonal(QString profileName, const ToxEncrypt* passkey);
     friendProp& getOrInsertFriendPropRef(const ToxPk& id);
     static ICoreSettings::ProxyType fixInvalidProxyType(ICoreSettings::ProxyType proxyType);
@@ -712,7 +709,6 @@ private:
     int themeColor;
 
     static CompatibleRecursiveMutex bigLock;
-    static Settings* settings;
     static const QString globalSettingsFile;
     static QThread* settingsThread;
     Paths paths;

--- a/src/persistence/smileypack.cpp
+++ b/src/persistence/smileypack.cpp
@@ -105,12 +105,13 @@ bool isAscii(const QString& string)
 
 } // namespace
 
-SmileyPack::SmileyPack()
+SmileyPack::SmileyPack(Settings& settings_)
     : cleanupTimer{new QTimer(this)}
+    , settings{settings_}
 {
     loadingMutex.lock();
-    QtConcurrent::run(this, &SmileyPack::load, Settings::getInstance().getSmileyPack());
-    connect(&Settings::getInstance(), &Settings::smileyPackChanged, this,
+    QtConcurrent::run(this, &SmileyPack::load, settings.getSmileyPack());
+    connect(&settings, &Settings::smileyPackChanged, this,
             &SmileyPack::onSmileyPackChanged);
     connect(cleanupTimer, &QTimer::timeout, this, &SmileyPack::cleanupIconsCache);
     cleanupTimer->start(CLEANUP_TIMEOUT);
@@ -348,5 +349,5 @@ std::shared_ptr<QIcon> SmileyPack::getAsIcon(const QString& emoticon) const
 void SmileyPack::onSmileyPackChanged()
 {
     loadingMutex.lock();
-    QtConcurrent::run(this, &SmileyPack::load, Settings::getInstance().getSmileyPack());
+    QtConcurrent::run(this, &SmileyPack::load, settings.getSmileyPack());
 }

--- a/src/persistence/smileypack.h
+++ b/src/persistence/smileypack.h
@@ -27,13 +27,14 @@
 #include <memory>
 
 class QTimer;
+class Settings;
 
 class SmileyPack : public QObject
 {
     Q_OBJECT
 
 public:
-    SmileyPack();
+    explicit SmileyPack(Settings&);
     SmileyPack(SmileyPack&) = delete;
     SmileyPack& operator=(const SmileyPack&) = delete;
     ~SmileyPack() override;
@@ -61,4 +62,5 @@ private:
     QTimer* cleanupTimer;
     QRegularExpression smilify;
     mutable QMutex loadingMutex;
+    Settings& settings;
 };

--- a/src/persistence/toxsave.cpp
+++ b/src/persistence/toxsave.cpp
@@ -18,17 +18,24 @@
 */
 
 #include "toxsave.h"
+#include "src/persistence/settings.h"
 #include "src/widget/gui.h"
 #include "src/widget/tool/profileimporter.h"
 #include <QCoreApplication>
 
-bool toxSaveEventHandler(const QByteArray& eventData)
+ToxSave::ToxSave(Settings& settings_)
+    : settings{settings_}
+{}
+
+bool ToxSave::toxSaveEventHandler(const QByteArray& eventData, void* userData)
 {
+    auto toxSave = static_cast<ToxSave*>(userData);
+
     if (!eventData.endsWith(".tox")) {
         return false;
     }
 
-    handleToxSave(eventData);
+    toxSave->handleToxSave(eventData);
     return true;
 }
 
@@ -38,8 +45,8 @@ bool toxSaveEventHandler(const QByteArray& eventData)
  * @param path Path to .tox file.
  * @return True if import success, false, otherwise.
  */
-bool handleToxSave(const QString& path)
+bool ToxSave::handleToxSave(const QString& path)
 {
-    ProfileImporter importer(GUI::getMainWidget());
+    ProfileImporter importer(settings, GUI::getMainWidget());
     return importer.importProfile(path);
 }

--- a/src/persistence/toxsave.h
+++ b/src/persistence/toxsave.h
@@ -21,8 +21,15 @@
 
 class QString;
 class QByteArray;
+class Settings;
 
-bool handleToxSave(const QString& path);
+class ToxSave
+{
+public:
+    explicit ToxSave(Settings&);
+    bool handleToxSave(const QString& path);
+    static bool toxSaveEventHandler(const QByteArray& eventData, void* userData);
 
-// Internals
-bool toxSaveEventHandler(const QByteArray& eventData);
+private:
+    Settings& settings;
+};

--- a/src/platform/autorun.h
+++ b/src/platform/autorun.h
@@ -21,10 +21,10 @@
 
 #ifdef QTOX_PLATFORM_EXT
 
-
+class Settings;
 namespace Platform {
-bool setAutorun(bool on);
-bool getAutorun();
+bool setAutorun(const Settings&, bool on);
+bool getAutorun(const Settings&);
 }
 
 #endif // QTOX_PLATFORM_EXT

--- a/src/platform/autorun_osx.cpp
+++ b/src/platform/autorun_osx.cpp
@@ -28,7 +28,7 @@ namespace {
 int state;
 } // namespace
 
-bool Platform::setAutorun(bool on)
+bool Platform::setAutorun(const Settings&, bool on)
 {
     QString qtoxPlist =
         QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::HomeLocation)
@@ -45,7 +45,7 @@ bool Platform::setAutorun(bool on)
     return true;
 }
 
-bool Platform::getAutorun()
+bool Platform::getAutorun(const Settings&)
 {
     return state;
 }

--- a/src/platform/autorun_win.cpp
+++ b/src/platform/autorun_win.cpp
@@ -45,19 +45,19 @@ inline tstring toTString(QString s)
 } // namespace
 
 namespace Platform {
-inline tstring currentCommandLine()
+inline tstring currentCommandLine(const Settings& settings)
 {
     return toTString("\"" + QApplication::applicationFilePath().replace('/', '\\') + "\" -p \""
-                     + Settings::getInstance().getCurrentProfile() + "\"");
+                     + settings.getCurrentProfile() + "\"");
 }
 
-inline tstring currentRegistryKeyName()
+inline tstring currentRegistryKeyName(const Settings& settings)
 {
-    return toTString("qTox - " + Settings::getInstance().getCurrentProfile());
+    return toTString("qTox - " + settings.getCurrentProfile());
 }
 }
 
-bool Platform::setAutorun(bool on)
+bool Platform::setAutorun(const Settings& settings, bool on)
 {
     HKEY key = nullptr;
     if (RegOpenKeyEx(HKEY_CURRENT_USER, TEXT("Software\\Microsoft\\Windows\\CurrentVersion\\Run"),
@@ -66,10 +66,10 @@ bool Platform::setAutorun(bool on)
         return false;
 
     bool result = false;
-    tstring keyName = currentRegistryKeyName();
+    tstring keyName = currentRegistryKeyName(settings);
 
     if (on) {
-        tstring path = currentCommandLine();
+        tstring path = currentCommandLine(settings);
         result = RegSetValueEx(key, keyName.c_str(), 0, REG_SZ, const_cast<PBYTE>(reinterpret_cast<const unsigned char*>(path.c_str())),
                                path.length() * sizeof(TCHAR))
                  == ERROR_SUCCESS;
@@ -80,7 +80,7 @@ bool Platform::setAutorun(bool on)
     return result;
 }
 
-bool Platform::getAutorun()
+bool Platform::getAutorun(const Settings& settings)
 {
     HKEY key = nullptr;
     if (RegOpenKeyEx(HKEY_CURRENT_USER, TEXT("Software\\Microsoft\\Windows\\CurrentVersion\\Run"),
@@ -88,7 +88,7 @@ bool Platform::getAutorun()
         != ERROR_SUCCESS)
         return false;
 
-    tstring keyName = currentRegistryKeyName();
+    tstring keyName = currentRegistryKeyName(settings);
 
     TCHAR path[MAX_PATH] = {0};
     DWORD length = sizeof(path);

--- a/src/platform/autorun_xdg.cpp
+++ b/src/platform/autorun_xdg.cpp
@@ -33,9 +33,9 @@ QString getAutostartDirPath()
     return config + "/autostart";
 }
 
-QString getAutostartFilePath(QString dir)
+QString getAutostartFilePath(const Settings& settings, QString dir)
 {
-    return dir + "/qTox - " + Settings::getInstance().getCurrentProfile() + ".desktop";
+    return dir + "/qTox - " + settings.getCurrentProfile() + ".desktop";
 }
 
 QString currentBinPath()
@@ -50,17 +50,17 @@ QString currentBinPath()
     }
 }
 
-inline QString profileRunCommand()
+inline QString profileRunCommand(const Settings& settings)
 {
     return "\"" + currentBinPath() + "\" -p \""
-           + Settings::getInstance().getCurrentProfile() + "\"";
+           + settings.getCurrentProfile() + "\"";
 }
 } // namespace
 
-bool Platform::setAutorun(bool on)
+bool Platform::setAutorun(const Settings& settings, bool on)
 {
     QString dirPath = getAutostartDirPath();
-    QFile desktop(getAutostartFilePath(dirPath));
+    QFile desktop(getAutostartFilePath(settings, dirPath));
     if (on) {
         if (!QDir().mkpath(dirPath) || !desktop.open(QFile::WriteOnly | QFile::Truncate))
             return false;
@@ -68,7 +68,7 @@ bool Platform::setAutorun(bool on)
         desktop.write("Type=Application\n");
         desktop.write("Name=qTox\n");
         desktop.write("Exec=");
-        desktop.write(profileRunCommand().toUtf8());
+        desktop.write(profileRunCommand(settings).toUtf8());
         desktop.write("\n");
         desktop.close();
         return true;
@@ -76,7 +76,7 @@ bool Platform::setAutorun(bool on)
         return desktop.remove();
 }
 
-bool Platform::getAutorun()
+bool Platform::getAutorun(const Settings& settings)
 {
-    return QFile(getAutostartFilePath(getAutostartDirPath())).exists();
+    return QFile(getAutostartFilePath(settings, getAutostartDirPath())).exists();
 }

--- a/src/platform/desktop_notifications/desktopnotify.cpp
+++ b/src/platform/desktop_notifications/desktopnotify.cpp
@@ -27,9 +27,10 @@
 #include <QDebug>
 #include <QThread>
 
-DesktopNotify::DesktopNotify()
+DesktopNotify::DesktopNotify(Settings& settings_)
     : notifyCore{Snore::SnoreCore::instance()}
     , snoreIcon{":/img/icons/qtox.svg"}
+    , settings{settings_}
 {
 
     notifyCore.loadPlugins(Snore::SnorePlugin::Backend);
@@ -44,8 +45,7 @@ DesktopNotify::DesktopNotify()
 
 void DesktopNotify::notifyMessage(const NotificationData& notificationData)
 {
-    const Settings& s = Settings::getInstance();
-    if(!(s.getNotify() && s.getDesktopNotify())) {
+    if(!(settings.getNotify() && settings.getDesktopNotify())) {
         return;
     }
 

--- a/src/platform/desktop_notifications/desktopnotify.h
+++ b/src/platform/desktop_notifications/desktopnotify.h
@@ -28,11 +28,13 @@
 #include <memory>
 #include <unordered_set>
 
+class Settings;
+
 class DesktopNotify : public QObject
 {
     Q_OBJECT
 public:
-    DesktopNotify();
+    explicit DesktopNotify(Settings&);
 
 public slots:
     void notifyMessage(const NotificationData& notificationData);
@@ -49,4 +51,5 @@ private:
     Snore::Icon snoreIcon;
     Snore::Notification lastNotification;
     uint latestId;
+    Settings& settings;
 };

--- a/src/video/cameradevice.cpp
+++ b/src/video/cameradevice.cpp
@@ -79,14 +79,16 @@ AvFindInputFormatRet iformat{nullptr};
 QHash<QString, CameraDevice*> CameraDevice::openDevices;
 QMutex CameraDevice::openDeviceLock, CameraDevice::iformatLock;
 
-CameraDevice::CameraDevice(const QString& devName_, AVFormatContext* context_)
+CameraDevice::CameraDevice(const QString& devName_, AVFormatContext* context_,
+    Settings& settings_)
     : devName{devName_}
     , context{context_}
     , refcount{1}
+    , settings{settings_}
 {
 }
 
-CameraDevice* CameraDevice::open(QString devName, AVDictionary** options)
+CameraDevice* CameraDevice::open(Settings& settings, QString devName, AVDictionary** options)
 {
     openDeviceLock.lock();
     AVFormatContext* fctx = nullptr;
@@ -131,7 +133,7 @@ CameraDevice* CameraDevice::open(QString devName, AVDictionary** options)
     fctx->max_analyze_duration = aduration;
 #endif
 
-    dev = new CameraDevice{devName, fctx};
+    dev = new CameraDevice{devName, fctx, settings};
     openDevices[devName] = dev;
 
 out:
@@ -151,7 +153,7 @@ out:
  * @param mode Mode of device to open.
  * @return CameraDevice if the device could be opened, nullptr otherwise.
  */
-CameraDevice* CameraDevice::open(QString devName, VideoMode mode)
+CameraDevice* CameraDevice::open(Settings& settings, QString devName, VideoMode mode)
 {
     if (!getDefaultInputFormat())
         return nullptr;
@@ -237,7 +239,7 @@ CameraDevice* CameraDevice::open(QString devName, VideoMode mode)
         std::ignore = mode;
     }
 
-    CameraDevice* dev = open(devName, &options);
+    CameraDevice* dev = open(settings, devName, &options);
     if (options) {
         av_dict_free(&options);
     }
@@ -395,9 +397,9 @@ QVector<QPair<QString, QString>> CameraDevice::getDeviceList()
  * @return The short name of the default device
  * This is either the device in the settings or the system default.
  */
-QString CameraDevice::getDefaultDeviceName()
+QString CameraDevice::getDefaultDeviceName(Settings& settings)
 {
-    QString defaultdev = Settings::getInstance().getVideoDev();
+    QString defaultdev = settings.getVideoDev();
 
     if (!getDefaultInputFormat())
         return defaultdev;

--- a/src/video/cameradevice.h
+++ b/src/video/cameradevice.h
@@ -31,11 +31,12 @@ struct AVFormatContext;
 struct AVInputFormat;
 struct AVDeviceInfoList;
 struct AVDictionary;
+class Settings;
 
 class CameraDevice
 {
 public:
-    static CameraDevice* open(QString devName, VideoMode mode = VideoMode());
+    static CameraDevice* open(Settings&, QString devName, VideoMode mode = VideoMode());
     void open();
     bool close();
 
@@ -45,13 +46,13 @@ public:
     static QString getPixelFormatString(uint32_t pixel_format);
     static bool betterPixelFormat(uint32_t a, uint32_t b);
 
-    static QString getDefaultDeviceName();
+    static QString getDefaultDeviceName(Settings& settings);
 
     static bool isScreen(const QString& devName);
 
 private:
-    CameraDevice(const QString& devName_, AVFormatContext* context_);
-    static CameraDevice* open(QString devName, AVDictionary** options);
+    CameraDevice(const QString& devName_, AVFormatContext* context_, Settings&);
+    static CameraDevice* open(Settings&, QString devName, AVDictionary** options);
     static bool getDefaultInputFormat();
     static QVector<QPair<QString, QString>> getRawDeviceListGeneric();
     static QVector<VideoMode> getScreenModes();
@@ -64,4 +65,5 @@ private:
     std::atomic_int refcount;
     static QHash<QString, CameraDevice*> openDevices;
     static QMutex openDeviceLock, iformatLock;
+    Settings& settings;
 };

--- a/src/video/camerasource.cpp
+++ b/src/video/camerasource.cpp
@@ -90,7 +90,7 @@ extern "C" {
  * @brief Remember how many times we subscribed for RAII
  */
 
-CameraSource::CameraSource()
+CameraSource::CameraSource(Settings& settings_)
     : deviceThread{new QThread}
     , deviceName{"none"}
     , device{nullptr}
@@ -103,6 +103,7 @@ CameraSource::CameraSource()
     , videoStreamIndex{-1}
     , isNone_{true}
     , subscriptions{0}
+    , settings{settings_}
 {
     qRegisterMetaType<VideoMode>("VideoMode");
     deviceThread->setObjectName("Device thread");
@@ -126,12 +127,12 @@ CameraSource::CameraSource()
  */
 void CameraSource::setupDefault()
 {
-    QString deviceName_ = CameraDevice::getDefaultDeviceName();
+    QString deviceName_ = CameraDevice::getDefaultDeviceName(settings);
     bool isScreen = CameraDevice::isScreen(deviceName_);
-    VideoMode mode_ = VideoMode(Settings::getInstance().getScreenRegion());
+    VideoMode mode_ = VideoMode(settings.getScreenRegion());
     if (!isScreen) {
-        mode_ = VideoMode(Settings::getInstance().getCamVideoRes());
-        mode_.FPS = Settings::getInstance().getCamVideoFPS();
+        mode_ = VideoMode(settings.getCamVideoRes());
+        mode_.FPS = settings.getCamVideoFPS();
     }
 
     setupDevice(deviceName_, mode_);
@@ -260,7 +261,7 @@ void CameraSource::openDevice()
     }
 
     // We need to create a new CameraDevice
-    device = CameraDevice::open(deviceName, mode);
+    device = CameraDevice::open(settings, deviceName, mode);
 
     if (!device) {
         qWarning() << "Failed to open device!";

--- a/src/video/camerasource.cpp
+++ b/src/video/camerasource.cpp
@@ -90,8 +90,6 @@ extern "C" {
  * @brief Remember how many times we subscribed for RAII
  */
 
-CameraSource* CameraSource::instance{nullptr};
-
 CameraSource::CameraSource()
     : deviceThread{new QThread}
     , deviceName{"none"}
@@ -121,22 +119,6 @@ CameraSource::CameraSource()
 }
 
 // clang-format on
-
-/**
- * @brief Returns the singleton instance.
- */
-CameraSource& CameraSource::getInstance()
-{
-    if (!instance)
-        instance = new CameraSource();
-    return *instance;
-}
-
-void CameraSource::destroyInstance()
-{
-    delete instance;
-    instance = nullptr;
-}
 
 /**
  * @brief Setup default device

--- a/src/video/camerasource.h
+++ b/src/video/camerasource.h
@@ -30,13 +30,14 @@
 
 class CameraDevice;
 struct AVCodecContext;
+class Settings;
 
 class CameraSource : public VideoSource
 {
     Q_OBJECT
 
 public:
-    CameraSource();
+    explicit CameraSource(Settings&);
     ~CameraSource();
     void setupDefault();
     bool isNone() const;
@@ -76,4 +77,5 @@ private:
 
     std::atomic_bool isNone_;
     std::atomic_int subscriptions;
+    Settings& settings;
 };

--- a/src/video/camerasource.h
+++ b/src/video/camerasource.h
@@ -36,8 +36,8 @@ class CameraSource : public VideoSource
     Q_OBJECT
 
 public:
-    static CameraSource& getInstance();
-    static void destroyInstance();
+    CameraSource();
+    ~CameraSource();
     void setupDefault();
     bool isNone() const;
 
@@ -53,8 +53,6 @@ signals:
     void openFailed();
 
 private:
-    CameraSource();
-    ~CameraSource();
     void stream();
 
 private slots:
@@ -78,6 +76,4 @@ private:
 
     std::atomic_bool isNone_;
     std::atomic_int subscriptions;
-
-    static CameraSource* instance;
 };

--- a/src/video/netcamview.cpp
+++ b/src/video/netcamview.cpp
@@ -47,12 +47,14 @@ const int BTN_PANEL_WIDTH = 250;
 const auto BTN_STYLE_SHEET_PATH = QStringLiteral("chatForm/fullScreenButtons.css");
 }
 
-NetCamView::NetCamView(ToxPk friendPk_, CameraSource& cameraSource_, QWidget* parent)
+NetCamView::NetCamView(ToxPk friendPk_, CameraSource& cameraSource_,
+    Settings& settings_, QWidget* parent)
     : QWidget(parent)
     , selfFrame{nullptr}
     , friendPk{friendPk_}
     , e(false)
     , cameraSource{cameraSource_}
+    , settings{settings_}
 {
     verLayout = new QVBoxLayout(this);
     setWindowTitle(tr("Tox video"));
@@ -77,7 +79,7 @@ NetCamView::NetCamView(ToxPk friendPk_, CameraSource& cameraSource_, QWidget* pa
 
     setStyleSheet("NetCamView { background-color: #c1c1c1; }");
     buttonPanel = new QFrame(this);
-    buttonPanel->setStyleSheet(Style::getStylesheet(BTN_STYLE_SHEET_PATH));
+    buttonPanel->setStyleSheet(Style::getStylesheet(BTN_STYLE_SHEET_PATH, settings));
     buttonPanel->setGeometry(0, 0, BTN_PANEL_WIDTH, BTN_PANEL_HEIGHT);
 
     QHBoxLayout* buttonPanelLayout = new QHBoxLayout(buttonPanel);
@@ -155,7 +157,7 @@ NetCamView::NetCamView(ToxPk friendPk_, CameraSource& cameraSource_, QWidget* pa
                                    videoSurface->setAvatar(pixmap);
                            });
 
-    QRect videoSize = Settings::getInstance().getCamVideoRes();
+    QRect videoSize = settings.getCamVideoRes();
     qDebug() << "SIZER" << videoSize;
 }
 
@@ -239,7 +241,7 @@ void NetCamView::setShowMessages(bool show, bool notify)
     toggleMessagesButton->setText(tr("Show messages"));
 
     if (notify) {
-        toggleMessagesButton->setIcon(QIcon(Style::getImagePath("chatArea/info.svg")));
+        toggleMessagesButton->setIcon(QIcon(Style::getImagePath("chatArea/info.svg", settings)));
     }
 }
 
@@ -301,7 +303,7 @@ QPushButton* NetCamView::createButton(const QString& name, const QString& state)
     btn->setAttribute(Qt::WA_LayoutUsesWidgetRect);
     btn->setObjectName(name);
     btn->setProperty("state", QVariant(state));
-    btn->setStyleSheet(Style::getStylesheet(BTN_STYLE_SHEET_PATH));
+    btn->setStyleSheet(Style::getStylesheet(BTN_STYLE_SHEET_PATH, settings));
 
     return btn;
 }
@@ -324,7 +326,7 @@ void NetCamView::toggleButtonState(QPushButton* btn)
         btn->setProperty("state", BTN_STATE_RED);
     }
 
-    btn->setStyleSheet(Style::getStylesheet(BTN_STYLE_SHEET_PATH));
+    btn->setStyleSheet(Style::getStylesheet(BTN_STYLE_SHEET_PATH, settings));
 }
 
 void NetCamView::updateButtonState(QPushButton* btn, bool active)
@@ -335,7 +337,7 @@ void NetCamView::updateButtonState(QPushButton* btn, bool active)
         btn->setProperty("state", BTN_STATE_RED);
     }
 
-    btn->setStyleSheet(Style::getStylesheet(BTN_STYLE_SHEET_PATH));
+    btn->setStyleSheet(Style::getStylesheet(BTN_STYLE_SHEET_PATH, settings));
 }
 
 void NetCamView::keyPressEvent(QKeyEvent *event)

--- a/src/video/netcamview.cpp
+++ b/src/video/netcamview.cpp
@@ -47,11 +47,12 @@ const int BTN_PANEL_WIDTH = 250;
 const auto BTN_STYLE_SHEET_PATH = QStringLiteral("chatForm/fullScreenButtons.css");
 }
 
-NetCamView::NetCamView(ToxPk friendPk_, QWidget* parent)
+NetCamView::NetCamView(ToxPk friendPk_, CameraSource& cameraSource_, QWidget* parent)
     : QWidget(parent)
     , selfFrame{nullptr}
     , friendPk{friendPk_}
     , e(false)
+    , cameraSource{cameraSource_}
 {
     verLayout = new QVBoxLayout(this);
     setWindowTitle(tr("Tox video"));
@@ -167,7 +168,7 @@ NetCamView::~NetCamView()
 void NetCamView::show(VideoSource* source, const QString& title)
 {
     setSource(source);
-    selfVideoSurface->setSource(&CameraSource::getInstance());
+    selfVideoSurface->setSource(&cameraSource);
 
     setTitle(title);
     QWidget::show();

--- a/src/video/netcamview.h
+++ b/src/video/netcamview.h
@@ -35,13 +35,14 @@ class QKeyEvent;
 class QCloseEvent;
 class QShowEvent;
 class CameraSource;
+class Settings;
 
 class NetCamView : public QWidget
 {
     Q_OBJECT
 
 public:
-    NetCamView(ToxPk friendPk_, CameraSource&, QWidget* parent = nullptr);
+    NetCamView(ToxPk friendPk_, CameraSource&, Settings&, QWidget* parent = nullptr);
     ~NetCamView();
 
     virtual void show(VideoSource* source, const QString& title);
@@ -97,4 +98,5 @@ private:
     QPushButton* endVideoButton = nullptr;
     QPushButton* exitFullScreenButton = nullptr;
     CameraSource& cameraSource;
+    Settings& settings;
 };

--- a/src/video/netcamview.h
+++ b/src/video/netcamview.h
@@ -34,13 +34,14 @@ class QPushButton;
 class QKeyEvent;
 class QCloseEvent;
 class QShowEvent;
+class CameraSource;
 
 class NetCamView : public QWidget
 {
     Q_OBJECT
 
 public:
-    NetCamView(ToxPk friendPk_, QWidget* parent = nullptr);
+    NetCamView(ToxPk friendPk_, CameraSource&, QWidget* parent = nullptr);
     ~NetCamView();
 
     virtual void show(VideoSource* source, const QString& title);
@@ -95,4 +96,5 @@ private:
     QPushButton* microphoneButton = nullptr;
     QPushButton* endVideoButton = nullptr;
     QPushButton* exitFullScreenButton = nullptr;
+    CameraSource& cameraSource;
 };

--- a/src/widget/about/aboutfriendform.cpp
+++ b/src/widget/about/aboutfriendform.cpp
@@ -36,10 +36,11 @@ QString getAutoAcceptDir(const QString& dir)
 
 } // namespace
 
-AboutFriendForm::AboutFriendForm(std::unique_ptr<IAboutFriend> _about, QWidget* parent)
+AboutFriendForm::AboutFriendForm(std::unique_ptr<IAboutFriend> about_, Settings& settings_, QWidget* parent)
     : QDialog(parent)
     , ui(new Ui::AboutFriendForm)
-    , about{std::move(_about)}
+    , about{std::move(about_)}
+    , settings{settings_}
 {
     ui->setupUi(this);
     ui->label_4->hide();
@@ -97,7 +98,7 @@ void AboutFriendForm::onAutoAcceptDirClicked()
 
 void AboutFriendForm::reloadTheme()
 {
-    setStyleSheet(Style::getStylesheet("window/general.css"));
+    setStyleSheet(Style::getStylesheet("window/general.css", settings));
 }
 
 void AboutFriendForm::onAutoAcceptDirChanged(const QString& path)

--- a/src/widget/about/aboutfriendform.h
+++ b/src/widget/about/aboutfriendform.h
@@ -30,17 +30,20 @@ namespace Ui {
 class AboutFriendForm;
 }
 
+class Settings;
+
 class AboutFriendForm : public QDialog
 {
     Q_OBJECT
 
 public:
-    AboutFriendForm(std::unique_ptr<IAboutFriend> about, QWidget* parent = nullptr);
+    AboutFriendForm(std::unique_ptr<IAboutFriend> about, Settings&, QWidget* parent = nullptr);
     ~AboutFriendForm();
 
 private:
     Ui::AboutFriendForm* ui;
     const std::unique_ptr<IAboutFriend> about;
+    Settings& settings;
 
 signals:
     void histroyRemoved();

--- a/src/widget/categorywidget.cpp
+++ b/src/widget/categorywidget.cpp
@@ -38,8 +38,9 @@ void CategoryWidget::emitChatroomWidget(QLayout* layout, int index)
     }
 }
 
-CategoryWidget::CategoryWidget(bool compact_, QWidget* parent)
+CategoryWidget::CategoryWidget(bool compact_, Settings& settings_, QWidget* parent)
     : GenericChatItemWidget(compact_, parent)
+    , settings{settings_}
 {
     container = new QWidget(this);
     container->setObjectName("circleWidgetContainer");
@@ -49,7 +50,7 @@ CategoryWidget::CategoryWidget(bool compact_, QWidget* parent)
     statusLabel->setObjectName("status");
     statusLabel->setTextFormat(Qt::PlainText);
 
-    statusPic.setPixmap(QPixmap(Style::getImagePath("chatArea/scrollBarRightArrow.svg")));
+    statusPic.setPixmap(QPixmap(Style::getImagePath("chatArea/scrollBarRightArrow.svg", settings)));
 
     fullLayout = new QVBoxLayout(this);
     fullLayout->setSpacing(0);
@@ -96,9 +97,9 @@ void CategoryWidget::setExpanded(bool isExpanded, bool save)
 
     QString pixmapPath;
     if (isExpanded)
-        pixmapPath = Style::getImagePath("chatArea/scrollBarDownArrow.svg");
+        pixmapPath = Style::getImagePath("chatArea/scrollBarDownArrow.svg", settings);
     else
-        pixmapPath = Style::getImagePath("chatArea/scrollBarRightArrow.svg");
+        pixmapPath = Style::getImagePath("chatArea/scrollBarRightArrow.svg", settings);
     statusPic.setPixmap(QPixmap(pixmapPath));
 
     if (save)

--- a/src/widget/categorywidget.h
+++ b/src/widget/categorywidget.h
@@ -28,12 +28,13 @@ class FriendListWidget;
 class FriendWidget;
 class QVBoxLayout;
 class QHBoxLayout;
+class Settings;
 
 class CategoryWidget : public GenericChatItemWidget
 {
     Q_OBJECT
 public:
-    explicit CategoryWidget(bool compact_, QWidget* parent = nullptr);
+    explicit CategoryWidget(bool compact_, Settings&, QWidget* parent = nullptr);
 
     bool isExpanded() const;
     void setExpanded(bool isExpanded, bool save = true);
@@ -83,4 +84,5 @@ private:
     QWidget* container;
     QFrame* lineFrame;
     bool expanded = false;
+    Settings& settings;
 };

--- a/src/widget/chatformheader.cpp
+++ b/src/widget/chatformheader.cpp
@@ -81,12 +81,12 @@ const QString MIC_TOOL_TIP[] = {
 };
 
 template <class T, class Fun>
-QPushButton* createButton(const QString& name, T* self, Fun onClickSlot)
+QPushButton* createButton(const QString& name, T* self, Fun onClickSlot, Settings& settings)
 {
     QPushButton* btn = new QPushButton();
     btn->setAttribute(Qt::WA_LayoutUsesWidgetRect);
     btn->setObjectName(name);
-    btn->setStyleSheet(Style::getStylesheet(STYLE_PATH));
+    btn->setStyleSheet(Style::getStylesheet(STYLE_PATH, settings));
     QObject::connect(btn, &QPushButton::clicked, self, onClickSlot);
     return btn;
 }
@@ -108,13 +108,14 @@ void setStateName(QAbstractButton* btn, State state)
 
 }
 
-ChatFormHeader::ChatFormHeader(QWidget* parent)
+ChatFormHeader::ChatFormHeader(Settings& settings_, QWidget* parent)
     : QWidget(parent)
     , mode{Mode::AV}
     , callState{CallButtonState::Disabled}
     , videoState{CallButtonState::Disabled}
     , volState{ToolButtonState::Disabled}
     , micState{ToolButtonState::Disabled}
+    , settings{settings_}
 {
     QHBoxLayout* headLayout = new QHBoxLayout();
     avatar = new MaskablePixmapWidget(this, AVATAR_SIZE, ":/img/avatar_mask.svg");
@@ -140,10 +141,10 @@ ChatFormHeader::ChatFormHeader(QWidget* parent)
     headTextLayout->addLayout(nameLine);
     headTextLayout->addStretch();
 
-    micButton = createButton("micButton", this, &ChatFormHeader::micMuteToggle);
-    volButton = createButton("volButton", this, &ChatFormHeader::volMuteToggle);
-    callButton = createButton("callButton", this, &ChatFormHeader::callTriggered);
-    videoButton = createButton("videoButton", this, &ChatFormHeader::videoCallTriggered);
+    micButton = createButton("micButton", this, &ChatFormHeader::micMuteToggle, settings);
+    volButton = createButton("volButton", this, &ChatFormHeader::volMuteToggle, settings);
+    callButton = createButton("callButton", this, &ChatFormHeader::callTriggered, settings);
+    videoButton = createButton("videoButton", this, &ChatFormHeader::videoCallTriggered, settings);
 
     QVBoxLayout* micButtonsLayout = new QVBoxLayout();
     micButtonsLayout->setSpacing(MIC_BUTTONS_LAYOUT_SPACING);
@@ -218,7 +219,7 @@ void ChatFormHeader::showOutgoingCall(bool video)
 void ChatFormHeader::createCallConfirm(bool video)
 {
     QWidget* btn = video ? videoButton : callButton;
-    callConfirm = std::unique_ptr<CallConfirmWidget>(new CallConfirmWidget(btn));
+    callConfirm = std::unique_ptr<CallConfirmWidget>(new CallConfirmWidget(settings, btn));
     connect(callConfirm.get(), &CallConfirmWidget::accepted, this, &ChatFormHeader::callAccepted);
     connect(callConfirm.get(), &CallConfirmWidget::rejected, this, &ChatFormHeader::callRejected);
 }
@@ -302,11 +303,11 @@ QSize ChatFormHeader::getAvatarSize() const
 
 void ChatFormHeader::reloadTheme()
 {
-    setStyleSheet(Style::getStylesheet("chatArea/chatHead.css"));
-    callButton->setStyleSheet(Style::getStylesheet(STYLE_PATH));
-    videoButton->setStyleSheet(Style::getStylesheet(STYLE_PATH));
-    volButton->setStyleSheet(Style::getStylesheet(STYLE_PATH));
-    micButton->setStyleSheet(Style::getStylesheet(STYLE_PATH));
+    setStyleSheet(Style::getStylesheet("chatArea/chatHead.css", settings));
+    callButton->setStyleSheet(Style::getStylesheet(STYLE_PATH, settings));
+    videoButton->setStyleSheet(Style::getStylesheet(STYLE_PATH, settings));
+    volButton->setStyleSheet(Style::getStylesheet(STYLE_PATH, settings));
+    micButton->setStyleSheet(Style::getStylesheet(STYLE_PATH, settings));
 }
 
 void ChatFormHeader::addWidget(QWidget* widget, int stretch, Qt::Alignment alignment)

--- a/src/widget/chatformheader.h
+++ b/src/widget/chatformheader.h
@@ -34,6 +34,7 @@ class QToolButton;
 class CallConfirmWidget;
 class QLabel;
 class ExtensionStatus;
+class Settings;
 
 class ChatFormHeader : public QWidget
 {
@@ -58,7 +59,7 @@ public:
         AV = Audio | Video
     };
 
-    ChatFormHeader(QWidget* parent = nullptr);
+    ChatFormHeader(Settings&, QWidget* parent = nullptr);
     ~ChatFormHeader();
 
     void setName(const QString& newName);
@@ -119,4 +120,5 @@ private:
     ToolButtonState micState;
 
     std::unique_ptr<CallConfirmWidget> callConfirm;
+    Settings& settings;
 };

--- a/src/widget/circlewidget.cpp
+++ b/src/widget/circlewidget.cpp
@@ -40,12 +40,14 @@
 
 QHash<int, CircleWidget*> CircleWidget::circleList;
 
-CircleWidget::CircleWidget(const Core &core_, FriendListWidget* parent, int id_)
-    : CategoryWidget(isCompact(), parent)
+CircleWidget::CircleWidget(const Core &core_, FriendListWidget* parent, int id_,
+    Settings& settings_)
+    : CategoryWidget(isCompact(), settings_, parent)
     , id(id_)
     , core{core_}
+    , settings{settings_}
 {
-    setName(Settings::getInstance().getCircleName(id), false);
+    setName(settings.getCircleName(id), false);
     circleList[id] = this;
 
     connect(nameLabel, &CroppingLabel::editFinished, [this](const QString& newName) {
@@ -58,7 +60,7 @@ CircleWidget::CircleWidget(const Core &core_, FriendListWidget* parent, int id_)
             nameLabel->minimizeMaximumWidth();
     });
 
-    setExpanded(Settings::getInstance().getCircleExpanded(id), false);
+    setExpanded(settings.getCircleExpanded(id), false);
     updateStatus();
 }
 
@@ -104,7 +106,7 @@ void CircleWidget::contextMenuEvent(QContextMenuEvent* event)
 
             friendList->removeCircleWidget(this);
 
-            int replacedCircle = Settings::getInstance().removeCircle(id);
+            int replacedCircle = settings.removeCircle(id);
 
             auto circleReplace = circleList.find(replacedCircle);
             if (circleReplace != circleList.end())
@@ -114,7 +116,7 @@ void CircleWidget::contextMenuEvent(QContextMenuEvent* event)
 
             circleList.remove(replacedCircle);
         } else if (selectedItem == openAction) {
-            ContentDialog* dialog = new ContentDialog(core);
+            ContentDialog* dialog = new ContentDialog(core, settings);
             emit newContentDialog(*dialog);
             for (int i = 0; i < friendOnlineLayout()->count(); ++i) {
                 QWidget* const widget = friendOnlineLayout()->itemAt(i)->widget();
@@ -179,11 +181,11 @@ void CircleWidget::dropEvent(QDropEvent* event)
         return;
 
     // Save CircleWidget before changing the Id
-    int circleId = Settings::getInstance().getFriendCircleID(toxPk);
+    int circleId = settings.getFriendCircleID(toxPk);
     CircleWidget* circleWidget = getFromID(circleId);
 
     addFriendWidget(widget, f->getStatus());
-    Settings::getInstance().savePersonal();
+    settings.savePersonal();
 
     if (circleWidget != nullptr) {
         circleWidget->updateStatus();
@@ -194,20 +196,20 @@ void CircleWidget::dropEvent(QDropEvent* event)
 
 void CircleWidget::onSetName()
 {
-    Settings::getInstance().setCircleName(id, getName());
+    settings.setCircleName(id, getName());
 }
 
 void CircleWidget::onExpand()
 {
-    Settings::getInstance().setCircleExpanded(id, isExpanded());
-    Settings::getInstance().savePersonal();
+    settings.setCircleExpanded(id, isExpanded());
+    settings.savePersonal();
 }
 
 void CircleWidget::onAddFriendWidget(FriendWidget* w)
 {
     const Friend* f = w->getFriend();
     ToxPk toxId = f->getPublicKey();
-    Settings::getInstance().setFriendCircleID(toxId, id);
+    settings.setFriendCircleID(toxId, id);
 }
 
 void CircleWidget::updateID(int index)
@@ -228,7 +230,7 @@ void CircleWidget::updateID(int index)
 
         if (friendWidget) {
             const Friend* f = friendWidget->getFriend();
-            Settings::getInstance().setFriendCircleID(f->getPublicKey(), id);
+            settings.setFriendCircleID(f->getPublicKey(), id);
         }
     }
 
@@ -238,7 +240,7 @@ void CircleWidget::updateID(int index)
 
         if (friendWidget) {
             const Friend* f = friendWidget->getFriend();
-            Settings::getInstance().setFriendCircleID(f->getPublicKey(), id);
+            settings.setFriendCircleID(f->getPublicKey(), id);
         }
     }
 }

--- a/src/widget/circlewidget.h
+++ b/src/widget/circlewidget.h
@@ -23,12 +23,13 @@
 
 class ContentDialog;
 class Core;
+class Settings;
 
 class CircleWidget final : public CategoryWidget
 {
     Q_OBJECT
 public:
-    explicit CircleWidget(const Core& core_, FriendListWidget* parent, int id_);
+    CircleWidget(const Core& core_, FriendListWidget* parent, int id_, Settings&);
     ~CircleWidget();
 
     void editName();
@@ -54,4 +55,5 @@ private:
     int id;
 
     const Core& core;
+    Settings& settings;
 };

--- a/src/widget/contentdialog.h
+++ b/src/widget/contentdialog.h
@@ -45,12 +45,13 @@ class GroupWidget;
 class QCloseEvent;
 class QSplitter;
 class QScrollArea;
+class Settings;
 
 class ContentDialog : public ActivateDialog, public IDialogs
 {
     Q_OBJECT
 public:
-    explicit ContentDialog(const Core& core, QWidget* parent = nullptr);
+    ContentDialog(const Core& core, Settings&, QWidget* parent = nullptr);
     ~ContentDialog() override;
 
     FriendWidget* addFriend(std::shared_ptr<FriendChatroom> chatroom, GenericChatForm* form);
@@ -135,4 +136,5 @@ private:
     QHash<const ContactId&, GenericChatForm*> contactChatForms;
 
     QString username;
+    Settings& settings;
 };

--- a/src/widget/contentlayout.cpp
+++ b/src/widget/contentlayout.cpp
@@ -24,14 +24,16 @@
 #include <QFrame>
 #include <QStyleFactory>
 
-ContentLayout::ContentLayout()
+ContentLayout::ContentLayout(Settings& settings_)
     : QVBoxLayout()
+    , settings{settings_}
 {
     init();
 }
 
-ContentLayout::ContentLayout(QWidget* parent)
+ContentLayout::ContentLayout(Settings& settings_, QWidget* parent)
     : QVBoxLayout(parent)
+    , settings{settings_}
 {
     init();
 
@@ -70,8 +72,8 @@ ContentLayout::~ContentLayout()
 void ContentLayout::reloadTheme()
 {
 #ifndef Q_OS_MAC
-    mainHead->setStyleSheet(Style::getStylesheet("settings/mainHead.css"));
-    mainContent->setStyleSheet(Style::getStylesheet("window/general.css"));
+    mainHead->setStyleSheet(Style::getStylesheet("settings/mainHead.css", settings));
+    mainContent->setStyleSheet(Style::getStylesheet("window/general.css", settings));
 #endif
 }
 
@@ -113,10 +115,10 @@ void ContentLayout::init()
     mainContent->setLayout(new QVBoxLayout);
     mainContent->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
 
-    if (QStyleFactory::keys().contains(Settings::getInstance().getStyle())
-        && Settings::getInstance().getStyle() != "None") {
-        mainHead->setStyle(QStyleFactory::create(Settings::getInstance().getStyle()));
-        mainContent->setStyle(QStyleFactory::create(Settings::getInstance().getStyle()));
+    if (QStyleFactory::keys().contains(settings.getStyle())
+        && settings.getStyle() != "None") {
+        mainHead->setStyle(QStyleFactory::create(settings.getStyle()));
+        mainContent->setStyle(QStyleFactory::create(settings.getStyle()));
     }
 
     connect(&GUI::getInstance(), &GUI::themeReload, this, &ContentLayout::reloadTheme);

--- a/src/widget/contentlayout.h
+++ b/src/widget/contentlayout.h
@@ -22,11 +22,13 @@
 #include <QBoxLayout>
 #include <QFrame>
 
+class Settings;
+
 class ContentLayout : public QVBoxLayout
 {
 public:
-    ContentLayout();
-    explicit ContentLayout(QWidget* parent);
+    ContentLayout(Settings&);
+    explicit ContentLayout(Settings&, QWidget* parent);
     ~ContentLayout();
 
     void clear();
@@ -35,6 +37,7 @@ public:
     QHBoxLayout mainHLineLayout;
     QWidget* mainContent;
     QWidget* mainHead;
+    Settings& settings;
 
 public slots:
     void reloadTheme();

--- a/src/widget/emoticonswidget.cpp
+++ b/src/widget/emoticonswidget.cpp
@@ -31,10 +31,11 @@
 
 #include <math.h>
 
-EmoticonsWidget::EmoticonsWidget(SmileyPack& smileyPack, QWidget* parent)
+EmoticonsWidget::EmoticonsWidget(SmileyPack& smileyPack, Settings& settings,
+    QWidget* parent)
     : QMenu(parent)
 {
-    setStyleSheet(Style::getStylesheet("emoticonWidget/emoticonWidget.css"));
+    setStyleSheet(Style::getStylesheet("emoticonWidget/emoticonWidget.css", settings));
     setLayout(&layout);
     layout.addWidget(&stack);
 
@@ -57,7 +58,7 @@ EmoticonsWidget::EmoticonsWidget(SmileyPack& smileyPack, QWidget* parent)
     int col = 0;
 
     // respect configured emoticon size
-    const int px = Settings::getInstance().getEmojiFontPointSize();
+    const int px = settings.getEmojiFontPointSize();
     const QSize size(px, px);
 
     // create pages

--- a/src/widget/emoticonswidget.h
+++ b/src/widget/emoticonswidget.h
@@ -28,12 +28,13 @@
 
 class QIcon;
 class SmileyPack;
+class Settings;
 
 class EmoticonsWidget : public QMenu
 {
     Q_OBJECT
 public:
-    explicit EmoticonsWidget(SmileyPack&, QWidget* parent = nullptr);
+    EmoticonsWidget(SmileyPack&, Settings&, QWidget* parent = nullptr);
 
 signals:
     void insertEmoticon(QString str);

--- a/src/widget/form/addfriendform.h
+++ b/src/widget/form/addfriendform.h
@@ -33,6 +33,7 @@
 class QTabWidget;
 
 class ContentLayout;
+class Settings;
 
 class AddFriendForm : public QObject
 {
@@ -45,7 +46,7 @@ public:
         FriendRequest = 2
     };
 
-    AddFriendForm(ToxId _ownId);
+    AddFriendForm(ToxId ownId_, Settings&);
     AddFriendForm(const AddFriendForm&) = delete;
     AddFriendForm& operator=(const AddFriendForm&) = delete;
     ~AddFriendForm();
@@ -113,4 +114,5 @@ private:
     QList<QString> contactsToImport;
 
     ToxId ownId;
+    Settings& settings;
 };

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -107,13 +107,15 @@ QString secondsToDHMS(quint32 duration)
 } // namespace
 
 ChatForm::ChatForm(Profile& profile, Friend* chatFriend, IChatLog& chatLog_,
-    IMessageDispatcher& messageDispatcher_, DocumentCache& documentCache_, SmileyPack& smileyPack_)
+    IMessageDispatcher& messageDispatcher_, DocumentCache& documentCache_,
+    SmileyPack& smileyPack_, CameraSource& cameraSource_)
     : GenericChatForm(profile.getCore(), chatFriend, chatLog_, messageDispatcher_,
         documentCache_, smileyPack_)
     , core{profile.getCore()}
     , f(chatFriend)
     , isTyping{false}
     , lastCallIsVideo{false}
+    , cameraSource{cameraSource_}
 {
     setName(f->getDisplayedName());
 
@@ -509,7 +511,7 @@ std::unique_ptr<NetCamView> ChatForm::createNetcam()
 {
     qDebug() << "creating netcam";
     uint32_t friendId = f->getId();
-    std::unique_ptr<NetCamView> view = std::unique_ptr<NetCamView>(new NetCamView(f->getPublicKey(), this));
+    std::unique_ptr<NetCamView> view = std::unique_ptr<NetCamView>(new NetCamView(f->getPublicKey(), cameraSource, this));
     CoreAV* av = core.getAv();
     VideoSource* source = av->getVideoSourceFromCall(friendId);
     view->show(source, f->getDisplayedName());

--- a/src/widget/form/chatform.h
+++ b/src/widget/form/chatform.h
@@ -50,7 +50,8 @@ class ChatForm : public GenericChatForm
     Q_OBJECT
 public:
     ChatForm(Profile& profile, Friend* chatFriend, IChatLog& chatLog_,
-        IMessageDispatcher& messageDispatcher_, DocumentCache&, SmileyPack&);
+        IMessageDispatcher& messageDispatcher_, DocumentCache&, SmileyPack&,
+        CameraSource&);
     ~ChatForm() override;
     void setStatusMessage(const QString& newMessage);
 
@@ -141,4 +142,5 @@ private:
     bool isTyping;
     bool lastCallIsVideo;
     std::unique_ptr<NetCamView> netcam;
+    CameraSource& cameraSource;
 };

--- a/src/widget/form/chatform.h
+++ b/src/widget/form/chatform.h
@@ -44,6 +44,7 @@ class QMoveEvent;
 class ImagePreviewButton;
 class DocumentCache;
 class SmileyPack;
+class Settings;
 
 class ChatForm : public GenericChatForm
 {
@@ -51,7 +52,7 @@ class ChatForm : public GenericChatForm
 public:
     ChatForm(Profile& profile, Friend* chatFriend, IChatLog& chatLog_,
         IMessageDispatcher& messageDispatcher_, DocumentCache&, SmileyPack&,
-        CameraSource&);
+        CameraSource&, Settings&);
     ~ChatForm() override;
     void setStatusMessage(const QString& newMessage);
 
@@ -143,4 +144,5 @@ private:
     bool lastCallIsVideo;
     std::unique_ptr<NetCamView> netcam;
     CameraSource& cameraSource;
+    Settings& settings;
 };

--- a/src/widget/form/filesform.cpp
+++ b/src/widget/form/filesform.cpp
@@ -324,8 +324,9 @@ namespace FileTransferList
         return true;
     }
 
-    Delegate::Delegate(QWidget* parent)
+    Delegate::Delegate(Settings& settings_, QWidget* parent)
         : QStyledItemDelegate(parent)
+        , settings{settings_}
     {}
 
     void Delegate::paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const
@@ -358,11 +359,11 @@ namespace FileTransferList
                 }
                 const auto localPaused = data.toBool();
                 QPixmap pausePixmap = localPaused
-                    ? QPixmap(Style::getImagePath("fileTransferInstance/arrow_black.svg"))
-                    : QPixmap(Style::getImagePath("fileTransferInstance/pause_dark.svg"));
+                    ? QPixmap(Style::getImagePath("fileTransferInstance/arrow_black.svg", settings))
+                    : QPixmap(Style::getImagePath("fileTransferInstance/pause_dark.svg", settings));
                 QApplication::style()->drawItemPixmap(painter, pauseRect(option), Qt::AlignCenter, pausePixmap);
 
-                QPixmap stopPixmap(Style::getImagePath("fileTransferInstance/no_dark.svg"));
+                QPixmap stopPixmap(Style::getImagePath("fileTransferInstance/no_dark.svg", settings));
                 QApplication::style()->drawItemPixmap(painter, stopRect(option), Qt::AlignCenter, stopPixmap);
                 return;
             }
@@ -401,7 +402,7 @@ namespace FileTransferList
     }
 
 
-    View::View(QAbstractItemModel* model, QWidget* parent)
+    View::View(QAbstractItemModel* model, Settings& settings, QWidget* parent)
         : QTableView(parent)
     {
         setModel(model);
@@ -416,14 +417,14 @@ namespace FileTransferList
         setShowGrid(false);
         setSelectionBehavior(QAbstractItemView::SelectRows);
         setSelectionMode(QAbstractItemView::SingleSelection);
-        setItemDelegate(new Delegate(this));
+        setItemDelegate(new Delegate(settings, this));
     }
 
     View::~View() = default;
 
 } // namespace FileTransferList
 
-FilesForm::FilesForm(CoreFile& coreFile)
+FilesForm::FilesForm(CoreFile& coreFile, Settings& settings)
     : QObject()
 {
     head = new QWidget();
@@ -453,8 +454,8 @@ FilesForm::FilesForm(CoreFile& coreFile)
     connect(sentModel, &FileTransferList::Model::togglePause, pauseFile);
     connect(sentModel, &FileTransferList::Model::cancel, cancelFileSend);
 
-    recvd = new FileTransferList::View(recvdModel);
-    sent = new FileTransferList::View(sentModel);
+    recvd = new FileTransferList::View(recvdModel, settings);
+    sent = new FileTransferList::View(sentModel, settings);
 
     main.addTab(recvd, QString());
     main.addTab(sent, QString());

--- a/src/widget/form/filesform.h
+++ b/src/widget/form/filesform.h
@@ -34,6 +34,7 @@
 
 class ContentLayout;
 class QTableView;
+class Settings;
 
 namespace FileTransferList
 {
@@ -88,16 +89,18 @@ namespace FileTransferList
     class Delegate : public QStyledItemDelegate
     {
     public:
-        Delegate(QWidget* parent = nullptr);
+        Delegate(Settings&, QWidget* parent = nullptr);
         void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const override;
 
         bool editorEvent(QEvent* event, QAbstractItemModel* model, const QStyleOptionViewItem& option, const QModelIndex& index) override;
+    private:
+        Settings& settings;
     };
 
     class View : public QTableView
     {
     public:
-        View(QAbstractItemModel* model, QWidget* parent = nullptr);
+        View(QAbstractItemModel* model, Settings&, QWidget* parent = nullptr);
         ~View();
 
     };
@@ -108,7 +111,7 @@ class FilesForm : public QObject
     Q_OBJECT
 
 public:
-    FilesForm(CoreFile& coreFile);
+    FilesForm(CoreFile& coreFile, Settings&);
     ~FilesForm();
 
     bool isShown() const;

--- a/src/widget/form/genericchatform.h
+++ b/src/widget/form/genericchatform.h
@@ -55,6 +55,7 @@ class IMessageDispatcher;
 struct Message;
 class DocumentCache;
 class SmileyPack;
+class Settings;
 
 namespace Ui {
 class MainWindow;
@@ -72,7 +73,7 @@ class GenericChatForm : public QWidget
 public:
     GenericChatForm(const Core& core_, const Contact* contact, IChatLog& chatLog_,
                     IMessageDispatcher& messageDispatcher_, DocumentCache&,
-                    SmileyPack&, QWidget* parent_ = nullptr);
+                    SmileyPack&, Settings&, QWidget* parent_ = nullptr);
     ~GenericChatForm() override;
 
     void setName(const QString& newName);
@@ -169,4 +170,5 @@ protected:
     IChatLog& chatLog;
     IMessageDispatcher& messageDispatcher;
     SmileyPack& smileyPack;
+    Settings& settings;
 };

--- a/src/widget/form/groupchatform.cpp
+++ b/src/widget/form/groupchatform.cpp
@@ -37,6 +37,7 @@
 #include "src/widget/tool/croppinglabel.h"
 #include "src/widget/translator.h"
 #include "src/persistence/igroupsettings.h"
+#include "src/persistence/settings.h"
 
 #include <QDragEnterEvent>
 #include <QMimeData>
@@ -83,9 +84,9 @@ QString editName(const QString& name)
  */
 
 GroupChatForm::GroupChatForm(Core& core_, Group* chatGroup, IChatLog& chatLog_,
-    IMessageDispatcher& messageDispatcher_, IGroupSettings& settings_, DocumentCache& documentCache_,
+    IMessageDispatcher& messageDispatcher_, Settings& settings_, DocumentCache& documentCache_,
         SmileyPack& smileyPack_)
-    : GenericChatForm(core_, chatGroup, chatLog_, messageDispatcher_, documentCache_, smileyPack_)
+    : GenericChatForm(core_, chatGroup, chatLog_, messageDispatcher_, documentCache_, smileyPack_, settings_)
     , core{core_}
     , group(chatGroup)
     , inCall(false)
@@ -216,7 +217,7 @@ void GroupChatForm::updateUserNames()
             label->setProperty("peerType", LABEL_PEER_TYPE_MUTED);
         }
 
-        label->setStyleSheet(Style::getStylesheet(PEER_LABEL_STYLE_SHEET_PATH));
+        label->setStyleSheet(Style::getStylesheet(PEER_LABEL_STYLE_SHEET_PATH, settings));
         peerLabels.insert(peerPk, label);
     }
 
@@ -285,7 +286,7 @@ void GroupChatForm::peerAudioPlaying(ToxPk peerPk)
         });
     }
 
-    peerLabels[peerPk]->setStyleSheet(Style::getStylesheet(PEER_LABEL_STYLE_SHEET_PATH));
+    peerLabels[peerPk]->setStyleSheet(Style::getStylesheet(PEER_LABEL_STYLE_SHEET_PATH, settings));
     peerAudioTimers[peerPk]->start(500);
 }
 
@@ -433,7 +434,7 @@ void GroupChatForm::onLabelContextMenuRequested(const QPoint& localPos)
     } else {
         toggleMuteAction = contextMenu->addAction(muteString);
     }
-    contextMenu->setStyleSheet(Style::getStylesheet(PEER_LABEL_STYLE_SHEET_PATH));
+    contextMenu->setStyleSheet(Style::getStylesheet(PEER_LABEL_STYLE_SHEET_PATH, settings));
 
     const QAction* selectedItem = contextMenu->exec(pos);
     if (selectedItem == toggleMuteAction) {

--- a/src/widget/form/groupchatform.h
+++ b/src/widget/form/groupchatform.h
@@ -21,6 +21,7 @@
 
 #include "genericchatform.h"
 #include "src/core/toxpk.h"
+#include "src/persistence/igroupsettings.h"
 #include <QMap>
 
 namespace Ui {
@@ -34,7 +35,6 @@ class GroupId;
 class IMessageDispatcher;
 struct Message;
 class Settings;
-class IGroupSettings;
 class DocumentCache;
 class SmileyPack;
 
@@ -43,7 +43,7 @@ class GroupChatForm : public GenericChatForm
     Q_OBJECT
 public:
     GroupChatForm(Core& core_, Group* chatGroup, IChatLog& chatLog_,
-        IMessageDispatcher& messageDispatcher_, IGroupSettings& settings_,
+        IMessageDispatcher& messageDispatcher_, Settings& settings_,
         DocumentCache&, SmileyPack&);
     ~GroupChatForm();
 
@@ -84,5 +84,5 @@ private:
     QLabel* nusersLabel;
     TabCompleter* tabber;
     bool inCall;
-    IGroupSettings& settings;
+    Settings& settings;
 };

--- a/src/widget/form/groupinviteform.cpp
+++ b/src/widget/form/groupinviteform.cpp
@@ -45,12 +45,13 @@
  * @brief This form contains all group invites you received
  */
 
-GroupInviteForm::GroupInviteForm()
+GroupInviteForm::GroupInviteForm(Settings& settings_)
     : headWidget(new QWidget(this))
     , headLabel(new QLabel(this))
     , createButton(new QPushButton(this))
     , inviteBox(new QGroupBox(this))
     , scroll(new QScrollArea(this))
+    , settings{settings_}
 {
     QVBoxLayout* layout = new QVBoxLayout(this);
     connect(createButton, &QPushButton::clicked,
@@ -123,7 +124,7 @@ bool GroupInviteForm::addGroupInvite(const GroupInvite& inviteInfo)
         }
     }
 
-    GroupInviteWidget* widget = new GroupInviteWidget(this, inviteInfo);
+    GroupInviteWidget* widget = new GroupInviteWidget(this, inviteInfo, settings);
     scroll->widget()->layout()->addWidget(widget);
     invites.append(widget);
     connect(widget, &GroupInviteWidget::accepted, [this] (const GroupInvite& inviteInfo_) {

--- a/src/widget/form/groupinviteform.h
+++ b/src/widget/form/groupinviteform.h
@@ -32,6 +32,7 @@ class QLabel;
 class QPushButton;
 class QScrollArea;
 class QSignalMapper;
+class Settings;
 
 namespace Ui {
 class MainWindow;
@@ -41,7 +42,7 @@ class GroupInviteForm : public QWidget
 {
     Q_OBJECT
 public:
-    GroupInviteForm();
+    explicit GroupInviteForm(Settings&);
     ~GroupInviteForm();
 
     void show(ContentLayout* contentLayout);
@@ -67,4 +68,5 @@ private:
     QGroupBox* inviteBox;
     QList<GroupInviteWidget*> invites;
     QScrollArea* scroll;
+    Settings& settings;
 };

--- a/src/widget/form/groupinvitewidget.cpp
+++ b/src/widget/form/groupinvitewidget.cpp
@@ -35,13 +35,14 @@
  * and provides buttons to accept/reject it
  */
 
-GroupInviteWidget::GroupInviteWidget(QWidget* parent, const GroupInvite& invite)
+GroupInviteWidget::GroupInviteWidget(QWidget* parent, const GroupInvite& invite, Settings& settings_)
     : QWidget(parent)
     , acceptButton(new QPushButton(this))
     , rejectButton(new QPushButton(this))
     , inviteMessageLabel(new CroppingLabel(this))
     , widgetLayout(new QHBoxLayout(this))
     , inviteInfo(invite)
+    , settings{settings_}
 {
     connect(acceptButton, &QPushButton::clicked, [=]() { emit accepted(inviteInfo); });
     connect(rejectButton, &QPushButton::clicked, [=]() { emit rejected(inviteInfo); });
@@ -59,8 +60,8 @@ void GroupInviteWidget::retranslateUi()
 {
     QString name = Nexus::getCore()->getFriendUsername(inviteInfo.getFriendId());
     QDateTime inviteDate = inviteInfo.getInviteDate();
-    QString date = inviteDate.toString(Settings::getInstance().getDateFormat());
-    QString time = inviteDate.toString(Settings::getInstance().getTimestampFormat());
+    QString date = inviteDate.toString(settings.getDateFormat());
+    QString time = inviteDate.toString(settings.getTimestampFormat());
 
     inviteMessageLabel->setText(
         tr("Invited by %1 on %2 at %3.").arg("<b>%1</b>").arg(name.toHtmlEscaped(), date, time));

--- a/src/widget/form/groupinvitewidget.h
+++ b/src/widget/form/groupinvitewidget.h
@@ -27,12 +27,13 @@ class CroppingLabel;
 
 class QHBoxLayout;
 class QPushButton;
+class Settings;
 
 class GroupInviteWidget : public QWidget
 {
     Q_OBJECT
 public:
-    GroupInviteWidget(QWidget* parent, const GroupInvite& invite);
+    GroupInviteWidget(QWidget* parent, const GroupInvite& invite, Settings&);
     void retranslateUi();
     const GroupInvite getInviteInfo() const;
 
@@ -46,4 +47,5 @@ private:
     CroppingLabel* inviteMessageLabel;
     QHBoxLayout* widgetLayout;
     GroupInvite inviteInfo;
+    Settings& settings;
 };

--- a/src/widget/form/profileform.cpp
+++ b/src/widget/form/profileform.cpp
@@ -99,10 +99,12 @@ const QPair<QString, QString> CAN_NOT_CHANGE_PASSWORD = {
 };
 } // namespace
 
-ProfileForm::ProfileForm(IProfileInfo* profileInfo_, QWidget* parent)
+ProfileForm::ProfileForm(IProfileInfo* profileInfo_, Settings& settings_,
+    QWidget* parent)
     : QWidget{parent}
     , qr{nullptr}
     , profileInfo{profileInfo_}
+    , settings{settings_}
 {
     bodyUI = new Ui::IdentitySettings;
     bodyUI->setupUi(this);
@@ -131,7 +133,7 @@ ProfileForm::ProfileForm(IProfileInfo* profileInfo_, QWidget* parent)
     profilePicture->installEventFilter(this);
     profilePicture->setAccessibleName("Profile avatar");
     profilePicture->setAccessibleDescription("Set a profile avatar shown to all contacts");
-    profilePicture->setStyleSheet(Style::getStylesheet("window/profile.css"));
+    profilePicture->setStyleSheet(Style::getStylesheet("window/profile.css", settings));
     connect(profilePicture, &MaskablePixmapWidget::clicked, this, &ProfileForm::onAvatarClicked);
     connect(profilePicture, &MaskablePixmapWidget::customContextMenuRequested,
             this, &ProfileForm::showProfilePictureContextMenu);
@@ -212,8 +214,8 @@ void ProfileForm::show(ContentLayout* contentLayout)
     contentLayout->mainContent->layout()->addWidget(this);
     QWidget::show();
     prFileLabelUpdate();
-    bool portable = Settings::getInstance().getMakeToxPortable();
-    QString defaultPath = QDir(Settings::getInstance().getPaths().getSettingsDirPath()).path().trimmed();
+    bool portable = settings.getMakeToxPortable();
+    QString defaultPath = QDir(settings.getPaths().getSettingsDirPath()).path().trimmed();
     QString appPath = QApplication::applicationDirPath();
     QString dirPath = portable ? appPath : defaultPath;
 

--- a/src/widget/form/profileform.h
+++ b/src/widget/form/profileform.h
@@ -29,6 +29,7 @@ class ContentLayout;
 class CroppingLabel;
 class IProfileInfo;
 class MaskablePixmapWidget;
+class Settings;
 
 namespace Ui {
 class IdentitySettings;
@@ -52,7 +53,7 @@ class ProfileForm : public QWidget
 {
     Q_OBJECT
 public:
-    ProfileForm(IProfileInfo* profileInfo_, QWidget* parent = nullptr);
+    ProfileForm(IProfileInfo* profileInfo_, Settings&, QWidget* parent = nullptr);
     ~ProfileForm();
     void show(ContentLayout* contentLayout);
     bool isShown() const;
@@ -92,4 +93,5 @@ private:
     QRWidget* qr;
     ClickableTE* toxId;
     IProfileInfo* profileInfo;
+    Settings& settings;
 };

--- a/src/widget/form/searchsettingsform.cpp
+++ b/src/widget/form/searchsettingsform.cpp
@@ -23,9 +23,10 @@
 #include "src/widget/style.h"
 #include "src/widget/form/loadhistorydialog.h"
 
-SearchSettingsForm::SearchSettingsForm(QWidget *parent) :
-    QWidget(parent),
-    ui(new Ui::SearchSettingsForm)
+SearchSettingsForm::SearchSettingsForm(Settings& settings_, QWidget *parent)
+    : QWidget(parent)
+    , ui(new Ui::SearchSettingsForm)
+    , settings{settings_}
 {
     ui->setupUi(this);
 
@@ -99,13 +100,13 @@ ParameterSearch SearchSettingsForm::getParameterSearch()
 
 void SearchSettingsForm::reloadTheme()
 {
-    ui->choiceDateButton->setStyleSheet(Style::getStylesheet(QStringLiteral("chatForm/buttons.css")));
-    ui->startDateLabel->setStyleSheet(Style::getStylesheet(QStringLiteral("chatForm/labels.css")));
+    ui->choiceDateButton->setStyleSheet(Style::getStylesheet(QStringLiteral("chatForm/buttons.css"), settings));
+    ui->startDateLabel->setStyleSheet(Style::getStylesheet(QStringLiteral("chatForm/labels.css"), settings));
 }
 
 void SearchSettingsForm::updateStartDateLabel()
 {
-    ui->startDateLabel->setText(startDate.toString(Settings::getInstance().getDateFormat()));
+    ui->startDateLabel->setText(startDate.toString(settings.getDateFormat()));
 }
 
 void SearchSettingsForm::setUpdate(const bool isUpdate_)
@@ -121,7 +122,7 @@ void SearchSettingsForm::onStartSearchSelected(const int index)
         ui->startDateLabel->setEnabled(true);
 
         ui->choiceDateButton->setProperty("state", QStringLiteral("green"));
-        ui->choiceDateButton->setStyleSheet(Style::getStylesheet(QStringLiteral("chatForm/buttons.css")));
+        ui->choiceDateButton->setStyleSheet(Style::getStylesheet(QStringLiteral("chatForm/buttons.css"), settings));
 
         if (startDate.isNull()) {
             startDate = QDate::currentDate();
@@ -133,7 +134,7 @@ void SearchSettingsForm::onStartSearchSelected(const int index)
         ui->startDateLabel->setEnabled(false);
 
         ui->choiceDateButton->setProperty("state", QString());
-        ui->choiceDateButton->setStyleSheet(Style::getStylesheet(QStringLiteral("chatForm/buttons.css")));
+        ui->choiceDateButton->setStyleSheet(Style::getStylesheet(QStringLiteral("chatForm/buttons.css"), settings));
     }
 
     setUpdate(true);

--- a/src/widget/form/searchsettingsform.h
+++ b/src/widget/form/searchsettingsform.h
@@ -25,13 +25,14 @@
 namespace Ui {
 class SearchSettingsForm;
 }
+class Settings;
 
 class SearchSettingsForm : public QWidget
 {
     Q_OBJECT
 
 public:
-    explicit SearchSettingsForm(QWidget *parent = nullptr);
+    explicit SearchSettingsForm(Settings&, QWidget *parent = nullptr);
     ~SearchSettingsForm();
 
     ParameterSearch getParameterSearch();
@@ -41,6 +42,7 @@ private:
     Ui::SearchSettingsForm *ui;
     QDate startDate;
     bool isUpdate{false};
+    Settings& settings;
 
     void updateStartDateLabel();
     void setUpdate(const bool isUpdate_);

--- a/src/widget/form/settings/advancedform.cpp
+++ b/src/widget/form/settings/advancedform.cpp
@@ -41,30 +41,30 @@
  * Is also contains "Reset settings" button and "Make portable" checkbox.
  */
 
-AdvancedForm::AdvancedForm()
+AdvancedForm::AdvancedForm(Settings& settings_)
     : GenericForm(QPixmap(":/img/settings/general.png"))
     , bodyUI(new Ui::AdvancedSettings)
+    , settings{settings_}
 {
     bodyUI->setupUi(this);
 
     // block all child signals during initialization
     const RecursiveSignalBlocker signalBlocker(this);
 
-    Settings& s = Settings::getInstance();
-    bodyUI->cbEnableIPv6->setChecked(s.getEnableIPv6());
-    bodyUI->cbMakeToxPortable->setChecked(Settings::getInstance().getMakeToxPortable());
-    bodyUI->proxyAddr->setText(s.getProxyAddr());
-    quint16 port = s.getProxyPort();
+    bodyUI->cbEnableIPv6->setChecked(settings.getEnableIPv6());
+    bodyUI->cbMakeToxPortable->setChecked(settings.getMakeToxPortable());
+    bodyUI->proxyAddr->setText(settings.getProxyAddr());
+    quint16 port = settings.getProxyPort();
     if (port > 0) {
         bodyUI->proxyPort->setValue(port);
     }
 
-    int index = static_cast<int>(s.getProxyType());
+    int index = static_cast<int>(settings.getProxyType());
     bodyUI->proxyType->setCurrentIndex(index);
     on_proxyType_currentIndexChanged(index);
-    const bool udpEnabled = !s.getForceTCP() && (s.getProxyType() == Settings::ProxyType::ptNone);
+    const bool udpEnabled = !settings.getForceTCP() && (settings.getProxyType() == Settings::ProxyType::ptNone);
     bodyUI->cbEnableUDP->setChecked(udpEnabled);
-    bodyUI->cbEnableLanDiscovery->setChecked(s.getEnableLanDiscovery() && udpEnabled);
+    bodyUI->cbEnableLanDiscovery->setChecked(settings.getEnableLanDiscovery() && udpEnabled);
     bodyUI->cbEnableLanDiscovery->setEnabled(udpEnabled);
 
     QString warningBody = tr("Unless you %1 know what you are doing, "
@@ -95,7 +95,7 @@ AdvancedForm::~AdvancedForm()
 
 void AdvancedForm::on_cbMakeToxPortable_stateChanged()
 {
-    Settings::getInstance().setMakeToxPortable(bodyUI->cbMakeToxPortable->isChecked());
+    settings.setMakeToxPortable(bodyUI->cbMakeToxPortable->isChecked());
 }
 void AdvancedForm::on_btnExportLog_clicked()
 {
@@ -107,7 +107,7 @@ void AdvancedForm::on_btnExportLog_clicked()
         return;
     }
 
-    QString logFileDir = Settings::getInstance().getPaths().getAppCacheDirPath();
+    QString logFileDir = settings.getPaths().getAppCacheDirPath();
     QString logfile = logFileDir + "qtox.log";
 
     QFile file(logfile);
@@ -126,7 +126,7 @@ void AdvancedForm::on_btnExportLog_clicked()
 
 void AdvancedForm::on_btnCopyDebug_clicked()
 {
-    QString logFileDir = Settings::getInstance().getPaths().getAppCacheDirPath();
+    QString logFileDir = settings.getPaths().getAppCacheDirPath();
     QString logfile = logFileDir + "qtox.log";
 
     QFile file(logfile);
@@ -163,32 +163,32 @@ void AdvancedForm::on_resetButton_clicked()
     if (!result)
         return;
 
-    Settings::getInstance().resetToDefault();
+    settings.resetToDefault();
     GUI::showInfo(titile, "Changes will take effect after restart");
 }
 
 void AdvancedForm::on_cbEnableIPv6_stateChanged()
 {
-    Settings::getInstance().setEnableIPv6(bodyUI->cbEnableIPv6->isChecked());
+    settings.setEnableIPv6(bodyUI->cbEnableIPv6->isChecked());
 }
 
 void AdvancedForm::on_cbEnableUDP_stateChanged()
 {
     const bool enableUdp = bodyUI->cbEnableUDP->isChecked();
-    Settings::getInstance().setForceTCP(!enableUdp);
-    const bool enableLanDiscovery = Settings::getInstance().getEnableLanDiscovery();
+    settings.setForceTCP(!enableUdp);
+    const bool enableLanDiscovery = settings.getEnableLanDiscovery();
     bodyUI->cbEnableLanDiscovery->setEnabled(enableUdp);
     bodyUI->cbEnableLanDiscovery->setChecked(enableUdp && enableLanDiscovery);
 }
 
 void AdvancedForm::on_cbEnableLanDiscovery_stateChanged()
 {
-    Settings::getInstance().setEnableLanDiscovery(bodyUI->cbEnableLanDiscovery->isChecked());
+    settings.setEnableLanDiscovery(bodyUI->cbEnableLanDiscovery->isChecked());
 }
 
 void AdvancedForm::on_proxyAddr_editingFinished()
 {
-    Settings::getInstance().setProxyAddr(bodyUI->proxyAddr->text());
+    settings.setProxyAddr(bodyUI->proxyAddr->text());
 }
 
 void AdvancedForm::on_proxyPort_valueChanged(int port)
@@ -197,7 +197,7 @@ void AdvancedForm::on_proxyPort_valueChanged(int port)
         port = 0;
     }
 
-    Settings::getInstance().setProxyPort(port);
+    settings.setProxyPort(port);
 }
 
 void AdvancedForm::on_proxyType_currentIndexChanged(int index)
@@ -211,7 +211,7 @@ void AdvancedForm::on_proxyType_currentIndexChanged(int index)
     bodyUI->cbEnableUDP->setEnabled(!proxyEnabled);
     bodyUI->cbEnableUDP->setChecked(!proxyEnabled);
 
-    Settings::getInstance().setProxyType(proxytype);
+    settings.setProxyType(proxytype);
 }
 
 /**

--- a/src/widget/form/settings/advancedform.h
+++ b/src/widget/form/settings/advancedform.h
@@ -22,6 +22,7 @@
 #include "genericsettings.h"
 
 class Core;
+class Settings;
 
 namespace Ui {
 class AdvancedSettings;
@@ -31,7 +32,7 @@ class AdvancedForm : public GenericForm
 {
     Q_OBJECT
 public:
-    AdvancedForm();
+    explicit AdvancedForm(Settings&);
     ~AdvancedForm();
     QString getFormName() final
     {
@@ -58,4 +59,5 @@ private:
 
 private:
     Ui::AdvancedSettings* bodyUI;
+    Settings& settings;
 };

--- a/src/widget/form/settings/generalform.cpp
+++ b/src/widget/form/settings/generalform.cpp
@@ -96,9 +96,10 @@ QStringList locales = {
  *
  * This form contains all settings that are not suited to other forms
  */
-GeneralForm::GeneralForm(SettingsWidget* myParent)
+GeneralForm::GeneralForm(SettingsWidget* myParent, Settings& settings_)
     : GenericForm(QPixmap(":/img/settings/general.png"))
     , bodyUI(new Ui::GeneralSettings)
+    , settings{settings_}
 {
     parent = myParent;
 
@@ -106,8 +107,6 @@ GeneralForm::GeneralForm(SettingsWidget* myParent)
 
     // block all child signals during initialization
     const RecursiveSignalBlocker signalBlocker(this);
-
-    Settings& s = Settings::getInstance();
 
 #ifndef UPDATE_CHECK_ENABLED
     bodyUI->checkUpdates->setVisible(false);
@@ -117,7 +116,7 @@ GeneralForm::GeneralForm(SettingsWidget* myParent)
     bodyUI->cbSpellChecking->setVisible(false);
 #endif
 
-    bodyUI->checkUpdates->setChecked(s.getCheckUpdates());
+    bodyUI->checkUpdates->setChecked(settings.getCheckUpdates());
 
     for (int i = 0; i < locales.size(); ++i) {
         QString langName;
@@ -136,29 +135,29 @@ GeneralForm::GeneralForm(SettingsWidget* myParent)
         bodyUI->transComboBox->insertItem(i, langName);
     }
 
-    bodyUI->transComboBox->setCurrentIndex(locales.indexOf(s.getTranslation()));
+    bodyUI->transComboBox->setCurrentIndex(locales.indexOf(settings.getTranslation()));
 
-    bodyUI->cbAutorun->setChecked(s.getAutorun());
+    bodyUI->cbAutorun->setChecked(settings.getAutorun());
 
-    bodyUI->cbSpellChecking->setChecked(s.getSpellCheckingEnabled());
-    bodyUI->lightTrayIcon->setChecked(s.getLightTrayIcon());
-    bool showSystemTray = s.getShowSystemTray();
+    bodyUI->cbSpellChecking->setChecked(settings.getSpellCheckingEnabled());
+    bodyUI->lightTrayIcon->setChecked(settings.getLightTrayIcon());
+    bool showSystemTray = settings.getShowSystemTray();
 
     bodyUI->showSystemTray->setChecked(showSystemTray);
-    bodyUI->startInTray->setChecked(s.getAutostartInTray());
+    bodyUI->startInTray->setChecked(settings.getAutostartInTray());
     bodyUI->startInTray->setEnabled(showSystemTray);
-    bodyUI->minimizeToTray->setChecked(s.getMinimizeToTray());
+    bodyUI->minimizeToTray->setChecked(settings.getMinimizeToTray());
     bodyUI->minimizeToTray->setEnabled(showSystemTray);
-    bodyUI->closeToTray->setChecked(s.getCloseToTray());
+    bodyUI->closeToTray->setChecked(settings.getCloseToTray());
     bodyUI->closeToTray->setEnabled(showSystemTray);
 
-    bodyUI->statusChanges->setChecked(s.getStatusChangeNotificationEnabled());
-    bodyUI->groupJoinLeaveMessages->setChecked(s.getShowGroupJoinLeaveMessages());
+    bodyUI->statusChanges->setChecked(settings.getStatusChangeNotificationEnabled());
+    bodyUI->groupJoinLeaveMessages->setChecked(settings.getShowGroupJoinLeaveMessages());
 
-    bodyUI->autoAwaySpinBox->setValue(s.getAutoAwayTime());
-    bodyUI->autoSaveFilesDir->setText(s.getGlobalAutoAcceptDir());
-    bodyUI->maxAutoAcceptSizeMB->setValue(static_cast<double>(s.getMaxAutoAcceptSize()) / 1024 / 1024);
-    bodyUI->autoacceptFiles->setChecked(s.getAutoSaveEnabled());
+    bodyUI->autoAwaySpinBox->setValue(settings.getAutoAwayTime());
+    bodyUI->autoSaveFilesDir->setText(settings.getGlobalAutoAcceptDir());
+    bodyUI->maxAutoAcceptSizeMB->setValue(static_cast<double>(settings.getMaxAutoAcceptSize()) / 1024 / 1024);
+    bodyUI->autoacceptFiles->setChecked(settings.getAutoSaveEnabled());
 
 
 #ifndef QTOX_PLATFORM_EXT
@@ -179,71 +178,71 @@ GeneralForm::~GeneralForm()
 void GeneralForm::on_transComboBox_currentIndexChanged(int index)
 {
     const QString& locale = locales[index];
-    Settings::getInstance().setTranslation(locale);
+    settings.setTranslation(locale);
     Translator::translate(locale);
 }
 
 void GeneralForm::on_cbAutorun_stateChanged()
 {
-    Settings::getInstance().setAutorun(bodyUI->cbAutorun->isChecked());
+    settings.setAutorun(bodyUI->cbAutorun->isChecked());
 }
 
 void GeneralForm::on_cbSpellChecking_stateChanged()
 {
-    Settings::getInstance().setSpellCheckingEnabled(bodyUI->cbSpellChecking->isChecked());
+    settings.setSpellCheckingEnabled(bodyUI->cbSpellChecking->isChecked());
 }
 
 void GeneralForm::on_showSystemTray_stateChanged()
 {
-    Settings::getInstance().setShowSystemTray(bodyUI->showSystemTray->isChecked());
-    Settings::getInstance().saveGlobal();
+    settings.setShowSystemTray(bodyUI->showSystemTray->isChecked());
+    settings.saveGlobal();
 }
 
 void GeneralForm::on_startInTray_stateChanged()
 {
-    Settings::getInstance().setAutostartInTray(bodyUI->startInTray->isChecked());
+    settings.setAutostartInTray(bodyUI->startInTray->isChecked());
 }
 
 void GeneralForm::on_closeToTray_stateChanged()
 {
-    Settings::getInstance().setCloseToTray(bodyUI->closeToTray->isChecked());
+    settings.setCloseToTray(bodyUI->closeToTray->isChecked());
 }
 
 void GeneralForm::on_lightTrayIcon_stateChanged()
 {
-    Settings::getInstance().setLightTrayIcon(bodyUI->lightTrayIcon->isChecked());
+    settings.setLightTrayIcon(bodyUI->lightTrayIcon->isChecked());
     emit updateIcons();
 }
 
 void GeneralForm::on_minimizeToTray_stateChanged()
 {
-    Settings::getInstance().setMinimizeToTray(bodyUI->minimizeToTray->isChecked());
+    settings.setMinimizeToTray(bodyUI->minimizeToTray->isChecked());
 }
 
 void GeneralForm::on_statusChanges_stateChanged()
 {
-    Settings::getInstance().setStatusChangeNotificationEnabled(bodyUI->statusChanges->isChecked());
+    settings.setStatusChangeNotificationEnabled(bodyUI->statusChanges->isChecked());
 }
 
 void GeneralForm::on_groupJoinLeaveMessages_stateChanged()
 {
-    Settings::getInstance().setShowGroupJoinLeaveMessages(bodyUI->groupJoinLeaveMessages->isChecked());
+    settings.setShowGroupJoinLeaveMessages(bodyUI->groupJoinLeaveMessages->isChecked());
 }
 
 void GeneralForm::on_autoAwaySpinBox_editingFinished()
 {
     int minutes = bodyUI->autoAwaySpinBox->value();
-    Settings::getInstance().setAutoAwayTime(minutes);
+    settings.setAutoAwayTime(minutes);
 }
 
 void GeneralForm::on_autoacceptFiles_stateChanged()
 {
-    Settings::getInstance().setAutoSaveEnabled(bodyUI->autoacceptFiles->isChecked());
+    settings.setAutoSaveEnabled(bodyUI->autoacceptFiles->isChecked());
 }
 
 void GeneralForm::on_autoSaveFilesDir_clicked()
 {
-    QString previousDir = Settings::getInstance().getGlobalAutoAcceptDir();
+    QString previousDir = settings.getGlobalAutoAcceptDir();
     QString directory =
         QFileDialog::getExistingDirectory(Q_NULLPTR,
                                           tr("Choose an auto accept directory", "popup title"),
@@ -251,7 +250,7 @@ void GeneralForm::on_autoSaveFilesDir_clicked()
     if (directory.isEmpty()) // cancel was pressed
         directory = previousDir;
 
-    Settings::getInstance().setGlobalAutoAcceptDir(directory);
+    settings.setGlobalAutoAcceptDir(directory);
     bodyUI->autoSaveFilesDir->setText(directory);
 }
 
@@ -260,12 +259,12 @@ void GeneralForm::on_maxAutoAcceptSizeMB_editingFinished()
     auto newMaxSizeMB = bodyUI->maxAutoAcceptSizeMB->value();
     auto newMaxSizeB = std::lround(newMaxSizeMB * 1024 * 1024);
 
-    Settings::getInstance().setMaxAutoAcceptSize(newMaxSizeB);
+    settings.setMaxAutoAcceptSize(newMaxSizeB);
 }
 
 void GeneralForm::on_checkUpdates_stateChanged()
 {
-    Settings::getInstance().setCheckUpdates(bodyUI->checkUpdates->isChecked());
+    settings.setCheckUpdates(bodyUI->checkUpdates->isChecked());
 }
 
 /**

--- a/src/widget/form/settings/generalform.h
+++ b/src/widget/form/settings/generalform.h
@@ -26,12 +26,13 @@ class GeneralSettings;
 }
 
 class SettingsWidget;
+class Settings;
 
 class GeneralForm : public GenericForm
 {
     Q_OBJECT
 public:
-    explicit GeneralForm(SettingsWidget* parent);
+    explicit GeneralForm(SettingsWidget* parent, Settings&);
     ~GeneralForm();
     QString getFormName() final
     {
@@ -63,4 +64,5 @@ private:
 private:
     Ui::GeneralSettings* bodyUI;
     SettingsWidget* parent;
+    Settings& settings;
 };

--- a/src/widget/form/settings/privacyform.cpp
+++ b/src/widget/form/settings/privacyform.cpp
@@ -39,10 +39,11 @@
 #include <chrono>
 #include <random>
 
-PrivacyForm::PrivacyForm(Core* _core)
+PrivacyForm::PrivacyForm(Core* core_, Settings& settings_)
     : GenericForm(QPixmap(":/img/settings/privacy.png"))
     , bodyUI(new Ui::PrivacySettings)
-    , core{_core}
+    , core{core_}
+    , settings{settings_}
 {
     bodyUI->setupUi(this);
 
@@ -61,7 +62,7 @@ PrivacyForm::~PrivacyForm()
 
 void PrivacyForm::on_cbKeepHistory_stateChanged()
 {
-    Settings::getInstance().setEnableLogging(bodyUI->cbKeepHistory->isChecked());
+    settings.setEnableLogging(bodyUI->cbKeepHistory->isChecked());
     if (!bodyUI->cbKeepHistory->isChecked()) {
         emit clearAllReceipts();
         QMessageBox::StandardButton dialogDelHistory;
@@ -77,7 +78,7 @@ void PrivacyForm::on_cbKeepHistory_stateChanged()
 
 void PrivacyForm::on_cbTypingNotification_stateChanged()
 {
-    Settings::getInstance().setTypingNotification(bodyUI->cbTypingNotification->isChecked());
+    settings.setTypingNotification(bodyUI->cbTypingNotification->isChecked());
 }
 
 void PrivacyForm::on_nospamLineEdit_editingFinished()
@@ -93,10 +94,10 @@ void PrivacyForm::on_nospamLineEdit_editingFinished()
 
 void PrivacyForm::showEvent(QShowEvent*)
 {
-    const Settings& s = Settings::getInstance();
+    const Settings& s = settings;
     bodyUI->nospamLineEdit->setText(core->getSelfId().getNoSpamString());
     bodyUI->cbTypingNotification->setChecked(s.getTypingNotification());
-    bodyUI->cbKeepHistory->setChecked(Settings::getInstance().getEnableLogging());
+    bodyUI->cbKeepHistory->setChecked(settings.getEnableLogging());
     bodyUI->blackListTextEdit->setText(s.getBlackList().join('\n'));
 }
 
@@ -125,7 +126,7 @@ void PrivacyForm::on_nospamLineEdit_textChanged()
 void PrivacyForm::on_blackListTextEdit_textChanged()
 {
     const QStringList strlist = bodyUI->blackListTextEdit->toPlainText().split('\n');
-    Settings::getInstance().setBlackList(strlist);
+    settings.setBlackList(strlist);
 }
 
 void PrivacyForm::retranslateUi()

--- a/src/widget/form/settings/privacyform.h
+++ b/src/widget/form/settings/privacyform.h
@@ -22,6 +22,7 @@
 #include "genericsettings.h"
 
 class Core;
+class Settings;
 
 namespace Ui {
 class PrivacySettings;
@@ -31,7 +32,7 @@ class PrivacyForm : public GenericForm
 {
     Q_OBJECT
 public:
-    PrivacyForm(Core* _core);
+    PrivacyForm(Core* core_, Settings&);
     ~PrivacyForm();
     QString getFormName() final
     {
@@ -56,4 +57,5 @@ private:
 private:
     Ui::PrivacySettings* bodyUI;
     Core* core;
+    Settings& settings;
 };

--- a/src/widget/form/settings/userinterfaceform.cpp
+++ b/src/widget/form/settings/userinterfaceform.cpp
@@ -54,9 +54,11 @@
  *
  * Restores all controls from the settings.
  */
-UserInterfaceForm::UserInterfaceForm(SmileyPack& smileyPack_, SettingsWidget* myParent)
+UserInterfaceForm::UserInterfaceForm(SmileyPack& smileyPack_, Settings& settings_,
+    SettingsWidget* myParent)
     : GenericForm(QPixmap(":/img/settings/general.png"))
     , smileyPack{smileyPack_}
+    , settings{settings_}
 {
     parent = myParent;
 
@@ -66,46 +68,45 @@ UserInterfaceForm::UserInterfaceForm(SmileyPack& smileyPack_, SettingsWidget* my
     // block all child signals during initialization
     const RecursiveSignalBlocker signalBlocker(this);
 
-    Settings& s = Settings::getInstance();
-    const QFont chatBaseFont = s.getChatMessageFont();
+    const QFont chatBaseFont = settings.getChatMessageFont();
     bodyUI->txtChatFontSize->setValue(QFontInfo(chatBaseFont).pixelSize());
     bodyUI->txtChatFont->setCurrentFont(chatBaseFont);
-    int index = static_cast<int>(s.getStylePreference());
+    int index = static_cast<int>(settings.getStylePreference());
     bodyUI->textStyleComboBox->setCurrentIndex(index);
-    bodyUI->useNameColors->setChecked(s.getEnableGroupChatsColor());
+    bodyUI->useNameColors->setChecked(settings.getEnableGroupChatsColor());
 
-    bodyUI->notify->setChecked(s.getNotify());
+    bodyUI->notify->setChecked(settings.getNotify());
     // Note: UI is boolean inversed from settings to maintain setting file backwards compatibility
-    bodyUI->groupOnlyNotfiyWhenMentioned->setChecked(!s.getGroupAlwaysNotify());
-    bodyUI->groupOnlyNotfiyWhenMentioned->setEnabled(s.getNotify());
-    bodyUI->notifySound->setChecked(s.getNotifySound());
-    bodyUI->notifyHide->setChecked(s.getNotifyHide());
-    bodyUI->notifySound->setEnabled(s.getNotify());
-    bodyUI->busySound->setChecked(s.getBusySound());
-    bodyUI->busySound->setEnabled(s.getNotifySound() && s.getNotify());
+    bodyUI->groupOnlyNotfiyWhenMentioned->setChecked(!settings.getGroupAlwaysNotify());
+    bodyUI->groupOnlyNotfiyWhenMentioned->setEnabled(settings.getNotify());
+    bodyUI->notifySound->setChecked(settings.getNotifySound());
+    bodyUI->notifyHide->setChecked(settings.getNotifyHide());
+    bodyUI->notifySound->setEnabled(settings.getNotify());
+    bodyUI->busySound->setChecked(settings.getBusySound());
+    bodyUI->busySound->setEnabled(settings.getNotifySound() && settings.getNotify());
 #if DESKTOP_NOTIFICATIONS
-    bodyUI->desktopNotify->setChecked(s.getDesktopNotify());
-    bodyUI->desktopNotify->setEnabled(s.getNotify());
+    bodyUI->desktopNotify->setChecked(settings.getDesktopNotify());
+    bodyUI->desktopNotify->setEnabled(settings.getNotify());
 #else
     bodyUI->desktopNotify->hide();
 #endif
 
-    bodyUI->showWindow->setChecked(s.getShowWindow());
+    bodyUI->showWindow->setChecked(settings.getShowWindow());
 
-    bodyUI->cbGroupchatPosition->setChecked(s.getGroupchatPosition());
-    bodyUI->cbCompactLayout->setChecked(s.getCompactLayout());
-    bodyUI->cbSeparateWindow->setChecked(s.getSeparateWindow());
-    bodyUI->cbDontGroupWindows->setChecked(s.getDontGroupWindows());
-    bodyUI->cbDontGroupWindows->setEnabled(s.getSeparateWindow());
-    bodyUI->cbShowIdenticons->setChecked(s.getShowIdenticons());
+    bodyUI->cbGroupchatPosition->setChecked(settings.getGroupchatPosition());
+    bodyUI->cbCompactLayout->setChecked(settings.getCompactLayout());
+    bodyUI->cbSeparateWindow->setChecked(settings.getSeparateWindow());
+    bodyUI->cbDontGroupWindows->setChecked(settings.getDontGroupWindows());
+    bodyUI->cbDontGroupWindows->setEnabled(settings.getSeparateWindow());
+    bodyUI->cbShowIdenticons->setChecked(settings.getShowIdenticons());
 
-    bodyUI->useEmoticons->setChecked(s.getUseEmoticons());
+    bodyUI->useEmoticons->setChecked(settings.getUseEmoticons());
     for (auto entry : SmileyPack::listSmileyPacks())
         bodyUI->smileyPackBrowser->addItem(entry.first, entry.second);
 
     smileLabels = {bodyUI->smile1, bodyUI->smile2, bodyUI->smile3, bodyUI->smile4, bodyUI->smile5};
 
-    int currentPack = bodyUI->smileyPackBrowser->findData(s.getSmileyPack());
+    int currentPack = bodyUI->smileyPackBrowser->findData(settings.getSmileyPack());
     bodyUI->smileyPackBrowser->setCurrentIndex(currentPack);
     reloadSmileys();
     bodyUI->smileyPackBrowser->setEnabled(bodyUI->useEmoticons->isChecked());
@@ -114,8 +115,8 @@ UserInterfaceForm::UserInterfaceForm(SmileyPack& smileyPack_, SettingsWidget* my
     bodyUI->styleBrowser->addItems(QStyleFactory::keys());
 
     QString style;
-    if (QStyleFactory::keys().contains(s.getStyle()))
-        style = s.getStyle();
+    if (QStyleFactory::keys().contains(settings.getStyle()))
+        style = settings.getStyle();
     else
         style = tr("None");
 
@@ -124,8 +125,8 @@ UserInterfaceForm::UserInterfaceForm(SmileyPack& smileyPack_, SettingsWidget* my
     for (QString color : Style::getThemeColorNames())
         bodyUI->themeColorCBox->addItem(color);
 
-    bodyUI->themeColorCBox->setCurrentIndex(s.getThemeColor());
-    bodyUI->emoticonSize->setValue(s.getEmojiFontPointSize());
+    bodyUI->themeColorCBox->setCurrentIndex(settings.getThemeColor());
+    bodyUI->emoticonSize->setValue(settings.getEmojiFontPointSize());
 
     QLocale ql;
     QStringList timeFormats;
@@ -138,7 +139,7 @@ UserInterfaceForm::UserInterfaceForm(SmileyPack& smileyPack_, SettingsWidget* my
 
     QRegularExpression re(QString("^[^\\n]{0,%0}$").arg(MAX_FORMAT_LENGTH));
     QRegularExpressionValidator* validator = new QRegularExpressionValidator(re, this);
-    QString timeFormat = s.getTimestampFormat();
+    QString timeFormat = settings.getTimestampFormat();
 
     if (!re.match(timeFormat).hasMatch())
         timeFormat = timeFormats[0];
@@ -159,7 +160,7 @@ UserInterfaceForm::UserInterfaceForm(SmileyPack& smileyPack_, SettingsWidget* my
     dateFormats.removeDuplicates();
     bodyUI->dateFormats->addItems(dateFormats);
 
-    QString dateFormat = s.getDateFormat();
+    QString dateFormat = settings.getDateFormat();
     if (!re.match(dateFormat).hasMatch())
         dateFormat = dateFormats[0];
 
@@ -180,9 +181,9 @@ UserInterfaceForm::~UserInterfaceForm()
 void UserInterfaceForm::on_styleBrowser_currentIndexChanged(QString style)
 {
     if (bodyUI->styleBrowser->currentIndex() == 0)
-        Settings::getInstance().setStyle("None");
+        settings.setStyle("None");
     else
-        Settings::getInstance().setStyle(style);
+        settings.setStyle(style);
 
     setStyle(QStyleFactory::create(style));
     parent->setBodyHeadStyle(style);
@@ -190,7 +191,7 @@ void UserInterfaceForm::on_styleBrowser_currentIndexChanged(QString style)
 
 void UserInterfaceForm::on_emoticonSize_editingFinished()
 {
-    Settings::getInstance().setEmojiFontPointSize(bodyUI->emoticonSize->value());
+    settings.setEmojiFontPointSize(bodyUI->emoticonSize->value());
 }
 
 void UserInterfaceForm::on_timestamp_editTextChanged(const QString& format)
@@ -198,8 +199,8 @@ void UserInterfaceForm::on_timestamp_editTextChanged(const QString& format)
     QString timeExample = QTime::currentTime().toString(format);
     bodyUI->timeExample->setText(timeExample);
 
-    Settings::getInstance().setTimestampFormat(format);
-    QString locale = Settings::getInstance().getTranslation();
+    settings.setTimestampFormat(format);
+    QString locale = settings.getTranslation();
     Translator::translate(locale);
 }
 
@@ -208,14 +209,14 @@ void UserInterfaceForm::on_dateFormats_editTextChanged(const QString& format)
     QString dateExample = QDate::currentDate().toString(format);
     bodyUI->dateExample->setText(dateExample);
 
-    Settings::getInstance().setDateFormat(format);
-    QString locale = Settings::getInstance().getTranslation();
+    settings.setDateFormat(format);
+    QString locale = settings.getTranslation();
     Translator::translate(locale);
 }
 
 void UserInterfaceForm::on_useEmoticons_stateChanged()
 {
-    Settings::getInstance().setUseEmoticons(bodyUI->useEmoticons->isChecked());
+    settings.setUseEmoticons(bodyUI->useEmoticons->isChecked());
     bodyUI->smileyPackBrowser->setEnabled(bodyUI->useEmoticons->isChecked());
 }
 
@@ -223,13 +224,13 @@ void UserInterfaceForm::on_textStyleComboBox_currentTextChanged()
 {
     Settings::StyleType styleType =
         static_cast<Settings::StyleType>(bodyUI->textStyleComboBox->currentIndex());
-    Settings::getInstance().setStylePreference(styleType);
+    settings.setStylePreference(styleType);
 }
 
 void UserInterfaceForm::on_smileyPackBrowser_currentIndexChanged(int index)
 {
     QString filename = bodyUI->smileyPackBrowser->itemData(index).toString();
-    Settings::getInstance().setSmileyPack(filename);
+    settings.setSmileyPack(filename);
     reloadSmileys();
 }
 
@@ -273,7 +274,7 @@ void UserInterfaceForm::reloadSmileys()
 void UserInterfaceForm::on_notify_stateChanged()
 {
     const bool notify = bodyUI->notify->isChecked();
-    Settings::getInstance().setNotify(notify);
+    settings.setNotify(notify);
     bodyUI->groupOnlyNotfiyWhenMentioned->setEnabled(notify);
     bodyUI->notifySound->setEnabled(notify);
     bodyUI->busySound->setEnabled(notify && bodyUI->notifySound->isChecked());
@@ -283,64 +284,64 @@ void UserInterfaceForm::on_notify_stateChanged()
 void UserInterfaceForm::on_notifySound_stateChanged()
 {
     const bool notify = bodyUI->notifySound->isChecked();
-    Settings::getInstance().setNotifySound(notify);
+    settings.setNotifySound(notify);
     bodyUI->busySound->setEnabled(notify);
 }
 
 void UserInterfaceForm::on_desktopNotify_stateChanged()
 {
     const bool notify = bodyUI->desktopNotify->isChecked();
-    Settings::getInstance().setDesktopNotify(notify);
+    settings.setDesktopNotify(notify);
 }
 
 void UserInterfaceForm::on_busySound_stateChanged()
 {
-    Settings::getInstance().setBusySound(bodyUI->busySound->isChecked());
+    settings.setBusySound(bodyUI->busySound->isChecked());
 }
 
 void UserInterfaceForm::on_showWindow_stateChanged()
 {
-    Settings::getInstance().setShowWindow(bodyUI->showWindow->isChecked());
+    settings.setShowWindow(bodyUI->showWindow->isChecked());
 }
 
 void UserInterfaceForm::on_groupOnlyNotfiyWhenMentioned_stateChanged()
 {
     // Note: UI is boolean inversed from settings to maintain setting file backwards compatibility
-    Settings::getInstance().setGroupAlwaysNotify(!bodyUI->groupOnlyNotfiyWhenMentioned->isChecked());
+    settings.setGroupAlwaysNotify(!bodyUI->groupOnlyNotfiyWhenMentioned->isChecked());
 }
 
 void UserInterfaceForm::on_cbCompactLayout_stateChanged()
 {
-    Settings::getInstance().setCompactLayout(bodyUI->cbCompactLayout->isChecked());
+    settings.setCompactLayout(bodyUI->cbCompactLayout->isChecked());
 }
 
 void UserInterfaceForm::on_cbSeparateWindow_stateChanged()
 {
     bool checked = bodyUI->cbSeparateWindow->isChecked();
     bodyUI->cbDontGroupWindows->setEnabled(checked);
-    Settings::getInstance().setSeparateWindow(checked);
+    settings.setSeparateWindow(checked);
 }
 
 void UserInterfaceForm::on_cbDontGroupWindows_stateChanged()
 {
-    Settings::getInstance().setDontGroupWindows(bodyUI->cbDontGroupWindows->isChecked());
+    settings.setDontGroupWindows(bodyUI->cbDontGroupWindows->isChecked());
 }
 
 void UserInterfaceForm::on_cbGroupchatPosition_stateChanged()
 {
-    Settings::getInstance().setGroupchatPosition(bodyUI->cbGroupchatPosition->isChecked());
+    settings.setGroupchatPosition(bodyUI->cbGroupchatPosition->isChecked());
 }
 
 void UserInterfaceForm::on_cbShowIdenticons_stateChanged()
 {
-    Settings::getInstance().setShowIdenticons(bodyUI->cbShowIdenticons->isChecked());
+    settings.setShowIdenticons(bodyUI->cbShowIdenticons->isChecked());
 }
 
 void UserInterfaceForm::on_themeColorCBox_currentIndexChanged(int)
 {
     int index = bodyUI->themeColorCBox->currentIndex();
-    Settings::getInstance().setThemeColor(index);
-    Style::setThemeColor(index);
+    settings.setThemeColor(index);
+    Style::setThemeColor(settings, index);
     Style::applyTheme();
 }
 
@@ -356,7 +357,7 @@ void UserInterfaceForm::retranslateUi()
 
     // Restore text style index once translation is complete
     bodyUI->textStyleComboBox->setCurrentIndex(
-        static_cast<int>(Settings::getInstance().getStylePreference()));
+        static_cast<int>(settings.getStylePreference()));
 
     QStringList colorThemes(Style::getThemeColorNames());
     for (int i = 0; i < colorThemes.size(); ++i) {
@@ -374,12 +375,12 @@ void UserInterfaceForm::on_txtChatFont_currentFontChanged(const QFont& f)
     if (QFontInfo(tmpFont).pixelSize() != px)
         tmpFont.setPixelSize(px);
 
-    Settings::getInstance().setChatMessageFont(tmpFont);
+    settings.setChatMessageFont(tmpFont);
 }
 
 void UserInterfaceForm::on_txtChatFontSize_valueChanged(int px)
 {
-    Settings& s = Settings::getInstance();
+    Settings& s = settings;
     QFont tmpFont = s.getChatMessageFont();
     const int fontSize = QFontInfo(tmpFont).pixelSize();
 
@@ -391,10 +392,10 @@ void UserInterfaceForm::on_txtChatFontSize_valueChanged(int px)
 
 void UserInterfaceForm::on_useNameColors_stateChanged(int value)
 {
-    Settings::getInstance().setEnableGroupChatsColor(value);
+    settings.setEnableGroupChatsColor(value);
 }
 
 void UserInterfaceForm::on_notifyHide_stateChanged(int value)
 {
-    Settings::getInstance().setNotifyHide(value);
+    settings.setNotifyHide(value);
 }

--- a/src/widget/form/settings/userinterfaceform.h
+++ b/src/widget/form/settings/userinterfaceform.h
@@ -27,6 +27,7 @@
 namespace Ui {
 class UserInterfaceSettings;
 }
+class Settings;
 
 class SmileyPack;
 
@@ -34,7 +35,7 @@ class UserInterfaceForm : public GenericForm
 {
     Q_OBJECT
 public:
-    UserInterfaceForm(SmileyPack&, SettingsWidget* myParent);
+    UserInterfaceForm(SmileyPack&, Settings&, SettingsWidget* myParent);
     ~UserInterfaceForm();
     QString getFormName() final
     {
@@ -77,4 +78,5 @@ private:
     Ui::UserInterfaceSettings* bodyUI;
     const int MAX_FORMAT_LENGTH = 128;
     SmileyPack& smileyPack;
+    Settings& settings;
 };

--- a/src/widget/form/settingswidget.cpp
+++ b/src/widget/form/settingswidget.cpp
@@ -42,12 +42,13 @@
 #include <memory>
 
 SettingsWidget::SettingsWidget(UpdateCheck* updateCheck, IAudioControl& audio,
-    Core* core, SmileyPack& smileyPack, CameraSource& cameraSource, Widget* parent)
+    Core* core, SmileyPack& smileyPack, CameraSource& cameraSource,
+        Settings& settings, Widget* parent)
     : QWidget(parent, Qt::Window)
 {
     CoreAV* coreAV = core->getAv();
-    IAudioSettings* audioSettings = &Settings::getInstance();
-    IVideoSettings* videoSettings = &Settings::getInstance();
+    IAudioSettings* audioSettings = &settings;
+    IVideoSettings* videoSettings = &settings;
 
     setAttribute(Qt::WA_DeleteOnClose);
 
@@ -57,16 +58,16 @@ SettingsWidget::SettingsWidget(UpdateCheck* updateCheck, IAudioControl& audio,
     settingsWidgets->setTabPosition(QTabWidget::North);
     bodyLayout->addWidget(settingsWidgets.get());
 
-    std::unique_ptr<GeneralForm> gfrm(new GeneralForm(this));
+    std::unique_ptr<GeneralForm> gfrm(new GeneralForm(this, settings));
     connect(gfrm.get(), &GeneralForm::updateIcons, parent, &Widget::updateIcons);
 
-    std::unique_ptr<UserInterfaceForm> uifrm(new UserInterfaceForm(smileyPack, this));
-    std::unique_ptr<PrivacyForm> pfrm(new PrivacyForm(core));
+    std::unique_ptr<UserInterfaceForm> uifrm(new UserInterfaceForm(smileyPack, settings, this));
+    std::unique_ptr<PrivacyForm> pfrm(new PrivacyForm(core, settings));
     connect(pfrm.get(), &PrivacyForm::clearAllReceipts, parent, &Widget::clearAllReceipts);
 
     AVForm* rawAvfrm = new AVForm(audio, coreAV, cameraSource, audioSettings, videoSettings);
     std::unique_ptr<AVForm> avfrm(rawAvfrm);
-    std::unique_ptr<AdvancedForm> expfrm(new AdvancedForm());
+    std::unique_ptr<AdvancedForm> expfrm(new AdvancedForm(settings));
     std::unique_ptr<AboutForm> abtfrm(new AboutForm(updateCheck));
 
 #if UPDATE_CHECK_ENABLED

--- a/src/widget/form/settingswidget.cpp
+++ b/src/widget/form/settingswidget.cpp
@@ -42,13 +42,12 @@
 #include <memory>
 
 SettingsWidget::SettingsWidget(UpdateCheck* updateCheck, IAudioControl& audio,
-    Core* core, SmileyPack& smileyPack, Widget* parent)
+    Core* core, SmileyPack& smileyPack, CameraSource& cameraSource, Widget* parent)
     : QWidget(parent, Qt::Window)
 {
     CoreAV* coreAV = core->getAv();
     IAudioSettings* audioSettings = &Settings::getInstance();
     IVideoSettings* videoSettings = &Settings::getInstance();
-    CameraSource& camera = CameraSource::getInstance();
 
     setAttribute(Qt::WA_DeleteOnClose);
 
@@ -65,7 +64,7 @@ SettingsWidget::SettingsWidget(UpdateCheck* updateCheck, IAudioControl& audio,
     std::unique_ptr<PrivacyForm> pfrm(new PrivacyForm(core));
     connect(pfrm.get(), &PrivacyForm::clearAllReceipts, parent, &Widget::clearAllReceipts);
 
-    AVForm* rawAvfrm = new AVForm(audio, coreAV, camera, audioSettings, videoSettings);
+    AVForm* rawAvfrm = new AVForm(audio, coreAV, cameraSource, audioSettings, videoSettings);
     std::unique_ptr<AVForm> avfrm(rawAvfrm);
     std::unique_ptr<AdvancedForm> expfrm(new AdvancedForm());
     std::unique_ptr<AboutForm> abtfrm(new AboutForm(updateCheck));

--- a/src/widget/form/settingswidget.h
+++ b/src/widget/form/settingswidget.h
@@ -39,12 +39,13 @@ class ContentLayout;
 class UpdateCheck;
 class Widget;
 class SmileyPack;
+class CameraSource;
 
 class SettingsWidget : public QWidget
 {
     Q_OBJECT
 public:
-    SettingsWidget(UpdateCheck* updateCheck, IAudioControl& audio, Core *core, SmileyPack&, Widget* parent = nullptr);
+    SettingsWidget(UpdateCheck* updateCheck, IAudioControl& audio, Core *core, SmileyPack&, CameraSource&, Widget* parent = nullptr);
     ~SettingsWidget();
 
     bool isShown() const;

--- a/src/widget/form/settingswidget.h
+++ b/src/widget/form/settingswidget.h
@@ -40,12 +40,14 @@ class UpdateCheck;
 class Widget;
 class SmileyPack;
 class CameraSource;
+class Settings;
 
 class SettingsWidget : public QWidget
 {
     Q_OBJECT
 public:
-    SettingsWidget(UpdateCheck* updateCheck, IAudioControl& audio, Core *core, SmileyPack&, CameraSource&, Widget* parent = nullptr);
+    SettingsWidget(UpdateCheck* updateCheck, IAudioControl& audio, Core *core,
+        SmileyPack&, CameraSource&, Settings&, Widget* parent = nullptr);
     ~SettingsWidget();
 
     bool isShown() const;

--- a/src/widget/friendlistwidget.h
+++ b/src/widget/friendlistwidget.h
@@ -38,13 +38,14 @@ class GenericChatroomWidget;
 class CategoryWidget;
 class Friend;
 class IFriendListItem;
+class Settings;
 
 class FriendListWidget : public QWidget
 {
     Q_OBJECT
 public:
     using SortingMode = Settings::FriendListSortingMode;
-    explicit FriendListWidget(const Core& _core, Widget* parent, bool groupsOnTop = true);
+    FriendListWidget(const Core&, Widget* parent, Settings&, bool groupsOnTop = true);
     ~FriendListWidget();
     void setMode(SortingMode mode);
     SortingMode getMode() const;
@@ -97,4 +98,5 @@ private:
     FriendListManager* manager;
 
     const Core& core;
+    Settings& settings;
 };

--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -56,10 +56,11 @@
  * For example, used on friend list.
  * When you click should open the chat with friend. Widget has a context menu.
  */
-FriendWidget::FriendWidget(std::shared_ptr<FriendChatroom> chatroom_, bool compact_)
-    : GenericChatroomWidget(compact_)
+FriendWidget::FriendWidget(std::shared_ptr<FriendChatroom> chatroom_, bool compact_, Settings& settings_)
+    : GenericChatroomWidget(compact_, settings_)
     , chatroom{chatroom_}
     , isDefaultAvatar{true}
+    , settings{settings_}
 {
     avatar->setPixmap(QPixmap(":/img/contact.svg"));
     statusPic.setPixmap(QPixmap(Status::getIconPath(Status::Status::Offline)));
@@ -188,10 +189,11 @@ void FriendWidget::removeChatWindow()
 
 namespace {
 
-std::tuple<CircleWidget*, FriendListWidget*> getCircleAndFriendList(const Friend* frnd, FriendWidget* fw)
+std::tuple<CircleWidget*, FriendListWidget*> getCircleAndFriendList(const Friend* frnd,
+    FriendWidget* fw, Settings& settings)
 {
     const auto pk = frnd->getPublicKey();
-    const auto circleId = Settings::getInstance().getFriendCircleID(pk);
+    const auto circleId = settings.getFriendCircleID(pk);
     auto circleWidget = CircleWidget::getFromID(circleId);
     auto w = circleWidget ? static_cast<QWidget*>(circleWidget) : static_cast<QWidget*>(fw);
     auto friendList = qobject_cast<FriendListWidget*>(w->parentWidget());
@@ -205,7 +207,7 @@ void FriendWidget::moveToNewCircle()
     const auto frnd = chatroom->getFriend();
     CircleWidget* circleWidget;
     FriendListWidget* friendList;
-    std::tie(circleWidget, friendList) = getCircleAndFriendList(frnd, this);
+    std::tie(circleWidget, friendList) = getCircleAndFriendList(frnd, this, settings);
 
     if (circleWidget != nullptr) {
         circleWidget->updateStatus();
@@ -215,7 +217,7 @@ void FriendWidget::moveToNewCircle()
         friendList->addCircleWidget(this);
     } else {
         const auto pk = frnd->getPublicKey();
-        auto& s = Settings::getInstance();
+        auto& s = settings;
         auto circleId = s.addCircle();
         s.setFriendCircleID(pk, circleId);
     }
@@ -226,13 +228,13 @@ void FriendWidget::removeFromCircle()
     const auto frnd = chatroom->getFriend();
     CircleWidget* circleWidget;
     FriendListWidget* friendList;
-    std::tie(circleWidget, friendList) = getCircleAndFriendList(frnd, this);
+    std::tie(circleWidget, friendList) = getCircleAndFriendList(frnd, this, settings);
 
     if (friendList != nullptr) {
         friendList->moveWidget(this, frnd->getStatus(), true);
     } else {
         const auto pk = frnd->getPublicKey();
-        auto& s = Settings::getInstance();
+        auto& s = settings;
         s.setFriendCircleID(pk, -1);
     }
 
@@ -245,8 +247,8 @@ void FriendWidget::moveToCircle(int newCircleId)
 {
     const auto frnd = chatroom->getFriend();
     const auto pk = frnd->getPublicKey();
-    const auto oldCircleId = Settings::getInstance().getFriendCircleID(pk);
-    auto& s = Settings::getInstance();
+    const auto oldCircleId = settings.getFriendCircleID(pk);
+    auto& s = settings;
     auto oldCircleWidget = CircleWidget::getFromID(oldCircleId);
     auto newCircleWidget = CircleWidget::getFromID(newCircleId);
 
@@ -279,9 +281,9 @@ void FriendWidget::changeAutoAccept(bool enable)
 void FriendWidget::showDetails()
 {
     const auto frnd = chatroom->getFriend();
-    const auto iabout = new AboutFriend(frnd, &Settings::getInstance());
+    const auto iabout = new AboutFriend(frnd, &settings);
     std::unique_ptr<IAboutFriend> about = std::unique_ptr<IAboutFriend>(iabout);
-    const auto aboutUser = new AboutFriendForm(std::move(about), this);
+    const auto aboutUser = new AboutFriendForm(std::move(about), settings, this);
     connect(aboutUser, &AboutFriendForm::histroyRemoved, this, &FriendWidget::friendHistoryRemoved);
     aboutUser->show();
 }
@@ -313,7 +315,7 @@ void FriendWidget::updateStatusLight()
     statusPic.setPixmap(QPixmap(Status::getIconPath(frnd->getStatus(), event)));
 
     if (event) {
-        const Settings& s = Settings::getInstance();
+        const Settings& s = settings;
         const uint32_t circleId = s.getFriendCircleID(frnd->getPublicKey());
         CircleWidget* circleWidget = CircleWidget::getFromID(circleId);
         if (circleWidget) {
@@ -383,7 +385,7 @@ QString FriendWidget::getNameItem() const
 QDateTime FriendWidget::getLastActivity() const
 {
     const auto frnd = chatroom->getFriend();
-    return Settings::getInstance().getFriendActivity(frnd->getPublicKey());
+    return settings.getFriendActivity(frnd->getPublicKey());
 }
 
 QWidget *FriendWidget::getWidget()

--- a/src/widget/friendwidget.h
+++ b/src/widget/friendwidget.h
@@ -29,12 +29,13 @@ class FriendChatroom;
 class QPixmap;
 class MaskablePixmapWidget;
 class CircleWidget;
+class Settings;
 
 class FriendWidget : public GenericChatroomWidget, public IFriendListItem
 {
     Q_OBJECT
 public:
-    FriendWidget(std::shared_ptr<FriendChatroom> chatform_, bool compact_);
+    FriendWidget(std::shared_ptr<FriendChatroom> chatform_, bool compact_, Settings&);
 
     void contextMenuEvent(QContextMenuEvent* event) final;
     void setAsActiveChatroom() final;
@@ -85,4 +86,5 @@ private slots:
 public:
     std::shared_ptr<FriendChatroom> chatroom;
     bool isDefaultAvatar;
+    Settings& settings;
 };

--- a/src/widget/genericchatroomwidget.cpp
+++ b/src/widget/genericchatroomwidget.cpp
@@ -25,9 +25,10 @@
 #include <QBoxLayout>
 #include <QMouseEvent>
 
-GenericChatroomWidget::GenericChatroomWidget(bool compact_, QWidget* parent)
+GenericChatroomWidget::GenericChatroomWidget(bool compact_, Settings& settings_, QWidget* parent)
     : GenericChatItemWidget(compact_, parent)
     , active{false}
+    , settings{settings_}
 {
     // avatar
     QSize size;
@@ -47,8 +48,7 @@ GenericChatroomWidget::GenericChatroomWidget(bool compact_, QWidget* parent)
     nameLabel->setForegroundRole(QPalette::WindowText);
     nameLabel->setObjectName("nameLabelObj");
 
-    Settings& s = Settings::getInstance();
-    connect(&s, &Settings::compactLayoutChanged, this, &GenericChatroomWidget::compactChange);
+    connect(&settings, &Settings::compactLayoutChanged, this, &GenericChatroomWidget::compactChange);
 
     setAutoFillBackground(true);
     reloadTheme();
@@ -158,7 +158,7 @@ QString GenericChatroomWidget::getTitle() const
 
 void GenericChatroomWidget::reloadTheme()
 {
-    setStyleSheet(Style::getStylesheet("genericChatRoomWidget/genericChatRoomWidget.css"));
+    setStyleSheet(Style::getStylesheet("genericChatRoomWidget/genericChatRoomWidget.css", settings));
 }
 
 void GenericChatroomWidget::activate()

--- a/src/widget/genericchatroomwidget.h
+++ b/src/widget/genericchatroomwidget.h
@@ -29,11 +29,13 @@ class ContentLayout;
 class Friend;
 class Group;
 class Contact;
+class Settings;
+
 class GenericChatroomWidget : public GenericChatItemWidget
 {
     Q_OBJECT
 public:
-    explicit GenericChatroomWidget(bool compact, QWidget* parent = nullptr);
+    explicit GenericChatroomWidget(bool compact, Settings&, QWidget* parent = nullptr);
 
 public slots:
     virtual void setAsActiveChatroom() = 0;
@@ -83,4 +85,5 @@ protected:
     MaskablePixmapWidget* avatar;
     CroppingLabel* statusMessageLabel;
     bool active;
+    Settings& settings;
 };

--- a/src/widget/groupwidget.cpp
+++ b/src/widget/groupwidget.cpp
@@ -41,8 +41,8 @@
 #include "src/widget/widget.h"
 #include "tool/croppinglabel.h"
 
-GroupWidget::GroupWidget(std::shared_ptr<GroupChatroom> chatroom_, bool compact_)
-    : GenericChatroomWidget(compact_)
+GroupWidget::GroupWidget(std::shared_ptr<GroupChatroom> chatroom_, bool compact_, Settings& settings_)
+    : GenericChatroomWidget(compact_, settings_)
     , groupId{chatroom_->getGroup()->getPersistentId()}
     , chatroom{chatroom_}
 {

--- a/src/widget/groupwidget.h
+++ b/src/widget/groupwidget.h
@@ -27,11 +27,13 @@
 
 #include <memory>
 
+class Settings;
+
 class GroupWidget final : public GenericChatroomWidget, public IFriendListItem
 {
     Q_OBJECT
 public:
-    GroupWidget(std::shared_ptr<GroupChatroom> chatroom_, bool compact);
+    GroupWidget(std::shared_ptr<GroupChatroom> chatroom_, bool compact, Settings&);
     ~GroupWidget();
     void setAsInactiveChatroom() final;
     void setAsActiveChatroom() final;

--- a/src/widget/loginscreen.h
+++ b/src/widget/loginscreen.h
@@ -25,6 +25,7 @@
 #include <QToolButton>
 
 class Profile;
+class Settings;
 
 namespace Ui {
 class LoginScreen;
@@ -35,7 +36,7 @@ class LoginScreen : public QDialog
     Q_OBJECT
 
 public:
-    LoginScreen(const QString& initialProfileName = QString(), QWidget* parent = nullptr);
+    LoginScreen(Settings&, const QString& initialProfileName = QString(), QWidget* parent = nullptr);
     ~LoginScreen();
     bool event(QEvent* event) final;
 
@@ -73,4 +74,5 @@ private:
 private:
     Ui::LoginScreen* ui;
     QShortcut quitShortcut;
+    Settings& settings;
 };

--- a/src/widget/notificationedgewidget.cpp
+++ b/src/widget/notificationedgewidget.cpp
@@ -19,16 +19,17 @@
 
 #include "notificationedgewidget.h"
 #include "style.h"
+#include "src/persistence/settings.h"
 #include <QBoxLayout>
 #include <QLabel>
 
 #include <QDebug>
 
-NotificationEdgeWidget::NotificationEdgeWidget(Position position, QWidget* parent)
+NotificationEdgeWidget::NotificationEdgeWidget(Position position, Settings& settings, QWidget* parent)
     : QWidget(parent)
 {
     setAttribute(Qt::WA_StyledBackground); // Show background.
-    setStyleSheet(Style::getStylesheet("notificationEdge/notificationEdge.css"));
+    setStyleSheet(Style::getStylesheet("notificationEdge/notificationEdge.css", settings));
     QHBoxLayout* layout = new QHBoxLayout(this);
     layout->addStretch();
 
@@ -39,9 +40,9 @@ NotificationEdgeWidget::NotificationEdgeWidget(Position position, QWidget* paren
     QLabel* arrowLabel = new QLabel(this);
 
     if (position == Top)
-        arrowLabel->setPixmap(QPixmap(Style::getImagePath("chatArea/scrollBarUpArrow.svg")));
+        arrowLabel->setPixmap(QPixmap(Style::getImagePath("chatArea/scrollBarUpArrow.svg", settings)));
     else
-        arrowLabel->setPixmap(QPixmap(Style::getImagePath("chatArea/scrollBarDownArrow.svg")));
+        arrowLabel->setPixmap(QPixmap(Style::getImagePath("chatArea/scrollBarDownArrow.svg", settings)));
 
     layout->addWidget(arrowLabel);
     layout->addStretch();

--- a/src/widget/notificationedgewidget.h
+++ b/src/widget/notificationedgewidget.h
@@ -22,6 +22,7 @@
 #include <QWidget>
 
 class QLabel;
+class Settings;
 
 class NotificationEdgeWidget final : public QWidget
 {
@@ -33,7 +34,7 @@ public:
         Bottom
     };
 
-    explicit NotificationEdgeWidget(Position position, QWidget* parent = nullptr);
+    NotificationEdgeWidget(Position position, Settings&, QWidget* parent = nullptr);
     void updateNotificationCount(int count);
 
 signals:

--- a/src/widget/notificationscrollarea.cpp
+++ b/src/widget/notificationscrollarea.cpp
@@ -31,7 +31,7 @@ NotificationScrollArea::NotificationScrollArea(QWidget* parent)
             &NotificationScrollArea::updateVisualTracking);
 }
 
-void NotificationScrollArea::trackWidget(GenericChatroomWidget* widget)
+void NotificationScrollArea::trackWidget(Settings& settings, GenericChatroomWidget* widget)
 {
     if (trackedWidgets.find(widget) != trackedWidgets.end())
         return;
@@ -41,7 +41,7 @@ void NotificationScrollArea::trackWidget(GenericChatroomWidget* widget)
         if (visibility == Above) {
             if (referencesAbove++ == 0) {
                 assert(topEdge == nullptr);
-                topEdge = new NotificationEdgeWidget(NotificationEdgeWidget::Top, this);
+                topEdge = new NotificationEdgeWidget(NotificationEdgeWidget::Top, settings, this);
                 connect(topEdge, &NotificationEdgeWidget::clicked, this,
                         &NotificationScrollArea::findPreviousWidget);
                 recalculateTopEdge();
@@ -51,7 +51,7 @@ void NotificationScrollArea::trackWidget(GenericChatroomWidget* widget)
         } else {
             if (referencesBelow++ == 0) {
                 assert(bottomEdge == nullptr);
-                bottomEdge = new NotificationEdgeWidget(NotificationEdgeWidget::Bottom, this);
+                bottomEdge = new NotificationEdgeWidget(NotificationEdgeWidget::Bottom, settings, this);
                 connect(bottomEdge, &NotificationEdgeWidget::clicked, this,
                         &NotificationScrollArea::findNextWidget);
                 recalculateBottomEdge();

--- a/src/widget/notificationscrollarea.h
+++ b/src/widget/notificationscrollarea.h
@@ -24,6 +24,7 @@
 
 class GenericChatroomWidget;
 class NotificationEdgeWidget;
+class Settings;
 
 class NotificationScrollArea final : public AdjustingScrollArea
 {
@@ -31,7 +32,7 @@ public:
     explicit NotificationScrollArea(QWidget* parent = nullptr);
 
 public slots:
-    void trackWidget(GenericChatroomWidget* widget);
+    void trackWidget(Settings& settings, GenericChatroomWidget* widget);
     void updateVisualTracking();
     void updateTracking(GenericChatroomWidget* widget);
 

--- a/src/widget/searchform.h
+++ b/src/widget/searchform.h
@@ -27,6 +27,7 @@ class QPushButton;
 class QLabel;
 class LineEdit;
 class SearchSettingsForm;
+class Settings;
 
 class SearchForm final : public QWidget
 {
@@ -38,7 +39,7 @@ public:
         Active = 2,      // Red
     };
 
-    explicit SearchForm(QWidget* parent = nullptr);
+    explicit SearchForm(Settings&, QWidget* parent = nullptr);
     void removeSearchPhrase();
     QString getSearchPhrase() const;
     ParameterSearch getParameterSearch();
@@ -61,7 +62,7 @@ private:
     QPushButton* hideButton;
     QPushButton* startButton;
     LineEdit* searchLine;
-    SearchSettingsForm* settings;
+    SearchSettingsForm* searchSettingsForm;
     QLabel* messageLabel;
 
     QString searchPhrase;
@@ -71,6 +72,7 @@ private:
     bool isChangedPhrase{false};
     bool isSearchInBegin{true};
     bool isPrevSearch{false};
+    Settings& settings;
 
 private slots:
     void changedSearchPhrase(const QString& text);

--- a/src/widget/style.h
+++ b/src/widget/style.h
@@ -24,6 +24,7 @@
 
 class QString;
 class QWidget;
+class Settings;
 
 class Style
 {
@@ -75,21 +76,21 @@ public:
     };
 
     static QStringList getThemeColorNames();
-    static const QString getStylesheet(const QString& filename, const QFont& baseFont = QFont());
-    static const QString getImagePath(const QString& filename);
-    static QString getThemeFolder();
+    static const QString getStylesheet(const QString& filename, Settings&, const QFont& baseFont = QFont());
+    static const QString getImagePath(const QString& filename, Settings&);
+    static QString getThemeFolder(Settings&);
     static QString getThemeName();
     static QColor getColor(ColorPalette entry);
     static QFont getFont(Font font);
-    static const QString resolve(const QString& filename, const QFont& baseFont = QFont());
+    static const QString resolve(const QString& filename, Settings&, const QFont& baseFont = QFont());
     static void repolish(QWidget* w);
-    static void setThemeColor(int color);
+    static void setThemeColor(Settings&, int color);
     static void setThemeColor(const QColor& color);
     static void applyTheme();
     static QPixmap scaleSvgImage(const QString& path, uint32_t width, uint32_t height);
-    static void initPalette();
+    static void initPalette(Settings&);
     static void initDictColor();
-    static QString getThemePath();
+    static QString getThemePath(Settings&);
 
 signals:
     void themeChanged();

--- a/src/widget/tool/callconfirmwidget.cpp
+++ b/src/widget/tool/callconfirmwidget.cpp
@@ -50,7 +50,7 @@
  * @brief Used to correct the rounding factors on non-square rects
  */
 
-CallConfirmWidget::CallConfirmWidget(const QWidget* anchor_)
+CallConfirmWidget::CallConfirmWidget(Settings& settings, const QWidget* anchor_)
     : QWidget()
     , anchor(anchor_)
     , rectW{120}
@@ -90,8 +90,8 @@ CallConfirmWidget::CallConfirmWidget(const QWidget* anchor_)
     reject->setFlat(true);
     accept->setStyleSheet("QPushButton{border:none;}");
     reject->setStyleSheet("QPushButton{border:none;}");
-    accept->setIcon(QIcon(Style::getImagePath("acceptCall/acceptCall.svg")));
-    reject->setIcon(QIcon(Style::getImagePath("rejectCall/rejectCall.svg")));
+    accept->setIcon(QIcon(Style::getImagePath("acceptCall/acceptCall.svg", settings)));
+    reject->setIcon(QIcon(Style::getImagePath("rejectCall/rejectCall.svg", settings)));
     accept->setIconSize(accept->size());
     reject->setIconSize(reject->size());
 

--- a/src/widget/tool/callconfirmwidget.h
+++ b/src/widget/tool/callconfirmwidget.h
@@ -27,12 +27,13 @@
 
 class QPaintEvent;
 class QShowEvent;
+class Settings;
 
 class CallConfirmWidget final : public QWidget
 {
     Q_OBJECT
 public:
-    explicit CallConfirmWidget(const QWidget* anchor_);
+    explicit CallConfirmWidget(Settings&, const QWidget* anchor_);
 
 signals:
     void accepted();

--- a/src/widget/tool/profileimporter.cpp
+++ b/src/widget/tool/profileimporter.cpp
@@ -35,8 +35,9 @@
  * to create dialog forms.
  */
 
-ProfileImporter::ProfileImporter(QWidget* parent)
+ProfileImporter::ProfileImporter(Settings& settings_, QWidget* parent)
     : QWidget(parent)
+    , settings{settings_}
 {
 }
 
@@ -105,7 +106,7 @@ bool ProfileImporter::importProfile(const QString& path)
         return false; // ingore importing non-tox file
     }
 
-    QString settingsPath = Settings::getInstance().getPaths().getSettingsDirPath();
+    QString settingsPath = settings.getPaths().getSettingsDirPath();
     QString profilePath = QDir(settingsPath).filePath(profile + Core::TOX_EXT);
 
     if (QFileInfo(profilePath).exists()) {

--- a/src/widget/tool/profileimporter.h
+++ b/src/widget/tool/profileimporter.h
@@ -20,16 +20,18 @@
 #pragma once
 
 #include <QWidget>
+class Settings;
 
 class ProfileImporter : public QWidget
 {
     Q_OBJECT
 
 public:
-    explicit ProfileImporter(QWidget* parent = nullptr);
+    explicit ProfileImporter(Settings&, QWidget* parent = nullptr);
     bool importProfile(const QString& path);
     bool importProfile();
 
 private:
     bool askQuestion(QString title, QString message);
+    Settings& settings;
 };

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -139,7 +139,8 @@ void Widget::acceptFileTransfer(const ToxFile& file, const QString& path)
 
 Widget* Widget::instance{nullptr};
 
-Widget::Widget(Profile &profile_, IAudioControl& audio_, QWidget* parent)
+Widget::Widget(Profile &profile_, IAudioControl& audio_, CameraSource& cameraSource_,
+    QWidget* parent)
     : QMainWindow(parent)
     , profile{profile_}
     , trayMenu{nullptr}
@@ -151,6 +152,7 @@ Widget::Widget(Profile &profile_, IAudioControl& audio_, QWidget* parent)
     , settings(Settings::getInstance())
     , smileyPack(new SmileyPack())
     , documentCache(new DocumentCache(*smileyPack))
+    , cameraSource{cameraSource_}
 {
     installEventFilter(this);
     QString locale = settings.getTranslation();
@@ -292,7 +294,8 @@ void Widget::init()
     updateCheck = std::unique_ptr<UpdateCheck>(new UpdateCheck(settings));
     connect(updateCheck.get(), &UpdateCheck::updateAvailable, this, &Widget::onUpdateAvailable);
 #endif
-    settingsWidget = new SettingsWidget(updateCheck.get(), audio, core, *smileyPack, this);
+    settingsWidget = new SettingsWidget(updateCheck.get(), audio, core, *smileyPack,
+        cameraSource, this);
 #if UPDATE_CHECK_ENABLED
     updateCheck->checkForUpdate();
 #endif
@@ -1190,7 +1193,7 @@ void Widget::addFriend(uint32_t friendId, const ToxPk& friendPk)
         std::make_shared<ChatHistory>(*newfriend, history, *core, settings,
                                       *friendMessageDispatcher);
     auto friendForm = new ChatForm(profile, newfriend, *chatHistory,
-        *friendMessageDispatcher, *documentCache, *smileyPack);
+        *friendMessageDispatcher, *documentCache, *smileyPack, cameraSource);
     connect(friendForm, &ChatForm::updateFriendActivity, this, &Widget::updateFriendActivity);
 
     friendMessageDispatchers[friendPk] = friendMessageDispatcher;

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -118,7 +118,7 @@ private:
     };
 
 public:
-    Widget(Profile& profile_, IAudioControl& audio_, CameraSource&,
+    Widget(Profile& profile_, IAudioControl& audio_, CameraSource&, Settings&,
         QWidget* parent = nullptr);
     ~Widget() override;
     void init();
@@ -388,4 +388,4 @@ private:
     CameraSource& cameraSource;
 };
 
-bool toxActivateEventHandler(const QByteArray& data);
+bool toxActivateEventHandler(const QByteArray& data, void* userData);

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -84,6 +84,7 @@ class Settings;
 class IChatLog;
 class ChatHistory;
 class SmileyPack;
+class CameraSource;
 class Widget final : public QMainWindow
 {
     Q_OBJECT
@@ -117,7 +118,8 @@ private:
     };
 
 public:
-    explicit Widget(Profile& profile_, IAudioControl& audio_, QWidget* parent = nullptr);
+    Widget(Profile& profile_, IAudioControl& audio_, CameraSource&,
+        QWidget* parent = nullptr);
     ~Widget() override;
     void init();
     void setCentralWidget(QWidget* widget, const QString& widgetName);
@@ -383,6 +385,7 @@ private:
 #endif
     std::unique_ptr<SmileyPack> smileyPack;
     std::unique_ptr<DocumentCache> documentCache;
+    CameraSource& cameraSource;
 };
 
 bool toxActivateEventHandler(const QByteArray& data);

--- a/test/persistence/smileypack_test.cpp
+++ b/test/persistence/smileypack_test.cpp
@@ -18,6 +18,7 @@
 */
 
 #include "src/persistence/smileypack.h"
+#include "src/persistence/settings.h"
 
 #include <QtTest/QtTest>
 #include <QSignalSpy>
@@ -40,6 +41,7 @@ private slots:
     void testSmilifyAsciiEmoticon();
 private:
     std::unique_ptr<QGuiApplication> app;
+    std::unique_ptr<Settings> settings;
 };
 
 TestSmileyPack::TestSmileyPack()
@@ -51,6 +53,7 @@ TestSmileyPack::TestSmileyPack()
     static int qtTestAppArgc = 3;
 
     app = std::unique_ptr<QGuiApplication>(new QGuiApplication(qtTestAppArgc, qtTestAppArgv));
+    settings = std::unique_ptr<Settings>(new Settings());
 }
 
 /**
@@ -58,7 +61,7 @@ TestSmileyPack::TestSmileyPack()
  */
 void TestSmileyPack::testSmilifySingleCharEmoji()
 {
-    SmileyPack smileyPack{};
+    SmileyPack smileyPack{*settings};
 
     auto result = smileyPack.smileyfied("😊");
     QVERIFY(result == SmileyPack::getAsRichText("😊"));
@@ -73,7 +76,7 @@ void TestSmileyPack::testSmilifySingleCharEmoji()
  */
 void TestSmileyPack::testSmilifyMultiCharEmoji()
 {
-    SmileyPack smileyPack{};
+    SmileyPack smileyPack{*settings};
 
     auto result = smileyPack.smileyfied("🇬🇧");
     QVERIFY(result == SmileyPack::getAsRichText("🇬🇧"));
@@ -94,7 +97,7 @@ void TestSmileyPack::testSmilifyMultiCharEmoji()
  */
 void TestSmileyPack::testSmilifyAsciiEmoticon()
 {
-    SmileyPack smileyPack{};
+    SmileyPack smileyPack{*settings};
 
     auto result = smileyPack.smileyfied(":-)");
     QVERIFY(result == SmileyPack::getAsRichText(":-)"));


### PR DESCRIPTION
* Make main.cpp's toxSave free functions into a ToxSave class so that it can be
  given Settings on construction.
* Add void* to IPC callbacks so that classes can get back to themselves.

Based on https://github.com/qTox/qTox/pull/6559.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6560)
<!-- Reviewable:end -->
