### PR TITLE
chore(cmake): Fix CheckAtomic.cmake to check sub-word atomics

### DIFF
--- a/cmake/CheckAtomic.cmake
+++ b/cmake/CheckAtomic.cmake
@@ -27,9 +27,12 @@ function(check_working_cxx_atomics varname)
   set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -std=c++11")
   CHECK_CXX_SOURCE_COMPILES("
 #include <atomic>
-std::atomic<int> x;
+#include <cstdint>
+std::atomic<uint8_t> x1;
+std::atomic<uint16_t> x2;
+std::atomic<uint32_t> x3;
 int main() {
-  return x;
+  return ++x1 + ++x2 + ++x3;
 }
 " ${varname})
   set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})


### PR DESCRIPTION
Platforms like riscv64 does have 32-bit or 64-bit atomics, but not 8-bit or 16-bit.

Modified `check_working_cxx_atomics` to check sub-word atomics as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6657)
<!-- Reviewable:end -->
