### PR TITLE
chore(Qt): Replace QGuiApplication usage with QApplication

### DIFF
--- a/src/appmanager.cpp
+++ b/src/appmanager.cpp
@@ -172,8 +172,8 @@ AppManager::AppManager(int argc, char** argv)
 void AppManager::preConstructionInitialization()
 {
 #if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
-    QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-    QGuiApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 #endif
     qInstallMessageHandler(logMessageHandler);
 }


### PR DESCRIPTION
QGuiApplication is for QML projects, QApplication is for Qt Widget projects.

We use QApplication everywhere else, so use here too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6640)
<!-- Reviewable:end -->
