### PR TITLE
fix(chatlog): Display correct system message timestamp in chatlog

### DIFF
--- a/src/chatlog/chatwidget.cpp
+++ b/src/chatlog/chatwidget.cpp
@@ -1440,7 +1440,7 @@ void ChatWidget::renderItem(const ChatLogItem& item, bool hideName, bool coloriz
 
         auto chatMessageType = getChatMessageType(systemMessage);
         chatMessage = ChatMessage::createChatInfoMessage(systemMessage.toString(),
-            chatMessageType, QDateTime::currentDateTime(), documentCache, settings,
+            chatMessageType, systemMessage.timestamp, documentCache, settings,
             style);
         // Ignore caller's decision to hide the name. We show the icon in the
         // slot of the sender's name so we always want it visible

--- a/src/persistence/history.cpp
+++ b/src/persistence/history.cpp
@@ -613,6 +613,7 @@ QList<History::HistMessage> History::getMessagesForChat(const ChatId& chatId, si
             assert(!it->isNull());
             SystemMessage systemMessage;
             systemMessage.messageType = static_cast<SystemMessageType>((*it++).toLongLong());
+            systemMessage.timestamp = timestamp;
 
             auto argEnd = std::next(it, systemMessage.args.size());
             std::transform(it, argEnd, systemMessage.args.begin(), [](const QVariant& arg) {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6607)
<!-- Reviewable:end -->
