### PR TITLE
refactor(Nexus): Remove Nexus::getCore

### DIFF
--- a/src/nexus.cpp
+++ b/src/nexus.cpp
@@ -279,19 +279,6 @@ void Nexus::destroyInstance()
 }
 
 /**
- * @brief Get core instance.
- * @return nullptr if not started, core instance otherwise.
- */
-Core* Nexus::getCore()
-{
-    Nexus& nexus_ = getInstance();
-    if (!nexus_.profile)
-        return nullptr;
-
-    return &nexus_.profile->getCore();
-}
-
-/**
  * @brief Get current user profile.
  * @return nullptr if not started, profile otherwise.
  */

--- a/src/nexus.h
+++ b/src/nexus.h
@@ -56,7 +56,6 @@ public:
     void setParser(QCommandLineParser* parser_);
     static Nexus& getInstance();
     static void destroyInstance();
-    static Core* getCore();
     static Profile* getProfile();
     static Widget* getDesktopGUI();
     static CameraSource& getCameraSource();

--- a/src/widget/form/addfriendform.cpp
+++ b/src/widget/form/addfriendform.cpp
@@ -62,11 +62,12 @@ namespace
  */
 
 AddFriendForm::AddFriendForm(ToxId ownId_, Settings& settings_, Style& style_,
-    IMessageBoxManager& messageBoxManager_)
+    IMessageBoxManager& messageBoxManager_, Core& core_)
     : ownId{ownId_}
     , settings{settings_}
     , style{style_}
     , messageBoxManager{messageBoxManager_}
