### PR TITLE
fix(apparmor): Import nvidia abstraction

### DIFF
--- a/security/apparmor/2.12.1/usr.bin.qtox
+++ b/security/apparmor/2.12.1/usr.bin.qtox
@@ -30,6 +30,7 @@ profile qtox /usr{,/local}/bin/qtox {
   #include <abstractions/ibus>
   #include <abstractions/kde>
   #include <abstractions/nameservice>
+  #include <abstractions/nvidia>
   #include <abstractions/openssl>
   #include <abstractions/video>
 

--- a/security/apparmor/2.13.2/usr.bin.qtox
+++ b/security/apparmor/2.13.2/usr.bin.qtox
@@ -34,6 +34,7 @@ profile qtox /usr{,/local}/bin/qtox {
   #include <abstractions/kde>
   #include <abstractions/mesa>
   #include <abstractions/nameservice>
+  #include <abstractions/nvidia>
   #include <abstractions/openssl>
   #include <abstractions/qt5-compose-cache-write>
   #include <abstractions/qt5-settings-write>

--- a/security/apparmor/2.13.3/usr.bin.qtox
+++ b/security/apparmor/2.13.3/usr.bin.qtox
@@ -34,6 +34,7 @@ profile qtox /usr{,/local}/bin/qtox {
   #include <abstractions/kde>
   #include <abstractions/mesa>
   #include <abstractions/nameservice>
+  #include <abstractions/nvidia>
   #include <abstractions/openssl>
   #include <abstractions/qt5-compose-cache-write>
   #include <abstractions/qt5-settings-write>


### PR DESCRIPTION
In Debian Sid, after upgrading to nvidia-tesla-470-driver, qTox forever freezes upon startup.

AppArmor denials:

```
type=AVC msg=audit(1666461161.036:2783): apparmor="DENIED"
operation="open" profile="qtox" name="/proc/modules" pid=5139
comm="qtox" requested_mask="r" denied_mask="r" fsuid=1000
ouid=0FSUID="vincas" OUID="root"

type=AVC msg=audit(1666461161.036:2784): apparmor="DENIED"
operation="exec" profile="qtox" name="/usr/bin/nvidia-modprobe" pid=5150
comm="qtox" requested_mask="x" denied_mask="x" fsuid=1000
ouid=0FSUID="vincas" OUID="root"

```

As it keeps waiting forever:

```
[pid  5306] clone(child_stack=NULL,
flags=CLONE_CHILD_CLEARTID|CLONE_CHILD_SETTID|SIGCHLDstrace: Process
5317 attached
, child_tidptr=0x7f41ea70d750) = 5317
[pid  5317] set_robust_list(0x7f41ea70d760, 24) = 0
[pid  5306] wait4(5317,  <unfinished ...>
[pid  5317] execve("/usr/bin/nvidia-modprobe",
["/usr/bin/nvidia-modprobe"], 0x7ffc19b67258 /* 0 vars */) = -1 EACCES
(Permission denied)
[pid  5317] write(7, "\1\0\0\0\0\0\0\0", 8) = 8
[pid  5315] <... poll resumed>)         = 1 ([{fd=7, revents=POLLIN}])
[pid  5317] futex(0x55ed33f3f4d0,
FUTEX_WAIT_BITSET_PRIVATE|FUTEX_CLOCK_REALTIME, 0, NULL,
FUTEX_BITSET_MATCH_ANY <unfinished ...>
[pid  5315] read(7, "\1\0\0\0\0\0\0\0", 16) = 8
[pid  5315] poll([{fd=7, events=POLLIN}, {fd=8, events=POLLIN}], 2, -1
<unfinished ...>
[pid  5314] <... poll resumed>)         = 1 ([{fd=3, revents=POLLIN}])
[pid  5314] recvmsg(3, {msg_name=NULL, msg_namelen=0,
msg_iov=[{iov_base="U\2P\1:\3\4\0\3\4\4\0\0\0\0\0\0\0\0\4\4\4\4\4\0\0\3\37%\2\0\0",
iov_len=4096}], msg_iovlen=1, msg_controllen=0, msg_flags=0}, 0) = 32
[pid  5314] write(5, "\1\0\0\0\0\0\0\0", 8) = 8
[pid  5314] poll([{fd=3, events=POLLIN}], 1, -1
```

Allowing to read /proc/modules and other nvidia-driver-related files (by importing abstractions/nvidia) fixes this issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qtox/qtox/6666)
<!-- Reviewable:end -->
