### PR TITLE
chore(CI): Backup NSIS ShellExecAsUser plugin

### DIFF
--- a/buildscripts/download/download_nsisshellexecasuser.sh
+++ b/buildscripts/download/download_nsisshellexecasuser.sh
@@ -21,6 +21,7 @@ NSISSHELLEXECASUSER_HASH=79bdd3e54a9ba9c30af85557b475d2322286f8726687f2e23afa772
 
 source "$(dirname "$(realpath "$0")")/common.sh"
 
+# Backup: https://web.archive.org/web/20220314233613/https://nsis.sourceforge.io/mediawiki/images/1/1d/ShellExecAsUserUnicodeUpdate.zip
 download_file https://nsis.sourceforge.io/mediawiki/images/1/1d/ShellExecAsUserUnicodeUpdate.zip
 
 if ! check_sha256 "$NSISSHELLEXECASUSER_HASH" ShellExecAsUserUnicodeUpdate.zip; then


### PR DESCRIPTION
As was done in the previous ANSI version prior to
beb38fa33b51be97361b11edc03c96a13d616a47

For reasons covered here:
https://github.com/qTox/qTox/commit/beb38fa33b51be97361b11edc03c96a13d616a47#r68688468

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6573)
<!-- Reviewable:end -->
