### PR TITLE
Macos autorun

### DIFF
--- a/src/platform/autorun_osx.cpp
+++ b/src/platform/autorun_osx.cpp
@@ -25,29 +25,30 @@
 #include <QStandardPaths>
 
 namespace {
-bool state;
+QString getAutorunFile()
+{
+    return QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::HomeLocation)
+            + QDir::separator() + "Library" + QDir::separator() + "LaunchAgents"
+            + QDir::separator() + "chat.tox.qtox.autorun.plist");
+}
 } // namespace
 
 bool Platform::setAutorun(const Settings& settings, bool on)
 {
     std::ignore = settings;
-    QString qtoxPlist =
-        QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::HomeLocation)
-                        + QDir::separator() + "Library" + QDir::separator() + "LaunchAgents"
-                        + QDir::separator() + "chat.tox.qtox.autorun.plist");
     QString qtoxDir =
         QDir::cleanPath(QCoreApplication::applicationDirPath() + QDir::separator() + "qtox");
-    QSettings autoRun(qtoxPlist, QSettings::NativeFormat);
+    QSettings autoRun(getAutorunFile(), QSettings::NativeFormat);
     autoRun.setValue("Label", "chat.tox.qtox.autorun");
     autoRun.setValue("Program", qtoxDir);
 
-    state = on;
-    autoRun.setValue("RunAtLoad", state);
+    autoRun.setValue("RunAtLoad", on);
     return true;
 }
 
 bool Platform::getAutorun(const Settings& settings)
 {
     std::ignore = settings;
-    return state;
+    QSettings autoRun(getAutorunFile(), QSettings::NativeFormat);
+    return autoRun.value("RunAtLoad", false).toBool();
 }

--- a/src/platform/autorun_osx.cpp
+++ b/src/platform/autorun_osx.cpp
@@ -25,11 +25,12 @@
 #include <QStandardPaths>
 
 namespace {
-int state;
+bool state;
 } // namespace
 
-bool Platform::setAutorun(const Settings&, bool on)
+bool Platform::setAutorun(const Settings& settings, bool on)
 {
+    std::ignore = settings;
     QString qtoxPlist =
         QDir::cleanPath(QStandardPaths::writableLocation(QStandardPaths::HomeLocation)
                         + QDir::separator() + "Library" + QDir::separator() + "LaunchAgents"
@@ -45,7 +46,8 @@ bool Platform::setAutorun(const Settings&, bool on)
     return true;
 }
 
-bool Platform::getAutorun(const Settings&)
+bool Platform::getAutorun(const Settings& settings)
 {
+    std::ignore = settings;
     return state;
 }


### PR DESCRIPTION
* [fix(macos): Fix macOS autorun not loading at start](https://github.com/qTox/qTox/pull/6577/commits/fbb75a57fae4e967ef9483a62ceb08904104c79e)
  macOS system.log was reporting "Unknown key for integer: RunAtLoad" and
not loading qTox at start despite
 ~/Library/LaunchAgents/chat.tox.qtox.autorun.plist being present.

  Changing the type from an int to a bool causes it to load successfully
on boot.

  Fix https://github.com/qTox/qTox/issues/2814

* [fix(macos): Represent autorun state in UI persistently](https://github.com/qTox/qTox/pull/6577/commits/170bca87d03adc2a8a55174e75c0514ed2a6b551)
  Check file setting rather than reporting a global value that isn't persisted
across client restart.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6577)
<!-- Reviewable:end -->
