### PR TITLE
refactor(IPC): Remove activate's handler reliance on global state

### DIFF
--- a/src/ipc.h
+++ b/src/ipc.h
@@ -26,6 +26,7 @@
 #include <QTimer>
 #include <ctime>
 #include <functional>
+#include <mutex>
 
 using IPCEventHandler = std::function<bool(const QByteArray&, void*)>;
 
@@ -42,7 +43,7 @@ protected:
     static const int OWNERSHIP_TIMEOUT_S = 5;
 
 public:
-    IPC(uint32_t profileId_);
+    explicit IPC(uint32_t profileId_);
     ~IPC();
 
     struct IPCEvent
@@ -69,6 +70,7 @@ public:
     time_t postEvent(const QString& name, const QByteArray& data = QByteArray(), uint32_t dest = 0);
     bool isCurrentOwner();
     void registerEventHandler(const QString& name, IPCEventHandler handler, void* userData);
+    void unregisterEventHandler(const QString& name);
     bool isEventAccepted(time_t time);
     bool waitUntilAccepted(time_t time, int32_t timeout = -1);
     bool isAttached() const;
@@ -93,5 +95,6 @@ private:
     uint64_t globalId;
     uint32_t profileId;
     QSharedMemory globalMemory;
+    mutable std::mutex eventHandlersMutex;
     QMap<QString, Callback> eventHandlers;
 };

--- a/src/nexus.cpp
+++ b/src/nexus.cpp
@@ -235,7 +235,8 @@ void Nexus::showMainGUI()
     assert(profile);
 
     // Create GUI
-    widget = new Widget(*profile, *audioControl, *cameraSource, *settings, *style);
+    widget = new Widget(*profile, *audioControl, *cameraSource, *settings, *style,
+        *ipc);
 
     // Start GUI
     widget->init();
@@ -347,6 +348,16 @@ CameraSource& Nexus::getCameraSource()
 void Nexus::setMessageBoxManager(IMessageBoxManager* messageBoxManager_)
 {
     messageBoxManager = messageBoxManager_;
+}
+
+void Nexus::setIpc(IPC* ipc_)
+{
+    ipc = ipc_;
+}
+
+void Nexus::registerActivate()
+{
+    widget->registerActivate();
 }
 
 #ifdef Q_OS_MAC

--- a/src/nexus.h
+++ b/src/nexus.h
@@ -35,6 +35,7 @@ class QCommandLineParser;
 class CameraSource;
 class Style;
 class IMessageBoxManager;
+class IPC;
 
 #ifdef Q_OS_MAC
 class QMenuBar;
@@ -53,12 +54,14 @@ public:
     void showMainGUI();
     void setSettings(Settings* settings_);
     void setMessageBoxManager(IMessageBoxManager* messageBoxManager);
+    void setIpc(IPC* ipc);
     void setParser(QCommandLineParser* parser_);
     static Nexus& getInstance();
     static void destroyInstance();
     Profile* getProfile();
     static Widget* getDesktopGUI();
     static CameraSource& getCameraSource();
+    void registerActivate();
 
 
 #ifdef Q_OS_MAC
@@ -113,4 +116,5 @@ private:
     std::unique_ptr<CameraSource> cameraSource;
     std::unique_ptr<Style> style;
     IMessageBoxManager* messageBoxManager = nullptr;
+    IPC* ipc = nullptr;
 };

--- a/src/persistence/toxsave.cpp
+++ b/src/persistence/toxsave.cpp
@@ -21,12 +21,22 @@
 #include "src/persistence/settings.h"
 #include "src/widget/widget.h"
 #include "src/nexus.h"
+#include "src/ipc.h"
 #include "src/widget/tool/profileimporter.h"
 #include <QCoreApplication>
+#include <QString>
 
-ToxSave::ToxSave(Settings& settings_)
+const QString ToxSave::eventHandlerKey = QStringLiteral("save");
+
+ToxSave::ToxSave(Settings& settings_, IPC& ipc_)
     : settings{settings_}
+    , ipc{ipc_}
 {}
+
+ToxSave::~ToxSave()
+{
+    ipc.unregisterEventHandler(eventHandlerKey);
+}
 
 bool ToxSave::toxSaveEventHandler(const QByteArray& eventData, void* userData)
 {

--- a/src/persistence/toxsave.h
+++ b/src/persistence/toxsave.h
@@ -22,14 +22,19 @@
 class QString;
 class QByteArray;
 class Settings;
+class IPC;
+class QString;
 
 class ToxSave
 {
 public:
-    explicit ToxSave(Settings& settings);
+    const static QString eventHandlerKey;
+    ToxSave(Settings& settings, IPC& ipc);
+    ~ToxSave();
     bool handleToxSave(const QString& path);
     static bool toxSaveEventHandler(const QByteArray& eventData, void* userData);
 
 private:
     Settings& settings;
+    IPC& ipc;
 };

--- a/src/widget/widget.h
+++ b/src/widget/widget.h
@@ -90,7 +90,7 @@ class IMessageBoxManager;
 class ContentDialogManager;
 class FriendList;
 class GroupList;
-class RemoveChatDialog;
+class IPC;
 
 class Widget final : public QMainWindow
 {
@@ -126,7 +126,7 @@ private:
 
 public:
     Widget(Profile& profile_, IAudioControl& audio_, CameraSource& cameraSource,
-        Settings& settings, Style& style, QWidget* parent = nullptr);
+        Settings& settings, Style& style, IPC& ipc, QWidget* parent = nullptr);
     ~Widget() override;
     void init();
     void setCentralWidget(QWidget* widget, const QString& widgetName);
@@ -154,6 +154,8 @@ public:
     bool groupsVisible() const;
 
     void resetIcon();
+    void registerActivate();
+    static bool toxActivateEventHandler(const QByteArray& data, void* userData);
 
 public slots:
     void reloadTheme();
@@ -397,6 +399,5 @@ private:
     std::unique_ptr<FriendList> friendList;
     std::unique_ptr<GroupList> groupList;
     std::unique_ptr<ContentDialogManager> contentDialogManager;
+    IPC& ipc;
 };
-
-bool toxActivateEventHandler(const QByteArray& data, void* userData);


### PR DESCRIPTION
Register in Widget's constructor so that handler can always get back to
Widget.

Add unregistration functionality so that the handler doesn't run when
we've returned to the login window or when exiting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6618)
<!-- Reviewable:end -->
