### PR TITLE
refactor(main): Remove unused sodium_init

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,7 +41,6 @@
 
 #include <QtWidgets/QMessageBox>
 #include <ctime>
-#include <sodium.h>
 #include <stdio.h>
 
 #if defined(Q_OS_UNIX)
@@ -288,12 +287,6 @@ int main(int argc, char* argv[])
         QObject::connect(settings.get(), &Settings::currentProfileIdChanged, &ipc, &IPC::setProfileId);
     } else {
         qWarning() << "Can't init IPC, maybe we're in a jail? Continuing with reduced multi-client functionality.";
-    }
-
-    // For the auto-updater
-    if (sodium_init() < 0) {
-        qCritical() << "Can't init libsodium";
-        return EXIT_FAILURE;
     }
 
 #ifdef LOG_TO_FILE


### PR DESCRIPTION
Was used by auto-updater which was removed in 7475ba4689fe84913d6feb6d8c6fb79b1d39c5f3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6602)
<!-- Reviewable:end -->