+    , core{core_}
 {
     tabWidget = new QTabWidget();
     main = new QWidget(tabWidget);
@@ -112,7 +113,7 @@ AddFriendForm::AddFriendForm(ToxId ownId_, Settings& settings_, Style& style_,
     connect(&sendButton, &QPushButton::clicked, this, &AddFriendForm::onSendTriggered);
     connect(&importSendButton, &QPushButton::clicked, this, &AddFriendForm::onImportSendClicked);
     connect(&importFileButton, &QPushButton::clicked, this, &AddFriendForm::onImportOpenClicked);
-    connect(Nexus::getCore(), &Core::usernameSet, this, &AddFriendForm::onUsernameSet);
+    connect(&core, &Core::usernameSet, this, &AddFriendForm::onUsernameSet);
 
     // accessibility stuff
     toxIdLabel.setAccessibleDescription(

--- a/src/widget/form/addfriendform.h
+++ b/src/widget/form/addfriendform.h
@@ -36,6 +36,7 @@ class ContentLayout;
 class Settings;
 class Style;
 class IMessageBoxManager;
+class Core;
 
 class AddFriendForm : public QObject
 {
@@ -49,7 +50,7 @@ public:
     };
 
     AddFriendForm(ToxId ownId_, Settings& settings, Style& style,
-        IMessageBoxManager& messageBoxManager);
+        IMessageBoxManager& messageBoxManager, Core& core);
     AddFriendForm(const AddFriendForm&) = delete;
     AddFriendForm& operator=(const AddFriendForm&) = delete;
     ~AddFriendForm();
@@ -120,4 +121,5 @@ private:
     Settings& settings;
     Style& style;
     IMessageBoxManager& messageBoxManager;
+    Core& core;
 };

--- a/src/widget/form/groupinviteform.cpp
+++ b/src/widget/form/groupinviteform.cpp
@@ -45,13 +45,14 @@
  * @brief This form contains all group invites you received
  */
 
-GroupInviteForm::GroupInviteForm(Settings& settings_)
+GroupInviteForm::GroupInviteForm(Settings& settings_, Core& core_)
     : headWidget(new QWidget(this))
     , headLabel(new QLabel(this))
     , createButton(new QPushButton(this))
     , inviteBox(new QGroupBox(this))
     , scroll(new QScrollArea(this))
     , settings{settings_}
+    , core{core_}
 {
     QVBoxLayout* layout = new QVBoxLayout(this);
     connect(createButton, &QPushButton::clicked,
@@ -124,7 +125,8 @@ bool GroupInviteForm::addGroupInvite(const GroupInvite& inviteInfo)
         }
     }
 
-    GroupInviteWidget* widget = new GroupInviteWidget(this, inviteInfo, settings);
+    GroupInviteWidget* widget = new GroupInviteWidget(this, inviteInfo, settings,
+        core);
     scroll->widget()->layout()->addWidget(widget);
     invites.append(widget);
     connect(widget, &GroupInviteWidget::accepted, [this] (const GroupInvite& inviteInfo_) {

--- a/src/widget/form/groupinviteform.h
+++ b/src/widget/form/groupinviteform.h
@@ -31,6 +31,7 @@ class QPushButton;
 class QScrollArea;
 class QSignalMapper;
 class Settings;
+class Core;
 
 namespace Ui {
 class MainWindow;
@@ -40,7 +41,7 @@ class GroupInviteForm : public QWidget
 {
     Q_OBJECT
 public:
-    explicit GroupInviteForm(Settings& settings);
+    GroupInviteForm(Settings& settings, Core& core);
     ~GroupInviteForm();
 
     void show(ContentLayout* contentLayout);
@@ -67,4 +68,5 @@ private:
     QList<GroupInviteWidget*> invites;
     QScrollArea* scroll;
     Settings& settings;
+    Core& core;
 };

--- a/src/widget/form/groupinvitewidget.cpp
+++ b/src/widget/form/groupinvitewidget.cpp
@@ -35,7 +35,8 @@
  * and provides buttons to accept/reject it
  */
 
-GroupInviteWidget::GroupInviteWidget(QWidget* parent, const GroupInvite& invite, Settings& settings_)
+GroupInviteWidget::GroupInviteWidget(QWidget* parent, const GroupInvite& invite,
+    Settings& settings_, Core& core_)
     : QWidget(parent)
     , acceptButton(new QPushButton(this))
     , rejectButton(new QPushButton(this))
@@ -43,6 +44,7 @@ GroupInviteWidget::GroupInviteWidget(QWidget* parent, const GroupInvite& invite,
     , widgetLayout(new QHBoxLayout(this))
     , inviteInfo(invite)
     , settings{settings_}
+    , core{core_}
 {
     connect(acceptButton, &QPushButton::clicked, [=]() { emit accepted(inviteInfo); });
     connect(rejectButton, &QPushButton::clicked, [=]() { emit rejected(inviteInfo); });
@@ -58,7 +60,7 @@ GroupInviteWidget::GroupInviteWidget(QWidget* parent, const GroupInvite& invite,
  */
 void GroupInviteWidget::retranslateUi()
 {
-    QString name = Nexus::getCore()->getFriendUsername(inviteInfo.getFriendId());
+    QString name = core.getFriendUsername(inviteInfo.getFriendId());
     QDateTime inviteDate = inviteInfo.getInviteDate();
     QString date = inviteDate.toString(settings.getDateFormat());
     QString time = inviteDate.toString(settings.getTimestampFormat());

--- a/src/widget/form/groupinvitewidget.h
+++ b/src/widget/form/groupinvitewidget.h
@@ -28,12 +28,14 @@ class CroppingLabel;
 class QHBoxLayout;
 class QPushButton;
 class Settings;
+class Core;
 
 class GroupInviteWidget : public QWidget
 {
     Q_OBJECT
 public:
-    GroupInviteWidget(QWidget* parent, const GroupInvite& invite, Settings& settings);
+    GroupInviteWidget(QWidget* parent, const GroupInvite& invite, Settings& settings,
+        Core& core);
     void retranslateUi();
     const GroupInvite getInviteInfo() const;
 
@@ -48,4 +50,5 @@ private:
     QHBoxLayout* widgetLayout;
     GroupInvite inviteInfo;
     Settings& settings;
+    Core& core;
 };

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -295,8 +295,9 @@ void Widget::init()
 
     CoreFile* coreFile = core->getCoreFile();
     filesForm = new FilesForm(*coreFile, settings, style, messageBoxManager);
-    addFriendForm = new AddFriendForm(core->getSelfId(), settings, style, messageBoxManager);
-    groupInviteForm = new GroupInviteForm(settings);
+    addFriendForm = new AddFriendForm(core->getSelfId(), settings, style,
+        messageBoxManager, *core);
+    groupInviteForm = new GroupInviteForm(settings, *core);
 
 #if UPDATE_CHECK_ENABLED
     updateCheck = std::unique_ptr<UpdateCheck>(new UpdateCheck(settings));


### PR DESCRIPTION
It relies on singleton state, instead just pass core to classes that need it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6587)
<!-- Reviewable:end -->
