### PR TITLE
fix(UI): Centre message boxes on main window

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -237,7 +237,7 @@ int main(int argc, char* argv[])
         qWarning() << "Couldn't load font";
     }
 
-    messageBoxManager = std::unique_ptr<MessageBoxManager>(new MessageBoxManager());
+    messageBoxManager = std::unique_ptr<MessageBoxManager>(new MessageBoxManager(nullptr));
     settings = std::unique_ptr<Settings>(new Settings(*messageBoxManager));
 
     QString locale = settings->getTranslation();

--- a/src/nexus.cpp
+++ b/src/nexus.cpp
@@ -235,7 +235,7 @@ void Nexus::showMainGUI()
     assert(profile);
 
     // Create GUI
-    widget = new Widget(*profile, *audioControl, *cameraSource, *settings, *style, *messageBoxManager);
+    widget = new Widget(*profile, *audioControl, *cameraSource, *settings, *style);
 
     // Start GUI
     widget->init();

--- a/src/persistence/profile.cpp
+++ b/src/persistence/profile.cpp
@@ -295,14 +295,13 @@ void Profile::initCore(const QByteArray& toxsave, Settings& s, bool isNewProfile
 }
 
 Profile::Profile(const QString& name_, std::unique_ptr<ToxEncrypt> passkey_, Paths& paths_,
-    Settings& settings_, IMessageBoxManager& messageBoxManager_)
+    Settings& settings_)
     : name{name_}
     , passkey{std::move(passkey_)}
     , isRemoved{false}
     , encrypted{passkey != nullptr}
     , paths{paths_}
     , settings{settings_}
-    , messageBoxManager{messageBoxManager_}
 {}
 
 /**
@@ -337,14 +336,14 @@ Profile* Profile::loadProfile(const QString& name, const QString& password, Sett
         return nullptr;
     }
 
-    Profile* p = new Profile(name, std::move(tmpKey), paths, settings, messageBoxManager);
+    Profile* p = new Profile(name, std::move(tmpKey), paths, settings);
 
     // Core settings are saved per profile, need to load them before starting Core
     constexpr bool isNewProfile = false;
     settings.updateProfileData(p, parser, isNewProfile);
 
     p->initCore(toxsave, settings, isNewProfile, cameraSource);
-    p->loadDatabase(password);
+    p->loadDatabase(password, messageBoxManager);
 
     return p;
 }
@@ -371,13 +370,13 @@ Profile* Profile::createProfile(const QString& name, const QString& password, Se
     }
 
     settings.createPersonal(name);
-    Profile* p = new Profile(name, std::move(tmpKey), paths, settings, messageBoxManager);
+    Profile* p = new Profile(name, std::move(tmpKey), paths, settings);
 
     constexpr bool isNewProfile = true;
     settings.updateProfileData(p, parser, isNewProfile);
 
     p->initCore(QByteArray(), settings, isNewProfile, cameraSource);
-    p->loadDatabase(password);
+    p->loadDatabase(password, messageBoxManager);
     return p;
 }
 
@@ -621,7 +620,7 @@ QByteArray Profile::loadAvatarData(const ToxPk& owner)
     return pic;
 }
 
-void Profile::loadDatabase(QString password)
+void Profile::loadDatabase(QString password, IMessageBoxManager& messageBoxManager)
 {
     assert(core);
 

--- a/src/persistence/profile.h
+++ b/src/persistence/profile.h
@@ -99,7 +99,7 @@ public slots:
     void onRequestSent(const ToxPk& friendPk, const QString& message);
 
 private slots:
-    void loadDatabase(QString password);
+    void loadDatabase(QString password, IMessageBoxManager& messageBoxManager);
     void saveAvatar(const ToxPk& owner, const QByteArray& avatar);
     void removeAvatar(const ToxPk& owner);
     void onSaveToxSave();
@@ -108,7 +108,7 @@ private slots:
 
 private:
     Profile(const QString& name_, std::unique_ptr<ToxEncrypt> passkey_, Paths& paths_,
-        Settings &settings_, IMessageBoxManager& messageBoxManager);
+        Settings &settings_);
     static QStringList getFilesByExt(QString extension, Settings& settings);
     QString avatarPath(const ToxPk& owner, bool forceUnencrypted = false);
     bool saveToxSave(QByteArray data);
@@ -128,5 +128,4 @@ private:
     std::unique_ptr<BootstrapNodeUpdater> bootstrapNodes;
     Paths& paths;
     Settings& settings;
-    IMessageBoxManager& messageBoxManager;
 };

--- a/src/widget/tool/messageboxmanager.cpp
+++ b/src/widget/tool/messageboxmanager.cpp
@@ -27,6 +27,11 @@
 #include <QDesktopServices>
 #include <QUrl>
 
+MessageBoxManager::MessageBoxManager(QWidget* parent)
+    : QWidget(parent)
+{
+}
+
 /**
  * @brief Show some text to the user.
  * @param title Title of information window.

--- a/src/widget/tool/messageboxmanager.h
+++ b/src/widget/tool/messageboxmanager.h
@@ -30,6 +30,7 @@ class MessageBoxManager : public QWidget, public IMessageBoxManager
 {
 Q_OBJECT
 public:
+    explicit MessageBoxManager(QWidget* parent);
     ~MessageBoxManager() override = default;
     void showInfo(const QString& title, const QString& msg) override;
     void showWarning(const QString& title, const QString& msg) override;

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -124,8 +124,7 @@ private:
 
 public:
     Widget(Profile& profile_, IAudioControl& audio_, CameraSource& cameraSource,
-        Settings& settings, Style& style, IMessageBoxManager& messageBoxManager,
-        QWidget* parent = nullptr);
+        Settings& settings, Style& style, QWidget* parent = nullptr);
     ~Widget() override;
     void init();
     void setCentralWidget(QWidget* widget, const QString& widgetName);
@@ -393,7 +392,7 @@ private:
     std::unique_ptr<DocumentCache> documentCache;
     CameraSource& cameraSource;
     Style& style;
-    IMessageBoxManager& messageBoxManager;
+    IMessageBoxManager* messageBoxManager = nullptr; // freed by Qt on destruction
     std::unique_ptr<FriendList> friendList;
     std::unique_ptr<ContentDialogManager> contentDialogManager;
 };


### PR DESCRIPTION
Setting the parent of MessageBoxManager to Widget has a dual effect of
centreing the QMessageBox's on Widget' window which we want, but also
giving ownership of MessageBoxManager to Widget, which causes Widget to
destroy it in Widget's destructor. Since the original MessageBoxManager
must outlive Widget to be used in Settings and when loading Profiles
before Widget is constructed, we don't want Widget to destroy it.

Instead of juggling MessageBoxManager's parent around dynamically when
Nexus changes the active Window, just construct a second one in Widget
to be used by all its children with the parent set on Widget, centreing
the window and allowing it to have ownership.

Settings and Profile still use the original parent-less
MessageBoxManager since they show popups before Widget is constructed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6598)
<!-- Reviewable:end -->
