### PR TITLE
fix(FriendList): exclusion of possible undefined behavior

### DIFF
--- a/src/model/friendlist/friendlistmanager.cpp
+++ b/src/model/friendlist/friendlistmanager.cpp
@@ -40,6 +40,11 @@ bool FriendListManager::getPositionsChanged() const
     return positionsChanged;
 }
 
+bool FriendListManager::getGroupsOnTop() const
+{
+    return groupsOnTop;
+}
+
 void FriendListManager::addFriendListItem(IFriendListItem *item)
 {
     if (item->isGroup() && item->getWidget() != nullptr) {

--- a/src/model/friendlist/friendlistmanager.h
+++ b/src/model/friendlist/friendlistmanager.h
@@ -38,6 +38,7 @@ public:
     bool needHideCircles() const;
     // If the contact positions have changed, need to redraw view
     bool getPositionsChanged() const;
+    bool getGroupsOnTop() const;
 
     void addFriendListItem(IFriendListItem* item);
     void removeFriendListItem(IFriendListItem* item);
@@ -69,11 +70,11 @@ private:
 
     bool byName = true;
     bool hideCircles = false;
-    bool groupsOnTop;
-    bool positionsChanged;
-    bool needSort;
+    bool groupsOnTop = true;
+    bool positionsChanged = false;
+    bool needSort = false;
     QVector<IFriendListItemPtr> items;
     // At startup, while the size of items is less than countContacts, the view will not be processed to improve performance
-    int countContacts;
+    int countContacts = 0;
 
 };

--- a/test/model/friendlistmanager_test.cpp
+++ b/test/model/friendlistmanager_test.cpp
@@ -148,6 +148,11 @@ public:
         return this;
     }
 
+    bool getGroupsOnTop()
+    {
+        return groupsOnTop;
+    }
+
     /**
      * @brief buildUnsorted Creates items to init the FriendListManager.
      * FriendListManager will own and manage these items
@@ -341,6 +346,7 @@ void TestFriendListManager::testSortByName()
     QCOMPARE(success, true);
     QCOMPARE(manager->getPositionsChanged(), false);
     QCOMPARE(manager->getItems().size(), sortedVec.size());
+    QCOMPARE(manager->getGroupsOnTop(),  listBuilder.getGroupsOnTop());
 
     for (int i = 0; i < sortedVec.size(); ++i) {
         IFriendListItem* fromManager = manager->getItems().at(i).get();


### PR DESCRIPTION
Fix #6606
Tested on Ubuntu. For always reproduced failure, I temporarily wrapped the contents of  `TestFriendListManager::testSortByName` in `for (int j = 0; j < 100; ++j) { ... }`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6614)
<!-- Reviewable:end -->
