### PR TITLE
Fix and heal database resume_file_id

### DIFF
--- a/src/persistence/dbupgrader.h
+++ b/src/persistence/dbupgrader.h
@@ -37,4 +37,5 @@ namespace DbUpgrader
     bool dbSchema6to7(RawDatabase& db);
     bool dbSchema7to8(RawDatabase& db);
     bool dbSchema8to9(RawDatabase& db);
+    bool dbSchema9to10(RawDatabase& db);
 }

--- a/src/persistence/history.cpp
+++ b/src/persistence/history.cpp
@@ -280,7 +280,7 @@ void History::removeFriendHistory(const ToxPk& friendPk)
     }
 }
 
-void History::onFileInserted(RowId dbId, QString fileId)
+void History::onFileInserted(RowId dbId, QByteArray fileId)
 {
     auto& fileInfo = fileInfos[fileId];
     if (fileInfo.finished) {
@@ -330,7 +330,7 @@ History::generateNewFileTransferQueries(const ToxPk& friendPk, const ToxPk& send
                                .arg(insertionData.size)
                                .arg(insertionData.direction)
                                .arg(ToxFile::CANCELED),
-                           {dispName.toUtf8(), insertionData.fileId.toUtf8(),
+                           {dispName.toUtf8(), insertionData.fileId,
                             insertionData.fileName.toUtf8(), insertionData.filePath.toUtf8(),
                             QByteArray()},
                            [weakThis, fileId](RowId id) {
@@ -362,7 +362,7 @@ RawDatabase::Query History::generateFileFinished(RowId id, bool success, const Q
     }
 }
 
-void History::addNewFileMessage(const ToxPk& friendPk, const QString& fileId,
+void History::addNewFileMessage(const ToxPk& friendPk, const QByteArray& fileId,
                                 const QString& fileName, const QString& filePath, int64_t size,
                                 const ToxPk& sender, const QDateTime& time, QString const& dispName)
 {
@@ -435,7 +435,7 @@ void History::addNewMessage(const ToxPk& friendPk, const QString& message, const
                                                 extensionSet, dispName, insertIdCallback));
 }
 
-void History::setFileFinished(const QString& fileId, bool success, const QString& filePath,
+void History::setFileFinished(const QByteArray& fileId, bool success, const QString& filePath,
                               const QByteArray& fileHash)
 {
     if (historyAccessBlocked()) {
@@ -562,7 +562,7 @@ QList<History::HistMessage> History::getMessagesForFriend(const ToxPk& friendPk,
             it = std::next(row.begin(), fileOffset);
             assert(!it->isNull());
             const auto fileKind = TOX_FILE_KIND_DATA;
-            const auto resumeFileId = (*it++).toString().toUtf8();
+            const auto resumeFileId = (*it++).toByteArray();
             const auto fileName = (*it++).toString();
             const auto filePath = (*it++).toString();
             const auto filesize = (*it++).toLongLong();

--- a/src/persistence/history.h
+++ b/src/persistence/history.h
@@ -117,7 +117,7 @@ struct FileDbInsertionData
     FileDbInsertionData();
 
     RowId historyId;
-    QString fileId;
+    QByteArray fileId;
     QString fileName;
     QString filePath;
     int64_t size;
@@ -199,13 +199,13 @@ public:
                        const QDateTime& time, bool isDelivered, ExtensionSet extensions,
                        QString dispName, const std::function<void(RowId)>& insertIdCallback = {});
 
-    void addNewFileMessage(const ToxPk& friendPk, const QString& fileId,
+    void addNewFileMessage(const ToxPk& friendPk, const QByteArray& fileId,
                            const QString& fileName, const QString& filePath, int64_t size,
                            const ToxPk& sender, const QDateTime& time, QString const& dispName);
 
     void addNewSystemMessage(const ToxPk& friendPk, const SystemMessage& systemMessage);
 
-    void setFileFinished(const QString& fileId, bool success, const QString& filePath, const QByteArray& fileHash);
+    void setFileFinished(const QByteArray& fileId, bool success, const QString& filePath, const QByteArray& fileHash);
     size_t getNumMessagesForFriend(const ToxPk& friendPk);
     size_t getNumMessagesForFriendBeforeDate(const ToxPk& friendPk, const QDateTime& date);
     QList<HistMessage> getMessagesForFriend(const ToxPk& friendPk, size_t firstIdx, size_t lastIdx);
@@ -219,10 +219,10 @@ public:
     void markAsBroken(RowId messageId, BrokenMessageReason reason);
 
 signals:
-    void fileInserted(RowId dbId, QString fileId);
+    void fileInserted(RowId dbId, QByteArray fileId);
 
 private slots:
-    void onFileInserted(RowId dbId, QString fileId);
+    void onFileInserted(RowId dbId, QByteArray fileId);
 
 private:
     QVector<RawDatabase::Query>
@@ -245,6 +245,6 @@ private:
     };
 
     // This needs to be a shared pointer to avoid callback lifetime issues
-    QHash<QString, FileInfo> fileInfos;
+    QHash<QByteArray, FileInfo> fileInfos;
     Settings& settings;
 };


### PR DESCRIPTION
* fix(history): Don't cast file_id to QString before inserting
    
    The implicit cast in addNewFileMessage's argument causes a conversion from the
binary data of file_id to be interpreted as UTF8 characters. On null bytes or
invalid UTF8, the resulting QString can be empty or truncated. Empty IDs causes
null file_restart_id's to be inserted into the database.
    
    Fixes the cause of #6553, but the database damage still needs to be healed.

* fix(history): Heal invalid resume_file_id's saved to history
    
    Replace underlength resume_file_id's with arbitrary data. Loaded file IDs are
not used for anything at this time, but they should not be null nor invalid.
Any 32-byte value is valid, so use all 0's for consistency.
    
    Fix #6553

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6580)
<!-- Reviewable:end -->
