### PR TITLE
chore(CI): Fix gitstats cloning by cloning with https

### DIFF
--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -563,7 +563,7 @@ jobs:
       - name: Install gitstats
         run: |
           sudo apt-get update && sudo apt-get install --no-install-recommends gnuplot
-          git clone git://github.com/hoxu/gitstats.git
+          git clone https://github.com/hoxu/gitstats.git
           cd gitstats
           sudo make install
       - name: Run


### PR DESCRIPTION
To resolve the error:
  The unauthenticated git protocol on port 9418 is no longer supported.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6570)
<!-- Reviewable:end -->
