### PR TITLE
fix(main): Construct ToxSave event handler

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -434,6 +434,7 @@ int main(int argc, char* argv[])
     }
 
     uriDialog = std::unique_ptr<ToxURIDialog>(new ToxURIDialog(nullptr, profile->getCore(), *messageBoxManager));
+    toxSave = std::unique_ptr<ToxSave>(new ToxSave{*settings});
 
     if (ipc.isAttached()) {
         // Start to accept Inter-process communication


### PR DESCRIPTION
Bug introduced in 0c967725df8a3f55474c59c48a6f40997c1b974e, when the class
was added but never constructed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6597)
<!-- Reviewable:end -->
