### PR TITLE
fix(build): Remove unnecessary dependencies

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -147,8 +147,6 @@ endif()
 # Try to find cmake toxcore libraries
 if(WIN32)
   search_dependency(TOXCORE             PACKAGE toxcore          OPTIONAL STATIC_PACKAGE)
-  search_dependency(TOXAV               PACKAGE toxav            OPTIONAL STATIC_PACKAGE)
-  search_dependency(TOXENCRYPTSAVE      PACKAGE toxencryptsave   OPTIONAL STATIC_PACKAGE)
 else()
   search_dependency(TOXCORE             PACKAGE toxcore          OPTIONAL)
 endif()

--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -151,8 +151,6 @@ if(WIN32)
   search_dependency(TOXENCRYPTSAVE      PACKAGE toxencryptsave   OPTIONAL STATIC_PACKAGE)
 else()
   search_dependency(TOXCORE             PACKAGE toxcore          OPTIONAL)
-  search_dependency(TOXAV               PACKAGE toxav            OPTIONAL)
-  search_dependency(TOXENCRYPTSAVE      PACKAGE toxencryptsave   OPTIONAL)
 endif()
 
 # If not found, use automake toxcore libraries


### PR DESCRIPTION
OS: Ubuntu
qTox version: master
Commit hash: 2197bce610f2abf5e561b1ee528313660b0f0fb9
toxcore: 0.2.18
Qt: 5.12.8

Hi 
I was trying to build qTox(master 2197bce610f2abf5e561b1ee528313660b0f0fb9) on clean environment and after

cmake .

-- Checking for module 'toxav'
--   No package 'toxav' found
-- TOXAV not found
-- Checking for module 'toxencryptsave'
--   No package 'toxencryptsave' found

I've also build toxcore(master 32ed67cbf346a17bad2f31a24e40bf78bf34fb71) and noted that in CMakeList.txt of toxcore
in a header we've got:

 ... The toxav, and toxencryptsave libraries are also not installed.

therefore I've removed it from CMakeList.txt file of qTox project. Note that objects containing functionality
of toxav and toxencryptsave are already in toxcore lib in the system:

/usr/local/lib$ ar -t libtoxcore.a 
...
rtp.c.o             
toxav.c.o                  <----
toxav_old.c.o
video.c.o
toxencryptsave.c.o  <----

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6648)
<!-- Reviewable:end -->
