### PR TITLE
feat(CI): Disallow unsafe implcit casts to QString

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,7 @@ endif()
 
 add_definitions(-DQT_NO_CAST_FROM_BYTEARRAY)
 add_definitions(-DQT_NO_CAST_TO_ASCII)
+add_definitions(-DQT_RESTRICTED_CAST_FROM_ASCII)
 
 include(CheckAtomic)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,8 @@ if (UNIX AND NOT APPLE)
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-z,relro")
 endif()
 
+add_definitions(-DQT_NO_CAST_FROM_BYTEARRAY)
+
 include(CheckAtomic)
 
 # Use ccache when available to speed up builds.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ if (UNIX AND NOT APPLE)
 endif()
 
 add_definitions(-DQT_NO_CAST_FROM_BYTEARRAY)
+add_definitions(-DQT_NO_CAST_TO_ASCII)
 
 include(CheckAtomic)
 

--- a/src/chatlog/chatwidget.cpp
+++ b/src/chatlog/chatwidget.cpp
@@ -690,7 +690,7 @@ QString ChatWidget::getSelectedText() const
             QString msg = line->content[1]->getText();
 
             out +=
-                QString(out.isEmpty() ? "[%2] %1: %3" : "\n[%2] %1: %3").arg(author, timestamp, msg);
+                QString(out.isEmpty() ? QStringLiteral("[%2] %1: %3") : QStringLiteral("\n[%2] %1: %3")).arg(author, timestamp, msg);
         });
 
         return out;

