### PR TITLE
fix(contacts): window with multiple friends contacts

### DIFF
--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -1359,19 +1359,18 @@ void Widget::openDialog(GenericChatroomWidget* widget, bool newWindow)
     widget->updateStatusLight();
 
     GenericChatForm* form;
-    GroupId id;
     const Friend* frnd = widget->getFriend();
     const Group* group = widget->getGroup();
+    bool chatFormIsSet;
     if (frnd) {
         form = chatForms[frnd->getPublicKey()];
+        contentDialogManager->focusChat(frnd->getPersistentId());
+        chatFormIsSet = contentDialogManager->chatWidgetExists(frnd->getPersistentId());
     } else {
-        id = group->getPersistentId();
-        form = groupChatForms[id].data();
+        form = groupChatForms[group->getPersistentId()].data();
+        contentDialogManager->focusChat(group->getPersistentId());
+        chatFormIsSet = contentDialogManager->chatWidgetExists(group->getPersistentId());
     }
-    bool chatFormIsSet;
-    contentDialogManager->focusChat(id);
-    chatFormIsSet = contentDialogManager->chatWidgetExists(id);
-
 
     if ((chatFormIsSet || form->isVisible()) && !newWindow) {
         return;


### PR DESCRIPTION
AFAIU when clicking on an already added friend contact, the `Widget::openDialog` function is called, which was not broke by the condition: `((chatFormIsSet || form->isVisible()) && !newWindow)` and execution continued as for a new friend contact. This resulted in a recursive call to `Widget::openDialog`.

~~Fix: 6412~~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6576)
<!-- Reviewable:end -->
