### PR TITLE
fix(History): Deep copy QByteArrays from SQL selects

### DIFF
--- a/src/persistence/db/rawdatabase.cpp
+++ b/src/persistence/db/rawdatabase.cpp
@@ -905,7 +905,7 @@ QVariant RawDatabase::extractData(sqlite3_stmt* stmt, int col)
     } else {
         const char* data = reinterpret_cast<const char*>(sqlite3_column_blob(stmt, col));
         int len = sqlite3_column_bytes(stmt, col);
-        return QByteArray::fromRawData(data, len);
+        return QByteArray(data, len);
     }
 }
 


### PR DESCRIPTION
We already deep copy all other data types. Especially with Qt types like
QByteArray, having a deep copy to start is important since it shallow
copies on any subsequent copy, so the callback provider only gets a
shallow copy in the QByteArray of the temporary data from SQLite.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6586)
<!-- Reviewable:end -->
