### PR TITLE
refactor(main): Move main global state into new AppManager class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,16 @@ if(NOT "${SMILEYS}" STREQUAL "DISABLED")
 endif()
 
 set(${PROJECT_NAME}_SOURCES
+  src/appmanager.cpp
+  src/appmanager.h
+  src/friendlist.cpp
+  src/friendlist.h
+  src/grouplist.cpp
+  src/grouplist.h
+  src/ipc.cpp
+  src/ipc.h
+  src/nexus.cpp
+  src/nexus.h
   src/chatlog/chatlinecontent.cpp
   src/chatlog/chatlinecontent.h
   src/chatlog/chatlinecontentproxy.cpp
@@ -250,12 +260,6 @@ set(${PROJECT_NAME}_SOURCES
   src/core/chatid.h
   src/core/toxstring.cpp
   src/core/toxstring.h
-  src/friendlist.cpp
-  src/friendlist.h
-  src/grouplist.cpp
-  src/grouplist.h
-  src/ipc.cpp
-  src/ipc.h
   src/model/about/aboutfriend.cpp
   src/model/about/aboutfriend.h
   src/model/about/iaboutfriend.cpp
@@ -315,8 +319,6 @@ set(${PROJECT_NAME}_SOURCES
   src/net/avatarbroadcaster.h
   src/net/toxuri.cpp
   src/net/toxuri.h
-  src/nexus.cpp
-  src/nexus.h
   src/persistence/db/rawdatabase.cpp
   src/persistence/db/rawdatabase.h
   src/persistence/db/upgrades/dbupgrader.cpp

--- a/src/appmanager.cpp
+++ b/src/appmanager.cpp
@@ -1,0 +1,444 @@
+/*
+    Copyright © 2022 by The qTox Project Contributors
+
+    This file is part of qTox, a Qt-based graphical interface for Tox.
+
+    qTox is libre software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    qTox is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with qTox.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "appmanager.h"
+
+#include "src/widget/tool/messageboxmanager.h"
+#include "src/persistence/settings.h"
+#include "src/persistence/toxsave.h"
+#include "src/persistence/profile.h"
+#include "src/ipc.h"
+#include "src/widget/translator.h"
+#include "src/nexus.h"
+#include "src/net/toxuri.h"
+#include "src/widget/widget.h"
+
+#if defined(Q_OS_UNIX)
+#include "src/platform/posixsignalnotifier.h"
+#endif
+
+#include <QApplication>
+#include <QFontDatabase>
+#include <QCommandLineParser>
+#include <QDir>
+#include <QMessageBox>
+#include <QObject>
+
+namespace
+{
+// logMessageHandler and associated data must be static due to qInstallMessageHandler's
+// inability to register a void* to get back to a class
+#ifdef LOG_TO_FILE
+QAtomicPointer<FILE> logFileFile = nullptr;
+QList<QByteArray>* logBuffer =
+    new QList<QByteArray>(); // Store log messages until log file opened
+QMutex* logBufferMutex = new QMutex();
+#endif
+
+void logMessageHandler(QtMsgType type, const QMessageLogContext& ctxt, const QString& msg)
+{
+    // Silence qWarning spam due to bug in QTextBrowser (trying to open a file for base64 images)
+    if (QString::fromUtf8(ctxt.function) == QString("virtual bool QFSFileEngine::open(QIODevice::OpenMode)")
+        && msg == QString("QFSFileEngine::open: No file name specified")) {
+        return;
+    }
+    if (msg.startsWith("Unable to find any suggestion for")) {
+        // Prevent sonnet's complaints from leaking user chat messages to logs
+        return;
+    }
+
+    if (msg == QString("attempted to send message with network family 10 (probably IPv6) on IPv4 socket")) {
+        // non-stop c-toxcore spam for IPv4 users: https://github.com/TokTok/c-toxcore/issues/1432
+        return;
+    }
+
+    QRegExp snoreFilter{QStringLiteral("Snore::Notification.*was already closed")};
+    if (type == QtWarningMsg
+        && msg.contains(snoreFilter))
+    {
+        // snorenotify logs this when we call requestCloseNotification correctly. The behaviour still works, so we'll
+        // just mask the warning for now. The issue has been reported upstream:
+        // https://github.com/qTox/qTox/pull/6073#pullrequestreview-420748519
+        return;
+    }
+
+    QString file = QString::fromUtf8(ctxt.file);
+    // We're not using QT_MESSAGELOG_FILE here, because that can be 0, NULL, or
+    // nullptr in release builds.
+    QString path = QString(__FILE__);
+    path = path.left(path.lastIndexOf('/') + 1);
+    if (file.startsWith(path)) {
+        file = file.mid(path.length());
+    }
+
+    // Time should be in UTC to save user privacy on log sharing
+    QTime time = QDateTime::currentDateTime().toUTC().time();
+    QString LogMsg =
+        QString("[%1 UTC] %2:%3 : ").arg(time.toString("HH:mm:ss.zzz")).arg(file).arg(ctxt.line);
+    switch (type) {
+    case QtDebugMsg:
+        LogMsg += "Debug";
+        break;
+    case QtInfoMsg:
+        LogMsg += "Info";
+        break;
+    case QtWarningMsg:
+        LogMsg += "Warning";
+        break;
+    case QtCriticalMsg:
+        LogMsg += "Critical";
+        break;
+    case QtFatalMsg:
+        LogMsg += "Fatal";
+        break;
+    default:
+        break;
+    }
+
+    LogMsg += ": " + msg + "\n";
+    QByteArray LogMsgBytes = LogMsg.toUtf8();
+    fwrite(LogMsgBytes.constData(), 1, LogMsgBytes.size(), stderr);
+
+#ifdef LOG_TO_FILE
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    FILE* logFilePtr = logFileFile.loadRelaxed(); // atomically load the file pointer
+#else
+    FILE* logFilePtr = logFileFile.load(); // atomically load the file pointer
+#endif
+    if (!logFilePtr) {
+        logBufferMutex->lock();
+        if (logBuffer)
+            logBuffer->append(LogMsgBytes);
+
+        logBufferMutex->unlock();
+    } else {
+        logBufferMutex->lock();
+        if (logBuffer) {
+            // empty logBuffer to file
+            foreach (QByteArray bufferedMsg, *logBuffer)
+                fwrite(bufferedMsg.constData(), 1, bufferedMsg.size(), logFilePtr);
+
+            delete logBuffer; // no longer needed
+            logBuffer = nullptr;
+        }
+        logBufferMutex->unlock();
+
+        fwrite(LogMsgBytes.constData(), 1, LogMsgBytes.size(), logFilePtr);
+        fflush(logFilePtr);
+    }
+#endif
+}
+
+bool toxURIEventHandler(const QByteArray& eventData, void* userData)
+{
+    ToxURIDialog* uriDialog = static_cast<ToxURIDialog*>(userData);
+    if (!eventData.startsWith("tox:")) {
+        return false;
+    }
+
+    if (!uriDialog) {
+        return false;
+    }
+
+    uriDialog->handleToxURI(QString::fromUtf8(eventData));
+    return true;
+}
+} // namespace
+
+AppManager::AppManager(int argc, char** argv)
+    : qapp((preConstructionInitialization(), new QApplication(argc, argv)))
+    , messageBoxManager(new MessageBoxManager(nullptr))
+    , settings(new Settings(*messageBoxManager))
+    , ipc(new IPC(settings->getCurrentProfileId()))
+    , toxSave(new ToxSave(*settings, *ipc))
+{
+}
+
+void AppManager::preConstructionInitialization()
+{
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
+    QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    QGuiApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+#endif
+    qInstallMessageHandler(logMessageHandler);
+}
+
+int AppManager::run()
+{
+#if defined(Q_OS_UNIX)
+    // PosixSignalNotifier is used only for terminating signals,
+    // so it's connected directly to quit() without any filtering.
+    connect(&PosixSignalNotifier::globalInstance(), &PosixSignalNotifier::activated,
+                     qapp.get(), &QApplication::quit);
+    PosixSignalNotifier::watchCommonTerminatingSignals();
+#endif
+
+    qapp->setApplicationName("qTox");
+#if QT_VERSION >= QT_VERSION_CHECK(5, 7, 0)
+    qapp->setDesktopFileName("io.github.qtox.qTox");
+#endif
+    qapp->setApplicationVersion("\nGit commit: " + QString(GIT_VERSION));
+
+    // Install Unicode 6.1 supporting font
+    // Keep this as close to the beginning of `main()` as possible, otherwise
+    // on systems that have poor support for Unicode qTox will look bad.
+    if (QFontDatabase::addApplicationFont("://font/DejaVuSans.ttf") == -1) {
+        qWarning() << "Couldn't load font";
+    }
+
+    QString locale = settings->getTranslation();
+    // We need to init the resources in the translations_library explicitely.
+    // See https://doc.qt.io/qt-5/resources.html#using-resources-in-a-library
+    Q_INIT_RESOURCE(translations);
+    Translator::translate(locale);
+
+    // Process arguments
+    QCommandLineParser parser;
+    parser.setApplicationDescription("qTox, version: " + QString(GIT_VERSION));
+    parser.addHelpOption();
+    parser.addVersionOption();
+    parser.addPositionalArgument("uri", tr("Tox URI to parse"));
+    parser.addOption(
+        QCommandLineOption(QStringList() << "p"
+                                         << "profile",
+                           tr("Starts new instance and loads specified profile."),
+                           tr("profile")));
+    parser.addOption(
+        QCommandLineOption(QStringList() << "l"
+                                         << "login",
+                           tr("Starts new instance and opens the login screen.")));
+    parser.addOption(QCommandLineOption(QStringList() << "I"
+                                                      << "IPv6",
+                                        tr("Sets IPv6 <on>/<off>. Default is ON."),
+                                        tr("on/off")));
+    parser.addOption(QCommandLineOption(QStringList() << "U"
+                                                      << "UDP",
+                                        tr("Sets UDP <on>/<off>. Default is ON."),
+                                        tr("on/off")));
+    parser.addOption(
+        QCommandLineOption(QStringList() << "L"
+                                         << "LAN",
+                           tr(
+                               "Sets LAN discovery <on>/<off>. UDP off overrides. Default is ON."),
+                           tr("on/off")));
+    parser.addOption(QCommandLineOption(QStringList() << "P"
+                                                      << "proxy",
+                                        tr("Sets proxy settings. Default is NONE."),
+                                        tr("(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)")));
+    parser.process(*qapp);
+
+    if (ipc->isAttached()) {
+        connect(settings.get(), &Settings::currentProfileIdChanged, ipc.get(), &IPC::setProfileId);
+    } else {
+        qWarning() << "Can't init IPC, maybe we're in a jail? Continuing with reduced multi-client functionality.";
+    }
+
+#ifdef LOG_TO_FILE
+    QString logFileDir = settings->getPaths().getAppCacheDirPath();
+    QDir(logFileDir).mkpath(".");
+
+    QString logfile = logFileDir + "qtox.log";
+    FILE* mainLogFilePtr = fopen(logfile.toLocal8Bit().constData(), "a");
+
+    // Trim log file if over 1MB
+    if (QFileInfo(logfile).size() > 1000000) {
+        qDebug() << "Log file over 1MB, rotating...";
+
+        // close old logfile (need for windows)
+        if (mainLogFilePtr)
+            fclose(mainLogFilePtr);
+
+        QDir dir(logFileDir);
+
+        // Check if log.1 already exists, and if so, delete it
+        if (dir.remove(logFileDir + "qtox.log.1"))
+            qDebug() << "Removed old log successfully";
+        else
+            qWarning() << "Unable to remove old log file";
+
+        if (!dir.rename(logFileDir + "qtox.log", logFileDir + "qtox.log.1"))
+            qCritical() << "Unable to move logs";
+
+        // open a new logfile
+        mainLogFilePtr = fopen(logfile.toLocal8Bit().constData(), "a");
+    }
+
+    if (!mainLogFilePtr)
+        qCritical() << "Couldn't open logfile" << logfile;
+
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    logFileFile.storeRelaxed(mainLogFilePtr); // atomically set the logFile
+#else
+    logFileFile.store(mainLogFilePtr); // atomically set the logFile
+#endif
+#endif
+
+    // Windows platform plugins DLL hell fix
+    QCoreApplication::addLibraryPath(QCoreApplication::applicationDirPath());
+    qapp->addLibraryPath("platforms");
+
+    qDebug() << "commit: " << GIT_VERSION;
+
+    QString profileName;
+    bool autoLogin = settings->getAutoLogin();
+
+    uint32_t ipcDest = 0;
+    bool doIpc = ipc->isAttached();
+    QString eventType, firstParam;
+    if (parser.isSet("p")) {
+        profileName = parser.value("p");
+        if (!Profile::exists(profileName, settings->getPaths())) {
+            qWarning() << "-p profile" << profileName + ".tox"
+                       << "doesn't exist, opening login screen";
+            doIpc = false;
+            autoLogin = false;
+        } else {
+            ipcDest = Settings::makeProfileId(profileName);
+            autoLogin = true;
+        }
+    } else if (parser.isSet("l")) {
+        doIpc = false;
+        autoLogin = false;
+    } else {
+        profileName = settings->getCurrentProfile();
+    }
+
+    if (parser.positionalArguments().empty()) {
+        eventType = "activate";
+    } else {
+        firstParam = parser.positionalArguments()[0];
+        // Tox URIs. If there's already another qTox instance running, we ask it to handle the URI
+        // and we exit
+        // Otherwise we start a new qTox instance and process it ourselves
+        if (firstParam.startsWith("tox:")) {
+            eventType = "uri";
+        } else if (firstParam.endsWith(".tox")) {
+            eventType = ToxSave::eventHandlerKey;
+        } else {
+            qCritical() << "Invalid argument";
+            return EXIT_FAILURE;
+        }
+    }
+
+    if (doIpc && !ipc->isCurrentOwner()) {
+        time_t event = ipc->postEvent(eventType, firstParam.toUtf8(), ipcDest);
+        // If someone else processed it, we're done here, no need to actually start qTox
+        if (ipc->waitUntilAccepted(event, 2)) {
+            if (eventType == "activate") {
+                qDebug()
+                    << "Another qTox instance is already running. If you want to start a second "
+                       "instance, please open login screen (qtox -l) or start with a profile (qtox "
+                       "-p <profile name>).";
+            } else {
+                qDebug() << "Event" << eventType << "was handled by other client.";
+            }
+            return EXIT_SUCCESS;
+        }
+    }
+
+    if (!Settings::verifyProxySettings(parser)) {
+        return -1;
+    }
+
+    // TODO(sudden6): remove once we get rid of Nexus
+    Nexus& nexus = Nexus::getInstance();
+    // TODO(kriby): Consider moving application initializing variables into a globalSettings object
+    //  note: Because Settings is shouldering global settings as well as model specific ones it
+    //  cannot be integrated into a central model object yet
+    nexus.setSettings(settings.get());
+    nexus.setMessageBoxManager(messageBoxManager.get());
+    nexus.setIpc(ipc.get());
+    auto& cameraSource = Nexus::getCameraSource();
+    // Autologin
+    // TODO (kriby): Shift responsibility of linking views to model objects from nexus
+    // Further: generate view instances separately (loginScreen, mainGUI, audio)
+    Profile* profile = nullptr;
+    if (autoLogin && Profile::exists(profileName, settings->getPaths()) && !Profile::isEncrypted(profileName, settings->getPaths())) {
+        profile = Profile::loadProfile(profileName, QString(), *settings, &parser, cameraSource, *messageBoxManager);
+        if (!profile) {
+            QMessageBox::information(nullptr, tr("Error"),
+                                     tr("Failed to load profile automatically."));
+        }
+    }
+    if (profile) {
+        nexus.bootstrapWithProfile(profile);
+    } else {
+        nexus.setParser(&parser);
+        int returnval = nexus.showLogin(profileName);
+        if (returnval == QDialog::Rejected) {
+            return -1;
+        }
+        profile = nexus.getProfile();
+    }
+
+    uriDialog = std::unique_ptr<ToxURIDialog>(new ToxURIDialog(nullptr, profile->getCore(), *messageBoxManager));
+
+    if (ipc->isAttached()) {
+        // Start to accept Inter-process communication
+        ipc->registerEventHandler("uri", &toxURIEventHandler, uriDialog.get());
+        ipc->registerEventHandler(ToxSave::eventHandlerKey, &ToxSave::toxSaveEventHandler, toxSave.get());
+        nexus.registerActivate();
+    }
+
+    // Event was not handled by already running instance therefore we handle it ourselves
+    if (eventType == "uri") {
+        uriDialog->handleToxURI(firstParam);
+    } else if (eventType == ToxSave::eventHandlerKey) {
+        toxSave->handleToxSave(firstParam);
+    }
+
+    connect(qapp.get(), &QApplication::aboutToQuit, this, &AppManager::cleanup);
+
+    return qapp->exec();
+}
+
+AppManager::~AppManager() = default;
+
+void AppManager::cleanup()
+{
+    // force save early even though destruction saves, because Windows OS will
+    // close qTox before cleanup() is finished if logging out or shutting down,
+    // once the top level window has exited, which occurs in ~Widget within
+    // ~Nexus. Re-ordering Nexus destruction is not trivial.
+    if (settings) {
+        settings->saveGlobal();
+        settings->savePersonal();
+        settings->sync();
+    }
+
+    Nexus::destroyInstance();
+    settings.reset();
+    qDebug() << "Cleanup success";
+
+    #ifdef LOG_TO_FILE
+    #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+        FILE* f = logFileFile.loadRelaxed();
+    #else
+        FILE* f = logFileFile.load();
+    #endif
+        if (f != nullptr) {
+            fclose(f);
+    #if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+            logFileFile.storeRelaxed(nullptr); // atomically disable logging to file
+    #else
+            logFileFile.store(nullptr); // atomically disable logging to file
+    #endif
+        }
+    #endif
+}

--- a/src/appmanager.h
+++ b/src/appmanager.h
@@ -1,5 +1,5 @@
 /*
-    Copyright © 2014-2019 by The qTox Project Contributors
+    Copyright © 2022 by The qTox Project Contributors
 
     This file is part of qTox, a Qt-based graphical interface for Tox.
 
@@ -17,16 +17,36 @@
     along with qTox.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "appmanager.h"
+#pragma once
 
-#include <QDebug>
-#include <QGuiApplication>
+#include <QObject>
 
-int main(int argc, char* argv[])
+#include <memory>
+
+class MessageBoxManager;
+class Settings;
+class ToxSave;
+class IPC;
+class QApplication;
+class ToxURIDialog;
+
+class AppManager : public QObject
 {
-    AppManager appManager(argc, argv);
-    int errorcode = appManager.run();
+    Q_OBJECT
 
-    qDebug() << "Exit with status" << errorcode;
-    return errorcode;
-}
+public:
+    AppManager(int argc, char** argv);
+    ~AppManager();
+    int run();
+
+private slots:
+    void cleanup();
+private:
+    void preConstructionInitialization();
+    std::unique_ptr<QApplication> qapp;
+    std::unique_ptr<MessageBoxManager> messageBoxManager;
+    std::unique_ptr<Settings> settings;
+    std::unique_ptr<IPC> ipc;
+    std::unique_ptr<ToxSave> toxSave;
+    std::unique_ptr<ToxURIDialog> uriDialog;
+};

--- a/translations/ar.ts
+++ b/translations/ar.ts
@@ -591,6 +591,57 @@ which may lead to problems with video calls.</source>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished">تحليل عنوان URI للتوكس</translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished">بدء تشغيل حالة جديدة ثم يقوم بتحميل الحساب الشخصي المحدد.</translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished">ملف شخصي</translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">خطأ</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2229,18 +2280,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation>تحليل عنوان URI للتوكس</translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation>بدء تشغيل حالة جديدة ثم يقوم بتحميل الحساب الشخصي المحدد.</translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation>ملف شخصي</translation>
-    </message>
-    <message>
         <source>%1 here! Tox me maybe?</source>
         <comment>Default message in Tox URI friend requests. Write something appropriate!</comment>
         <translation>%1 هنا! هل تود التواصل بالتوكس معي؟</translation>
@@ -2288,10 +2327,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation>مكالمة واردة...</translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2309,10 +2344,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
     <message>
         <source>Dark violet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2343,30 +2374,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/ar.ts
+++ b/translations/ar.ts
@@ -594,15 +594,15 @@ which may lead to problems with video calls.</source>
     <name>AppManager</name>
     <message>
         <source>Tox URI to parse</source>
-        <translation type="unfinished">تحليل عنوان URI للتوكس</translation>
+        <translation>تحليل عنوان URI للتوكس</translation>
     </message>
     <message>
         <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished">بدء تشغيل حالة جديدة ثم يقوم بتحميل الحساب الشخصي المحدد.</translation>
+        <translation>بدء تشغيل حالة جديدة ثم يقوم بتحميل الحساب الشخصي المحدد.</translation>
     </message>
     <message>
         <source>profile</source>
-        <translation type="unfinished">ملف شخصي</translation>
+        <translation>ملف شخصي</translation>
     </message>
     <message>
         <source>Starts new instance and opens the login screen.</source>

--- a/translations/be.ts
+++ b/translations/be.ts
@@ -588,6 +588,57 @@ which may lead to problems with video calls.</source>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished">Tox URI для разбору</translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished">Запускае новы экзэмпляр і загружае указаны профіль.</translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished">профіль</translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished">Запускае новы экзэмпляр і адкрывае экран уваходу.</translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Памылка</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2225,18 +2276,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation>Tox URI для разбору</translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation>Запускае новы экзэмпляр і загружае указаны профіль.</translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation>профіль</translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation>Агаданы</translation>
     </message>
@@ -2284,10 +2323,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation>qTox не можа адкрыць журнал чату, ён будзе адключаны.</translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation>Запускае новы экзэмпляр і адкрывае экран уваходу.</translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation>Цёмны</translation>
     </message>
@@ -2306,10 +2341,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Dark violet</source>
         <translation>Цёмна-фіялетавы</translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>online</source>
@@ -2339,30 +2370,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/be.ts
+++ b/translations/be.ts
@@ -591,19 +591,19 @@ which may lead to problems with video calls.</source>
     <name>AppManager</name>
     <message>
         <source>Tox URI to parse</source>
-        <translation type="unfinished">Tox URI для разбору</translation>
+        <translation>Tox URI для разбору</translation>
     </message>
     <message>
         <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished">Запускае новы экзэмпляр і загружае указаны профіль.</translation>
+        <translation>Запускае новы экзэмпляр і загружае указаны профіль.</translation>
     </message>
     <message>
         <source>profile</source>
-        <translation type="unfinished">профіль</translation>
+        <translation>профіль</translation>
     </message>
     <message>
         <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished">Запускае новы экзэмпляр і адкрывае экран уваходу.</translation>
+        <translation>Запускае новы экзэмпляр і адкрывае экран уваходу.</translation>
     </message>
     <message>
         <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>

--- a/translations/bg.ts
+++ b/translations/bg.ts
@@ -592,6 +592,57 @@ which may lead to problems with video calls.</source>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished">Tox URI за подаване</translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished">Стартира нова инстанция и зарежда избран профил.</translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished">профил</translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished">Стартира ново копие и отваря екрана за вписване.</translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished">Задай IPv6 &lt;вкл.&gt;/&lt;изкл.&gt;. по подр. е ВКЛ.</translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished">включено/изключено</translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished">Задай UDP &lt;вкл.&gt;/&lt;изкл.&gt;. по подр. е ВКЛ.</translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished">Задай LAN откриване на &lt;вкл.&gt;/&lt;изкл.&gt;. UDP изключено го пренаписва. по подр. е ВКЛ.</translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished">Задава настройки на прокси сървър. По подразбиране е „Липсва“</translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished">(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Грешка</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished">Грешка при автоматично зареждане на профил.</translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2226,18 +2277,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation>Tox URI за подаване</translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation>Стартира нова инстанция и зарежда избран профил.</translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation>профил</translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation>По подразбиране</translation>
     </message>
@@ -2285,10 +2324,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation>Работен плот</translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation>Стартира ново копие и отваря екрана за вписване.</translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation>Тъмен</translation>
     </message>
@@ -2307,10 +2342,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Dark violet</source>
         <translation>Тъмно виолетово</translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
-        <translation>Грешка при автоматично зареждане на профил.</translation>
     </message>
     <message>
         <source>online</source>
@@ -2341,30 +2372,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation>Преформатиране на текст…</translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation>Задай IPv6 &lt;вкл.&gt;/&lt;изкл.&gt;. по подр. е ВКЛ.</translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation>включено/изключено</translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation>Задай UDP &lt;вкл.&gt;/&lt;изкл.&gt;. по подр. е ВКЛ.</translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation>Задай LAN откриване на &lt;вкл.&gt;/&lt;изкл.&gt;. UDP изключено го пренаписва. по подр. е ВКЛ.</translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation>Задава настройки на прокси сървър. По подразбиране е „Липсва“</translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
-        <translation>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</translation>
     </message>
     <message>
         <source>%1 message(s) from %2 chats</source>

--- a/translations/bg.ts
+++ b/translations/bg.ts
@@ -595,43 +595,43 @@ which may lead to problems with video calls.</source>
     <name>AppManager</name>
     <message>
         <source>Tox URI to parse</source>
-        <translation type="unfinished">Tox URI за подаване</translation>
+        <translation>Tox URI за подаване</translation>
     </message>
     <message>
         <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished">Стартира нова инстанция и зарежда избран профил.</translation>
+        <translation>Стартира нова инстанция и зарежда избран профил.</translation>
     </message>
     <message>
         <source>profile</source>
-        <translation type="unfinished">профил</translation>
+        <translation>профил</translation>
     </message>
     <message>
         <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished">Стартира ново копие и отваря екрана за вписване.</translation>
+        <translation>Стартира ново копие и отваря екрана за вписване.</translation>
     </message>
     <message>
         <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished">Задай IPv6 &lt;вкл.&gt;/&lt;изкл.&gt;. по подр. е ВКЛ.</translation>
+        <translation>Задай IPv6 &lt;вкл.&gt;/&lt;изкл.&gt;. по подр. е ВКЛ.</translation>
     </message>
     <message>
         <source>on/off</source>
-        <translation type="unfinished">включено/изключено</translation>
+        <translation>включено/изключено</translation>
     </message>
     <message>
         <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished">Задай UDP &lt;вкл.&gt;/&lt;изкл.&gt;. по подр. е ВКЛ.</translation>
+        <translation>Задай UDP &lt;вкл.&gt;/&lt;изкл.&gt;. по подр. е ВКЛ.</translation>
     </message>
     <message>
         <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished">Задай LAN откриване на &lt;вкл.&gt;/&lt;изкл.&gt;. UDP изключено го пренаписва. по подр. е ВКЛ.</translation>
+        <translation>Задай LAN откриване на &lt;вкл.&gt;/&lt;изкл.&gt;. UDP изключено го пренаписва. по подр. е ВКЛ.</translation>
     </message>
     <message>
         <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished">Задава настройки на прокси сървър. По подразбиране е „Липсва“</translation>
+        <translation>Задава настройки на прокси сървър. По подразбиране е „Липсва“</translation>
     </message>
     <message>
         <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
-        <translation type="unfinished">(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</translation>
+        <translation>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</translation>
     </message>
     <message>
         <source>Error</source>
@@ -639,7 +639,7 @@ which may lead to problems with video calls.</source>
     </message>
     <message>
         <source>Failed to load profile automatically.</source>
-        <translation type="unfinished">Грешка при автоматично зареждане на профил.</translation>
+        <translation>Грешка при автоматично зареждане на профил.</translation>
     </message>
 </context>
 <context>

--- a/translations/cs.ts
+++ b/translations/cs.ts
@@ -592,6 +592,57 @@ může dojít během video hovoru k výpadkům či jiným problémům.</translat
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished">Tox URI pro zpracování</translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished">Spustit novou instanci a nahrát profil.</translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished">profil</translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished">Spustí novou instanci a otevře přihlašovací obrazovku.</translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished">Nastavuje IPv6 &lt;povoleno&gt;/&lt;zakázáno&gt;. Výchozí je POVOLENO.</translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished">povoleno/zakázáno</translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished">Nastavuje UDP &lt;povoleno&gt;/&lt;zakázáno&gt;. Výchozí je POVOLENO.</translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished">Nastavuje vyhledávání v Místní síti (LAN discovery) &lt;povoleno&gt;/&lt;zakázáno&gt;. Přepíše UDP zakázáno. Výchozí je POVOLENO.</translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished">Nastavení proxy serveru. Výchozí je NONE (žádný).</translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished">(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Chyba</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished">Nepodařilo se automaticky načíst profil.</translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2229,18 +2280,6 @@ ID zahrnuje kód NoSpam (modře) a kontrolní součet (šedě).</translation>
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation>Tox URI pro zpracování</translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation>Spustit novou instanci a nahrát profil.</translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation>profil</translation>
-    </message>
-    <message>
         <source>%1 here! Tox me maybe?</source>
         <comment>Default message in Tox URI friend requests. Write something appropriate!</comment>
         <translation>Jsem %1 ! Napíšeš mi ?</translation>
@@ -2288,10 +2327,6 @@ ID zahrnuje kód NoSpam (modře) a kontrolní součet (šedě).</translation>
         <translation>Plocha</translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation>Spustí novou instanci a otevře přihlašovací obrazovku.</translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation>Tmavý</translation>
     </message>
@@ -2310,10 +2345,6 @@ ID zahrnuje kód NoSpam (modře) a kontrolní součet (šedě).</translation>
     <message>
         <source>Dark violet</source>
         <translation>Tmavě fialová</translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
-        <translation>Nepodařilo se automaticky načíst profil.</translation>
     </message>
     <message>
         <source>online</source>
@@ -2344,30 +2375,6 @@ ID zahrnuje kód NoSpam (modře) a kontrolní součet (šedě).</translation>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation>Přeformátování textu…</translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation>Nastavuje IPv6 &lt;povoleno&gt;/&lt;zakázáno&gt;. Výchozí je POVOLENO.</translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation>povoleno/zakázáno</translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation>Nastavuje UDP &lt;povoleno&gt;/&lt;zakázáno&gt;. Výchozí je POVOLENO.</translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation>Nastavuje vyhledávání v Místní síti (LAN discovery) &lt;povoleno&gt;/&lt;zakázáno&gt;. Přepíše UDP zakázáno. Výchozí je POVOLENO.</translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation>Nastavení proxy serveru. Výchozí je NONE (žádný).</translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
-        <translation>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</translation>
     </message>
     <message>
         <source>%1 message(s) from %2 chats</source>

--- a/translations/cs.ts
+++ b/translations/cs.ts
@@ -595,43 +595,43 @@ může dojít během video hovoru k výpadkům či jiným problémům.</translat
     <name>AppManager</name>
     <message>
         <source>Tox URI to parse</source>
-        <translation type="unfinished">Tox URI pro zpracování</translation>
+        <translation>Tox URI pro zpracování</translation>
     </message>
     <message>
         <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished">Spustit novou instanci a nahrát profil.</translation>
+        <translation>Spustit novou instanci a nahrát profil.</translation>
     </message>
     <message>
         <source>profile</source>
-        <translation type="unfinished">profil</translation>
+        <translation>profil</translation>
     </message>
     <message>
         <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished">Spustí novou instanci a otevře přihlašovací obrazovku.</translation>
+        <translation>Spustí novou instanci a otevře přihlašovací obrazovku.</translation>
     </message>
     <message>
         <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished">Nastavuje IPv6 &lt;povoleno&gt;/&lt;zakázáno&gt;. Výchozí je POVOLENO.</translation>
+        <translation>Nastavuje IPv6 &lt;povoleno&gt;/&lt;zakázáno&gt;. Výchozí je POVOLENO.</translation>
     </message>
     <message>
         <source>on/off</source>
-        <translation type="unfinished">povoleno/zakázáno</translation>
+        <translation>povoleno/zakázáno</translation>
     </message>
     <message>
         <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished">Nastavuje UDP &lt;povoleno&gt;/&lt;zakázáno&gt;. Výchozí je POVOLENO.</translation>
+        <translation>Nastavuje UDP &lt;povoleno&gt;/&lt;zakázáno&gt;. Výchozí je POVOLENO.</translation>
     </message>
     <message>
         <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished">Nastavuje vyhledávání v Místní síti (LAN discovery) &lt;povoleno&gt;/&lt;zakázáno&gt;. Přepíše UDP zakázáno. Výchozí je POVOLENO.</translation>
+        <translation>Nastavuje vyhledávání v Místní síti (LAN discovery) &lt;povoleno&gt;/&lt;zakázáno&gt;. Přepíše UDP zakázáno. Výchozí je POVOLENO.</translation>
     </message>
     <message>
         <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished">Nastavení proxy serveru. Výchozí je NONE (žádný).</translation>
+        <translation>Nastavení proxy serveru. Výchozí je NONE (žádný).</translation>
     </message>
     <message>
         <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
-        <translation type="unfinished">(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</translation>
+        <translation>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</translation>
     </message>
     <message>
         <source>Error</source>
@@ -639,7 +639,7 @@ může dojít během video hovoru k výpadkům či jiným problémům.</translat
     </message>
     <message>
         <source>Failed to load profile automatically.</source>
-        <translation type="unfinished">Nepodařilo se automaticky načíst profil.</translation>
+        <translation>Nepodařilo se automaticky načíst profil.</translation>
     </message>
 </context>
 <context>

--- a/translations/da.ts
+++ b/translations/da.ts
@@ -1364,7 +1364,7 @@ instead of closing entirely.</source>
     </message>
     <message>
         <source>Profile</source>
-        <translation type="unfinished">Profil</translation>
+        <translation>Profil</translation>
     </message>
     <message>
         <source>Rename profile.</source>

--- a/translations/da.ts
+++ b/translations/da.ts
@@ -586,6 +586,57 @@ which may lead to problems with video calls.</source>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Fejl</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2212,18 +2263,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2271,10 +2310,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2292,10 +2327,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
     <message>
         <source>Dark violet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2326,30 +2357,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/de.ts
+++ b/translations/de.ts
@@ -591,6 +591,57 @@ dadurch kann es zu Problemen bei Videoanrufen kommen.</translation>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished">Zu parsende Tox-URI</translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished">Startet eine neue Instanz und lädt das angegebene Profil.</translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished">Profil</translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished">Startet eine neue Instanz und öffnet den Anmeldebildschirm.</translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished">Stellt IPv6 &lt;on&gt;/&lt;off&gt;. Standardmäßig auf ON.</translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished">ein/aus</translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished">Legt UDP-&lt;on&gt;/&lt;off&gt; fest. Der Standardwert ist ON.</translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished">Legt die LAN-Erkennungs-&lt;on&gt;/&lt;off&gt; fest. UDP deaktivierte Außerkraftsetzungen. Der Standardwert ist ON.</translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished">Legt Proxy-Einstellungen fest. Der Standardwert ist KEINE.</translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished">(SOCKS5/HTTP/KEINE):(ADRESSE):(PORT)</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Fehler</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished">Das automatische Laden des Profils ist fehlgeschlagen.</translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2234,18 +2285,6 @@ Diese ID enthält den NoSpam-Code (in blau) und die Prüfsumme (in grau).</trans
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation>Zu parsende Tox-URI</translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation>Startet eine neue Instanz und lädt das angegebene Profil.</translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation>Profil</translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation>Standard</translation>
     </message>
@@ -2293,10 +2332,6 @@ Diese ID enthält den NoSpam-Code (in blau) und die Prüfsumme (in grau).</trans
         <translation>qTox konnte Ihr Gesprächsprotokoll nicht öffnen. Das Speichern der Gespräche wird deaktiviert!</translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation>Startet eine neue Instanz und öffnet den Anmeldebildschirm.</translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation>Dunkel</translation>
     </message>
@@ -2315,10 +2350,6 @@ Diese ID enthält den NoSpam-Code (in blau) und die Prüfsumme (in grau).</trans
     <message>
         <source>Dark violet</source>
         <translation>Dunkelviolett</translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
-        <translation>Das automatische Laden des Profils ist fehlgeschlagen.</translation>
     </message>
     <message>
         <source>online</source>
@@ -2349,30 +2380,6 @@ Diese ID enthält den NoSpam-Code (in blau) und die Prüfsumme (in grau).</trans
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation>Neuformatierung des Texts...</translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation>Stellt IPv6 &lt;on&gt;/&lt;off&gt;. Standardmäßig auf ON.</translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation>ein/aus</translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation>Legt UDP-&lt;on&gt;/&lt;off&gt; fest. Der Standardwert ist ON.</translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation>Legt die LAN-Erkennungs-&lt;on&gt;/&lt;off&gt; fest. UDP deaktivierte Außerkraftsetzungen. Der Standardwert ist ON.</translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation>Legt Proxy-Einstellungen fest. Der Standardwert ist KEINE.</translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
-        <translation>(SOCKS5/HTTP/KEINE):(ADRESSE):(PORT)</translation>
     </message>
     <message>
         <source>%1 message(s) from %2 chats</source>

--- a/translations/de.ts
+++ b/translations/de.ts
@@ -594,43 +594,43 @@ dadurch kann es zu Problemen bei Videoanrufen kommen.</translation>
     <name>AppManager</name>
     <message>
         <source>Tox URI to parse</source>
-        <translation type="unfinished">Zu parsende Tox-URI</translation>
+        <translation>Zu parsende Tox-URI</translation>
     </message>
     <message>
         <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished">Startet eine neue Instanz und lädt das angegebene Profil.</translation>
+        <translation>Startet eine neue Instanz und lädt das angegebene Profil.</translation>
     </message>
     <message>
         <source>profile</source>
-        <translation type="unfinished">Profil</translation>
+        <translation>Profil</translation>
     </message>
     <message>
         <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished">Startet eine neue Instanz und öffnet den Anmeldebildschirm.</translation>
+        <translation>Startet eine neue Instanz und öffnet den Anmeldebildschirm.</translation>
     </message>
     <message>
         <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished">Stellt IPv6 &lt;on&gt;/&lt;off&gt;. Standardmäßig auf ON.</translation>
+        <translation>Stellt IPv6 &lt;on&gt;/&lt;off&gt;. Standardmäßig auf ON.</translation>
     </message>
     <message>
         <source>on/off</source>
-        <translation type="unfinished">ein/aus</translation>
+        <translation>ein/aus</translation>
     </message>
     <message>
         <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished">Legt UDP-&lt;on&gt;/&lt;off&gt; fest. Der Standardwert ist ON.</translation>
+        <translation>Legt UDP-&lt;on&gt;/&lt;off&gt; fest. Der Standardwert ist ON.</translation>
     </message>
     <message>
         <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished">Legt die LAN-Erkennungs-&lt;on&gt;/&lt;off&gt; fest. UDP deaktivierte Außerkraftsetzungen. Der Standardwert ist ON.</translation>
+        <translation>Legt die LAN-Erkennungs-&lt;on&gt;/&lt;off&gt; fest. UDP deaktivierte Außerkraftsetzungen. Der Standardwert ist ON.</translation>
     </message>
     <message>
         <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished">Legt Proxy-Einstellungen fest. Der Standardwert ist KEINE.</translation>
+        <translation>Legt Proxy-Einstellungen fest. Der Standardwert ist KEINE.</translation>
     </message>
     <message>
         <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
-        <translation type="unfinished">(SOCKS5/HTTP/KEINE):(ADRESSE):(PORT)</translation>
+        <translation>(SOCKS5/HTTP/KEINE):(ADRESSE):(PORT)</translation>
     </message>
     <message>
         <source>Error</source>
@@ -638,7 +638,7 @@ dadurch kann es zu Problemen bei Videoanrufen kommen.</translation>
     </message>
     <message>
         <source>Failed to load profile automatically.</source>
-        <translation type="unfinished">Das automatische Laden des Profils ist fehlgeschlagen.</translation>
+        <translation>Das automatische Laden des Profils ist fehlgeschlagen.</translation>
     </message>
 </context>
 <context>

--- a/translations/el.ts
+++ b/translations/el.ts
@@ -587,6 +587,57 @@ which may lead to problems with video calls.</source>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished">Tox URI για ανάλυση</translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished">Ξεκινά νέο συμβάν και φορτώνει το επιλεγμένο προφίλ.</translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished">προφίλ</translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished">Εκκινεί μία νέα συνεδρία και ανοίγει το παράθυρο διαλόγου σύνδεσης.</translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Σφάλμα</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2213,18 +2264,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation>Tox URI για ανάλυση</translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation>Ξεκινά νέο συμβάν και φορτώνει το επιλεγμένο προφίλ.</translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation>προφίλ</translation>
-    </message>
-    <message>
         <source>%1 here! Tox me maybe?</source>
         <comment>Default message in Tox URI friend requests. Write something appropriate!</comment>
         <translation>%1 εδώ! Θέλεις να μιλήσουμε στο Tox;</translation>
@@ -2272,10 +2311,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation>Το qTox δεν μπόρεσε να ανοίξει τα αρχεία καταγραφής των συνομιλιών σας, γι&apos; αυτό θα απενεργοποιηθούν.</translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation>Εκκινεί μία νέα συνεδρία και ανοίγει το παράθυρο διαλόγου σύνδεσης.</translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2293,10 +2328,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
     <message>
         <source>Dark violet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2327,30 +2358,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/el.ts
+++ b/translations/el.ts
@@ -590,19 +590,19 @@ which may lead to problems with video calls.</source>
     <name>AppManager</name>
     <message>
         <source>Tox URI to parse</source>
-        <translation type="unfinished">Tox URI για ανάλυση</translation>
+        <translation>Tox URI για ανάλυση</translation>
     </message>
     <message>
         <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished">Ξεκινά νέο συμβάν και φορτώνει το επιλεγμένο προφίλ.</translation>
+        <translation>Ξεκινά νέο συμβάν και φορτώνει το επιλεγμένο προφίλ.</translation>
     </message>
     <message>
         <source>profile</source>
-        <translation type="unfinished">προφίλ</translation>
+        <translation>προφίλ</translation>
     </message>
     <message>
         <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished">Εκκινεί μία νέα συνεδρία και ανοίγει το παράθυρο διαλόγου σύνδεσης.</translation>
+        <translation>Εκκινεί μία νέα συνεδρία και ανοίγει το παράθυρο διαλόγου σύνδεσης.</translation>
     </message>
     <message>
         <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>

--- a/translations/eo.ts
+++ b/translations/eo.ts
@@ -583,6 +583,57 @@ which may lead to problems with video calls.</source>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished">profilo</translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Eraro</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2201,18 +2252,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation>profilo</translation>
-    </message>
-    <message>
         <source>%1 here! Tox me maybe?</source>
         <comment>Default message in Tox URI friend requests. Write something appropriate!</comment>
         <translation>Jen %1! Toksu min, eble?</translation>
@@ -2260,10 +2299,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2281,10 +2316,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
     <message>
         <source>Dark violet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2315,30 +2346,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/eo.ts
+++ b/translations/eo.ts
@@ -594,7 +594,7 @@ which may lead to problems with video calls.</source>
     </message>
     <message>
         <source>profile</source>
-        <translation type="unfinished">profilo</translation>
+        <translation>profilo</translation>
     </message>
     <message>
         <source>Starts new instance and opens the login screen.</source>

--- a/translations/es.ts
+++ b/translations/es.ts
@@ -592,6 +592,57 @@ lo que puede provocar problemas en las videollamadas.</translation>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished">URI Tox a utilizar</translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished">Inicia una nueva instancia de qTox y carga el perfil especificado.</translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished">perfil</translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished">Inicia una nueva instancia y abre la pantalla de inicio de sesión.</translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished">Establece IPv6 &lt;on&gt;/&lt;off&gt;. El valor predeterminado es ON.</translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished">encendido/apagado</translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished">Establece UDP &lt;on&gt;/&lt;off&gt;. Por defecto es ON.</translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished">Establece el descubrimiento de LAN &lt;activado&gt;/&lt;desactivado&gt;. UDP deshabilitado elimina esta opción. El valor predeterminado es ACTIVADO.</translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished">Establece la configuración del proxy. Por defecto es NINGUNO.</translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished">(SOCKS5/HTTP/ NINGUNO):(DIRECCIÓN):(PUERTA)</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Error</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished">No se pudo cargar el perfil automáticamente.</translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2226,18 +2277,6 @@ Este ID incluye el código NoSpam (en azul), y la suma de comprobación (en gris
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation>URI Tox a utilizar</translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation>Inicia una nueva instancia de qTox y carga el perfil especificado.</translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation>perfil</translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation>Predeterminado</translation>
     </message>
@@ -2285,10 +2324,6 @@ Este ID incluye el código NoSpam (en azul), y la suma de comprobación (en gris
         <translation>qTox no pudo abrir tus historiales de chat, serán deshabilitados.</translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation>Inicia una nueva instancia y abre la pantalla de inicio de sesión.</translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation>Oscuro</translation>
     </message>
@@ -2307,10 +2342,6 @@ Este ID incluye el código NoSpam (en azul), y la suma de comprobación (en gris
     <message>
         <source>Dark violet</source>
         <translation>Morado</translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
-        <translation>No se pudo cargar el perfil automáticamente.</translation>
     </message>
     <message>
         <source>online</source>
@@ -2341,30 +2372,6 @@ Este ID incluye el código NoSpam (en azul), y la suma de comprobación (en gris
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation>Reformateando el texto...</translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation>Establece IPv6 &lt;on&gt;/&lt;off&gt;. El valor predeterminado es ON.</translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation>encendido/apagado</translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation>Establece UDP &lt;on&gt;/&lt;off&gt;. Por defecto es ON.</translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation>Establece el descubrimiento de LAN &lt;activado&gt;/&lt;desactivado&gt;. UDP deshabilitado elimina esta opción. El valor predeterminado es ACTIVADO.</translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation>Establece la configuración del proxy. Por defecto es NINGUNO.</translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
-        <translation>(SOCKS5/HTTP/ NINGUNO):(DIRECCIÓN):(PUERTA)</translation>
     </message>
     <message>
         <source>%1 message(s) from %2 chats</source>

--- a/translations/es.ts
+++ b/translations/es.ts
@@ -595,43 +595,43 @@ lo que puede provocar problemas en las videollamadas.</translation>
     <name>AppManager</name>
     <message>
         <source>Tox URI to parse</source>
-        <translation type="unfinished">URI Tox a utilizar</translation>
+        <translation>URI Tox a utilizar</translation>
     </message>
     <message>
         <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished">Inicia una nueva instancia de qTox y carga el perfil especificado.</translation>
+        <translation>Inicia una nueva instancia de qTox y carga el perfil especificado.</translation>
     </message>
     <message>
         <source>profile</source>
-        <translation type="unfinished">perfil</translation>
+        <translation>perfil</translation>
     </message>
     <message>
         <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished">Inicia una nueva instancia y abre la pantalla de inicio de sesión.</translation>
+        <translation>Inicia una nueva instancia y abre la pantalla de inicio de sesión.</translation>
     </message>
     <message>
         <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished">Establece IPv6 &lt;on&gt;/&lt;off&gt;. El valor predeterminado es ON.</translation>
+        <translation>Establece IPv6 &lt;on&gt;/&lt;off&gt;. El valor predeterminado es ON.</translation>
     </message>
     <message>
         <source>on/off</source>
-        <translation type="unfinished">encendido/apagado</translation>
+        <translation>encendido/apagado</translation>
     </message>
     <message>
         <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished">Establece UDP &lt;on&gt;/&lt;off&gt;. Por defecto es ON.</translation>
+        <translation>Establece UDP &lt;on&gt;/&lt;off&gt;. Por defecto es ON.</translation>
     </message>
     <message>
         <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished">Establece el descubrimiento de LAN &lt;activado&gt;/&lt;desactivado&gt;. UDP deshabilitado elimina esta opción. El valor predeterminado es ACTIVADO.</translation>
+        <translation>Establece el descubrimiento de LAN &lt;activado&gt;/&lt;desactivado&gt;. UDP deshabilitado elimina esta opción. El valor predeterminado es ACTIVADO.</translation>
     </message>
     <message>
         <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished">Establece la configuración del proxy. Por defecto es NINGUNO.</translation>
+        <translation>Establece la configuración del proxy. Por defecto es NINGUNO.</translation>
     </message>
     <message>
         <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
-        <translation type="unfinished">(SOCKS5/HTTP/ NINGUNO):(DIRECCIÓN):(PUERTA)</translation>
+        <translation>(SOCKS5/HTTP/ NINGUNO):(DIRECCIÓN):(PUERTA)</translation>
     </message>
     <message>
         <source>Error</source>
@@ -639,7 +639,7 @@ lo que puede provocar problemas en las videollamadas.</translation>
     </message>
     <message>
         <source>Failed to load profile automatically.</source>
-        <translation type="unfinished">No se pudo cargar el perfil automáticamente.</translation>
+        <translation>No se pudo cargar el perfil automáticamente.</translation>
     </message>
 </context>
 <context>

--- a/translations/et.ts
+++ b/translations/et.ts
@@ -594,43 +594,43 @@ mis võib põhjustada probleeme videokõnedega.</translation>
     <name>AppManager</name>
     <message>
         <source>Tox URI to parse</source>
-        <translation type="unfinished">Toxi URI, mida kasutada</translation>
+        <translation>Toxi URI, mida kasutada</translation>
     </message>
     <message>
         <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished">Käivitab uue üksuse ja laeb määratud profiili.</translation>
+        <translation>Käivitab uue üksuse ja laeb määratud profiili.</translation>
     </message>
     <message>
         <source>profile</source>
-        <translation type="unfinished">profiil</translation>
+        <translation>profiil</translation>
     </message>
     <message>
         <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished">Käivitab uue koopia ja avab sisselogimise ekraani.</translation>
+        <translation>Käivitab uue koopia ja avab sisselogimise ekraani.</translation>
     </message>
     <message>
         <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished">Saad IPv6 võrguprotokolli kasutamise &lt;sisse&gt;/&lt;välja&gt; lülitada. Vaikimisi on ta kasutusel.</translation>
+        <translation>Saad IPv6 võrguprotokolli kasutamise &lt;sisse&gt;/&lt;välja&gt; lülitada. Vaikimisi on ta kasutusel.</translation>
     </message>
     <message>
         <source>on/off</source>
-        <translation type="unfinished">sisse/välja</translation>
+        <translation>sisse/välja</translation>
     </message>
     <message>
         <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished">Saad UPD võrguprotokolli kasutamise &lt;sisse&gt;/&lt;välja&gt; lülitada. Vaikimisi on ta kasutusel.</translation>
+        <translation>Saad UPD võrguprotokolli kasutamise &lt;sisse&gt;/&lt;välja&gt; lülitada. Vaikimisi on ta kasutusel.</translation>
     </message>
     <message>
         <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished">Saad seadmete tuvastamise kohtvõrgus &lt;sisse&gt;/&lt;välja&gt; lülitada. Vaikimisi on ta kasutusel.</translation>
+        <translation>Saad seadmete tuvastamise kohtvõrgus &lt;sisse&gt;/&lt;välja&gt; lülitada. Vaikimisi on ta kasutusel.</translation>
     </message>
     <message>
         <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished">Saad seadistada puhverserveri kasutamise. Vaikimisi on puhverserver seadistamata.</translation>
+        <translation>Saad seadistada puhverserveri kasutamise. Vaikimisi on puhverserver seadistamata.</translation>
     </message>
     <message>
         <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
-        <translation type="unfinished">(SOCKS5/HTTP/NONE):(aadress):(port)</translation>
+        <translation>(SOCKS5/HTTP/NONE):(aadress):(port)</translation>
     </message>
     <message>
         <source>Error</source>
@@ -638,7 +638,7 @@ mis võib põhjustada probleeme videokõnedega.</translation>
     </message>
     <message>
         <source>Failed to load profile automatically.</source>
-        <translation type="unfinished">Profiili automaatne laadimine ebaõnnestus.</translation>
+        <translation>Profiili automaatne laadimine ebaõnnestus.</translation>
     </message>
 </context>
 <context>

--- a/translations/et.ts
+++ b/translations/et.ts
@@ -591,6 +591,57 @@ mis võib põhjustada probleeme videokõnedega.</translation>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished">Toxi URI, mida kasutada</translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished">Käivitab uue üksuse ja laeb määratud profiili.</translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished">profiil</translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished">Käivitab uue koopia ja avab sisselogimise ekraani.</translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished">Saad IPv6 võrguprotokolli kasutamise &lt;sisse&gt;/&lt;välja&gt; lülitada. Vaikimisi on ta kasutusel.</translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished">sisse/välja</translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished">Saad UPD võrguprotokolli kasutamise &lt;sisse&gt;/&lt;välja&gt; lülitada. Vaikimisi on ta kasutusel.</translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished">Saad seadmete tuvastamise kohtvõrgus &lt;sisse&gt;/&lt;välja&gt; lülitada. Vaikimisi on ta kasutusel.</translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished">Saad seadistada puhverserveri kasutamise. Vaikimisi on puhverserver seadistamata.</translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished">(SOCKS5/HTTP/NONE):(aadress):(port)</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Viga</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished">Profiili automaatne laadimine ebaõnnestus.</translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2227,19 +2278,6 @@ See ID sisaldab NoSpam koodi (sinine) ja kontrollsumma (hall).</translation>
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation>Toxi URI, mida kasutada</translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translatorcomment>Pole parim tõlge</translatorcomment>
-        <translation>Käivitab uue üksuse ja laeb määratud profiili.</translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation>profiil</translation>
-    </message>
-    <message>
         <source>%1 here! Tox me maybe?</source>
         <comment>Default message in Tox URI friend requests. Write something appropriate!</comment>
         <translation>%1 siin! Ehk liitud minuga Tox keskkonnas?</translation>
@@ -2287,10 +2325,6 @@ See ID sisaldab NoSpam koodi (sinine) ja kontrollsumma (hall).</translation>
         <translation>Sissetulev kõne...</translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation>Käivitab uue koopia ja avab sisselogimise ekraani.</translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation>Tume</translation>
     </message>
@@ -2309,10 +2343,6 @@ See ID sisaldab NoSpam koodi (sinine) ja kontrollsumma (hall).</translation>
     <message>
         <source>Dark violet</source>
         <translation>Tumelilla</translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
-        <translation>Profiili automaatne laadimine ebaõnnestus.</translation>
     </message>
     <message>
         <source>online</source>
@@ -2343,30 +2373,6 @@ See ID sisaldab NoSpam koodi (sinine) ja kontrollsumma (hall).</translation>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation>Vormindan teksti uuesti...</translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation>Saad IPv6 võrguprotokolli kasutamise &lt;sisse&gt;/&lt;välja&gt; lülitada. Vaikimisi on ta kasutusel.</translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation>sisse/välja</translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation>Saad UPD võrguprotokolli kasutamise &lt;sisse&gt;/&lt;välja&gt; lülitada. Vaikimisi on ta kasutusel.</translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation>Saad seadmete tuvastamise kohtvõrgus &lt;sisse&gt;/&lt;välja&gt; lülitada. Vaikimisi on ta kasutusel.</translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation>Saad seadistada puhverserveri kasutamise. Vaikimisi on puhverserver seadistamata.</translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
-        <translation>(SOCKS5/HTTP/NONE):(aadress):(port)</translation>
     </message>
     <message>
         <source>%1 message(s) from %2 chats</source>

--- a/translations/fa.ts
+++ b/translations/fa.ts
@@ -589,19 +589,19 @@ which may lead to problems with video calls.</source>
     <name>AppManager</name>
     <message>
         <source>Tox URI to parse</source>
-        <translation type="unfinished">آدرس (URI ) Tox به جهت پردازش</translation>
+        <translation>آدرس (URI ) Tox به جهت پردازش</translation>
     </message>
     <message>
         <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished">یک اجرای جدید از برنامه را ضمن بارگذاری پروفایل انتخاب شده ایجاد خواهد کرد.</translation>
+        <translation>یک اجرای جدید از برنامه را ضمن بارگذاری پروفایل انتخاب شده ایجاد خواهد کرد.</translation>
     </message>
     <message>
         <source>profile</source>
-        <translation type="unfinished">پروفایل</translation>
+        <translation>پروفایل</translation>
     </message>
     <message>
         <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished">یک اجرای جدید را آغاز خواهد کرد و صفحه ورود را نشان خواهد داد.</translation>
+        <translation>یک اجرای جدید را آغاز خواهد کرد و صفحه ورود را نشان خواهد داد.</translation>
     </message>
     <message>
         <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
@@ -633,7 +633,7 @@ which may lead to problems with video calls.</source>
     </message>
     <message>
         <source>Failed to load profile automatically.</source>
-        <translation type="unfinished">بارگذاری خودکار نمایه موفق نبود.</translation>
+        <translation>بارگذاری خودکار نمایه موفق نبود.</translation>
     </message>
 </context>
 <context>

--- a/translations/fa.ts
+++ b/translations/fa.ts
@@ -586,6 +586,57 @@ which may lead to problems with video calls.</source>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished">آدرس (URI ) Tox به جهت پردازش</translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished">یک اجرای جدید از برنامه را ضمن بارگذاری پروفایل انتخاب شده ایجاد خواهد کرد.</translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished">پروفایل</translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished">یک اجرای جدید را آغاز خواهد کرد و صفحه ورود را نشان خواهد داد.</translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">خطا</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished">بارگذاری خودکار نمایه موفق نبود.</translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2217,18 +2268,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation>آدرس (URI ) Tox به جهت پردازش</translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation>یک اجرای جدید از برنامه را ضمن بارگذاری پروفایل انتخاب شده ایجاد خواهد کرد.</translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation>پروفایل</translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation>پیش فرض</translation>
     </message>
@@ -2276,10 +2315,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation>امکان بازکردن لاگ های چت شما برای qTox وجود نداشت، این امکان غیر فعال میشود.</translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation>یک اجرای جدید را آغاز خواهد کرد و صفحه ورود را نشان خواهد داد.</translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation>تیره</translation>
     </message>
@@ -2298,10 +2333,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Dark violet</source>
         <translation>بنفش تیره</translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
-        <translation>بارگذاری خودکار نمایه موفق نبود.</translation>
     </message>
     <message>
         <source>online</source>
@@ -2331,30 +2362,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/fi.ts
+++ b/translations/fi.ts
@@ -594,43 +594,43 @@ mikä voi johtaa ongelmiin videopuheluissa.</translation>
     <name>AppManager</name>
     <message>
         <source>Tox URI to parse</source>
-        <translation type="unfinished">Tox URI:t järjestettäväksi</translation>
+        <translation>Tox URI:t järjestettäväksi</translation>
     </message>
     <message>
         <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished">Käynnistää uuden instanssin ja lataa määritetyn profiilin.</translation>
+        <translation>Käynnistää uuden instanssin ja lataa määritetyn profiilin.</translation>
     </message>
     <message>
         <source>profile</source>
-        <translation type="unfinished">Profiili</translation>
+        <translation>Profiili</translation>
     </message>
     <message>
         <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished">Aloittaa uuden istunnon ja avaa kirjautumisikkunan.</translation>
+        <translation>Aloittaa uuden istunnon ja avaa kirjautumisikkunan.</translation>
     </message>
     <message>
         <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished">Kytke IPv6 &lt;päälle&gt;/&lt;pois&gt;. IPv6 on oletuksenä PÄÄLLÄ.</translation>
+        <translation>Kytke IPv6 &lt;päälle&gt;/&lt;pois&gt;. IPv6 on oletuksenä PÄÄLLÄ.</translation>
     </message>
     <message>
         <source>on/off</source>
-        <translation type="unfinished">päällä/pois</translation>
+        <translation>päällä/pois</translation>
     </message>
     <message>
         <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished">Kytke UDP &lt;päällä&gt;/&lt;pois&gt;. Oletukena PÄÄLLÄ.</translation>
+        <translation>Kytke UDP &lt;päällä&gt;/&lt;pois&gt;. Oletukena PÄÄLLÄ.</translation>
     </message>
     <message>
         <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished">Asettaa lähiverkon etsinnän &lt;päälle&gt;/&lt;pois&gt;. Ei toimi jos UDP ei ole käytössä. Oletksena asetus on PÄÄLLÄ.</translation>
+        <translation>Asettaa lähiverkon etsinnän &lt;päälle&gt;/&lt;pois&gt;. Ei toimi jos UDP ei ole käytössä. Oletksena asetus on PÄÄLLÄ.</translation>
     </message>
     <message>
         <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished">Aseta proxy-asetukset. Oletaksena proxy ei ole käytössä.</translation>
+        <translation>Aseta proxy-asetukset. Oletaksena proxy ei ole käytössä.</translation>
     </message>
     <message>
         <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
-        <translation type="unfinished">(SOCKS5/HTTP/NONE:(osoite):(portti)</translation>
+        <translation>(SOCKS5/HTTP/NONE:(osoite):(portti)</translation>
     </message>
     <message>
         <source>Error</source>
@@ -638,7 +638,7 @@ mikä voi johtaa ongelmiin videopuheluissa.</translation>
     </message>
     <message>
         <source>Failed to load profile automatically.</source>
-        <translation type="unfinished">Profiilin automaattinen lataaminen epäonnistui.</translation>
+        <translation>Profiilin automaattinen lataaminen epäonnistui.</translation>
     </message>
 </context>
 <context>

--- a/translations/fi.ts
+++ b/translations/fi.ts
@@ -591,6 +591,57 @@ mikä voi johtaa ongelmiin videopuheluissa.</translation>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished">Tox URI:t järjestettäväksi</translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished">Käynnistää uuden instanssin ja lataa määritetyn profiilin.</translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished">Profiili</translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished">Aloittaa uuden istunnon ja avaa kirjautumisikkunan.</translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished">Kytke IPv6 &lt;päälle&gt;/&lt;pois&gt;. IPv6 on oletuksenä PÄÄLLÄ.</translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished">päällä/pois</translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished">Kytke UDP &lt;päällä&gt;/&lt;pois&gt;. Oletukena PÄÄLLÄ.</translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished">Asettaa lähiverkon etsinnän &lt;päälle&gt;/&lt;pois&gt;. Ei toimi jos UDP ei ole käytössä. Oletksena asetus on PÄÄLLÄ.</translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished">Aseta proxy-asetukset. Oletaksena proxy ei ole käytössä.</translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished">(SOCKS5/HTTP/NONE:(osoite):(portti)</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Virhe</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished">Profiilin automaattinen lataaminen epäonnistui.</translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2225,18 +2276,6 @@ Tämä ID sisältää spammin estävän koodin(joka on sinisellä), ja tarkistus
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation>Tox URI:t järjestettäväksi</translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation>Käynnistää uuden instanssin ja lataa määritetyn profiilin.</translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation>Profiili</translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation>Oletus</translation>
     </message>
@@ -2284,10 +2323,6 @@ Tämä ID sisältää spammin estävän koodin(joka on sinisellä), ja tarkistus
         <translation>qTox ei pystynyt avaamaan chatti-logeja. Ne kytketään pois.</translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation>Aloittaa uuden istunnon ja avaa kirjautumisikkunan.</translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation>Tumma</translation>
     </message>
@@ -2306,10 +2341,6 @@ Tämä ID sisältää spammin estävän koodin(joka on sinisellä), ja tarkistus
     <message>
         <source>Dark violet</source>
         <translation>Tummanvioletti</translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
-        <translation>Profiilin automaattinen lataaminen epäonnistui.</translation>
     </message>
     <message>
         <source>online</source>
@@ -2340,30 +2371,6 @@ Tämä ID sisältää spammin estävän koodin(joka on sinisellä), ja tarkistus
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation>Uudelleenmuotoillaan tekstiä...</translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation>Kytke IPv6 &lt;päälle&gt;/&lt;pois&gt;. IPv6 on oletuksenä PÄÄLLÄ.</translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation>päällä/pois</translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation>Kytke UDP &lt;päällä&gt;/&lt;pois&gt;. Oletukena PÄÄLLÄ.</translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation>Asettaa lähiverkon etsinnän &lt;päälle&gt;/&lt;pois&gt;. Ei toimi jos UDP ei ole käytössä. Oletksena asetus on PÄÄLLÄ.</translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation>Aseta proxy-asetukset. Oletaksena proxy ei ole käytössä.</translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
-        <translation>(SOCKS5/HTTP/NONE:(osoite):(portti)</translation>
     </message>
     <message>
         <source>%1 message(s) from %2 chats</source>

--- a/translations/fr.ts
+++ b/translations/fr.ts
@@ -591,6 +591,57 @@ ce qui peut entraîner des problèmes lors des appels vidéo.</translation>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished">URI Tox à analyser</translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished">Démarrer une nouvelle instance et charger le profil spécifié.</translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished">profil</translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished">Démarre une nouvelle instance et ouvre l&apos;écran de connexion.</translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished">Définit IPv6 &lt;on&gt;/&lt;off&gt;. La valeur par défaut est ON.</translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished">marche/arrêt</translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished">Définit UDP &lt;on&gt;/&lt;off&gt;. La valeur par défaut est ON.</translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished">Définit la découverte LAN &lt;on&gt;/&lt;off&gt;. UDP &quot;off&quot; élimine cette option. La valeur par défaut est ON.</translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished">Définit les paramètres du proxy. La valeur par défaut est AUCUN.</translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished">(SOCKS5/HTTP/NONE):(ADRESSE):(PORT)</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Erreur</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished">Impossible de charger le profil automatiquement.</translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2225,18 +2276,6 @@ Cet identifiant comprend le code NoSpam (en bleu) et la somme de contrôle (en g
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation>URI Tox à analyser</translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation>Démarrer une nouvelle instance et charger le profil spécifié.</translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation>profil</translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation>Défaut</translation>
     </message>
@@ -2284,10 +2323,6 @@ Cet identifiant comprend le code NoSpam (en bleu) et la somme de contrôle (en g
         <translation>qTox ne peux pas ouvrir vos journaux de discussions. Ils seront désactivés.</translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation>Démarre une nouvelle instance et ouvre l&apos;écran de connexion.</translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation>Foncé</translation>
     </message>
@@ -2306,10 +2341,6 @@ Cet identifiant comprend le code NoSpam (en bleu) et la somme de contrôle (en g
     <message>
         <source>Dark violet</source>
         <translation>Violet foncé</translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
-        <translation>Impossible de charger le profil automatiquement.</translation>
     </message>
     <message>
         <source>online</source>
@@ -2340,30 +2371,6 @@ Cet identifiant comprend le code NoSpam (en bleu) et la somme de contrôle (en g
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation>Reformatage du texte ...</translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation>Définit IPv6 &lt;on&gt;/&lt;off&gt;. La valeur par défaut est ON.</translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation>marche/arrêt</translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation>Définit UDP &lt;on&gt;/&lt;off&gt;. La valeur par défaut est ON.</translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation>Définit la découverte LAN &lt;on&gt;/&lt;off&gt;. UDP &quot;off&quot; élimine cette option. La valeur par défaut est ON.</translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation>Définit les paramètres du proxy. La valeur par défaut est AUCUN.</translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
-        <translation>(SOCKS5/HTTP/NONE):(ADRESSE):(PORT)</translation>
     </message>
     <message>
         <source>%1 message(s) from %2 chats</source>

--- a/translations/fr.ts
+++ b/translations/fr.ts
@@ -594,43 +594,43 @@ ce qui peut entraîner des problèmes lors des appels vidéo.</translation>
     <name>AppManager</name>
     <message>
         <source>Tox URI to parse</source>
-        <translation type="unfinished">URI Tox à analyser</translation>
+        <translation>URI Tox à analyser</translation>
     </message>
     <message>
         <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished">Démarrer une nouvelle instance et charger le profil spécifié.</translation>
+        <translation>Démarrer une nouvelle instance et charger le profil spécifié.</translation>
     </message>
     <message>
         <source>profile</source>
-        <translation type="unfinished">profil</translation>
+        <translation>profil</translation>
     </message>
     <message>
         <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished">Démarre une nouvelle instance et ouvre l&apos;écran de connexion.</translation>
+        <translation>Démarre une nouvelle instance et ouvre l&apos;écran de connexion.</translation>
     </message>
     <message>
         <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished">Définit IPv6 &lt;on&gt;/&lt;off&gt;. La valeur par défaut est ON.</translation>
+        <translation>Définit IPv6 &lt;on&gt;/&lt;off&gt;. La valeur par défaut est ON.</translation>
     </message>
     <message>
         <source>on/off</source>
-        <translation type="unfinished">marche/arrêt</translation>
+        <translation>marche/arrêt</translation>
     </message>
     <message>
         <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished">Définit UDP &lt;on&gt;/&lt;off&gt;. La valeur par défaut est ON.</translation>
+        <translation>Définit UDP &lt;on&gt;/&lt;off&gt;. La valeur par défaut est ON.</translation>
     </message>
     <message>
         <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished">Définit la découverte LAN &lt;on&gt;/&lt;off&gt;. UDP &quot;off&quot; élimine cette option. La valeur par défaut est ON.</translation>
+        <translation>Définit la découverte LAN &lt;on&gt;/&lt;off&gt;. UDP &quot;off&quot; élimine cette option. La valeur par défaut est ON.</translation>
     </message>
     <message>
         <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished">Définit les paramètres du proxy. La valeur par défaut est AUCUN.</translation>
+        <translation>Définit les paramètres du proxy. La valeur par défaut est AUCUN.</translation>
     </message>
     <message>
         <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
-        <translation type="unfinished">(SOCKS5/HTTP/NONE):(ADRESSE):(PORT)</translation>
+        <translation>(SOCKS5/HTTP/NONE):(ADRESSE):(PORT)</translation>
     </message>
     <message>
         <source>Error</source>
@@ -638,7 +638,7 @@ ce qui peut entraîner des problèmes lors des appels vidéo.</translation>
     </message>
     <message>
         <source>Failed to load profile automatically.</source>
-        <translation type="unfinished">Impossible de charger le profil automatiquement.</translation>
+        <translation>Impossible de charger le profil automatiquement.</translation>
     </message>
 </context>
 <context>

--- a/translations/gl.ts
+++ b/translations/gl.ts
@@ -590,19 +590,19 @@ which may lead to problems with video calls.</source>
     <name>AppManager</name>
     <message>
         <source>Tox URI to parse</source>
-        <translation type="unfinished">Tox URI para analizar</translation>
+        <translation>Tox URI para analizar</translation>
     </message>
     <message>
         <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished">Inicia unha nova instancia e carga o perfil especificado.</translation>
+        <translation>Inicia unha nova instancia e carga o perfil especificado.</translation>
     </message>
     <message>
         <source>profile</source>
-        <translation type="unfinished">perfil</translation>
+        <translation>perfil</translation>
     </message>
     <message>
         <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished">Inicia unha nova instancia e abre a pantalla de inicio de sesión.</translation>
+        <translation>Inicia unha nova instancia e abre a pantalla de inicio de sesión.</translation>
     </message>
     <message>
         <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
@@ -634,7 +634,7 @@ which may lead to problems with video calls.</source>
     </message>
     <message>
         <source>Failed to load profile automatically.</source>
-        <translation type="unfinished">Erro ao cargar o perfil automaticamente.</translation>
+        <translation>Erro ao cargar o perfil automaticamente.</translation>
     </message>
 </context>
 <context>

--- a/translations/gl.ts
+++ b/translations/gl.ts
@@ -587,6 +587,57 @@ which may lead to problems with video calls.</source>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished">Tox URI para analizar</translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished">Inicia unha nova instancia e carga o perfil especificado.</translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished">perfil</translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished">Inicia unha nova instancia e abre a pantalla de inicio de sesión.</translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Erro</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished">Erro ao cargar o perfil automaticamente.</translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2221,18 +2272,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation>Tox URI para analizar</translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation>Inicia unha nova instancia e carga o perfil especificado.</translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation>perfil</translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation>Por defecto</translation>
     </message>
@@ -2280,10 +2319,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation>qTox non puido abrir os seus rexistros de charla, estarán desactivados.</translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation>Inicia unha nova instancia e abre a pantalla de inicio de sesión.</translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation>Escuro</translation>
     </message>
@@ -2302,10 +2337,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Dark violet</source>
         <translation>Violeta escura</translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
-        <translation>Erro ao cargar o perfil automaticamente.</translation>
     </message>
     <message>
         <source>online</source>
@@ -2335,30 +2366,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/he.ts
+++ b/translations/he.ts
@@ -583,6 +583,57 @@ which may lead to problems with video calls.</source>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2209,18 +2260,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2268,10 +2307,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2289,10 +2324,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
     <message>
         <source>Dark violet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2323,30 +2354,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/hr.ts
+++ b/translations/hr.ts
@@ -588,6 +588,57 @@ which may lead to problems with video calls.</source>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished">Tox URI za raščlanjivanje</translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished">Pokreće novu instancu i učitava odabrani profil.</translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished">profil</translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished">Pokreće novu instancu i otvara prozor za prijavu.</translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Pogreška</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished">Neuspjelo automatsko učitavanje profila.</translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2217,18 +2268,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation>Tox URI za raščlanjivanje</translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation>Pokreće novu instancu i učitava odabrani profil.</translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation>profil</translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation>Standardno</translation>
     </message>
@@ -2276,10 +2315,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation>Radna površina</translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation>Pokreće novu instancu i otvara prozor za prijavu.</translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation>Tamno</translation>
     </message>
@@ -2298,10 +2333,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Dark violet</source>
         <translation>Tamnoljubičasto</translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
-        <translation>Neuspjelo automatsko učitavanje profila.</translation>
     </message>
     <message>
         <source>online</source>
@@ -2331,30 +2362,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/hr.ts
+++ b/translations/hr.ts
@@ -591,19 +591,19 @@ which may lead to problems with video calls.</source>
     <name>AppManager</name>
     <message>
         <source>Tox URI to parse</source>
-        <translation type="unfinished">Tox URI za raščlanjivanje</translation>
+        <translation>Tox URI za raščlanjivanje</translation>
     </message>
     <message>
         <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished">Pokreće novu instancu i učitava odabrani profil.</translation>
+        <translation>Pokreće novu instancu i učitava odabrani profil.</translation>
     </message>
     <message>
         <source>profile</source>
-        <translation type="unfinished">profil</translation>
+        <translation>profil</translation>
     </message>
     <message>
         <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished">Pokreće novu instancu i otvara prozor za prijavu.</translation>
+        <translation>Pokreće novu instancu i otvara prozor za prijavu.</translation>
     </message>
     <message>
         <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
@@ -635,7 +635,7 @@ which may lead to problems with video calls.</source>
     </message>
     <message>
         <source>Failed to load profile automatically.</source>
-        <translation type="unfinished">Neuspjelo automatsko učitavanje profila.</translation>
+        <translation>Neuspjelo automatsko učitavanje profila.</translation>
     </message>
 </context>
 <context>

--- a/translations/hu.ts
+++ b/translations/hu.ts
@@ -586,6 +586,57 @@ which may lead to problems with video calls.</source>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished">Tox URI elemzés</translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished">Új folyamatot indít, és betölt egy megadott profilt.</translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished">profil</translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished">Új folyamat indítása, és a bejelentkezési képernyő megnyitása.</translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Hiba</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished">Profil automatikus betöltése sikertelen.</translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2209,18 +2260,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation>Tox URI elemzés</translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation>Új folyamatot indít, és betölt egy megadott profilt.</translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation>profil</translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation>Alapértelmezett</translation>
     </message>
@@ -2268,10 +2307,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation>Asztal</translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation>Új folyamat indítása, és a bejelentkezési képernyő megnyitása.</translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation>Sötét</translation>
     </message>
@@ -2290,10 +2325,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Dark violet</source>
         <translation>Sötétlila</translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
-        <translation>Profil automatikus betöltése sikertelen.</translation>
     </message>
     <message>
         <source>online</source>
@@ -2323,30 +2354,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/hu.ts
+++ b/translations/hu.ts
@@ -589,19 +589,19 @@ which may lead to problems with video calls.</source>
     <name>AppManager</name>
     <message>
         <source>Tox URI to parse</source>
-        <translation type="unfinished">Tox URI elemzés</translation>
+        <translation>Tox URI elemzés</translation>
     </message>
     <message>
         <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished">Új folyamatot indít, és betölt egy megadott profilt.</translation>
+        <translation>Új folyamatot indít, és betölt egy megadott profilt.</translation>
     </message>
     <message>
         <source>profile</source>
-        <translation type="unfinished">profil</translation>
+        <translation>profil</translation>
     </message>
     <message>
         <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished">Új folyamat indítása, és a bejelentkezési képernyő megnyitása.</translation>
+        <translation>Új folyamat indítása, és a bejelentkezési képernyő megnyitása.</translation>
     </message>
     <message>
         <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
@@ -633,7 +633,7 @@ which may lead to problems with video calls.</source>
     </message>
     <message>
         <source>Failed to load profile automatically.</source>
-        <translation type="unfinished">Profil automatikus betöltése sikertelen.</translation>
+        <translation>Profil automatikus betöltése sikertelen.</translation>
     </message>
 </context>
 <context>

--- a/translations/is.ts
+++ b/translations/is.ts
@@ -583,6 +583,57 @@ which may lead to problems with video calls.</source>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2209,18 +2260,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2268,10 +2307,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2289,10 +2324,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
     <message>
         <source>Dark violet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2323,30 +2354,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/it.ts
+++ b/translations/it.ts
@@ -591,6 +591,57 @@ il che può portare a problemi con le videochiamate.</translation>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished">URI Tox da interpretare</translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished">Avvia una nuova istanza caricando il profilo selezionato.</translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished">profilo</translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished">Apre una nuova istanza con la finestra d&apos;accesso.</translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Errore</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished">Impossibile caricare automaticamente il profilo.</translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2222,18 +2273,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation>URI Tox da interpretare</translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation>Avvia una nuova istanza caricando il profilo selezionato.</translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation>profilo</translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation>Default</translation>
     </message>
@@ -2281,10 +2320,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation>Scrivania</translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation>Apre una nuova istanza con la finestra d&apos;accesso.</translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation>Scuro</translation>
     </message>
@@ -2303,10 +2338,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Dark violet</source>
         <translation>Viola scuro</translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
-        <translation>Impossibile caricare automaticamente il profilo.</translation>
     </message>
     <message>
         <source>online</source>
@@ -2336,30 +2367,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/it.ts
+++ b/translations/it.ts
@@ -594,19 +594,19 @@ il che può portare a problemi con le videochiamate.</translation>
     <name>AppManager</name>
     <message>
         <source>Tox URI to parse</source>
-        <translation type="unfinished">URI Tox da interpretare</translation>
+        <translation>URI Tox da interpretare</translation>
     </message>
     <message>
         <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished">Avvia una nuova istanza caricando il profilo selezionato.</translation>
+        <translation>Avvia una nuova istanza caricando il profilo selezionato.</translation>
     </message>
     <message>
         <source>profile</source>
-        <translation type="unfinished">profilo</translation>
+        <translation>profilo</translation>
     </message>
     <message>
         <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished">Apre una nuova istanza con la finestra d&apos;accesso.</translation>
+        <translation>Apre una nuova istanza con la finestra d&apos;accesso.</translation>
     </message>
     <message>
         <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
@@ -638,7 +638,7 @@ il che può portare a problemi con le videochiamate.</translation>
     </message>
     <message>
         <source>Failed to load profile automatically.</source>
-        <translation type="unfinished">Impossibile caricare automaticamente il profilo.</translation>
+        <translation>Impossibile caricare automaticamente il profilo.</translation>
     </message>
 </context>
 <context>

--- a/translations/ja.ts
+++ b/translations/ja.ts
@@ -586,6 +586,57 @@ which may lead to problems with video calls.</source>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished">解析用の Tox URI</translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished">新しいインスタンスを起動して、指定されたプロファイルを読み込みます。</translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished">プロファイル</translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished">新しいインスタンスを開始して、ログイン画面を開いてください。</translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">エラー</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2208,18 +2259,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation>解析用の Tox URI</translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation>新しいインスタンスを起動して、指定されたプロファイルを読み込みます。</translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation>プロファイル</translation>
-    </message>
-    <message>
         <source>%1 here! Tox me maybe?</source>
         <comment>Default message in Tox URI friend requests. Write something appropriate!</comment>
         <translation>%1 だよ！Tox で会話しない？</translation>
@@ -2267,10 +2306,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation>お電話です…</translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation>新しいインスタンスを開始して、ログイン画面を開いてください。</translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2288,10 +2323,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
     <message>
         <source>Dark violet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2322,30 +2353,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/ja.ts
+++ b/translations/ja.ts
@@ -589,19 +589,19 @@ which may lead to problems with video calls.</source>
     <name>AppManager</name>
     <message>
         <source>Tox URI to parse</source>
-        <translation type="unfinished">解析用の Tox URI</translation>
+        <translation>解析用の Tox URI</translation>
     </message>
     <message>
         <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished">新しいインスタンスを起動して、指定されたプロファイルを読み込みます。</translation>
+        <translation>新しいインスタンスを起動して、指定されたプロファイルを読み込みます。</translation>
     </message>
     <message>
         <source>profile</source>
-        <translation type="unfinished">プロファイル</translation>
+        <translation>プロファイル</translation>
     </message>
     <message>
         <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished">新しいインスタンスを開始して、ログイン画面を開いてください。</translation>
+        <translation>新しいインスタンスを開始して、ログイン画面を開いてください。</translation>
     </message>
     <message>
         <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>

--- a/translations/kn.ts
+++ b/translations/kn.ts
@@ -583,6 +583,57 @@ which may lead to problems with video calls.</source>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2209,18 +2260,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2268,10 +2307,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2289,10 +2324,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
     <message>
         <source>Dark violet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2323,30 +2354,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/ko.ts
+++ b/translations/ko.ts
@@ -584,6 +584,57 @@ which may lead to problems with video calls.</source>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2207,18 +2258,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2266,10 +2305,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2287,10 +2322,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
     <message>
         <source>Dark violet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2321,30 +2352,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/lt.ts
+++ b/translations/lt.ts
@@ -595,43 +595,43 @@ dėl to gali kilti vaizdo skambučių problemų.</translation>
     <name>AppManager</name>
     <message>
         <source>Tox URI to parse</source>
-        <translation type="unfinished">analizuoti Tox URI</translation>
+        <translation>analizuoti Tox URI</translation>
     </message>
     <message>
         <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished">Atidaro naują langą ir aktyvuoja nurodytą profilį.</translation>
+        <translation>Atidaro naują langą ir aktyvuoja nurodytą profilį.</translation>
     </message>
     <message>
         <source>profile</source>
-        <translation type="unfinished">profilis</translation>
+        <translation>profilis</translation>
     </message>
     <message>
         <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished">Paleidžia naują egzempliorių ir atveria prisijungimo ekraną.</translation>
+        <translation>Paleidžia naują egzempliorių ir atveria prisijungimo ekraną.</translation>
     </message>
     <message>
         <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished">Nustato IPv6 &lt;įjungta&gt;/&lt;išjungta&gt;. Numatytoji reikšmė yra ĮJUNGTA.</translation>
+        <translation>Nustato IPv6 &lt;įjungta&gt;/&lt;išjungta&gt;. Numatytoji reikšmė yra ĮJUNGTA.</translation>
     </message>
     <message>
         <source>on/off</source>
-        <translation type="unfinished">įjungta/išjungta</translation>
+        <translation>įjungta/išjungta</translation>
     </message>
     <message>
         <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished">Nustato UDP &lt;įjungta&gt;/&lt;išjungta&gt;. Numatytoji reikšmė yra ĮJUNGTA.</translation>
+        <translation>Nustato UDP &lt;įjungta&gt;/&lt;išjungta&gt;. Numatytoji reikšmė yra ĮJUNGTA.</translation>
     </message>
     <message>
         <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished">Nustato LAN aptikimą &lt;įjungta&gt;/&lt;išjungta&gt;. UDP išjungimas turi viršenybę. Numatytasis yra ĮJUNGTA.</translation>
+        <translation>Nustato LAN aptikimą &lt;įjungta&gt;/&lt;išjungta&gt;. UDP išjungimas turi viršenybę. Numatytasis yra ĮJUNGTA.</translation>
     </message>
     <message>
         <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished">Nustato įgaliotojo serverio nustatymus. Numatytoji reikšmė yra NĖRA.</translation>
+        <translation>Nustato įgaliotojo serverio nustatymus. Numatytoji reikšmė yra NĖRA.</translation>
     </message>
     <message>
         <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
-        <translation type="unfinished">(SOCKS5/HTTP/NĖRA):(ADRESAS):(PRIEVADAS)</translation>
+        <translation>(SOCKS5/HTTP/NĖRA):(ADRESAS):(PRIEVADAS)</translation>
     </message>
     <message>
         <source>Error</source>
@@ -639,7 +639,7 @@ dėl to gali kilti vaizdo skambučių problemų.</translation>
     </message>
     <message>
         <source>Failed to load profile automatically.</source>
-        <translation type="unfinished">Nepavyko automatiškai įkelti profilio.</translation>
+        <translation>Nepavyko automatiškai įkelti profilio.</translation>
     </message>
 </context>
 <context>

--- a/translations/lt.ts
+++ b/translations/lt.ts
@@ -592,6 +592,57 @@ dėl to gali kilti vaizdo skambučių problemų.</translation>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished">analizuoti Tox URI</translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished">Atidaro naują langą ir aktyvuoja nurodytą profilį.</translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished">profilis</translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished">Paleidžia naują egzempliorių ir atveria prisijungimo ekraną.</translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished">Nustato IPv6 &lt;įjungta&gt;/&lt;išjungta&gt;. Numatytoji reikšmė yra ĮJUNGTA.</translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished">įjungta/išjungta</translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished">Nustato UDP &lt;įjungta&gt;/&lt;išjungta&gt;. Numatytoji reikšmė yra ĮJUNGTA.</translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished">Nustato LAN aptikimą &lt;įjungta&gt;/&lt;išjungta&gt;. UDP išjungimas turi viršenybę. Numatytasis yra ĮJUNGTA.</translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished">Nustato įgaliotojo serverio nustatymus. Numatytoji reikšmė yra NĖRA.</translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished">(SOCKS5/HTTP/NĖRA):(ADRESAS):(PRIEVADAS)</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Klaida</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished">Nepavyko automatiškai įkelti profilio.</translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2231,18 +2282,6 @@ Pasidalinkite ja su draugais, kad pradėtumėte kalbėtis.
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation>analizuoti Tox URI</translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation>Atidaro naują langą ir aktyvuoja nurodytą profilį.</translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation>profilis</translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation>Numatyta</translation>
     </message>
@@ -2290,10 +2329,6 @@ Pasidalinkite ja su draugais, kad pradėtumėte kalbėtis.
         <translation>qTox nepavyko atidaryti pokalbių žurnalo, todėl jis buvo išjungtas.</translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation>Paleidžia naują egzempliorių ir atveria prisijungimo ekraną.</translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation>Tamsi</translation>
     </message>
@@ -2312,10 +2347,6 @@ Pasidalinkite ja su draugais, kad pradėtumėte kalbėtis.
     <message>
         <source>Dark violet</source>
         <translation>Tamsiai violetinė</translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
-        <translation>Nepavyko automatiškai įkelti profilio.</translation>
     </message>
     <message>
         <source>online</source>
@@ -2346,30 +2377,6 @@ Pasidalinkite ja su draugais, kad pradėtumėte kalbėtis.
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation>Performatuojamas tekstas...</translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation>Nustato IPv6 &lt;įjungta&gt;/&lt;išjungta&gt;. Numatytoji reikšmė yra ĮJUNGTA.</translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation>įjungta/išjungta</translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation>Nustato UDP &lt;įjungta&gt;/&lt;išjungta&gt;. Numatytoji reikšmė yra ĮJUNGTA.</translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation>Nustato LAN aptikimą &lt;įjungta&gt;/&lt;išjungta&gt;. UDP išjungimas turi viršenybę. Numatytasis yra ĮJUNGTA.</translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation>Nustato įgaliotojo serverio nustatymus. Numatytoji reikšmė yra NĖRA.</translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
-        <translation>(SOCKS5/HTTP/NĖRA):(ADRESAS):(PRIEVADAS)</translation>
     </message>
     <message>
         <source>%1 message(s) from %2 chats</source>

--- a/translations/lv.ts
+++ b/translations/lv.ts
@@ -595,19 +595,19 @@ kas var radīt video zvanu problēmas.</translation>
     <name>AppManager</name>
     <message>
         <source>Tox URI to parse</source>
-        <translation type="unfinished">Tox URI apstrādei</translation>
+        <translation>Tox URI apstrādei</translation>
     </message>
     <message>
         <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished">Uzsāk jaunu instanci un ielādē norādīto profilu.</translation>
+        <translation>Uzsāk jaunu instanci un ielādē norādīto profilu.</translation>
     </message>
     <message>
         <source>profile</source>
-        <translation type="unfinished">profils</translation>
+        <translation>profils</translation>
     </message>
     <message>
         <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished">Uzsāk jaunu instanci un atver pieteikšanās logu.</translation>
+        <translation>Uzsāk jaunu instanci un atver pieteikšanās logu.</translation>
     </message>
     <message>
         <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>

--- a/translations/lv.ts
+++ b/translations/lv.ts
@@ -592,6 +592,57 @@ kas var radīt video zvanu problēmas.</translation>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished">Tox URI apstrādei</translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished">Uzsāk jaunu instanci un ielādē norādīto profilu.</translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished">profils</translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished">Uzsāk jaunu instanci un atver pieteikšanās logu.</translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Kļūda</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2232,18 +2283,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation>Tox URI apstrādei</translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation>Uzsāk jaunu instanci un ielādē norādīto profilu.</translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation>profils</translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation>Noklusējuma</translation>
     </message>
@@ -2291,10 +2330,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation>qTox nevar atvērt tērzēšanas vēsturi, tā tiks atslēgta.</translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation>Uzsāk jaunu instanci un atver pieteikšanās logu.</translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation>Tumšs</translation>
     </message>
@@ -2313,10 +2348,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Dark violet</source>
         <translation>Tumši violets</translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>online</source>
@@ -2346,30 +2377,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mk.ts
+++ b/translations/mk.ts
@@ -591,19 +591,19 @@ which may lead to problems with video calls.</source>
     <name>AppManager</name>
     <message>
         <source>Tox URI to parse</source>
-        <translation type="unfinished">Tox URI за парсирање</translation>
+        <translation>Tox URI за парсирање</translation>
     </message>
     <message>
         <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished">Отвора нова инстанца и го вчитува специфицираниот профил.</translation>
+        <translation>Отвора нова инстанца и го вчитува специфицираниот профил.</translation>
     </message>
     <message>
         <source>profile</source>
-        <translation type="unfinished">профил</translation>
+        <translation>профил</translation>
     </message>
     <message>
         <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished">Започни нов пример и отвори го екранот за најава.</translation>
+        <translation>Започни нов пример и отвори го екранот за најава.</translation>
     </message>
     <message>
         <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>

--- a/translations/mk.ts
+++ b/translations/mk.ts
@@ -588,6 +588,57 @@ which may lead to problems with video calls.</source>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished">Tox URI за парсирање</translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished">Отвора нова инстанца и го вчитува специфицираниот профил.</translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished">профил</translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished">Започни нов пример и отвори го екранот за најава.</translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Грешка</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2225,18 +2276,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation>Tox URI за парсирање</translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation>Отвора нова инстанца и го вчитува специфицираниот профил.</translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation>профил</translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation></translation>
     </message>
@@ -2284,10 +2323,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation>qTox не можеше да ги отвори вашите разговорни дневници, тие ќе бидат оневозможени.</translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation>Започни нов пример и отвори го екранот за најава.</translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2305,10 +2340,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
     <message>
         <source>Dark violet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2339,30 +2370,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/nl.ts
+++ b/translations/nl.ts
@@ -587,6 +587,57 @@ which may lead to problems with video calls.</source>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished">Te verwerken Tox-URI</translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished">Start nieuwe instantie en laadt specifiek profiel.</translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished">profiel</translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished">Start nieuwe instantie en opent aanmeldscherm.</translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Fout</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished">Kon profiel niet automatisch laden.</translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2213,18 +2264,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation>Te verwerken Tox-URI</translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation>Start nieuwe instantie en laadt specifiek profiel.</translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation>profiel</translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation>Standaard</translation>
     </message>
@@ -2272,10 +2311,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation>Bureaublad</translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation>Start nieuwe instantie en opent aanmeldscherm.</translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation>Donker</translation>
     </message>
@@ -2294,10 +2329,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Dark violet</source>
         <translation>Donkerviolet</translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
-        <translation>Kon profiel niet automatisch laden.</translation>
     </message>
     <message>
         <source>online</source>
@@ -2327,30 +2358,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/nl.ts
+++ b/translations/nl.ts
@@ -590,19 +590,19 @@ which may lead to problems with video calls.</source>
     <name>AppManager</name>
     <message>
         <source>Tox URI to parse</source>
-        <translation type="unfinished">Te verwerken Tox-URI</translation>
+        <translation>Te verwerken Tox-URI</translation>
     </message>
     <message>
         <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished">Start nieuwe instantie en laadt specifiek profiel.</translation>
+        <translation>Start nieuwe instantie en laadt specifiek profiel.</translation>
     </message>
     <message>
         <source>profile</source>
-        <translation type="unfinished">profiel</translation>
+        <translation>profiel</translation>
     </message>
     <message>
         <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished">Start nieuwe instantie en opent aanmeldscherm.</translation>
+        <translation>Start nieuwe instantie en opent aanmeldscherm.</translation>
     </message>
     <message>
         <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
@@ -634,7 +634,7 @@ which may lead to problems with video calls.</source>
     </message>
     <message>
         <source>Failed to load profile automatically.</source>
-        <translation type="unfinished">Kon profiel niet automatisch laden.</translation>
+        <translation>Kon profiel niet automatisch laden.</translation>
     </message>
 </context>
 <context>

--- a/translations/nl_BE.ts
+++ b/translations/nl_BE.ts
@@ -587,6 +587,57 @@ which may lead to problems with video calls.</source>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished">Te verwerken Tox-URI</translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished">Start nieuwe instantie en laadt specifiek profiel.</translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished">profiel</translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished">Start nieuwe instantie en opent aanmeldingsscherm.</translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Fout</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2221,18 +2272,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation>Te verwerken Tox-URI</translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation>Start nieuwe instantie en laadt specifiek profiel.</translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation>profiel</translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation>Standaard</translation>
     </message>
@@ -2280,10 +2319,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation>qTox kon uw gespreksgeschiedenis niet openen, ze zal uitgeschakeld worden.</translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation>Start nieuwe instantie en opent aanmeldingsscherm.</translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2301,10 +2336,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
     <message>
         <source>Dark violet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2335,30 +2366,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/nl_BE.ts
+++ b/translations/nl_BE.ts
@@ -590,19 +590,19 @@ which may lead to problems with video calls.</source>
     <name>AppManager</name>
     <message>
         <source>Tox URI to parse</source>
-        <translation type="unfinished">Te verwerken Tox-URI</translation>
+        <translation>Te verwerken Tox-URI</translation>
     </message>
     <message>
         <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished">Start nieuwe instantie en laadt specifiek profiel.</translation>
+        <translation>Start nieuwe instantie en laadt specifiek profiel.</translation>
     </message>
     <message>
         <source>profile</source>
-        <translation type="unfinished">profiel</translation>
+        <translation>profiel</translation>
     </message>
     <message>
         <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished">Start nieuwe instantie en opent aanmeldingsscherm.</translation>
+        <translation>Start nieuwe instantie en opent aanmeldingsscherm.</translation>
     </message>
     <message>
         <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>

--- a/translations/no_nb.ts
+++ b/translations/no_nb.ts
@@ -592,6 +592,57 @@ noe som kan forårsake problemer i videosamtaler.</translation>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished">Tox-URI som skal analyseres</translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished">Starter en ny instanse og laster valgt profil.</translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished">profil</translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished">Starter ny instans og åpner innloggingsskjermen.</translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished">Slår IPv6 &lt;på&gt;/&lt;av&gt;. Forvalget er PÅ.</translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished">av/på</translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished">Slår UDP &lt;på&gt;/&lt;av&gt;. Forvalget er PÅ.</translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished">Setter LAN-oppdagelse &lt;på&gt;/&lt;av&gt;. UDP «av» overstyrer. Forvalget er PÅ.</translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished">Setter mellomtjenerinnstillinger. Forvalget er INGEN.</translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished">(SOCKS5/HTTP/INGEN):(ADRESSE):(PORT)</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Feilmelding</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished">Klarte ikke å laste inn profil automatisk.</translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2227,18 +2278,6 @@ Denne ID-en inkluderer NoSpam-koden (i blått), og sjekksummen (i grått).</tran
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation>Tox-URI som skal analyseres</translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation>Starter en ny instanse og laster valgt profil.</translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation>profil</translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation>Standard</translation>
     </message>
@@ -2286,10 +2325,6 @@ Denne ID-en inkluderer NoSpam-koden (i blått), og sjekksummen (i grått).</tran
         <translation>Skrivebord</translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation>Starter ny instans og åpner innloggingsskjermen.</translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation>Mørkt</translation>
     </message>
@@ -2308,10 +2343,6 @@ Denne ID-en inkluderer NoSpam-koden (i blått), og sjekksummen (i grått).</tran
     <message>
         <source>Dark violet</source>
         <translation>Mørkelilla</translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
-        <translation>Klarte ikke å laste inn profil automatisk.</translation>
     </message>
     <message>
         <source>online</source>
@@ -2342,30 +2373,6 @@ Denne ID-en inkluderer NoSpam-koden (i blått), og sjekksummen (i grått).</tran
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation type="unfinished">Reformaterer tekst …</translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished">Slår IPv6 &lt;på&gt;/&lt;av&gt;. Forvalget er PÅ.</translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation>av/på</translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished">Slår UDP &lt;på&gt;/&lt;av&gt;. Forvalget er PÅ.</translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation>Setter LAN-oppdagelse &lt;på&gt;/&lt;av&gt;. UDP «av» overstyrer. Forvalget er PÅ.</translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation>Setter mellomtjenerinnstillinger. Forvalget er INGEN.</translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
-        <translation>(SOCKS5/HTTP/INGEN):(ADRESSE):(PORT)</translation>
     </message>
     <message>
         <source>%1 message(s) from %2 chats</source>

--- a/translations/no_nb.ts
+++ b/translations/no_nb.ts
@@ -595,19 +595,19 @@ noe som kan forårsake problemer i videosamtaler.</translation>
     <name>AppManager</name>
     <message>
         <source>Tox URI to parse</source>
-        <translation type="unfinished">Tox-URI som skal analyseres</translation>
+        <translation>Tox-URI som skal analyseres</translation>
     </message>
     <message>
         <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished">Starter en ny instanse og laster valgt profil.</translation>
+        <translation>Starter en ny instanse og laster valgt profil.</translation>
     </message>
     <message>
         <source>profile</source>
-        <translation type="unfinished">profil</translation>
+        <translation>profil</translation>
     </message>
     <message>
         <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished">Starter ny instans og åpner innloggingsskjermen.</translation>
+        <translation>Starter ny instans og åpner innloggingsskjermen.</translation>
     </message>
     <message>
         <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
@@ -615,7 +615,7 @@ noe som kan forårsake problemer i videosamtaler.</translation>
     </message>
     <message>
         <source>on/off</source>
-        <translation type="unfinished">av/på</translation>
+        <translation>av/på</translation>
     </message>
     <message>
         <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
@@ -623,15 +623,15 @@ noe som kan forårsake problemer i videosamtaler.</translation>
     </message>
     <message>
         <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished">Setter LAN-oppdagelse &lt;på&gt;/&lt;av&gt;. UDP «av» overstyrer. Forvalget er PÅ.</translation>
+        <translation>Setter LAN-oppdagelse &lt;på&gt;/&lt;av&gt;. UDP «av» overstyrer. Forvalget er PÅ.</translation>
     </message>
     <message>
         <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished">Setter mellomtjenerinnstillinger. Forvalget er INGEN.</translation>
+        <translation>Setter mellomtjenerinnstillinger. Forvalget er INGEN.</translation>
     </message>
     <message>
         <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
-        <translation type="unfinished">(SOCKS5/HTTP/INGEN):(ADRESSE):(PORT)</translation>
+        <translation>(SOCKS5/HTTP/INGEN):(ADRESSE):(PORT)</translation>
     </message>
     <message>
         <source>Error</source>
@@ -639,7 +639,7 @@ noe som kan forårsake problemer i videosamtaler.</translation>
     </message>
     <message>
         <source>Failed to load profile automatically.</source>
-        <translation type="unfinished">Klarte ikke å laste inn profil automatisk.</translation>
+        <translation>Klarte ikke å laste inn profil automatisk.</translation>
     </message>
 </context>
 <context>

--- a/translations/pl.ts
+++ b/translations/pl.ts
@@ -601,19 +601,19 @@ co może powodować problemy z rozmowami wideo.</translation>
     <name>AppManager</name>
     <message>
         <source>Tox URI to parse</source>
-        <translation type="unfinished">Adres URI Tox do sprawdzenia</translation>
+        <translation>Adres URI Tox do sprawdzenia</translation>
     </message>
     <message>
         <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished">Uruchamia nową instancję i ładuje wybrany profil.</translation>
+        <translation>Uruchamia nową instancję i ładuje wybrany profil.</translation>
     </message>
     <message>
         <source>profile</source>
-        <translation type="unfinished">profil</translation>
+        <translation>profil</translation>
     </message>
     <message>
         <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished">Otwiera nowe okno z ekranem logowania.</translation>
+        <translation>Otwiera nowe okno z ekranem logowania.</translation>
     </message>
     <message>
         <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>

--- a/translations/pl.ts
+++ b/translations/pl.ts
@@ -598,6 +598,57 @@ co może powodować problemy z rozmowami wideo.</translation>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished">Adres URI Tox do sprawdzenia</translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished">Uruchamia nową instancję i ładuje wybrany profil.</translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished">profil</translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished">Otwiera nowe okno z ekranem logowania.</translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Błąd</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2248,19 +2299,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation>Adres URI Tox do sprawdzenia</translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translatorcomment>better translation?</translatorcomment>
-        <translation>Uruchamia nową instancję i ładuje wybrany profil.</translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation>profil</translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation>Domyślny</translation>
     </message>
@@ -2310,10 +2348,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation>qTox nie był w stanie otworzyć Twojej historii, zostanie ona wyłączona.</translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation>Otwiera nowe okno z ekranem logowania.</translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2331,10 +2365,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
     <message>
         <source>Dark violet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2365,30 +2395,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/pt.ts
+++ b/translations/pt.ts
@@ -591,6 +591,57 @@ o que pode levar a problemas com as vídeo-chamadas.</translation>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished">URI do Tox para processar</translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished">Inicia uma nova instância e carrega o perfil especificado.</translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished">perfil</translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished">Inicia uma nova instância e abre o ecrã de início de sessão.</translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished">Define IPv6 &lt;ativado&gt;/&lt;desativado&gt;. O padrão é ATIVADO.</translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished">ligado/desligado</translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished">Define UDP &lt;ativado&gt;/&lt;desativado&gt;. O padrão é ATIVADO.</translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished">Define a descoberta da LAN &lt;ativada&gt;/&lt;desativada&gt;. O UDP desativado elimina esta opção. O padrão é ATIVADA.</translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished">Define as configurações de proxy. O padrão é NENHUM.</translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished">(SOCKS5/HTTP/NENHUM):(ENDEREÇO):(PORTA)</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Erro</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished">Falha ao carregar o perfil automaticamente.</translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2225,18 +2276,6 @@ Este ID inclui o código NoSpam (em azul) e o checkum (em cinzento).</translatio
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation>URI do Tox para processar</translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation>Inicia uma nova instância e carrega o perfil especificado.</translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation>perfil</translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation>Padrão</translation>
     </message>
@@ -2284,10 +2323,6 @@ Este ID inclui o código NoSpam (em azul) e o checkum (em cinzento).</translatio
         <translation>Área de trabalho</translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation>Inicia uma nova instância e abre o ecrã de início de sessão.</translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation>Escuro</translation>
     </message>
@@ -2306,10 +2341,6 @@ Este ID inclui o código NoSpam (em azul) e o checkum (em cinzento).</translatio
     <message>
         <source>Dark violet</source>
         <translation>Escuro violeta</translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
-        <translation>Falha ao carregar o perfil automaticamente.</translation>
     </message>
     <message>
         <source>online</source>
@@ -2340,30 +2371,6 @@ Este ID inclui o código NoSpam (em azul) e o checkum (em cinzento).</translatio
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation>Reformatando o texto...</translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation>Define IPv6 &lt;ativado&gt;/&lt;desativado&gt;. O padrão é ATIVADO.</translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation>ligado/desligado</translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation>Define UDP &lt;ativado&gt;/&lt;desativado&gt;. O padrão é ATIVADO.</translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation>Define a descoberta da LAN &lt;ativada&gt;/&lt;desativada&gt;. O UDP desativado elimina esta opção. O padrão é ATIVADA.</translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation>Define as configurações de proxy. O padrão é NENHUM.</translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
-        <translation>(SOCKS5/HTTP/NENHUM):(ENDEREÇO):(PORTA)</translation>
     </message>
     <message>
         <source>%1 message(s) from %2 chats</source>

--- a/translations/pt.ts
+++ b/translations/pt.ts
@@ -594,43 +594,43 @@ o que pode levar a problemas com as vídeo-chamadas.</translation>
     <name>AppManager</name>
     <message>
         <source>Tox URI to parse</source>
-        <translation type="unfinished">URI do Tox para processar</translation>
+        <translation>URI do Tox para processar</translation>
     </message>
     <message>
         <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished">Inicia uma nova instância e carrega o perfil especificado.</translation>
+        <translation>Inicia uma nova instância e carrega o perfil especificado.</translation>
     </message>
     <message>
         <source>profile</source>
-        <translation type="unfinished">perfil</translation>
+        <translation>perfil</translation>
     </message>
     <message>
         <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished">Inicia uma nova instância e abre o ecrã de início de sessão.</translation>
+        <translation>Inicia uma nova instância e abre o ecrã de início de sessão.</translation>
     </message>
     <message>
         <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished">Define IPv6 &lt;ativado&gt;/&lt;desativado&gt;. O padrão é ATIVADO.</translation>
+        <translation>Define IPv6 &lt;ativado&gt;/&lt;desativado&gt;. O padrão é ATIVADO.</translation>
     </message>
     <message>
         <source>on/off</source>
-        <translation type="unfinished">ligado/desligado</translation>
+        <translation>ligado/desligado</translation>
     </message>
     <message>
         <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished">Define UDP &lt;ativado&gt;/&lt;desativado&gt;. O padrão é ATIVADO.</translation>
+        <translation>Define UDP &lt;ativado&gt;/&lt;desativado&gt;. O padrão é ATIVADO.</translation>
     </message>
     <message>
         <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished">Define a descoberta da LAN &lt;ativada&gt;/&lt;desativada&gt;. O UDP desativado elimina esta opção. O padrão é ATIVADA.</translation>
+        <translation>Define a descoberta da LAN &lt;ativada&gt;/&lt;desativada&gt;. O UDP desativado elimina esta opção. O padrão é ATIVADA.</translation>
     </message>
     <message>
         <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished">Define as configurações de proxy. O padrão é NENHUM.</translation>
+        <translation>Define as configurações de proxy. O padrão é NENHUM.</translation>
     </message>
     <message>
         <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
-        <translation type="unfinished">(SOCKS5/HTTP/NENHUM):(ENDEREÇO):(PORTA)</translation>
+        <translation>(SOCKS5/HTTP/NENHUM):(ENDEREÇO):(PORTA)</translation>
     </message>
     <message>
         <source>Error</source>
@@ -638,7 +638,7 @@ o que pode levar a problemas com as vídeo-chamadas.</translation>
     </message>
     <message>
         <source>Failed to load profile automatically.</source>
-        <translation type="unfinished">Falha ao carregar o perfil automaticamente.</translation>
+        <translation>Falha ao carregar o perfil automaticamente.</translation>
     </message>
 </context>
 <context>

--- a/translations/pt_BR.ts
+++ b/translations/pt_BR.ts
@@ -591,6 +591,57 @@ o que pode levar a problemas com as videochamadas.</translation>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished">UTI Tox para interpretar</translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished">Inicia uma nova instância e carrega o perfil especificado.</translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished">perfil</translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished">Inicia nova instância e abre a tela de login.</translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished">Define IPv6 &lt;ativado&gt;/&lt;desativado&gt;. O padrão é ATIVADO.</translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished">ligado/desligado</translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished">Define UDP &lt;ativado&gt;/&lt;desativado&gt;. O padrão é ATIVADO.</translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished">Define a descoberta da LAN &lt;ativada&gt;/&lt;desativada&gt;. O UDP desativado elimina esta opção. O padrão é ATIVADA.</translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished">Define as configurações de proxy. O padrão é NENHUM.</translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished">(SOCKS5/HTTP/NENHUM):(ENDEREÇO):(PORTA)</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Erro</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished">Falha ao carregar o perfil automaticamente.</translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2233,18 +2284,6 @@ Este ID inclui o código NoSpam (em azul) e o checkum (em cinza).</translation>
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation>UTI Tox para interpretar</translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation>Inicia uma nova instância e carrega o perfil especificado.</translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation>perfil</translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation>Padrão</translation>
     </message>
@@ -2292,10 +2331,6 @@ Este ID inclui o código NoSpam (em azul) e o checkum (em cinza).</translation>
         <translation>O qTox não pôde abrir seus registros de bate-papo, eles serão desativados.</translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation>Inicia nova instância e abre a tela de login.</translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation>Escuro</translation>
     </message>
@@ -2314,10 +2349,6 @@ Este ID inclui o código NoSpam (em azul) e o checkum (em cinza).</translation>
     <message>
         <source>Dark violet</source>
         <translation>Roxo</translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
-        <translation>Falha ao carregar o perfil automaticamente.</translation>
     </message>
     <message>
         <source>online</source>
@@ -2348,30 +2379,6 @@ Este ID inclui o código NoSpam (em azul) e o checkum (em cinza).</translation>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation>Reformatando o texto...</translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation>Define IPv6 &lt;ativado&gt;/&lt;desativado&gt;. O padrão é ATIVADO.</translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation>ligado/desligado</translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation>Define UDP &lt;ativado&gt;/&lt;desativado&gt;. O padrão é ATIVADO.</translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation>Define a descoberta da LAN &lt;ativada&gt;/&lt;desativada&gt;. O UDP desativado elimina esta opção. O padrão é ATIVADA.</translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation>Define as configurações de proxy. O padrão é NENHUM.</translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
-        <translation>(SOCKS5/HTTP/NENHUM):(ENDEREÇO):(PORTA)</translation>
     </message>
     <message>
         <source>%1 message(s) from %2 chats</source>

--- a/translations/pt_BR.ts
+++ b/translations/pt_BR.ts
@@ -594,43 +594,43 @@ o que pode levar a problemas com as videochamadas.</translation>
     <name>AppManager</name>
     <message>
         <source>Tox URI to parse</source>
-        <translation type="unfinished">UTI Tox para interpretar</translation>
+        <translation>UTI Tox para interpretar</translation>
     </message>
     <message>
         <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished">Inicia uma nova instância e carrega o perfil especificado.</translation>
+        <translation>Inicia uma nova instância e carrega o perfil especificado.</translation>
     </message>
     <message>
         <source>profile</source>
-        <translation type="unfinished">perfil</translation>
+        <translation>perfil</translation>
     </message>
     <message>
         <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished">Inicia nova instância e abre a tela de login.</translation>
+        <translation>Inicia nova instância e abre a tela de login.</translation>
     </message>
     <message>
         <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished">Define IPv6 &lt;ativado&gt;/&lt;desativado&gt;. O padrão é ATIVADO.</translation>
+        <translation>Define IPv6 &lt;ativado&gt;/&lt;desativado&gt;. O padrão é ATIVADO.</translation>
     </message>
     <message>
         <source>on/off</source>
-        <translation type="unfinished">ligado/desligado</translation>
+        <translation>ligado/desligado</translation>
     </message>
     <message>
         <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished">Define UDP &lt;ativado&gt;/&lt;desativado&gt;. O padrão é ATIVADO.</translation>
+        <translation>Define UDP &lt;ativado&gt;/&lt;desativado&gt;. O padrão é ATIVADO.</translation>
     </message>
     <message>
         <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished">Define a descoberta da LAN &lt;ativada&gt;/&lt;desativada&gt;. O UDP desativado elimina esta opção. O padrão é ATIVADA.</translation>
+        <translation>Define a descoberta da LAN &lt;ativada&gt;/&lt;desativada&gt;. O UDP desativado elimina esta opção. O padrão é ATIVADA.</translation>
     </message>
     <message>
         <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished">Define as configurações de proxy. O padrão é NENHUM.</translation>
+        <translation>Define as configurações de proxy. O padrão é NENHUM.</translation>
     </message>
     <message>
         <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
-        <translation type="unfinished">(SOCKS5/HTTP/NENHUM):(ENDEREÇO):(PORTA)</translation>
+        <translation>(SOCKS5/HTTP/NENHUM):(ENDEREÇO):(PORTA)</translation>
     </message>
     <message>
         <source>Error</source>
@@ -638,7 +638,7 @@ o que pode levar a problemas com as videochamadas.</translation>
     </message>
     <message>
         <source>Failed to load profile automatically.</source>
-        <translation type="unfinished">Falha ao carregar o perfil automaticamente.</translation>
+        <translation>Falha ao carregar o perfil automaticamente.</translation>
     </message>
 </context>
 <context>

--- a/translations/ro.ts
+++ b/translations/ro.ts
@@ -592,6 +592,57 @@ ceea ce poate duce la probleme cu apelurile video.</translation>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished">Tox URI pentru analiză</translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished">Porniți o instanță nouă și încărcați profilul specificat.</translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished">profil</translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished">Pornește o nouă instanță și deschide ecranul de conectare.</translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished">Setați IPv6 &lt;pornit&gt;/&lt;oprit&gt;. Implicit este PORNIT.</translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished">pornit/oprit</translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished">Setați UDP &lt;pornit&gt;/&lt;oprit&gt;. Implicit este PORNIT.</translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished">Setați descoperire LAN &lt;pornit&gt;/&lt;oprit&gt;. UDP suprascriere oprita. Implicit este PORNIT.</translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished">Setează setările proxy. Valoarea implicită este NIMIC.</translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished">(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Eroare</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished">Nu s-a putut încărca automat profilul.</translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2237,18 +2288,6 @@ Acest ID include codul NoSpam (în albastru) și suma de control (în gri).</tra
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation>Tox URI pentru analiză</translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation>Porniți o instanță nouă și încărcați profilul specificat.</translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation>profil</translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation>Implicit</translation>
     </message>
@@ -2296,10 +2335,6 @@ Acest ID include codul NoSpam (în albastru) și suma de control (în gri).</tra
         <translation>qTox nu au putut deschide jurnalele de discuții, vor fi dezactivate.</translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation>Pornește o nouă instanță și deschide ecranul de conectare.</translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation>Întunecat</translation>
     </message>
@@ -2318,10 +2353,6 @@ Acest ID include codul NoSpam (în albastru) și suma de control (în gri).</tra
     <message>
         <source>Dark violet</source>
         <translation>Violet închis</translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
-        <translation>Nu s-a putut încărca automat profilul.</translation>
     </message>
     <message>
         <source>online</source>
@@ -2352,30 +2383,6 @@ Acest ID include codul NoSpam (în albastru) și suma de control (în gri).</tra
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation>Se reformatează textul...</translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation>Setați IPv6 &lt;pornit&gt;/&lt;oprit&gt;. Implicit este PORNIT.</translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation>pornit/oprit</translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation>Setați UDP &lt;pornit&gt;/&lt;oprit&gt;. Implicit este PORNIT.</translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation>Setați descoperire LAN &lt;pornit&gt;/&lt;oprit&gt;. UDP suprascriere oprita. Implicit este PORNIT.</translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation>Setează setările proxy. Valoarea implicită este NIMIC.</translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
-        <translation>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</translation>
     </message>
     <message>
         <source>%1 message(s) from %2 chats</source>

--- a/translations/ro.ts
+++ b/translations/ro.ts
@@ -595,43 +595,43 @@ ceea ce poate duce la probleme cu apelurile video.</translation>
     <name>AppManager</name>
     <message>
         <source>Tox URI to parse</source>
-        <translation type="unfinished">Tox URI pentru analiză</translation>
+        <translation>Tox URI pentru analiză</translation>
     </message>
     <message>
         <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished">Porniți o instanță nouă și încărcați profilul specificat.</translation>
+        <translation>Porniți o instanță nouă și încărcați profilul specificat.</translation>
     </message>
     <message>
         <source>profile</source>
-        <translation type="unfinished">profil</translation>
+        <translation>profil</translation>
     </message>
     <message>
         <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished">Pornește o nouă instanță și deschide ecranul de conectare.</translation>
+        <translation>Pornește o nouă instanță și deschide ecranul de conectare.</translation>
     </message>
     <message>
         <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished">Setați IPv6 &lt;pornit&gt;/&lt;oprit&gt;. Implicit este PORNIT.</translation>
+        <translation>Setați IPv6 &lt;pornit&gt;/&lt;oprit&gt;. Implicit este PORNIT.</translation>
     </message>
     <message>
         <source>on/off</source>
-        <translation type="unfinished">pornit/oprit</translation>
+        <translation>pornit/oprit</translation>
     </message>
     <message>
         <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished">Setați UDP &lt;pornit&gt;/&lt;oprit&gt;. Implicit este PORNIT.</translation>
+        <translation>Setați UDP &lt;pornit&gt;/&lt;oprit&gt;. Implicit este PORNIT.</translation>
     </message>
     <message>
         <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished">Setați descoperire LAN &lt;pornit&gt;/&lt;oprit&gt;. UDP suprascriere oprita. Implicit este PORNIT.</translation>
+        <translation>Setați descoperire LAN &lt;pornit&gt;/&lt;oprit&gt;. UDP suprascriere oprita. Implicit este PORNIT.</translation>
     </message>
     <message>
         <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished">Setează setările proxy. Valoarea implicită este NIMIC.</translation>
+        <translation>Setează setările proxy. Valoarea implicită este NIMIC.</translation>
     </message>
     <message>
         <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
-        <translation type="unfinished">(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</translation>
+        <translation>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</translation>
     </message>
     <message>
         <source>Error</source>
@@ -639,7 +639,7 @@ ceea ce poate duce la probleme cu apelurile video.</translation>
     </message>
     <message>
         <source>Failed to load profile automatically.</source>
-        <translation type="unfinished">Nu s-a putut încărca automat profilul.</translation>
+        <translation>Nu s-a putut încărca automat profilul.</translation>
     </message>
 </context>
 <context>

--- a/translations/ru.ts
+++ b/translations/ru.ts
@@ -593,6 +593,57 @@ which may lead to problems with video calls.</source>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished">Tox URI для обработки</translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished">Запускает новый экземпляр и загружает указанный профиль.</translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished">профиль</translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished">Запускает новый экземпляр и открывает экран входа.</translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished">Устанавливает IPv6 &lt;включённым&gt;/&lt;выключенным&gt;. По стандарту он ВКЛЮЧЁН.</translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished">включить/выключить</translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished">Устанавливает UDP &lt;включённым&gt;/&lt;выключенным&gt;. По стандарту он ВКЛЮЧЁН.</translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished">Устанавливает обнаружение LAN &lt;включённым&gt;/&lt;выключенным&gt;. Перезаписывает отключённый UDP. По стандарту оно ВКЛЮЧЕНО.</translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished">Устанавливает настройки прокси. По стандарту они ОТСУТСТВУЮТ.</translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished">(SOCKS5/HTTP/ОТСУТСТВУЕТ):(АДРЕС):(ПОРТ)</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Ошибка</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished">Не удалось загрузить профиль автоматически.</translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2232,21 +2283,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translatorcomment>Без перевода, так как весь остальной CLI на английском</translatorcomment>
-        <translation>Tox URI для обработки</translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translatorcomment>Без перевода, так как весь остальной CLI на английском</translatorcomment>
-        <translation>Запускает новый экземпляр и загружает указанный профиль.</translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translatorcomment>Без перевода, так как весь остальной CLI на английском</translatorcomment>
-        <translation>профиль</translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation>По умолчанию</translation>
     </message>
@@ -2294,10 +2330,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation>qTox не может загрузить историю переписки, она будет отключена.</translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation>Запускает новый экземпляр и открывает экран входа.</translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation>Темный</translation>
     </message>
@@ -2316,10 +2348,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Dark violet</source>
         <translation>Темно-фиолетовый</translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
-        <translation>Не удалось загрузить профиль автоматически.</translation>
     </message>
     <message>
         <source>online</source>
@@ -2350,30 +2378,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation>Переформатирование текста...</translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation>Устанавливает IPv6 &lt;включённым&gt;/&lt;выключенным&gt;. По стандарту он ВКЛЮЧЁН.</translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation>включить/выключить</translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation>Устанавливает UDP &lt;включённым&gt;/&lt;выключенным&gt;. По стандарту он ВКЛЮЧЁН.</translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation>Устанавливает обнаружение LAN &lt;включённым&gt;/&lt;выключенным&gt;. Перезаписывает отключённый UDP. По стандарту оно ВКЛЮЧЕНО.</translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation>Устанавливает настройки прокси. По стандарту они ОТСУТСТВУЮТ.</translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
-        <translation>(SOCKS5/HTTP/ОТСУТСТВУЕТ):(АДРЕС):(ПОРТ)</translation>
     </message>
     <message>
         <source>%1 message(s) from %2 chats</source>

--- a/translations/ru.ts
+++ b/translations/ru.ts
@@ -596,43 +596,43 @@ which may lead to problems with video calls.</source>
     <name>AppManager</name>
     <message>
         <source>Tox URI to parse</source>
-        <translation type="unfinished">Tox URI для обработки</translation>
+        <translation>Tox URI для обработки</translation>
     </message>
     <message>
         <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished">Запускает новый экземпляр и загружает указанный профиль.</translation>
+        <translation>Запускает новый экземпляр и загружает указанный профиль.</translation>
     </message>
     <message>
         <source>profile</source>
-        <translation type="unfinished">профиль</translation>
+        <translation>профиль</translation>
     </message>
     <message>
         <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished">Запускает новый экземпляр и открывает экран входа.</translation>
+        <translation>Запускает новый экземпляр и открывает экран входа.</translation>
     </message>
     <message>
         <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished">Устанавливает IPv6 &lt;включённым&gt;/&lt;выключенным&gt;. По стандарту он ВКЛЮЧЁН.</translation>
+        <translation>Устанавливает IPv6 &lt;включённым&gt;/&lt;выключенным&gt;. По стандарту он ВКЛЮЧЁН.</translation>
     </message>
     <message>
         <source>on/off</source>
-        <translation type="unfinished">включить/выключить</translation>
+        <translation>включить/выключить</translation>
     </message>
     <message>
         <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished">Устанавливает UDP &lt;включённым&gt;/&lt;выключенным&gt;. По стандарту он ВКЛЮЧЁН.</translation>
+        <translation>Устанавливает UDP &lt;включённым&gt;/&lt;выключенным&gt;. По стандарту он ВКЛЮЧЁН.</translation>
     </message>
     <message>
         <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished">Устанавливает обнаружение LAN &lt;включённым&gt;/&lt;выключенным&gt;. Перезаписывает отключённый UDP. По стандарту оно ВКЛЮЧЕНО.</translation>
+        <translation>Устанавливает обнаружение LAN &lt;включённым&gt;/&lt;выключенным&gt;. Перезаписывает отключённый UDP. По стандарту оно ВКЛЮЧЕНО.</translation>
     </message>
     <message>
         <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished">Устанавливает настройки прокси. По стандарту они ОТСУТСТВУЮТ.</translation>
+        <translation>Устанавливает настройки прокси. По стандарту они ОТСУТСТВУЮТ.</translation>
     </message>
     <message>
         <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
-        <translation type="unfinished">(SOCKS5/HTTP/ОТСУТСТВУЕТ):(АДРЕС):(ПОРТ)</translation>
+        <translation>(SOCKS5/HTTP/ОТСУТСТВУЕТ):(АДРЕС):(ПОРТ)</translation>
     </message>
     <message>
         <source>Error</source>
@@ -640,7 +640,7 @@ which may lead to problems with video calls.</source>
     </message>
     <message>
         <source>Failed to load profile automatically.</source>
-        <translation type="unfinished">Не удалось загрузить профиль автоматически.</translation>
+        <translation>Не удалось загрузить профиль автоматически.</translation>
     </message>
 </context>
 <context>

--- a/translations/si.ts
+++ b/translations/si.ts
@@ -583,6 +583,57 @@ which may lead to problems with video calls.</source>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2209,18 +2260,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2268,10 +2307,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2289,10 +2324,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
     <message>
         <source>Dark violet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2323,30 +2354,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/sk.ts
+++ b/translations/sk.ts
@@ -595,43 +595,43 @@ Rýchlosť vášho pripojenia nemusí byť vždy dostačujúca pre vyššiu kval
     <name>AppManager</name>
     <message>
         <source>Tox URI to parse</source>
-        <translation type="unfinished">Tox URI na preskúmanie</translation>
+        <translation>Tox URI na preskúmanie</translation>
     </message>
     <message>
         <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished">Spustí novú inštanciu a načíta zadaný profil.</translation>
+        <translation>Spustí novú inštanciu a načíta zadaný profil.</translation>
     </message>
     <message>
         <source>profile</source>
-        <translation type="unfinished">profil</translation>
+        <translation>profil</translation>
     </message>
     <message>
         <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished">Spustí novú inštanciu a otvorí prihlasovacie okno.</translation>
+        <translation>Spustí novú inštanciu a otvorí prihlasovacie okno.</translation>
     </message>
     <message>
         <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished">Nastaví IPv6 na &lt;zapnuté&gt;/&lt;vypnuté&gt;. Predvolená hodnota je zapnuté.</translation>
+        <translation>Nastaví IPv6 na &lt;zapnuté&gt;/&lt;vypnuté&gt;. Predvolená hodnota je zapnuté.</translation>
     </message>
     <message>
         <source>on/off</source>
-        <translation type="unfinished">zapnuté/vypnuté</translation>
+        <translation>zapnuté/vypnuté</translation>
     </message>
     <message>
         <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished">Nastaví UDP na &lt;zapnuté&gt;/&lt;vypnuté&gt;. Predvolená hodnota je zapnuté.</translation>
+        <translation>Nastaví UDP na &lt;zapnuté&gt;/&lt;vypnuté&gt;. Predvolená hodnota je zapnuté.</translation>
     </message>
     <message>
         <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished">Nastaví zisťovanie cez LAN na &lt;zapnuté&gt;/&lt;vypnuté&gt;. Vypnuté UDP má prednosť. Predvolená hodnota je zapnuté.</translation>
+        <translation>Nastaví zisťovanie cez LAN na &lt;zapnuté&gt;/&lt;vypnuté&gt;. Vypnuté UDP má prednosť. Predvolená hodnota je zapnuté.</translation>
     </message>
     <message>
         <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished">Nastaví nastavenia proxy. Predvolená hodnota je žiadne.</translation>
+        <translation>Nastaví nastavenia proxy. Predvolená hodnota je žiadne.</translation>
     </message>
     <message>
         <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
-        <translation type="unfinished">(SOCKS5/HTTP/ŽIADNE):(ADRESA):(PORT)</translation>
+        <translation>(SOCKS5/HTTP/ŽIADNE):(ADRESA):(PORT)</translation>
     </message>
     <message>
         <source>Error</source>
@@ -639,7 +639,7 @@ Rýchlosť vášho pripojenia nemusí byť vždy dostačujúca pre vyššiu kval
     </message>
     <message>
         <source>Failed to load profile automatically.</source>
-        <translation type="unfinished">Automatické načítanie profilu zlyhalo.</translation>
+        <translation>Automatické načítanie profilu zlyhalo.</translation>
     </message>
 </context>
 <context>

--- a/translations/sk.ts
+++ b/translations/sk.ts
@@ -592,6 +592,57 @@ Rýchlosť vášho pripojenia nemusí byť vždy dostačujúca pre vyššiu kval
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished">Tox URI na preskúmanie</translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished">Spustí novú inštanciu a načíta zadaný profil.</translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished">profil</translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished">Spustí novú inštanciu a otvorí prihlasovacie okno.</translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished">Nastaví IPv6 na &lt;zapnuté&gt;/&lt;vypnuté&gt;. Predvolená hodnota je zapnuté.</translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished">zapnuté/vypnuté</translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished">Nastaví UDP na &lt;zapnuté&gt;/&lt;vypnuté&gt;. Predvolená hodnota je zapnuté.</translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished">Nastaví zisťovanie cez LAN na &lt;zapnuté&gt;/&lt;vypnuté&gt;. Vypnuté UDP má prednosť. Predvolená hodnota je zapnuté.</translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished">Nastaví nastavenia proxy. Predvolená hodnota je žiadne.</translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished">(SOCKS5/HTTP/ŽIADNE):(ADRESA):(PORT)</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Chyba</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished">Automatické načítanie profilu zlyhalo.</translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2237,18 +2288,6 @@ Toto ID obsahuje kód NoSpam (modrou) a kontrolný súčet (šedou).</translatio
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation>Tox URI na preskúmanie</translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation>Spustí novú inštanciu a načíta zadaný profil.</translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation>profil</translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation>Predvolená</translation>
     </message>
@@ -2296,10 +2335,6 @@ Toto ID obsahuje kód NoSpam (modrou) a kontrolný súčet (šedou).</translatio
         <translation>qTox nemohol otvoriť vaše chatové logy, logovanie bude vypnuté.</translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation>Spustí novú inštanciu a otvorí prihlasovacie okno.</translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation>Tmavá</translation>
     </message>
@@ -2318,10 +2353,6 @@ Toto ID obsahuje kód NoSpam (modrou) a kontrolný súčet (šedou).</translatio
     <message>
         <source>Dark violet</source>
         <translation>Tmavofialová</translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
-        <translation>Automatické načítanie profilu zlyhalo.</translation>
     </message>
     <message>
         <source>online</source>
@@ -2352,30 +2383,6 @@ Toto ID obsahuje kód NoSpam (modrou) a kontrolný súčet (šedou).</translatio
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation>Preformátovanie textu...</translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation>Nastaví IPv6 na &lt;zapnuté&gt;/&lt;vypnuté&gt;. Predvolená hodnota je zapnuté.</translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation>zapnuté/vypnuté</translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation>Nastaví UDP na &lt;zapnuté&gt;/&lt;vypnuté&gt;. Predvolená hodnota je zapnuté.</translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation>Nastaví zisťovanie cez LAN na &lt;zapnuté&gt;/&lt;vypnuté&gt;. Vypnuté UDP má prednosť. Predvolená hodnota je zapnuté.</translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation>Nastaví nastavenia proxy. Predvolená hodnota je žiadne.</translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
-        <translation>(SOCKS5/HTTP/ŽIADNE):(ADRESA):(PORT)</translation>
     </message>
     <message>
         <source>%1 message(s) from %2 chats</source>

--- a/translations/sl.ts
+++ b/translations/sl.ts
@@ -592,15 +592,15 @@ which may lead to problems with video calls.</source>
     <name>AppManager</name>
     <message>
         <source>Tox URI to parse</source>
-        <translation type="unfinished">Tox URI za interpretirati</translation>
+        <translation>Tox URI za interpretirati</translation>
     </message>
     <message>
         <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished">Odpre novo okno z določenim profilom.</translation>
+        <translation>Odpre novo okno z določenim profilom.</translation>
     </message>
     <message>
         <source>profile</source>
-        <translation type="unfinished">profil</translation>
+        <translation>profil</translation>
     </message>
     <message>
         <source>Starts new instance and opens the login screen.</source>

--- a/translations/sl.ts
+++ b/translations/sl.ts
@@ -589,6 +589,57 @@ which may lead to problems with video calls.</source>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished">Tox URI za interpretirati</translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished">Odpre novo okno z določenim profilom.</translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished">profil</translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Napaka</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2218,19 +2269,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translatorcomment>Preveri</translatorcomment>
-        <translation>Tox URI za interpretirati</translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation>Odpre novo okno z določenim profilom.</translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation>profil</translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation>Privzeto</translation>
     </message>
@@ -2278,10 +2316,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2299,10 +2333,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
     <message>
         <source>Dark violet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2333,30 +2363,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/sq.ts
+++ b/translations/sq.ts
@@ -583,6 +583,57 @@ which may lead to problems with video calls.</source>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2209,18 +2260,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2268,10 +2307,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2289,10 +2324,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
     <message>
         <source>Dark violet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2323,30 +2354,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/sr.ts
+++ b/translations/sr.ts
@@ -588,6 +588,57 @@ which may lead to problems with video calls.</source>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished">Токс путања заобраду</translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished">Покрените нови примерак и учитајте наведени профил.</translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished">профил</translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished">Покрените нови примерак и отворите екран за пријаву.</translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Грешка</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished">Нисам успео да сам учитам профил.</translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2225,18 +2276,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation>Токс путања заобраду</translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation>Покрените нови примерак и учитајте наведени профил.</translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation>профил</translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation>основна</translation>
     </message>
@@ -2284,10 +2323,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation>q-Токс не може да отвори ваше дневнике ћаскања, биће искључени.</translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation>Покрените нови примерак и отворите екран за пријаву.</translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation>Тамна</translation>
     </message>
@@ -2306,10 +2341,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Dark violet</source>
         <translation>Тамно љубичаста</translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
-        <translation>Нисам успео да сам учитам профил.</translation>
     </message>
     <message>
         <source>online</source>
@@ -2339,30 +2370,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/sr.ts
+++ b/translations/sr.ts
@@ -591,19 +591,19 @@ which may lead to problems with video calls.</source>
     <name>AppManager</name>
     <message>
         <source>Tox URI to parse</source>
-        <translation type="unfinished">Токс путања заобраду</translation>
+        <translation>Токс путања заобраду</translation>
     </message>
     <message>
         <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished">Покрените нови примерак и учитајте наведени профил.</translation>
+        <translation>Покрените нови примерак и учитајте наведени профил.</translation>
     </message>
     <message>
         <source>profile</source>
-        <translation type="unfinished">профил</translation>
+        <translation>профил</translation>
     </message>
     <message>
         <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished">Покрените нови примерак и отворите екран за пријаву.</translation>
+        <translation>Покрените нови примерак и отворите екран за пријаву.</translation>
     </message>
     <message>
         <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
@@ -635,7 +635,7 @@ which may lead to problems with video calls.</source>
     </message>
     <message>
         <source>Failed to load profile automatically.</source>
-        <translation type="unfinished">Нисам успео да сам учитам профил.</translation>
+        <translation>Нисам успео да сам учитам профил.</translation>
     </message>
 </context>
 <context>

--- a/translations/sr_Latn.ts
+++ b/translations/sr_Latn.ts
@@ -591,19 +591,19 @@ which may lead to problems with video calls.</source>
     <name>AppManager</name>
     <message>
         <source>Tox URI to parse</source>
-        <translation type="unfinished">Tox URI za raščlaniti</translation>
+        <translation>Tox URI za raščlaniti</translation>
     </message>
     <message>
         <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished">Pokreće novi primerak i učitava navedeni profil.</translation>
+        <translation>Pokreće novi primerak i učitava navedeni profil.</translation>
     </message>
     <message>
         <source>profile</source>
-        <translation type="unfinished">profil</translation>
+        <translation>profil</translation>
     </message>
     <message>
         <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished">Pokreće novi primerak i otvara ekran za prijavu.</translation>
+        <translation>Pokreće novi primerak i otvara ekran za prijavu.</translation>
     </message>
     <message>
         <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>

--- a/translations/sr_Latn.ts
+++ b/translations/sr_Latn.ts
@@ -588,6 +588,57 @@ which may lead to problems with video calls.</source>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished">Tox URI za raščlaniti</translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished">Pokreće novi primerak i učitava navedeni profil.</translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished">profil</translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished">Pokreće novi primerak i otvara ekran za prijavu.</translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Greška</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2226,18 +2277,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation>Tox URI za raščlaniti</translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation>Pokreće novi primerak i učitava navedeni profil.</translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation>profil</translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation>podrazumevana</translation>
     </message>
@@ -2285,10 +2324,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation>qTox ne može da otvori vaše dnevnike ćaskanja, biće onemogućeni.</translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation>Pokreće novi primerak i otvara ekran za prijavu.</translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2306,10 +2341,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
     <message>
         <source>Dark violet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2340,30 +2371,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/sv.ts
+++ b/translations/sv.ts
@@ -591,6 +591,57 @@ vilket kan leda till problem med videosamtal.</translation>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished">Tox-URI för att tolka</translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished">Startar ny instans och läser in angiven profil.</translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished">profil</translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished">Startar ny instans och öppnar loginskärmen.</translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished">Ställer in IPv6 &lt;på&gt;/&lt;av&gt;. Standardvärdet är PÅ.</translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished">på/av</translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished">Ställer in UDP &lt;på&gt;/&lt;av&gt;. Standardvärdet är PÅ.</translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished">Ställer in LAN-upptäckt &lt;på&gt;/&lt;av&gt;. UDP av har prioritet. Standardvärdet är PÅ.</translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Fel</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished">Det gick inte att läsa in profilen automatiskt.</translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2225,18 +2276,6 @@ ID:t innehåller NoSpam-koden (i blått) och kontrollsumman (i grått).</transla
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation>Tox-URI för att tolka</translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation>Startar ny instans och läser in angiven profil.</translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation>profil</translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation>Standard</translation>
     </message>
@@ -2284,10 +2323,6 @@ ID:t innehåller NoSpam-koden (i blått) och kontrollsumman (i grått).</transla
         <translation>Skrivbord</translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation>Startar ny instans och öppnar loginskärmen.</translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation>Mörk</translation>
     </message>
@@ -2306,10 +2341,6 @@ ID:t innehåller NoSpam-koden (i blått) och kontrollsumman (i grått).</transla
     <message>
         <source>Dark violet</source>
         <translation>Mörk lila</translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
-        <translation>Det gick inte att läsa in profilen automatiskt.</translation>
     </message>
     <message>
         <source>online</source>
@@ -2340,30 +2371,6 @@ ID:t innehåller NoSpam-koden (i blått) och kontrollsumman (i grått).</transla
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation>Omformaterar text...</translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation>Ställer in IPv6 &lt;på&gt;/&lt;av&gt;. Standardvärdet är PÅ.</translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation>på/av</translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation>Ställer in UDP &lt;på&gt;/&lt;av&gt;. Standardvärdet är PÅ.</translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation>Ställer in LAN-upptäckt &lt;på&gt;/&lt;av&gt;. UDP av har prioritet. Standardvärdet är PÅ.</translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 message(s) from %2 chats</source>

--- a/translations/sv.ts
+++ b/translations/sv.ts
@@ -594,35 +594,35 @@ vilket kan leda till problem med videosamtal.</translation>
     <name>AppManager</name>
     <message>
         <source>Tox URI to parse</source>
-        <translation type="unfinished">Tox-URI för att tolka</translation>
+        <translation>Tox-URI för att tolka</translation>
     </message>
     <message>
         <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished">Startar ny instans och läser in angiven profil.</translation>
+        <translation>Startar ny instans och läser in angiven profil.</translation>
     </message>
     <message>
         <source>profile</source>
-        <translation type="unfinished">profil</translation>
+        <translation>profil</translation>
     </message>
     <message>
         <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished">Startar ny instans och öppnar loginskärmen.</translation>
+        <translation>Startar ny instans och öppnar loginskärmen.</translation>
     </message>
     <message>
         <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished">Ställer in IPv6 &lt;på&gt;/&lt;av&gt;. Standardvärdet är PÅ.</translation>
+        <translation>Ställer in IPv6 &lt;på&gt;/&lt;av&gt;. Standardvärdet är PÅ.</translation>
     </message>
     <message>
         <source>on/off</source>
-        <translation type="unfinished">på/av</translation>
+        <translation>på/av</translation>
     </message>
     <message>
         <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished">Ställer in UDP &lt;på&gt;/&lt;av&gt;. Standardvärdet är PÅ.</translation>
+        <translation>Ställer in UDP &lt;på&gt;/&lt;av&gt;. Standardvärdet är PÅ.</translation>
     </message>
     <message>
         <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished">Ställer in LAN-upptäckt &lt;på&gt;/&lt;av&gt;. UDP av har prioritet. Standardvärdet är PÅ.</translation>
+        <translation>Ställer in LAN-upptäckt &lt;på&gt;/&lt;av&gt;. UDP av har prioritet. Standardvärdet är PÅ.</translation>
     </message>
     <message>
         <source>Sets proxy settings. Default is NONE.</source>
@@ -638,7 +638,7 @@ vilket kan leda till problem med videosamtal.</translation>
     </message>
     <message>
         <source>Failed to load profile automatically.</source>
-        <translation type="unfinished">Det gick inte att läsa in profilen automatiskt.</translation>
+        <translation>Det gick inte att läsa in profilen automatiskt.</translation>
     </message>
 </context>
 <context>

--- a/translations/sw.ts
+++ b/translations/sw.ts
@@ -583,6 +583,57 @@ which may lead to problems with video calls.</source>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2209,18 +2260,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2268,10 +2307,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2289,10 +2324,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
     <message>
         <source>Dark violet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2323,30 +2354,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/ta.ts
+++ b/translations/ta.ts
@@ -588,6 +588,57 @@ qTox இல் தாங்கள் சிக்கலோ பாதுகாப
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2215,18 +2266,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2274,10 +2313,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2295,10 +2330,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
     <message>
         <source>Dark violet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2329,30 +2360,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/tr.ts
+++ b/translations/tr.ts
@@ -596,43 +596,43 @@ bu da video görüşmelerinde sorunlara yol açabilir.</translation>
     <name>AppManager</name>
     <message>
         <source>Tox URI to parse</source>
-        <translation type="unfinished">İşlenecek Tox URI&apos;si</translation>
+        <translation>İşlenecek Tox URI&apos;si</translation>
     </message>
     <message>
         <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished">Yeni örnek başlatır ve belirtilen profili yükler.</translation>
+        <translation>Yeni örnek başlatır ve belirtilen profili yükler.</translation>
     </message>
     <message>
         <source>profile</source>
-        <translation type="unfinished">profil</translation>
+        <translation>profil</translation>
     </message>
     <message>
         <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished">Yeni örnek başlatır ve giriş ekranını açar.</translation>
+        <translation>Yeni örnek başlatır ve giriş ekranını açar.</translation>
     </message>
     <message>
         <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished">IPv6&apos;yı &lt;açık&gt;/&lt;kapalı&gt; olarak ayarlar. Öntanımlı olarak AÇIK&apos;tır.</translation>
+        <translation>IPv6&apos;yı &lt;açık&gt;/&lt;kapalı&gt; olarak ayarlar. Öntanımlı olarak AÇIK&apos;tır.</translation>
     </message>
     <message>
         <source>on/off</source>
-        <translation type="unfinished">açık/kapalı</translation>
+        <translation>açık/kapalı</translation>
     </message>
     <message>
         <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished">UDP&apos;yi &lt;açık&gt;/&lt;kapalı&gt; olarak ayarlar. Öntanımlı olarak AÇIK&apos;tır.</translation>
+        <translation>UDP&apos;yi &lt;açık&gt;/&lt;kapalı&gt; olarak ayarlar. Öntanımlı olarak AÇIK&apos;tır.</translation>
     </message>
     <message>
         <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished">LAN keşfini &lt;açık&gt;/&lt;kapalı&gt; olarak ayarlar. UDP&apos;yi kapatmak geçersiz kılar. Öntanımlı olarak AÇIK&apos;tır.</translation>
+        <translation>LAN keşfini &lt;açık&gt;/&lt;kapalı&gt; olarak ayarlar. UDP&apos;yi kapatmak geçersiz kılar. Öntanımlı olarak AÇIK&apos;tır.</translation>
     </message>
     <message>
         <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished">Vekil ayarlarını belirler. Öntanımlı olarak YOK&apos;tur.</translation>
+        <translation>Vekil ayarlarını belirler. Öntanımlı olarak YOK&apos;tur.</translation>
     </message>
     <message>
         <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
-        <translation type="unfinished">(SOCKS5/HTTP/YOK):(ADRES):(BAĞLANTI NOKTASI)</translation>
+        <translation>(SOCKS5/HTTP/YOK):(ADRES):(BAĞLANTI NOKTASI)</translation>
     </message>
     <message>
         <source>Error</source>
@@ -640,7 +640,7 @@ bu da video görüşmelerinde sorunlara yol açabilir.</translation>
     </message>
     <message>
         <source>Failed to load profile automatically.</source>
-        <translation type="unfinished">Profil otomatik olarak yüklenemedi.</translation>
+        <translation>Profil otomatik olarak yüklenemedi.</translation>
     </message>
 </context>
 <context>

--- a/translations/tr.ts
+++ b/translations/tr.ts
@@ -593,6 +593,57 @@ bu da video görüşmelerinde sorunlara yol açabilir.</translation>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished">İşlenecek Tox URI&apos;si</translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished">Yeni örnek başlatır ve belirtilen profili yükler.</translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished">profil</translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished">Yeni örnek başlatır ve giriş ekranını açar.</translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished">IPv6&apos;yı &lt;açık&gt;/&lt;kapalı&gt; olarak ayarlar. Öntanımlı olarak AÇIK&apos;tır.</translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished">açık/kapalı</translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished">UDP&apos;yi &lt;açık&gt;/&lt;kapalı&gt; olarak ayarlar. Öntanımlı olarak AÇIK&apos;tır.</translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished">LAN keşfini &lt;açık&gt;/&lt;kapalı&gt; olarak ayarlar. UDP&apos;yi kapatmak geçersiz kılar. Öntanımlı olarak AÇIK&apos;tır.</translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished">Vekil ayarlarını belirler. Öntanımlı olarak YOK&apos;tur.</translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished">(SOCKS5/HTTP/YOK):(ADRES):(BAĞLANTI NOKTASI)</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Hata</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished">Profil otomatik olarak yüklenemedi.</translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2225,18 +2276,6 @@ Bu kimlik NoSpam kodunu (mavi) ve sağlama toplamını (gri) içerir.</translati
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation>İşlenecek Tox URI&apos;si</translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation>Yeni örnek başlatır ve belirtilen profili yükler.</translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation>profil</translation>
-    </message>
-    <message>
         <source>%1 here! Tox me maybe?</source>
         <comment>Default message in Tox URI friend requests. Write something appropriate!</comment>
         <translation>%1 burada! Beni Toxlarsın belki?</translation>
@@ -2284,10 +2323,6 @@ Bu kimlik NoSpam kodunu (mavi) ve sağlama toplamını (gri) içerir.</translati
         <translation>qTox sohbet günlüklerinizi açamadı, devre dışı bırakılacaklar.</translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation>Yeni örnek başlatır ve giriş ekranını açar.</translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation>Koyu</translation>
     </message>
@@ -2306,10 +2341,6 @@ Bu kimlik NoSpam kodunu (mavi) ve sağlama toplamını (gri) içerir.</translati
     <message>
         <source>Dark violet</source>
         <translation>Koyu menekşe</translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
-        <translation>Profil otomatik olarak yüklenemedi.</translation>
     </message>
     <message>
         <source>online</source>
@@ -2340,30 +2371,6 @@ Bu kimlik NoSpam kodunu (mavi) ve sağlama toplamını (gri) içerir.</translati
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation>Metin yeniden biçimlendiriliyor...</translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation>IPv6&apos;yı &lt;açık&gt;/&lt;kapalı&gt; olarak ayarlar. Öntanımlı olarak AÇIK&apos;tır.</translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation>açık/kapalı</translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation>UDP&apos;yi &lt;açık&gt;/&lt;kapalı&gt; olarak ayarlar. Öntanımlı olarak AÇIK&apos;tır.</translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation>LAN keşfini &lt;açık&gt;/&lt;kapalı&gt; olarak ayarlar. UDP&apos;yi kapatmak geçersiz kılar. Öntanımlı olarak AÇIK&apos;tır.</translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation>Vekil ayarlarını belirler. Öntanımlı olarak YOK&apos;tur.</translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
-        <translation>(SOCKS5/HTTP/YOK):(ADRES):(BAĞLANTI NOKTASI)</translation>
     </message>
     <message>
         <source>%1 message(s) from %2 chats</source>

--- a/translations/ug.ts
+++ b/translations/ug.ts
@@ -590,19 +590,19 @@ which may lead to problems with video calls.</source>
     <name>AppManager</name>
     <message>
         <source>Tox URI to parse</source>
-        <translation type="unfinished">Tox ئۇلانما ئارېسى</translation>
+        <translation>Tox ئۇلانما ئارېسى</translation>
     </message>
     <message>
         <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished">يېڭىدىن ئارخىپ قۇرۇپ بەلگىلەنگەن ھۆججەتنى كىرگۈزۈش.</translation>
+        <translation>يېڭىدىن ئارخىپ قۇرۇپ بەلگىلەنگەن ھۆججەتنى كىرگۈزۈش.</translation>
     </message>
     <message>
         <source>profile</source>
-        <translation type="unfinished">ئارخىپ</translation>
+        <translation>ئارخىپ</translation>
     </message>
     <message>
         <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished">يېڭىدىن ئۆزنەك قۇرۇپ كىرىش كۆزنىكىنى ئېچىش.</translation>
+        <translation>يېڭىدىن ئۆزنەك قۇرۇپ كىرىش كۆزنىكىنى ئېچىش.</translation>
     </message>
     <message>
         <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>

--- a/translations/ug.ts
+++ b/translations/ug.ts
@@ -587,6 +587,57 @@ which may lead to problems with video calls.</source>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished">Tox ئۇلانما ئارېسى</translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished">يېڭىدىن ئارخىپ قۇرۇپ بەلگىلەنگەن ھۆججەتنى كىرگۈزۈش.</translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished">ئارخىپ</translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished">يېڭىدىن ئۆزنەك قۇرۇپ كىرىش كۆزنىكىنى ئېچىش.</translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">خاتا</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2221,18 +2272,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation>Tox ئۇلانما ئارېسى</translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation>يېڭىدىن ئارخىپ قۇرۇپ بەلگىلەنگەن ھۆججەتنى كىرگۈزۈش.</translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation>ئارخىپ</translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation>ئىتىراپلىق</translation>
     </message>
@@ -2280,10 +2319,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation>سۆھبەت خاتىرىڭىز ئېچىلمىدى، ئۇلارنى چەكلىۋەتسىڭىز بولىدۇ.</translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation>يېڭىدىن ئۆزنەك قۇرۇپ كىرىش كۆزنىكىنى ئېچىش.</translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2301,10 +2336,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
     <message>
         <source>Dark violet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2335,30 +2366,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/uk.ts
+++ b/translations/uk.ts
@@ -588,6 +588,57 @@ which may lead to problems with video calls.</source>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished">Tox URI для розбору</translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished">Запускає новий екземпляр і завантажує вказаний профіль.</translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished">профіль</translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">Помилка</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2222,18 +2273,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation>Tox URI для розбору</translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation>Запускає новий екземпляр і завантажує вказаний профіль.</translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation>профіль</translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation>Типовий</translation>
     </message>
@@ -2284,10 +2323,6 @@ It&apos;s difficult to translate &quot;Tox me maybe&quot; because in Ukrainian n
         <translation>Робочий стіл</translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2305,10 +2340,6 @@ It&apos;s difficult to translate &quot;Tox me maybe&quot; because in Ukrainian n
     </message>
     <message>
         <source>Dark violet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2339,30 +2370,6 @@ It&apos;s difficult to translate &quot;Tox me maybe&quot; because in Ukrainian n
     <message>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/uk.ts
+++ b/translations/uk.ts
@@ -591,15 +591,15 @@ which may lead to problems with video calls.</source>
     <name>AppManager</name>
     <message>
         <source>Tox URI to parse</source>
-        <translation type="unfinished">Tox URI для розбору</translation>
+        <translation>Tox URI для розбору</translation>
     </message>
     <message>
         <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished">Запускає новий екземпляр і завантажує вказаний профіль.</translation>
+        <translation>Запускає новий екземпляр і завантажує вказаний профіль.</translation>
     </message>
     <message>
         <source>profile</source>
-        <translation type="unfinished">профіль</translation>
+        <translation>профіль</translation>
     </message>
     <message>
         <source>Starts new instance and opens the login screen.</source>

--- a/translations/ur.ts
+++ b/translations/ur.ts
@@ -591,6 +591,57 @@ which may lead to problems with video calls.</source>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2217,18 +2268,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2276,10 +2315,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2297,10 +2332,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
     <message>
         <source>Dark violet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2331,30 +2362,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -590,6 +590,57 @@ which may lead to problems with video calls.</source>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished">Tox URI 解析</translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished">开始一个新的实例并加载指定的配置文件。</translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished">用户配置文件</translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished">开启一个新进程并打开登录界面。</translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished">设置 IPv6 &lt;开&gt;/&lt;关&gt;。 默认为开。</translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished">开/关</translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished">设置 UDP &lt;开&gt;/&lt;关&gt;。 默认为开。</translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished">设置局域网发现 &lt;开&gt;/&lt;关&gt;。 UDP 关 重写。 默认为开。</translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished">设置代理设置。默认值为 NONE。</translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished">(SOCKS5/HTTP/NONE):(地址):(端口)</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">错误</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished">无法自动加载配置文件。</translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2221,18 +2272,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation>Tox URI 解析</translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation>开始一个新的实例并加载指定的配置文件。</translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation>用户配置文件</translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation>默认</translation>
     </message>
@@ -2280,10 +2319,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation>桌面</translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation>开启一个新进程并打开登录界面。</translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation>暗色</translation>
     </message>
@@ -2302,10 +2337,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Dark violet</source>
         <translation>紫罗兰</translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
-        <translation>无法自动加载配置文件。</translation>
     </message>
     <message>
         <source>online</source>
@@ -2336,30 +2367,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
         <translation>重新格式化文本...</translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation>设置 IPv6 &lt;开&gt;/&lt;关&gt;。 默认为开。</translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation>开/关</translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation>设置 UDP &lt;开&gt;/&lt;关&gt;。 默认为开。</translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation>设置局域网发现 &lt;开&gt;/&lt;关&gt;。 UDP 关 重写。 默认为开。</translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation>设置代理设置。默认值为 NONE。</translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
-        <translation>(SOCKS5/HTTP/NONE):(地址):(端口)</translation>
     </message>
     <message>
         <source>%1 message(s) from %2 chats</source>

--- a/translations/zh_CN.ts
+++ b/translations/zh_CN.ts
@@ -593,43 +593,43 @@ which may lead to problems with video calls.</source>
     <name>AppManager</name>
     <message>
         <source>Tox URI to parse</source>
-        <translation type="unfinished">Tox URI 解析</translation>
+        <translation>Tox URI 解析</translation>
     </message>
     <message>
         <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished">开始一个新的实例并加载指定的配置文件。</translation>
+        <translation>开始一个新的实例并加载指定的配置文件。</translation>
     </message>
     <message>
         <source>profile</source>
-        <translation type="unfinished">用户配置文件</translation>
+        <translation>用户配置文件</translation>
     </message>
     <message>
         <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished">开启一个新进程并打开登录界面。</translation>
+        <translation>开启一个新进程并打开登录界面。</translation>
     </message>
     <message>
         <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished">设置 IPv6 &lt;开&gt;/&lt;关&gt;。 默认为开。</translation>
+        <translation>设置 IPv6 &lt;开&gt;/&lt;关&gt;。 默认为开。</translation>
     </message>
     <message>
         <source>on/off</source>
-        <translation type="unfinished">开/关</translation>
+        <translation>开/关</translation>
     </message>
     <message>
         <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished">设置 UDP &lt;开&gt;/&lt;关&gt;。 默认为开。</translation>
+        <translation>设置 UDP &lt;开&gt;/&lt;关&gt;。 默认为开。</translation>
     </message>
     <message>
         <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished">设置局域网发现 &lt;开&gt;/&lt;关&gt;。 UDP 关 重写。 默认为开。</translation>
+        <translation>设置局域网发现 &lt;开&gt;/&lt;关&gt;。 UDP 关 重写。 默认为开。</translation>
     </message>
     <message>
         <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished">设置代理设置。默认值为 NONE。</translation>
+        <translation>设置代理设置。默认值为 NONE。</translation>
     </message>
     <message>
         <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
-        <translation type="unfinished">(SOCKS5/HTTP/NONE):(地址):(端口)</translation>
+        <translation>(SOCKS5/HTTP/NONE):(地址):(端口)</translation>
     </message>
     <message>
         <source>Error</source>
@@ -637,7 +637,7 @@ which may lead to problems with video calls.</source>
     </message>
     <message>
         <source>Failed to load profile automatically.</source>
-        <translation type="unfinished">无法自动加载配置文件。</translation>
+        <translation>无法自动加载配置文件。</translation>
     </message>
 </context>
 <context>

--- a/translations/zh_TW.ts
+++ b/translations/zh_TW.ts
@@ -586,6 +586,57 @@ which may lead to problems with video calls.</source>
     </message>
 </context>
 <context>
+    <name>AppManager</name>
+    <message>
+        <source>Tox URI to parse</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starts new instance and loads specified profile.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>profile</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Starts new instance and opens the login screen.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>on/off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sets proxy settings. Default is NONE.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation type="unfinished">錯誤</translation>
+    </message>
+    <message>
+        <source>Failed to load profile automatically.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatForm</name>
     <message>
         <source>Send a file</source>
@@ -2209,18 +2260,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
 <context>
     <name>QObject</name>
     <message>
-        <source>Tox URI to parse</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Starts new instance and loads specified profile.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>profile</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2268,10 +2307,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Starts new instance and opens the login screen.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2289,10 +2324,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     </message>
     <message>
         <source>Dark violet</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Failed to load profile automatically.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2323,30 +2354,6 @@ This ID includes the NoSpam code (in blue), and the checksum (in gray).</source>
     <message>
         <source>Reformatting text...</source>
         <comment>Waiting for text to be reformatted</comment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets IPv6 &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>on/off</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets UDP &lt;on&gt;/&lt;off&gt;. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets LAN discovery &lt;on&gt;/&lt;off&gt;. UDP off overrides. Default is ON.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sets proxy settings. Default is NONE.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>(SOCKS5/HTTP/NONE):(ADDRESS):(PORT)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>


### PR DESCRIPTION
main() couldn't hold its own state since cleanup() needed access to it.
Having the state in a class allows QApplication::aboutToQuit to call
into a member function with access to the state.

Data used in logging still needs to be global due to
qInstallMessageHandler not accepting a void* to get back to this.

Set QGuiApplication attributes before constructing AppManager since they
must be set before the QApplication is constructed.

Keep logic largely unchanged, but with a defined destruction order.

Destruction is still abnormal due to QApplication::aboutToQuit forcing
us to do partial cleanup before QApplication returns, since some OSes
will kill qTox before the QApplication returns.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6603)
<!-- Reviewable:end -->
