### PR TITLE
fix(CI): Fix commit message check on single commit PRs

### DIFF
--- a/.ci-scripts/verify-commit-format.sh
+++ b/.ci-scripts/verify-commit-format.sh
@@ -21,5 +21,5 @@ set -eu -o pipefail
 
 # Verify commit messages
 readarray -t COMMITS <<<$(curl -s ${GITHUB_CONTEXT} | jq -r '.[0,-1].sha')
-COMMIT_RANGE="${COMMITS[1]}..${COMMITS[0]}"
+COMMIT_RANGE="${COMMITS[1]}~1..${COMMITS[0]}"
 bash ./verify-commit-messages.sh "$COMMIT_RANGE"


### PR DESCRIPTION
The range of COMMIT..COMMIT does not count the starting commit, so
single commit PRs are completely unchecked, and multi commit PRs don't
have their first commit checked.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6615)
<!-- Reviewable:end -->