--- a/src/chatlog/content/filetransferwidget.cpp
+++ b/src/chatlog/content/filetransferwidget.cpp
@@ -328,7 +328,7 @@ void FileTransferWidget::updateFileProgress(ToxFile const& file)
         if (speed > 0) {
             // ETA
             QTime toGo = QTime(0, 0).addSecs(remainingTime);
-            QString format = toGo.hour() > 0 ? "hh:mm:ss" : "mm:ss";
+            QString format = toGo.hour() > 0 ? QStringLiteral("hh:mm:ss") : QStringLiteral("mm:ss");
             ui->etaLabel->setText(toGo.toString(format));
         } else {
             ui->etaLabel->setText("");

--- a/src/core/chatid.cpp
+++ b/src/core/chatid.cpp
@@ -77,7 +77,7 @@ bool ChatId::operator<(const ChatId& other) const
  */
 QString ChatId::toString() const
 {
-    return id.toHex().toUpper();
+    return QString::fromUtf8(id.toHex()).toUpper();
 }
 
 /**

--- a/src/core/corefile.cpp
+++ b/src/core/corefile.cpp
@@ -379,7 +379,7 @@ void CoreFile::onFileReceiveCallback(Tox* tox, uint32_t friendId, uint32_t fileI
     #endif
     qDebug() << QString("Received file request %1:%2 kind %3").arg(friendId).arg(fileId).arg(kind);
 
-    ToxFile file{fileId, friendId, filename.getBytes(), "", filesize, ToxFile::RECEIVING};
+    ToxFile file{fileId, friendId, filename.getQString(), "", filesize, ToxFile::RECEIVING};
     file.fileKind = kind;
     file.resumeFileId.resize(TOX_FILE_ID_LENGTH);
     Tox_Err_File_Get fileGetErr;

--- a/src/core/toxid.cpp
+++ b/src/core/toxid.cpp
@@ -114,7 +114,7 @@ ToxId::ToxId(const uint8_t* rawId, int len)
 
 void ToxId::constructToxId(const QByteArray& rawId)
 {
-    if (rawId.length() == ToxId::size && isToxId(rawId.toHex().toUpper())) {
+    if (rawId.length() == ToxId::size && isToxId(QString::fromUtf8(rawId.toHex()).toUpper())) {
         toxId = QByteArray(rawId); // construct from full toxid
     } else {
         assert(!"ToxId constructed with invalid input");
@@ -149,7 +149,7 @@ bool ToxId::operator!=(const ToxId& other) const
  */
 QString ToxId::toString() const
 {
-    return toxId.toHex().toUpper();
+    return QString::fromUtf8(toxId.toHex()).toUpper();
 }
 
 /**
@@ -194,7 +194,7 @@ ToxPk ToxId::getPublicKey() const
 QString ToxId::getNoSpamString() const
 {
     if (toxId.length() == ToxId::size) {
-        return toxId.mid(ToxPk::size, ToxId::nospamSize).toHex().toUpper();
+        return QString::fromUtf8(toxId.mid(ToxPk::size, ToxId::nospamSize).toHex()).toUpper();
     }
 
     return {};

--- a/src/core/toxlogger.cpp
+++ b/src/core/toxlogger.cpp
@@ -33,7 +33,7 @@ QByteArray cleanPath(const char *file)
 {
     // for privacy, make the path relative to the c-toxcore source directory
     const QRegularExpression pathCleaner(QLatin1String{"[\\s|\\S]*c-toxcore."});
-    QByteArray cleanedPath = QString{file}.remove(pathCleaner).toUtf8();
+    QByteArray cleanedPath = QString::fromUtf8(file).remove(pathCleaner).toUtf8();
     cleanedPath.append('\0');
     return cleanedPath;
 }

--- a/src/ipc.cpp
+++ b/src/ipc.cpp
@@ -52,7 +52,7 @@ namespace
             qWarning() << "Failed to get current username. Will use a global IPC.";
             user = "";
         }
-        return QString("qtox-" IPC_PROTOCOL_VERSION "-") + user;
+        return QString("qtox-" IPC_PROTOCOL_VERSION "-") + QString::fromUtf8(user);
     }
 } // namespace
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -95,7 +95,7 @@ void cleanup()
 void logMessageHandler(QtMsgType type, const QMessageLogContext& ctxt, const QString& msg)
 {
     // Silence qWarning spam due to bug in QTextBrowser (trying to open a file for base64 images)
-    if (ctxt.function == QString("virtual bool QFSFileEngine::open(QIODevice::OpenMode)")
+    if (QString::fromUtf8(ctxt.function) == QString("virtual bool QFSFileEngine::open(QIODevice::OpenMode)")
         && msg == QString("QFSFileEngine::open: No file name specified")) {
         return;
     }
@@ -119,7 +119,7 @@ void logMessageHandler(QtMsgType type, const QMessageLogContext& ctxt, const QSt
         return;
     }
 
-    QString file = ctxt.file;
+    QString file = QString::fromUtf8(ctxt.file);
     // We're not using QT_MESSAGELOG_FILE here, because that can be 0, NULL, or
     // nullptr in release builds.
     QString path = QString(__FILE__);
@@ -199,7 +199,7 @@ bool toxURIEventHandler(const QByteArray& eventData, void* userData)
         return false;
     }
 
-    uriDialog->handleToxURI(eventData);
+    uriDialog->handleToxURI(QString::fromUtf8(eventData));
     return true;
 }
 
@@ -438,9 +438,9 @@ int main(int argc, char* argv[])
 
     // Event was not handled by already running instance therefore we handle it ourselves
     if (eventType == "uri") {
-        uriDialog->handleToxURI(firstParam.toUtf8());
+        uriDialog->handleToxURI(firstParam);
     } else if (eventType == "save") {
-        toxSave->handleToxSave(firstParam.toUtf8());
+        toxSave->handleToxSave(firstParam);
     }
 
     QObject::connect(a.get(), &QApplication::aboutToQuit, cleanup);

--- a/src/model/message.cpp
+++ b/src/model/message.cpp
@@ -47,11 +47,11 @@ namespace {
                 }
                 --splitPos;
             }
-            splittedMsgs.append(QString{ba_message.left(splitPos + 1)});
+            splittedMsgs.append(QString::fromUtf8(ba_message.left(splitPos + 1)));
             ba_message = ba_message.mid(splitPos + 1);
         }
 
-        splittedMsgs.append(QString{ba_message});
+        splittedMsgs.append(QString::fromUtf8(ba_message));
         return splittedMsgs;
     }
 }

--- a/src/net/bootstrapnodeupdater.cpp
+++ b/src/net/bootstrapnodeupdater.cpp
@@ -163,7 +163,7 @@ QList<DhtServer> loadNodesFile(QString file)
         return {};
     }
 
-    QString nodesJson = nodesFile.readAll();
+    QString nodesJson = QString::fromUtf8(nodesFile.readAll());
     nodesFile.close();
 
     auto jsonDoc = QJsonDocument::fromJson(nodesJson.toUtf8());

--- a/src/persistence/db/rawdatabase.cpp
+++ b/src/persistence/db/rawdatabase.cpp
@@ -696,7 +696,7 @@ QString RawDatabase::deriveKey(const QString& password)
     const std::unique_ptr<Tox_Pass_Key, PassKeyDeleter> key(tox_pass_key_derive_with_salt(
         reinterpret_cast<const uint8_t*>(passData.data()),
         static_cast<std::size_t>(passData.size()), expandConstant, nullptr));
-    return QByteArray(reinterpret_cast<char*>(key.get()) + 32, 32).toHex();
+    return QString::fromUtf8(QByteArray(reinterpret_cast<char*>(key.get()) + 32, 32).toHex());
 }
 
 /**
@@ -724,7 +724,7 @@ QString RawDatabase::deriveKey(const QString& password, const QByteArray& salt)
         reinterpret_cast<const uint8_t*>(passData.data()),
         static_cast<std::size_t>(passData.size()),
         reinterpret_cast<const uint8_t*>(salt.constData()), nullptr));
-    return QByteArray(reinterpret_cast<char*>(key.get()) + 32, 32).toHex();
+    return QString::fromUtf8(QByteArray(reinterpret_cast<char*>(key.get()) + 32, 32).toHex());
 }
 
 /**
@@ -876,7 +876,7 @@ void RawDatabase::process()
  */
 QString RawDatabase::anonymizeQuery(const QByteArray& query)
 {
-    QString queryString(query);
+    QString queryString = QString::fromUtf8(query);
     queryString.replace(QRegularExpression("chat.public_key='[A-F0-9]{64}'"),
                         "char.public_key='<HERE IS PUBLIC KEY>'");
     queryString.replace(QRegularExpression("timestamp BETWEEN \\d{5,} AND \\d{5,}"),
@@ -935,8 +935,8 @@ void RawDatabase::regexp(sqlite3_context* ctx, int argc, sqlite3_value** argv, c
 {
     std::ignore = argc;
     QRegularExpression regex;
-    const QString str1(reinterpret_cast<const char*>(sqlite3_value_text(argv[0])));
-    const QString str2(reinterpret_cast<const char*>(sqlite3_value_text(argv[1])));
+    const QString str1 = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_value_text(argv[0])));
+    const QString str2 = QString::fromUtf8(reinterpret_cast<const char*>(sqlite3_value_text(argv[1])));
 
     regex.setPattern(str1);
     regex.setPatternOptions(cs);

--- a/src/persistence/profile.cpp
+++ b/src/persistence/profile.cpp
@@ -553,7 +553,7 @@ QString Profile::avatarPath(const ToxPk& owner, bool forceUnencrypted)
     QByteArray hash(hashSize, 0);
     crypto_generichash(reinterpret_cast<uint8_t*>(hash.data()), hashSize, reinterpret_cast<uint8_t*>(idData.data()), idData.size(),
                        reinterpret_cast<uint8_t*>(pubkeyData.data()), pubkeyData.size());
-    return paths.getSettingsDirPath() + "avatars/" + hash.toHex().toUpper() + ".png";
+    return paths.getSettingsDirPath() + "avatars/" + QString::fromUtf8(hash.toHex()).toUpper() + ".png";
 }
 
 /**

--- a/src/persistence/serialize.cpp
+++ b/src/persistence/serialize.cpp
@@ -44,7 +44,7 @@ QString dataToString(QByteArray data)
     data.remove(0, i);
     data.truncate(strlen);
 
-    return QString(data);
+    return QString::fromUtf8(data);
 }
 
 uint64_t dataToUint64(const QByteArray& data)

--- a/src/persistence/toxsave.cpp
+++ b/src/persistence/toxsave.cpp
@@ -36,7 +36,7 @@ bool ToxSave::toxSaveEventHandler(const QByteArray& eventData, void* userData)
         return false;
     }
 
-    toxSave->handleToxSave(eventData);
+    toxSave->handleToxSave(QString::fromUtf8(eventData));
     return true;
 }
 

--- a/src/platform/camera/avfoundation.mm
+++ b/src/platform/camera/avfoundation.mm
@@ -57,7 +57,7 @@ QVector<VideoMode> avfoundation::getDeviceModes(QString devName)
         return result;
     }
     else {
-        NSString* deviceName = [NSString stringWithCString:devName.toUtf8() encoding:NSUTF8StringEncoding];
+        NSString* deviceName = [NSString stringWithCString:devName.toUtf8().constData() encoding:NSUTF8StringEncoding];
         AVCaptureDevice* device = [AVCaptureDevice deviceWithUniqueID:deviceName];
 
         if (device == nil) {

--- a/src/platform/camera/directshow.cpp
+++ b/src/platform/camera/directshow.cpp
@@ -99,7 +99,7 @@ QVector<QPair<QString, QString>> DirectShow::getDeviceList()
             goto fail;
         devHumanName = wcharToUtf8(var.bstrVal);
 
-        devices += {QString("video=") + devIdString, devHumanName};
+        devices += {QString("video=") + QString::fromUtf8(devIdString), QString::fromUtf8(devHumanName)};
 
     fail:
         if (olestr && coMalloc)
@@ -156,7 +156,7 @@ static IBaseFilter* getDevFilter(QString devName)
             if (devIdString[i] == ':')
                 devIdString[i] = '_';
 
-        if (devName != devIdString)
+        if (devName.toUtf8().constData() != devIdString)
             goto fail;
 
         if (m->BindToObject(nullptr, nullptr, IID_IBaseFilter, reinterpret_cast<void**>(&devFilter)) != S_OK)

--- a/src/platform/camera/v4l2.cpp
+++ b/src/platform/camera/v4l2.cpp
@@ -195,7 +195,7 @@ QVector<QPair<QString, QString>> v4l2::getDeviceList()
     dirent* e;
     while ((e = readdir(dir)))
         if (!strncmp(e->d_name, "video", 5) || !strncmp(e->d_name, "vbi", 3))
-            deviceFiles += QString("/dev/") + e->d_name;
+            deviceFiles += QString("/dev/") + QString::fromUtf8(e->d_name);
     closedir(dir);
 
     for (QString file : deviceFiles) {
@@ -210,7 +210,7 @@ QVector<QPair<QString, QString>> v4l2::getDeviceList()
         close(fd);
 
         if (caps.device_caps & V4L2_CAP_VIDEO_CAPTURE)
-            devices += {file, reinterpret_cast<const char*>(caps.card)};
+            devices += {file, QString::fromUtf8(reinterpret_cast<const char*>(caps.card))};
     }
     return devices;
 }

--- a/src/video/cameradevice.cpp
+++ b/src/video/cameradevice.cpp
@@ -195,7 +195,7 @@ CameraDevice* CameraDevice::open(QString devName, VideoMode mode)
         devName += QString("+%1,%2").arg(QString().setNum(mode.x), QString().setNum(mode.y));
 
         av_dict_set(&options, "framerate", framerate.c_str(), 0);
-    } else if (iformat->name == QString("video4linux2,v4l2") && mode) {
+    } else if (QString::fromUtf8(iformat->name) == QString("video4linux2,v4l2") && mode) {
         av_dict_set(&options, "video_size", videoSize.c_str(), 0);
         av_dict_set(&options, "framerate", framerate.c_str(), 0);
         const std::string pixelFormatStr = v4l2::getPixelFormatString(mode.pixel_format).toStdString();
@@ -215,13 +215,13 @@ CameraDevice* CameraDevice::open(QString devName, VideoMode mode)
         av_dict_set(&options, "offset_x", offsetX.c_str(), 0);
         av_dict_set(&options, "offset_y", offsetY.c_str(), 0);
         av_dict_set(&options, "video_size", videoSize.c_str(), 0);
-    } else if (iformat->name == QString("dshow") && mode) {
+    } else if (QString::fromUtf8(iformat->name) == QString("dshow") && mode) {
         av_dict_set(&options, "video_size", videoSize.c_str(), 0);
         av_dict_set(&options, "framerate", framerate.c_str(), 0);
     }
 #endif
 #ifdef Q_OS_OSX
-    else if (iformat->name == QString("avfoundation")) {
+    else if (QString::fromUtf8(iformat->name) == QString("avfoundation")) {
         if (mode) {
             av_dict_set(&options, "video_size", videoSize.c_str(), 0);
             av_dict_set(&options, "framerate", framerate.c_str(), 0);
@@ -330,8 +330,8 @@ QVector<QPair<QString, QString>> CameraDevice::getRawDeviceListGeneric()
     devices.resize(devlist->nb_devices);
     for (int i = 0; i < devlist->nb_devices; ++i) {
         AVDeviceInfo* dev = devlist->devices[i];
-        devices[i].first = dev->device_name;
-        devices[i].second = dev->device_description;
+        devices[i].first = QString::fromUtf8(dev->device_name);
+        devices[i].second = QString::fromUtf8(dev->device_description);
     }
     avdevice_free_list_devices(&devlist);
     return devices;
@@ -354,34 +354,34 @@ QVector<QPair<QString, QString>> CameraDevice::getDeviceList()
     if (!iformat)
         ;
 #ifdef Q_OS_WIN
-    else if (iformat->name == QString("dshow"))
+    else if (QString::fromUtf8(iformat->name) == QString("dshow"))
         devices += DirectShow::getDeviceList();
 #endif
 #if USING_V4L
-    else if (iformat->name == QString("video4linux2,v4l2"))
+    else if (QString::fromUtf8(iformat->name) == QString("video4linux2,v4l2"))
         devices += v4l2::getDeviceList();
 #endif
 #ifdef Q_OS_OSX
-    else if (iformat->name == QString("avfoundation"))
+    else if (QString::fromUtf8(iformat->name) == QString("avfoundation"))
         devices += avfoundation::getDeviceList();
 #endif
     else
         devices += getRawDeviceListGeneric();
 
     if (idesktopFormat) {
-        if (idesktopFormat->name == QString("x11grab")) {
+        if (QString::fromUtf8(idesktopFormat->name) == QString("x11grab")) {
             QString dev = "x11grab#";
             QByteArray display = qgetenv("DISPLAY");
 
             if (display.isNull())
                 dev += ":0";
             else
-                dev += display.constData();
+                dev += QString::fromUtf8(display.constData());
 
             devices.push_back(QPair<QString, QString>{
                 dev, QObject::tr("Desktop", "Desktop as a camera input for screen sharing")});
         }
-        if (idesktopFormat->name == QString("gdigrab"))
+        if (QString::fromUtf8(idesktopFormat->name) == QString("gdigrab"))
             devices.push_back(QPair<QString, QString>{
                 "gdigrab#desktop",
                 QObject::tr("Desktop", "Desktop as a camera input for screen sharing")});
@@ -459,15 +459,15 @@ QVector<VideoMode> CameraDevice::getVideoModes(QString devName)
     else if (isScreen(devName))
         return getScreenModes();
 #ifdef Q_OS_WIN
-    else if (iformat->name == QString("dshow"))
+    else if (QString::fromUtf8(iformat->name) == QString("dshow"))
         return DirectShow::getDeviceModes(devName);
 #endif
 #if USING_V4L
-    else if (iformat->name == QString("video4linux2,v4l2"))
+    else if (QString::fromUtf8(iformat->name) == QString("video4linux2,v4l2"))
         return v4l2::getDeviceModes(devName);
 #endif
 #ifdef Q_OS_OSX
-    else if (iformat->name == QString("avfoundation"))
+    else if (QString::fromUtf8(iformat->name) == QString("avfoundation"))
         return avfoundation::getDeviceModes(devName);
 #endif
     else

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -288,7 +288,7 @@ void ChatForm::onTextEditChanged()
 void ChatForm::onAttachClicked()
 {
     QStringList paths = QFileDialog::getOpenFileNames(Q_NULLPTR, tr("Send a file"),
-                                                      QDir::homePath(), nullptr, nullptr);
+                                                      QDir::homePath(), QString(), nullptr);
 
     if (paths.isEmpty()) {
         return;

--- a/src/widget/form/profileform.cpp
+++ b/src/widget/form/profileform.cpp
@@ -302,7 +302,7 @@ QString ProfileForm::getSupportedImageFilter()
 {
     QString res;
     for (auto type : QImageReader::supportedImageFormats()) {
-        res += QString("*.%1 ").arg(QString(type));
+        res += QString("*.%1 ").arg(QString::fromUtf8(type));
     }
 
     return tr("Images (%1)", "filetype filter").arg(res.left(res.size() - 1));

--- a/src/widget/form/settings/aboutform.cpp
+++ b/src/widget/form/settings/aboutform.cpp
@@ -157,7 +157,7 @@ void AboutForm::replaceVersions()
                                "Replaces `%2` in the `A list of all known…`"))));
 
     bodyUI->clickToReport->setText(
-        createLink("https://github.com/qTox/qTox/issues/new?body=" + QUrl(issueBody).toEncoded(),
+        createLink("https://github.com/qTox/qTox/issues/new?body=" + QString::fromUtf8(QUrl(issueBody).toEncoded()),
                    QString("<b>%1</b>").arg(tr("Click here to report a bug."))));
 
 

--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -434,7 +434,7 @@ void FriendWidget::onAvatarRemoved(const ToxPk& friendPk)
 
     isDefaultAvatar = true;
 
-    const QString path = QString(":/img/contact%1.svg").arg(isActive() ? "_dark" : "");
+    const QString path = QString(":/img/contact%1.svg").arg(isActive() ? QStringLiteral("_dark") : QString());
     avatar->setPixmap(QPixmap(path));
 }
 

--- a/src/widget/imagepreviewwidget.cpp
+++ b/src/widget/imagepreviewwidget.cpp
@@ -98,7 +98,7 @@ QString getToolTipDisplayingImage(const QPixmap& image)
     previewImage.save(&buffer, "PNG");
     buffer.close();
 
-    return "<img src=data:image/png;base64," + imageData.toBase64() + "/>";
+    return "<img src=data:image/png;base64," + QString::fromUtf8(imageData.toBase64()) + "/>";
 }
 
 } // namespace

--- a/src/widget/style.cpp
+++ b/src/widget/style.cpp
@@ -233,7 +233,7 @@ const QString Style::resolve(const QString& filename, Settings& settings, const 
 
     QFile file{fullPath};
     if (file.open(QFile::ReadOnly | QFile::Text)) {
-        qss = file.readAll();
+        qss = QString::fromUtf8(file.readAll());
     } else {
         qWarning() << "Failed to open file:" << fullPath;
 
@@ -241,7 +241,7 @@ const QString Style::resolve(const QString& filename, Settings& settings, const 
         QFile defaultFile{fullPath};
 
         if (defaultFile.open(QFile::ReadOnly | QFile::Text)) {
-            qss = defaultFile.readAll();
+            qss = QString::fromUtf8(defaultFile.readAll());
         } else {
             qWarning() << "Failed to open default file:" << fullPath;
             return {};

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -556,7 +556,7 @@ void Widget::updateIcons()
 
     const QString assetSuffix = Status::getAssetSuffix(static_cast<Status::Status>(
                                     ui->statusButton->property("status").toInt()))
-                                + (eventIcon ? "_event" : "");
+                                + (eventIcon ? QStringLiteral("_event") : QString());
 
     // Some builds of Qt appear to have a bug in icon loading:
     // QIcon::hasThemeIcon is sometimes unaware that the icon returned
@@ -588,7 +588,7 @@ void Widget::updateIcons()
     if (!hasThemeIconBug && QIcon::hasThemeIcon("qtox-" + assetSuffix)) {
         ico = QIcon::fromTheme("qtox-" + assetSuffix);
     } else {
-        QString color = settings.getLightTrayIcon() ? "light" : "dark";
+        QString color = settings.getLightTrayIcon() ? QStringLiteral("light") : QStringLiteral("dark");
         QString path = ":/img/taskbar/" + color + "/taskbar_" + assetSuffix + ".svg";
         QSvgRenderer renderer(path);
 
@@ -2484,9 +2484,9 @@ inline QIcon Widget::prepareIcon(QString path, int w, int h)
 {
 #ifdef Q_OS_LINUX
 
-    QString desktop = getenv("XDG_CURRENT_DESKTOP");
+    QString desktop = QString::fromUtf8(getenv("XDG_CURRENT_DESKTOP"));
     if (desktop.isEmpty()) {
-        desktop = getenv("DESKTOP_SESSION");
+        desktop = QString::fromUtf8(getenv("DESKTOP_SESSION"));
     }
 
     desktop = desktop.toLower();

--- a/test/model/friendmessagedispatcher_test.cpp
+++ b/test/model/friendmessagedispatcher_test.cpp
@@ -400,7 +400,7 @@ void TestFriendMessageDispatcher::testActionMessagesSplitWithExtensions()
     auto reallyLongMessage = QString("a");
 
     for (uint64_t i = 0; i < testMaxExtendedMessageSize + 50; ++i) {
-        reallyLongMessage += i;
+        reallyLongMessage += QString().number(i);
     }
 
     friendMessageDispatcher->sendMessage(true, reallyLongMessage);

--- a/test/persistence/smileypack_test.cpp
+++ b/test/persistence/smileypack_test.cpp
@@ -116,7 +116,7 @@ void TestSmileyPack::testSmilifyAsciiEmoticon()
     auto result = smileyPack.smileyfied(":-)");
     QVERIFY(result == SmileyPack::getAsRichText(":-)"));
 
-    constexpr auto testMsg = "Some:-)Letters";
+    const auto testMsg = QStringLiteral("Some:-)Letters");
     result = smileyPack.smileyfied(testMsg);
 
     // Nothing has changed. Ascii smileys are only considered

--- a/util/src/display.cpp
+++ b/util/src/display.cpp
@@ -30,5 +30,5 @@ QString getHumanReadableSize(uint64_t size)
         exp = std::min(static_cast<int>(log(size) / log(1024)), static_cast<int>(sizeof(suffix) / sizeof(suffix[0]) - 1));
     }
 
-    return QString().setNum(size / pow(1024, exp), 'f', exp > 1 ? 2 : 0).append(suffix[exp]);
+    return QString().setNum(size / pow(1024, exp), 'f', exp > 1 ? 2 : 0).append(QString::fromUtf8(suffix[exp]));
 }


### PR DESCRIPTION
Note that I have a branch with QT_NO_CAST_FROM_ASCII applied and relevant changes: https://github.com/anthonybilinski/qTox/tree/no_implicit_cast, but it seems excessive for little additional safety gain.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6616)
<!-- Reviewable:end -->
