### PR TITLE
feat(chatlog): Add custom web handler as hyperlink

### DIFF
--- a/src/chatlog/textformatter.cpp
+++ b/src/chatlog/textformatter.cpp
@@ -93,6 +93,7 @@ const QVector<QRegularExpression> URI_WORD_PATTERNS = {
     QRegularExpression(QStringLiteral(R"((?<=^|\s)\S*(magnet:[?]((xt(.\d)?=urn:)|(mt=)|(kt=)|(tr=)|(dn=)|(xl=)|(xs=)|(as=)|(x.))[\S| ]+))")),
     QRegularExpression(QStringLiteral(R"((?<=^|\s)\S*(gemini://\S+))")),
     QRegularExpression(QStringLiteral(R"((?<=^|\s)\S*(ed2k://\|file\|\S+))")),
+    QRegularExpression(QStringLiteral(R"((?<=^|\s)\S*(web+\S+:\S+))")),
 };
 
 


### PR DESCRIPTION
Adds support for custom web scheme handlers. See [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/registerProtocolHandler#permitted_schemes) for more info.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6645)
<!-- Reviewable:end -->
