### PR TITLE
fix(History): Correct SQL query for empty finished file transfer

### DIFF
--- a/src/persistence/history.cpp
+++ b/src/persistence/history.cpp
@@ -355,7 +355,7 @@ RawDatabase::Query History::generateFileFinished(RowId id, bool success, const Q
                                   {filePath.toUtf8(), fileHash});
     } else {
         return RawDatabase::Query(QStringLiteral("UPDATE file_transfers "
-                                                 "SET finished = %1 "
+                                                 "SET file_state = %1 "
                                                  "WHERE id = %2")
                                       .arg(file_state)
                                       .arg(id.get()));


### PR DESCRIPTION
"finished" is not a field in file_transfers. Bug has been present since
initially introduced in d9b39b3102eff686a072630610c199639f0d8219.

Had no real effect since file transfers are inserted with initial state
CANCELLED, which is usually the case for a 0-length finished file, but
it still logged an SQL error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6585)
<!-- Reviewable:end -->
