### PR TITLE
chore(CI): Revert macOS runner hack needed for keg-only git install

### DIFF
--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -512,8 +512,6 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v3
-      - name: Remove keg-only git install
-        run: brew remove git@2.35.1
       - name: Homebrew dependencies to build dependencies
         run: brew update && brew upgrade && brew bundle --file ./osx/Brewfile-DepBuildDeps
       - name: Build dependencies
@@ -558,8 +556,6 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Remove keg-only git install
-        run: brew remove git@2.35.1
       - name: Homebrew
         run: brew update && brew upgrade && brew bundle --file ./osx/Brewfile
       - name: Install toxcore and toxext


### PR DESCRIPTION
This reverts commit f8e834c5c09f65188cda1c2483c7ef9f045988e4.

Appears to no longer be an issue, brew is not using the pre-installed
version of git automatically without error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6634)
<!-- Reviewable:end -->
