### PR TITLE
fix(tests): Mock Settings for SmileyPack test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,6 +323,8 @@ set(${PROJECT_NAME}_SOURCES
   src/persistence/igroupsettings.h
   src/persistence/inotificationsettings.cpp
   src/persistence/inotificationsettings.h
+  src/persistence/ismileysettings.cpp
+  src/persistence/ismileysettings.h
   src/persistence/offlinemsgengine.cpp
   src/persistence/offlinemsgengine.h
   src/persistence/paths.cpp

--- a/src/persistence/ismileysettings.cpp
+++ b/src/persistence/ismileysettings.cpp
@@ -1,0 +1,22 @@
+/*
+    Copyright © 2022 by The qTox Project Contributors
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "ismileysettings.h"
+
+ISmileySettings::~ISmileySettings() = default;

--- a/src/persistence/ismileysettings.h
+++ b/src/persistence/ismileysettings.h
@@ -1,0 +1,32 @@
+/*
+    Copyright © 2022 by The qTox Project Contributors
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include "util/interface.h"
+
+#include <QString>
+
+class ISmileySettings
+{
+public:
+    virtual ~ISmileySettings();
+    virtual QString getSmileyPack() const = 0;
+    DECLARE_SIGNAL(smileyPackChanged, const QString& name);
+};

--- a/src/persistence/settings.h
+++ b/src/persistence/settings.h
@@ -28,6 +28,7 @@
 #include "src/persistence/ifriendsettings.h"
 #include "src/persistence/igroupsettings.h"
 #include "src/persistence/inotificationsettings.h"
+#include "src/persistence/ismileysettings.h"
 #include "src/video/ivideosettings.h"
 
 #include "util/compatiblerecursivemutex.h"
@@ -54,7 +55,8 @@ class Settings : public QObject,
                  public IGroupSettings,
                  public IAudioSettings,
                  public IVideoSettings,
-                 public INotificationSettings
+                 public INotificationSettings,
+                 public ISmileySettings
 {
     Q_OBJECT
 
@@ -219,7 +221,6 @@ signals:
 
     // ChatView
     void useEmoticonsChanged(bool enabled);
-    void smileyPackChanged(const QString& name);
     void emojiFontPointSizeChanged(int size);
     void dontGroupWindowsChanged(bool enabled);
     void groupchatPositionChanged(bool enabled);
@@ -407,8 +408,9 @@ public:
     bool isAnimationEnabled() const;
     void setAnimationEnabled(bool newValue);
 
-    QString getSmileyPack() const;
+    QString getSmileyPack() const override;
     void setSmileyPack(const QString& value);
+    SIGNAL_IMPL(Settings, smileyPackChanged, const QString& name);
 
     int getThemeColor() const;
     void setThemeColor(int value);

--- a/src/persistence/smileypack.cpp
+++ b/src/persistence/smileypack.cpp
@@ -105,14 +105,14 @@ bool isAscii(const QString& string)
 
 } // namespace
 
-SmileyPack::SmileyPack(Settings& settings_)
+SmileyPack::SmileyPack(ISmileySettings& settings_)
     : cleanupTimer{new QTimer(this)}
     , settings{settings_}
 {
     loadingMutex.lock();
     QtConcurrent::run(this, &SmileyPack::load, settings.getSmileyPack());
-    connect(&settings, &Settings::smileyPackChanged, this,
-            &SmileyPack::onSmileyPackChanged);
+    settings.connectTo_smileyPackChanged(this,
+        [&](const QString&) { onSmileyPackChanged(); });
     connect(cleanupTimer, &QTimer::timeout, this, &SmileyPack::cleanupIconsCache);
     cleanupTimer->start(CLEANUP_TIMEOUT);
 }

--- a/src/persistence/smileypack.h
+++ b/src/persistence/smileypack.h
@@ -27,14 +27,14 @@
 #include <memory>
 
 class QTimer;
-class Settings;
+class ISmileySettings;
 
 class SmileyPack : public QObject
 {
     Q_OBJECT
 
 public:
-    explicit SmileyPack(Settings&);
+    explicit SmileyPack(ISmileySettings&);
     SmileyPack(SmileyPack&) = delete;
     SmileyPack& operator=(const SmileyPack&) = delete;
     ~SmileyPack() override;
@@ -62,5 +62,5 @@ private:
     QTimer* cleanupTimer;
     QRegularExpression smilify;
     mutable QMutex loadingMutex;
-    Settings& settings;
+    ISmileySettings& settings;
 };

--- a/test/persistence/smileypack_test.cpp
+++ b/test/persistence/smileypack_test.cpp
@@ -17,8 +17,9 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include "src/persistence/ismileysettings.h"
 #include "src/persistence/smileypack.h"
-#include "src/persistence/settings.h"
+#include "util/interface.h"
 
 #include <QtTest/QtTest>
 #include <QSignalSpy>
@@ -28,6 +29,19 @@
 #include <QGuiApplication>
 
 #include <memory>
+
+class MockSettings : public QObject, public ISmileySettings
+{
+Q_OBJECT
+public:
+    QString getSmileyPack() const override;
+    SIGNAL_IMPL(MockSettings, smileyPackChanged, const QString& name);
+};
+
+QString MockSettings::getSmileyPack() const
+{
+    return ":/smileys/emojione/emoticons.xml";
+}
 
 class TestSmileyPack : public QObject
 {
@@ -41,7 +55,7 @@ private slots:
     void testSmilifyAsciiEmoticon();
 private:
     std::unique_ptr<QGuiApplication> app;
-    std::unique_ptr<Settings> settings;
+    std::unique_ptr<MockSettings> settings;
 };
 
 TestSmileyPack::TestSmileyPack()
@@ -53,7 +67,7 @@ TestSmileyPack::TestSmileyPack()
     static int qtTestAppArgc = 3;
 
     app = std::unique_ptr<QGuiApplication>(new QGuiApplication(qtTestAppArgc, qtTestAppArgv));
-    settings = std::unique_ptr<Settings>(new Settings());
+    settings = std::unique_ptr<MockSettings>(new MockSettings());
 }
 
 /**


### PR DESCRIPTION
Settings upgrades global settings on construction, which can cause the
SmileyPack test to be inconsistent based on file system state.

Fix #6530

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6568)
<!-- Reviewable:end -->
