### PR TITLE
refactor(Nexus): Remove all uses of getProfile in child classes

### DIFF
--- a/src/model/about/aboutfriend.cpp
+++ b/src/model/about/aboutfriend.cpp
@@ -24,9 +24,10 @@
 #include "src/persistence/profile.h"
 #include "src/persistence/ifriendsettings.h"
 
-AboutFriend::AboutFriend(const Friend* f_, IFriendSettings* const settings_)
+AboutFriend::AboutFriend(const Friend* f_, IFriendSettings* const settings_, Profile& profile_)
     : f{f_}
     , settings{settings_}
+    , profile{profile_}
 {
     settings->connectTo_contactNoteChanged(this, [=](const ToxPk& pk, const QString& note) {
         std::ignore = pk;
@@ -65,7 +66,7 @@ ToxPk AboutFriend::getPublicKey() const
 QPixmap AboutFriend::getAvatar() const
 {
     const ToxPk pk = f->getPublicKey();
-    const QPixmap avatar = Nexus::getProfile()->loadAvatar(pk);
+    const QPixmap avatar = profile.loadAvatar(pk);
     return avatar.isNull() ? QPixmap(QStringLiteral(":/img/contact_dark.svg"))
                            : avatar;
 }
@@ -125,7 +126,7 @@ void AboutFriend::setAutoGroupInvite(bool enabled)
 bool AboutFriend::clearHistory()
 {
     const ToxPk pk = f->getPublicKey();
-    History* const history = Nexus::getProfile()->getHistory();
+    History* const history = profile.getHistory();
     if (history) {
         history->removeChatHistory(pk);
         return true;
@@ -136,7 +137,7 @@ bool AboutFriend::clearHistory()
 
 bool AboutFriend::isHistoryExistence()
 {
-    History* const history = Nexus::getProfile()->getHistory();
+    History* const history = profile.getHistory();
     if (history) {
         const ToxPk pk = f->getPublicKey();
         return history->historyExists(pk);

--- a/src/model/about/aboutfriend.h
+++ b/src/model/about/aboutfriend.h
@@ -27,13 +27,14 @@
 
 class Friend;
 class IFriendSettings;
+class Profile;
 
 class AboutFriend : public QObject, public IAboutFriend
 {
     Q_OBJECT
 
 public:
-    AboutFriend(const Friend* f_, IFriendSettings* const settings);
+    AboutFriend(const Friend* f_, IFriendSettings* const settings, Profile& profile);
 
     QString getName() const override;
     QString getStatusMessage() const override;
@@ -70,4 +71,5 @@ public:
 private:
     const Friend* const f;
     IFriendSettings* const settings;
+    Profile& profile;
 };

--- a/src/nexus.cpp
+++ b/src/nexus.cpp
@@ -284,7 +284,7 @@ void Nexus::destroyInstance()
  */
 Profile* Nexus::getProfile()
 {
-    return getInstance().profile;
+    return profile;
 }
 
 /**

--- a/src/nexus.h
+++ b/src/nexus.h
@@ -56,7 +56,7 @@ public:
     void setParser(QCommandLineParser* parser_);
     static Nexus& getInstance();
     static void destroyInstance();
-    static Profile* getProfile();
+    Profile* getProfile();
     static Widget* getDesktopGUI();
     static CameraSource& getCameraSource();
 

--- a/src/persistence/settings.cpp
+++ b/src/persistence/settings.cpp
@@ -598,8 +598,7 @@ void Settings::resetToDefault()
 
     // Remove file with profile settings
     QDir dir(paths.getSettingsDirPath());
-    Profile* profile = Nexus::getProfile();
-    QString localPath = dir.filePath(profile->getName() + ".ini");
+    QString localPath = dir.filePath(loadedProfile->getName() + ".ini");
     QFile local(localPath);
     if (local.exists())
         local.remove();

--- a/src/video/netcamview.cpp
+++ b/src/video/netcamview.cpp
@@ -48,7 +48,7 @@ const auto BTN_STYLE_SHEET_PATH = QStringLiteral("chatForm/fullScreenButtons.css
 }
 
 NetCamView::NetCamView(ToxPk friendPk_, CameraSource& cameraSource_,
-    Settings& settings_, Style& style_, QWidget* parent)
+    Settings& settings_, Style& style_, Profile& profile, QWidget* parent)
     : QWidget(parent)
     , selfFrame{nullptr}
     , friendPk{friendPk_}
@@ -115,12 +115,12 @@ NetCamView::NetCamView(ToxPk friendPk_, CameraSource& cameraSource_,
     buttonPanelLayout->addWidget(exitFullScreenButton);
     buttonPanelLayout->addStretch();
 
-    videoSurface = new VideoSurface(Nexus::getProfile()->loadAvatar(friendPk), this);
+    videoSurface = new VideoSurface(profile.loadAvatar(friendPk), this);
     videoSurface->setMinimumHeight(256);
 
     verLayout->insertWidget(0, videoSurface, 1);
 
-    selfVideoSurface = new VideoSurface(Nexus::getProfile()->loadAvatar(), this, true);
+    selfVideoSurface = new VideoSurface(profile.loadAvatar(), this, true);
     selfVideoSurface->setObjectName(QStringLiteral("CamVideoSurface"));
     selfVideoSurface->setMouseTracking(true);
     selfVideoSurface->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
@@ -149,10 +149,10 @@ NetCamView::NetCamView(ToxPk friendPk_, CameraSource& cameraSource_,
         selfFrame->resetBoundary(boundingRect);
     });
 
-    connections += connect(Nexus::getProfile(), &Profile::selfAvatarChanged,
+    connections += connect(&profile, &Profile::selfAvatarChanged,
                            [this](const QPixmap& pixmap) { selfVideoSurface->setAvatar(pixmap); });
 
-    connections += connect(Nexus::getProfile(), &Profile::friendAvatarChanged,
+    connections += connect(&profile, &Profile::friendAvatarChanged,
                            [this](ToxPk friendPkArg, const QPixmap& pixmap) {
                                if (friendPk == friendPkArg)
                                    videoSurface->setAvatar(pixmap);

--- a/src/video/netcamview.h
+++ b/src/video/netcamview.h
@@ -37,6 +37,7 @@ class QShowEvent;
 class CameraSource;
 class Settings;
 class Style;
+class Profile;
 
 class NetCamView : public QWidget
 {
@@ -44,7 +45,7 @@ class NetCamView : public QWidget
 
 public:
     NetCamView(ToxPk friendPk_, CameraSource& cameraSource, Settings& settings,
-        Style& style, QWidget* parent = nullptr);
+        Style& style, Profile& profile, QWidget* parent = nullptr);
     ~NetCamView();
 
     virtual void show(VideoSource* source, const QString& title);

--- a/src/widget/circlewidget.cpp
+++ b/src/widget/circlewidget.cpp
@@ -42,7 +42,7 @@ QHash<int, CircleWidget*> CircleWidget::circleList;
 
 CircleWidget::CircleWidget(const Core &core_, FriendListWidget* parent, int id_,
     Settings& settings_, Style& style_, IMessageBoxManager& messageBoxManager_,
-    FriendList& friendList_)
+    FriendList& friendList_, Profile& profile_)
     : CategoryWidget(isCompact(), settings_, style_, parent)
     , id(id_)
     , core{core_}
@@ -50,6 +50,7 @@ CircleWidget::CircleWidget(const Core &core_, FriendListWidget* parent, int id_,
     , style{style_}
     , messageBoxManager{messageBoxManager_}
     , friendList{friendList_}
+    , profile{profile_}
 {
     setName(settings.getCircleName(id), false);
     circleList[id] = this;
@@ -120,7 +121,8 @@ void CircleWidget::contextMenuEvent(QContextMenuEvent* event)
 
             circleList.remove(replacedCircle);
         } else if (selectedItem == openAction) {
-            ContentDialog* dialog = new ContentDialog(core, settings, style, messageBoxManager, friendList);
+            ContentDialog* dialog = new ContentDialog(core, settings, style, messageBoxManager,
+                friendList, profile);
             emit newContentDialog(*dialog);
             for (int i = 0; i < friendOnlineLayout()->count(); ++i) {
                 QWidget* const widget = friendOnlineLayout()->itemAt(i)->widget();

--- a/src/widget/circlewidget.h
+++ b/src/widget/circlewidget.h
@@ -27,13 +27,15 @@ class Settings;
 class Style;
 class IMessageBoxManager;
 class FriendList;
+class Profile;
 
 class CircleWidget final : public CategoryWidget
 {
     Q_OBJECT
 public:
     CircleWidget(const Core& core_, FriendListWidget* parent, int id_, Settings& settings,
-        Style& style, IMessageBoxManager& messageboxManager, FriendList& friendList);
+        Style& style, IMessageBoxManager& messageboxManager, FriendList& friendList,
+        Profile& profile);
     ~CircleWidget();
 
     void editName();
@@ -63,4 +65,5 @@ private:
     Style& style;
     IMessageBoxManager& messageBoxManager;
     FriendList& friendList;
+    Profile& profile;
 };

--- a/src/widget/contentdialog.cpp
+++ b/src/widget/contentdialog.cpp
@@ -55,7 +55,7 @@ const QSize defaultSize(720, 400);
 
 ContentDialog::ContentDialog(const Core &core, Settings& settings_,
     Style& style_, IMessageBoxManager& messageBoxManager_, FriendList& friendList_,
-    QWidget* parent)
+    Profile& profile_, QWidget* parent)
     : ActivateDialog(style_, parent, Qt::Window)
     , splitter{new QSplitter(this)}
     , friendLayout{new FriendListLayout(this)}
@@ -66,6 +66,7 @@ ContentDialog::ContentDialog(const Core &core, Settings& settings_,
     , style{style_}
     , messageBoxManager{messageBoxManager_}
     , friendList{friendList_}
+    , profile{profile_}
 {
     friendLayout->setMargin(0);
     friendLayout->setSpacing(0);
@@ -162,7 +163,8 @@ FriendWidget* ContentDialog::addFriend(std::shared_ptr<FriendChatroom> chatroom,
     const auto compact = settings.getCompactLayout();
     auto frnd = chatroom->getFriend();
     const auto& friendPk = frnd->getPublicKey();
-    auto friendWidget = new FriendWidget(chatroom, compact, settings, style, messageBoxManager);
+    auto friendWidget = new FriendWidget(chatroom, compact, settings, style,
+        messageBoxManager, profile);
     emit connectFriendWidget(*friendWidget);
     chatWidgets[friendPk] = friendWidget;
     friendLayout->addFriendWidget(friendWidget, frnd->getStatus());

--- a/src/widget/contentdialog.h
+++ b/src/widget/contentdialog.h
@@ -49,6 +49,7 @@ class Settings;
 class Style;
 class IMessageBoxManager;
 class FriendList;
+class Profile;
 
 class ContentDialog : public ActivateDialog, public IDialogs
 {
@@ -56,7 +57,7 @@ class ContentDialog : public ActivateDialog, public IDialogs
 public:
     ContentDialog(const Core& core, Settings& settings, Style& style,
         IMessageBoxManager& messageBoxManager, FriendList& friendList,
-        QWidget* parent = nullptr);
+        Profile& profile, QWidget* parent = nullptr);
     ~ContentDialog() override;
 
     FriendWidget* addFriend(std::shared_ptr<FriendChatroom> chatroom, GenericChatForm* form);
@@ -145,4 +146,5 @@ private:
     Style& style;
     IMessageBoxManager& messageBoxManager;
     FriendList& friendList;
+    Profile& profile;
 };

--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -106,14 +106,14 @@ QString secondsToDHMS(quint32 duration)
 }
 } // namespace
 
-ChatForm::ChatForm(Profile& profile, Friend* chatFriend, IChatLog& chatLog_,
+ChatForm::ChatForm(Profile& profile_, Friend* chatFriend, IChatLog& chatLog_,
     IMessageDispatcher& messageDispatcher_, DocumentCache& documentCache_,
     SmileyPack& smileyPack_, CameraSource& cameraSource_, Settings& settings_,
     Style& style_, IMessageBoxManager& messageBoxManager,
     ContentDialogManager& contentDialogManager_, FriendList& friendList_)
-    : GenericChatForm(profile.getCore(), chatFriend, chatLog_, messageDispatcher_,
+    : GenericChatForm(profile_.getCore(), chatFriend, chatLog_, messageDispatcher_,
         documentCache_, smileyPack_, settings_, style_, messageBoxManager, friendList_)
-    , core{profile.getCore()}
+    , core{profile_.getCore()}
     , f(chatFriend)
     , isTyping{false}
     , lastCallIsVideo{false}
@@ -121,6 +121,7 @@ ChatForm::ChatForm(Profile& profile, Friend* chatFriend, IChatLog& chatLog_,
     , settings{settings_}
     , style{style_}
     , contentDialogManager{contentDialogManager_}
+    , profile{profile_}
 {
     setName(f->getDisplayedName());
 
@@ -517,7 +518,7 @@ std::unique_ptr<NetCamView> ChatForm::createNetcam()
     qDebug() << "creating netcam";
     uint32_t friendId = f->getId();
     std::unique_ptr<NetCamView> view = std::unique_ptr<NetCamView>(
-        new NetCamView(f->getPublicKey(), cameraSource, settings, style, this));
+        new NetCamView(f->getPublicKey(), cameraSource, settings, style, profile, this));
     CoreAV* av = core.getAv();
     VideoSource* source = av->getVideoSourceFromCall(friendId);
     view->show(source, f->getDisplayedName());

--- a/src/widget/form/chatform.h
+++ b/src/widget/form/chatform.h
@@ -46,6 +46,7 @@ class DocumentCache;
 class SmileyPack;
 class Settings;
 class Style;
+class Profile;
 class IMessageBoxManager;
 class ContentDialogManager;
 class FriendList;
@@ -152,4 +153,5 @@ private:
     Settings& settings;
     Style& style;
     ContentDialogManager& contentDialogManager;
+    Profile& profile;
 };

--- a/src/widget/form/settings/privacyform.cpp
+++ b/src/widget/form/settings/privacyform.cpp
@@ -38,11 +38,12 @@
 #include <chrono>
 #include <random>
 
-PrivacyForm::PrivacyForm(Core* core_, Settings& settings_, Style& style)
+PrivacyForm::PrivacyForm(Core* core_, Settings& settings_, Style& style, Profile& profile_)
     : GenericForm(QPixmap(":/img/settings/privacy.png"), style)
     , bodyUI(new Ui::PrivacySettings)
     , core{core_}
     , settings{settings_}
+    , profile{profile_}
 {
     bodyUI->setupUi(this);
 
@@ -70,7 +71,7 @@ void PrivacyForm::on_cbKeepHistory_stateChanged()
                                   tr("Do you want to permanently delete all chat history?"),
                                   QMessageBox::Yes | QMessageBox::No);
         if (dialogDelHistory == QMessageBox::Yes) {
-            Nexus::getProfile()->getHistory()->eraseHistory();
+            profile.getHistory()->eraseHistory();
         }
     }
 }

--- a/src/widget/form/settings/privacyform.h
+++ b/src/widget/form/settings/privacyform.h
@@ -24,6 +24,7 @@
 class Core;
 class Settings;
 class Style;
+class Profile;
 
 namespace Ui {
 class PrivacySettings;
@@ -33,7 +34,7 @@ class PrivacyForm : public GenericForm
 {
     Q_OBJECT
 public:
-    PrivacyForm(Core* core_, Settings& settings, Style& style);
+    PrivacyForm(Core* core_, Settings& settings, Style& style, Profile& profile);
     ~PrivacyForm();
     QString getFormName() final
     {
@@ -59,4 +60,5 @@ private:
     Ui::PrivacySettings* bodyUI;
     Core* core;
     Settings& settings;
+    Profile& profile;
 };

--- a/src/widget/form/settingswidget.cpp
+++ b/src/widget/form/settingswidget.cpp
@@ -43,7 +43,8 @@
 
 SettingsWidget::SettingsWidget(UpdateCheck* updateCheck, IAudioControl& audio,
     Core* core, SmileyPack& smileyPack, CameraSource& cameraSource,
-        Settings& settings, Style& style, IMessageBoxManager& messageBoxManager, Widget* parent)
+        Settings& settings, Style& style, IMessageBoxManager& messageBoxManager,
+        Profile& profile, Widget* parent)
     : QWidget(parent, Qt::Window)
 {
     CoreAV* coreAV = core->getAv();
@@ -62,7 +63,7 @@ SettingsWidget::SettingsWidget(UpdateCheck* updateCheck, IAudioControl& audio,
     connect(gfrm.get(), &GeneralForm::updateIcons, parent, &Widget::updateIcons);
 
     std::unique_ptr<UserInterfaceForm> uifrm(new UserInterfaceForm(smileyPack, settings, style, this));
-    std::unique_ptr<PrivacyForm> pfrm(new PrivacyForm(core, settings, style));
+    std::unique_ptr<PrivacyForm> pfrm(new PrivacyForm(core, settings, style, profile));
     connect(pfrm.get(), &PrivacyForm::clearAllReceipts, parent, &Widget::clearAllReceipts);
 
     AVForm* rawAvfrm = new AVForm(audio, coreAV, cameraSource, audioSettings, videoSettings, style);

--- a/src/widget/form/settingswidget.h
+++ b/src/widget/form/settingswidget.h
@@ -43,6 +43,7 @@ class CameraSource;
 class Settings;
 class Style;
 class IMessageBoxManager;
+class Profile;
 
 class SettingsWidget : public QWidget
 {
@@ -50,7 +51,8 @@ class SettingsWidget : public QWidget
 public:
     SettingsWidget(UpdateCheck* updateCheck, IAudioControl& audio, Core *core,
         SmileyPack& smileyPack, CameraSource& cameraSource, Settings& settings,
-        Style& style, IMessageBoxManager& messageBoxManager, Widget* parent = nullptr);
+        Style& style, IMessageBoxManager& messageBoxManager, Profile& profile,
+        Widget* parent = nullptr);
     ~SettingsWidget();
 
     bool isShown() const;

--- a/src/widget/friendlistwidget.cpp
+++ b/src/widget/friendlistwidget.cpp
@@ -101,13 +101,14 @@ qint64 timeUntilTomorrow()
 
 FriendListWidget::FriendListWidget(const Core &core_, Widget* parent,
     Settings& settings_, Style& style_, IMessageBoxManager& messageBoxManager_,
-    FriendList& friendList_, bool groupsOnTop)
+    FriendList& friendList_, Profile& profile_, bool groupsOnTop)
     : QWidget(parent)
     , core{core_}
     , settings{settings_}
     , style{style_}
     , messageBoxManager{messageBoxManager_}
     , friendList{friendList_}
+    , profile{profile_}
 {
     int countContacts = core.getFriendList().size();
     manager = new FriendListManager(countContacts, this);
@@ -620,7 +621,7 @@ CircleWidget* FriendListWidget::createCircleWidget(int id)
     }
 
     CircleWidget* circleWidget = new CircleWidget(core, this, id, settings, style,
-        messageBoxManager, friendList);
+        messageBoxManager, friendList, profile);
     emit connectCircleWidget(*circleWidget);
     connect(this, &FriendListWidget::onCompactChanged, circleWidget, &CircleWidget::onCompactChanged);
     connect(circleWidget, &CircleWidget::renameRequested, this, &FriendListWidget::renameCircleWidget);

--- a/src/widget/friendlistwidget.h
+++ b/src/widget/friendlistwidget.h
@@ -42,6 +42,7 @@ class Settings;
 class Style;
 class IMessageBoxManager;
 class FriendList;
+class Profile;
 
 class FriendListWidget : public QWidget
 {
@@ -49,7 +50,7 @@ class FriendListWidget : public QWidget
 public:
     using SortingMode = Settings::FriendListSortingMode;
     FriendListWidget(const Core& core, Widget* parent, Settings& settings, Style& style,
-        IMessageBoxManager& messageBoxManager, FriendList& friendList,
+        IMessageBoxManager& messageBoxManager, FriendList& friendList, Profile& profile,
         bool groupsOnTop = true);
     ~FriendListWidget();
     void setMode(SortingMode mode);
@@ -107,4 +108,5 @@ private:
     Style& style;
     IMessageBoxManager& messageBoxManager;
     FriendList& friendList;
+    Profile& profile;
 };

--- a/src/widget/friendwidget.cpp
+++ b/src/widget/friendwidget.cpp
@@ -57,13 +57,15 @@
  * When you click should open the chat with friend. Widget has a context menu.
  */
 FriendWidget::FriendWidget(std::shared_ptr<FriendChatroom> chatroom_, bool compact_,
-    Settings& settings_, Style& style_, IMessageBoxManager& messageBoxManager_)
+    Settings& settings_, Style& style_, IMessageBoxManager& messageBoxManager_,
+    Profile& profile_)
     : GenericChatroomWidget(compact_, settings_, style_)
     , chatroom{chatroom_}
     , isDefaultAvatar{true}
     , settings{settings_}
     , style{style_}
     , messageBoxManager{messageBoxManager_}
+    , profile{profile_}
 {
     avatar->setPixmap(QPixmap(":/img/contact.svg"));
     statusPic.setPixmap(QPixmap(Status::getIconPath(Status::Status::Offline)));
@@ -284,7 +286,7 @@ void FriendWidget::changeAutoAccept(bool enable)
 void FriendWidget::showDetails()
 {
     const auto frnd = chatroom->getFriend();
-    const auto iabout = new AboutFriend(frnd, &settings);
+    const auto iabout = new AboutFriend(frnd, &settings, profile);
     std::unique_ptr<IAboutFriend> about = std::unique_ptr<IAboutFriend>(iabout);
     const auto aboutUser = new AboutFriendForm(std::move(about), settings, style,
         messageBoxManager, this);

--- a/src/widget/friendwidget.h
+++ b/src/widget/friendwidget.h
@@ -32,13 +32,15 @@ class CircleWidget;
 class Settings;
 class Style;
 class IMessageBoxManager;
+class Profile;
 
 class FriendWidget : public GenericChatroomWidget, public IFriendListItem
 {
     Q_OBJECT
 public:
     FriendWidget(std::shared_ptr<FriendChatroom> chatroom, bool compact_,
-        Settings& settings, Style& style, IMessageBoxManager& messageBoxManager);
+        Settings& settings, Style& style, IMessageBoxManager& messageBoxManager,
+        Profile& profile);
 
     void contextMenuEvent(QContextMenuEvent* event) final;
     void setAsActiveChatroom() final;
@@ -92,4 +94,5 @@ public:
     Settings& settings;
     Style& style;
     IMessageBoxManager& messageBoxManager;
+    Profile& profile;
 };

--- a/src/widget/widget.cpp
+++ b/src/widget/widget.cpp
@@ -268,7 +268,7 @@ void Widget::init()
     sharedMessageProcessorParams.reset(new MessageProcessor::SharedParams(core->getMaxMessageSize(), coreExt->getMaxExtendedMessageSize()));
 
     chatListWidget = new FriendListWidget(*core, this, settings, style,
-        *messageBoxManager, *friendList, settings.getGroupchatPosition());
+        *messageBoxManager, *friendList, profile, settings.getGroupchatPosition());
     connect(chatListWidget, &FriendListWidget::searchCircle, this, &Widget::searchCircle);
     connect(chatListWidget, &FriendListWidget::connectCircleWidget, this,
             &Widget::connectCircleWidget);
@@ -306,7 +306,7 @@ void Widget::init()
     connect(updateCheck.get(), &UpdateCheck::updateAvailable, this, &Widget::onUpdateAvailable);
 #endif
     settingsWidget = new SettingsWidget(updateCheck.get(), audio, core, *smileyPack,
-        cameraSource, settings, style, *messageBoxManager, this);
+        cameraSource, settings, style, *messageBoxManager, profile, this);
 #if UPDATE_CHECK_ENABLED
     updateCheck->checkForUpdate();
 #endif
@@ -1159,7 +1159,7 @@ void Widget::addFriend(uint32_t friendId, const ToxPk& friendPk)
     auto rawChatroom = new FriendChatroom(newfriend, contentDialogManager.get(), *core, settings);
     std::shared_ptr<FriendChatroom> chatroom(rawChatroom);
     const auto compact = settings.getCompactLayout();
-    auto widget = new FriendWidget(chatroom, compact, settings, style, *messageBoxManager);
+    auto widget = new FriendWidget(chatroom, compact, settings, style, *messageBoxManager, profile);
     connectFriendWidget(*widget);
     auto history = profile.getHistory();
 
@@ -1831,7 +1831,7 @@ void Widget::onUpdateAvailable()
 ContentDialog* Widget::createContentDialog() const
 {
     ContentDialog* contentDialog = new ContentDialog(*core, settings, style,
-        *messageBoxManager, *friendList);
+        *messageBoxManager, *friendList, profile);
 
     registerContentDialog(*contentDialog);
     return contentDialog;


### PR DESCRIPTION
Pass Profile to where it's needed to move away from requiring singleton Nexus.

Keep non-static getProfile for use by by main.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6617)
<!-- Reviewable:end -->
