### PR TITLE
feat(chatform, audio): Adding shortut SHIFT+` (~ tilde) for muting mic.

### DIFF
--- a/src/widget/form/chatform.cpp
+++ b/src/widget/form/chatform.cpp
@@ -58,6 +58,7 @@
 #include <QScrollBar>
 #include <QSplitter>
 #include <QStringBuilder>
+#include <QShortcut>
 
 #include <cassert>
 
@@ -221,6 +222,9 @@ ChatForm::ChatForm(Profile& profile_, Friend* chatFriend, IChatLog& chatLog_,
     setAcceptDrops(true);
     retranslateUi();
     Translator::registerHandler(std::bind(&ChatForm::retranslateUi, this), this);
+
+    // shortcut for mute (SHIFT+ `), (SHIFT + grave accent, gives tilde)
+    new QShortcut(Qt::SHIFT | 0x60, this, SLOT(onMicMuteShortcutToggle()));
 }
 
 ChatForm::~ChatForm()
@@ -456,6 +460,15 @@ void ChatForm::onMicMuteToggle()
     CoreAV* av = core.getAv();
     av->toggleMuteCallInput(f);
     updateMuteMicButton();
+}
+
+void ChatForm::onMicMuteShortcutToggle()
+{
+    CoreAV* av = core.getAv();
+    if(av->isCallActive(f))
+    {
+    	onMicMuteToggle();
+    }
 }
 
 void ChatForm::onVolMuteToggle()

--- a/src/widget/form/chatform.h
+++ b/src/widget/form/chatform.h
@@ -102,6 +102,7 @@ private slots:
     void onAnswerCallTriggered(bool video);
     void onRejectCallTriggered();
     void onMicMuteToggle();
+    void onMicMuteShortcutToggle();
     void onVolMuteToggle();
 
     void onFriendStatusChanged(const ToxPk& friendPk, Status::Status status);


### PR DESCRIPTION
OS: Ubuntu
qTox version: master
Commit hash: https://github.com/qTox/qTox/commit/2197bce610f2abf5e561b1ee528313660b0f0fb9
toxcore: 0.2.18
Qt: 5.12.8

https://github.com/qTox/qTox/issues/6574
In this commit unfortunately focus still has to be on qTox window.