### PR TITLE
fix(AppManager): Don't create temporary copy of argc

### DIFF
--- a/src/appmanager.cpp
+++ b/src/appmanager.cpp
@@ -162,7 +162,7 @@ bool toxURIEventHandler(const QByteArray& eventData, void* userData)
 }
 } // namespace
 
-AppManager::AppManager(int argc, char** argv)
+AppManager::AppManager(int& argc, char** argv)
     : qapp((preConstructionInitialization(), new QApplication(argc, argv)))
     , messageBoxManager(new MessageBoxManager(nullptr))
     , settings(new Settings(*messageBoxManager))

--- a/src/appmanager.h
+++ b/src/appmanager.h
@@ -36,7 +36,7 @@ class AppManager : public QObject
     Q_OBJECT
 
 public:
-    AppManager(int argc, char** argv);
+    AppManager(int& argc, char** argv);
     ~AppManager();
     int run();
 


### PR DESCRIPTION
QApplication takes argc by reference, so copying it in to AppManager's
constructor causes QApplication's to have an invalid reference once AppManager's
constructor returns.

Instead just reference main's argc.

Fix #6641

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6644)
<!-- Reviewable:end -->
